### PR TITLE
The introduction of golangci-lint during the CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,4 +19,5 @@ pipeline:
       # Build
       - go build
       - go test -timeout 20m -v ./... -race
+      - golangci-lint run
     secrets: [TEST_USERNAME, TEST_PASSWORD]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,6 @@ linters:
   - goconst
   - gocyclo
   - govet
-  - interfacer
   - lll
   - maligned
   - megacheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,6 @@ linters:
   - maligned
   - megacheck
   - megacheck
-  - misspell
   - nakedret
   - prealloc
   - unconvert

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,4 @@ linters:
   - lll
   - maligned
   - megacheck
-  - prealloc
   - unparam
-  - varcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,5 @@ linters:
   - megacheck
   - nakedret
   - prealloc
-  - unconvert
   - unparam
   - varcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,8 @@ linters-settings:
   goconst:
     min-len: 2
     min-occurrences: 2
+  lll:
+    line-length: 160
 
   misspell:
     locale: US
@@ -25,7 +27,6 @@ linters:
   - goconst
   - gocyclo
   - govet
-  - lll
   - maligned
   - megacheck
   - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,6 @@ linters:
   - goconst
   - gocyclo
   - govet
-  - ineffassign
   - interfacer
   - lll
   - maligned

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,40 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 13 # Should be 10 but was brought to 13 to speed up the development
+  maligned:
+    suggest-new: true
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+
+  misspell:
+    locale: US
+
+linters:
+  enable-all: true
+  disable:
+  - deadcode
+  - dupl
+  - errcheck
+  - goconst
+  - gocyclo
+  - gofmt
+  - govet
+  - ineffassign
+  - interfacer
+  - lll
+  - maligned
+  - megacheck
+  - megacheck
+  - misspell
+  - nakedret
+  - prealloc
+  - unconvert
+  - unparam
+  - varcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
   - errcheck
   - goconst
   - gocyclo
-  - gofmt
   - govet
   - ineffassign
   - interfacer

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,8 +30,6 @@ linters:
   - lll
   - maligned
   - megacheck
-  - megacheck
-  - nakedret
   - prealloc
   - unparam
   - varcheck

--- a/arduino/cores/cores.go
+++ b/arduino/cores/cores.go
@@ -111,9 +111,10 @@ func (platform *Platform) GetOrCreateRelease(version *semver.Version) (*Platform
 	return release, nil
 }
 
-// GetRelease returns the specified release corresponding the provided version,
+// GetReleaseRelaxedVersion returns the specified release corresponding the provided version,
 // or nil if not found.
-func (platform *Platform) GetRelease(version *semver.Version) *PlatformRelease {
+func (platform *Platform) GetReleaseVersion(version *semver.Version) *PlatformRelease {
+	// use as an fmt.Stringer
 	return platform.Releases[version.String()]
 }
 
@@ -124,7 +125,7 @@ func (platform *Platform) GetLatestRelease() *PlatformRelease {
 	if latestVersion == nil {
 		return nil
 	}
-	return platform.GetRelease(latestVersion)
+	return platform.GetReleaseVersion(latestVersion)
 }
 
 // GetAllReleasesVersions returns all the version numbers in this Platform Package.

--- a/arduino/cores/cores.go
+++ b/arduino/cores/cores.go
@@ -23,7 +23,7 @@ import (
 	"github.com/arduino/go-paths-helper"
 
 	"github.com/arduino/arduino-cli/arduino/resources"
-	properties "github.com/arduino/go-properties-map"
+	"github.com/arduino/go-properties-map"
 	"go.bug.st/relaxed-semver"
 )
 
@@ -111,9 +111,9 @@ func (platform *Platform) GetOrCreateRelease(version *semver.Version) (*Platform
 	return release, nil
 }
 
-// GetReleaseRelaxedVersion returns the specified release corresponding the provided version,
+// FindReleaseWithRelaxedVersion returns the specified release corresponding the provided version,
 // or nil if not found.
-func (platform *Platform) GetReleaseVersion(version *semver.Version) *PlatformRelease {
+func (platform *Platform) FindReleaseWithVersion(version *semver.Version) *PlatformRelease {
 	// use as an fmt.Stringer
 	return platform.Releases[version.String()]
 }
@@ -125,7 +125,7 @@ func (platform *Platform) GetLatestRelease() *PlatformRelease {
 	if latestVersion == nil {
 		return nil
 	}
-	return platform.GetReleaseVersion(latestVersion)
+	return platform.FindReleaseWithVersion(latestVersion)
 }
 
 // GetAllReleasesVersions returns all the version numbers in this Platform Package.

--- a/arduino/cores/fqbn_test.go
+++ b/arduino/cores/fqbn_test.go
@@ -119,5 +119,7 @@ func TestFQBN(t *testing.T) {
 	require.Equal(t, f.Package, "arduino")
 	require.Equal(t, f.PlatformArch, "avr")
 	require.Equal(t, f.BoardID, "uno")
-	require.Equal(t, "properties.Map{\n  \"cpu\": \"atmega\",\n  \"extra\": \"core=arduino\",\n  \"speed\": \"1000\",\n}", f.Configs.Dump())
+	require.Equal(t,
+		"properties.Map{\n  \"cpu\": \"atmega\",\n  \"extra\": \"core=arduino\",\n  \"speed\": \"1000\",\n}",
+		f.Configs.Dump())
 }

--- a/arduino/cores/packageindex/index.go
+++ b/arduino/cores/packageindex/index.go
@@ -72,7 +72,7 @@ type indexToolRelease struct {
 	Systems []indexToolReleaseFlavour `json:"systems,required"`
 }
 
-// indexToolReleaseFlavour represents a single tool flavour in the package_index.json file.
+// indexToolReleaseFlavour represents a single tool flavor in the package_index.json file.
 type indexToolReleaseFlavour struct {
 	OS              string      `json:"host,required"`
 	URL             string      `json:"url,required"`
@@ -178,15 +178,15 @@ func (inToolRelease indexToolRelease) extractToolIn(outPackage *cores.Package) {
 	outTool := outPackage.GetOrCreateTool(inToolRelease.Name)
 
 	outToolRelease := outTool.GetOrCreateRelease(inToolRelease.Version)
-	outToolRelease.Flavours = inToolRelease.extractFlavours()
+	outToolRelease.Flavors = inToolRelease.extractFlavours()
 }
 
-// extractFlavours extracts a map[OS]Flavour object from an indexToolRelease entry.
-func (inToolRelease indexToolRelease) extractFlavours() []*cores.Flavour {
-	ret := make([]*cores.Flavour, len(inToolRelease.Systems))
+// extractFlavours extracts a map[OS]Flavor object from an indexToolRelease entry.
+func (inToolRelease indexToolRelease) extractFlavours() []*cores.Flavor {
+	ret := make([]*cores.Flavor, len(inToolRelease.Systems))
 	for i, flavour := range inToolRelease.Systems {
 		size, _ := flavour.Size.Int64()
-		ret[i] = &cores.Flavour{
+		ret[i] = &cores.Flavor{
 			OS: flavour.OS,
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: flavour.ArchiveFileName,

--- a/arduino/cores/packagemanager/download.go
+++ b/arduino/cores/packagemanager/download.go
@@ -81,7 +81,7 @@ func (pm *PackageManager) FindPlatformReleaseDependencies(item *PlatformReferenc
 
 	var release *cores.PlatformRelease
 	if item.PlatformVersion != nil {
-		release = platform.GetRelease(item.PlatformVersion)
+		release = platform.GetReleaseVersion(item.PlatformVersion)
 		if release == nil {
 			return nil, nil, fmt.Errorf("required version %s not found for platform %s", item.PlatformVersion, platform.String())
 		}

--- a/arduino/cores/packagemanager/download.go
+++ b/arduino/cores/packagemanager/download.go
@@ -81,7 +81,7 @@ func (pm *PackageManager) FindPlatformReleaseDependencies(item *PlatformReferenc
 
 	var release *cores.PlatformRelease
 	if item.PlatformVersion != nil {
-		release = platform.GetReleaseVersion(item.PlatformVersion)
+		release = platform.FindReleaseWithVersion(item.PlatformVersion)
 		if release == nil {
 			return nil, nil, fmt.Errorf("required version %s not found for platform %s", item.PlatformVersion, platform.String())
 		}

--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -162,7 +162,7 @@ func (pm *PackageManager) ResolveFQBN(fqbn *cores.FQBN) (
 	platformRelease := platform.GetInstalled()
 	if platformRelease == nil {
 		return targetPackage, nil, nil, nil, nil,
-			fmt.Errorf("Platform %s is not installed", platformRelease)
+			fmt.Errorf("platform %s is not installed", platformRelease)
 	}
 
 	// Find board
@@ -210,14 +210,14 @@ func (pm *PackageManager) LoadPackageIndex(URL *url.URL) error {
 
 // Package looks for the Package with the given name, returning a structure
 // able to perform further operations on that given resource
-func (pm *PackageManager) Package(name string) *packageActions {
+func (pm *PackageManager) Package(name string) *PackageActions {
 	//TODO: perhaps these 2 structure should be merged? cores.Packages vs pkgmgr??
 	var err error
 	thePackage := pm.packages.Packages[name]
 	if thePackage == nil {
 		err = fmt.Errorf("package '%s' not found", name)
 	}
-	return &packageActions{
+	return &PackageActions{
 		aPackage:     thePackage,
 		forwardError: err,
 	}
@@ -225,16 +225,16 @@ func (pm *PackageManager) Package(name string) *packageActions {
 
 // Actions that can be done on a Package
 
-// packageActions defines what actions can be performed on the specific Package
+// PackageActions defines what actions can be performed on the specific Package
 // It serves as a status container for the fluent APIs
-type packageActions struct {
+type PackageActions struct {
 	aPackage     *cores.Package
 	forwardError error
 }
 
 // Tool looks for the Tool with the given name, returning a structure
 // able to perform further operations on that given resource
-func (pa *packageActions) Tool(name string) *toolActions {
+func (pa *PackageActions) Tool(name string) *ToolActions {
 	var tool *cores.Tool
 	err := pa.forwardError
 	if err == nil {
@@ -244,7 +244,7 @@ func (pa *packageActions) Tool(name string) *toolActions {
 			err = fmt.Errorf("tool '%s' not found in package '%s'", name, pa.aPackage.Name)
 		}
 	}
-	return &toolActions{
+	return &ToolActions{
 		tool:         tool,
 		forwardError: err,
 	}
@@ -254,15 +254,15 @@ func (pa *packageActions) Tool(name string) *toolActions {
 
 // Actions that can be done on a Tool
 
-// toolActions defines what actions can be performed on the specific Tool
+// ToolActions defines what actions can be performed on the specific Tool
 // It serves as a status container for the fluent APIs
-type toolActions struct {
+type ToolActions struct {
 	tool         *cores.Tool
 	forwardError error
 }
 
 // Get returns the final representation of the Tool
-func (ta *toolActions) Get() (*cores.Tool, error) {
+func (ta *ToolActions) Get() (*cores.Tool, error) {
 	err := ta.forwardError
 	if err == nil {
 		return ta.tool, nil
@@ -271,7 +271,7 @@ func (ta *toolActions) Get() (*cores.Tool, error) {
 }
 
 // IsInstalled checks whether any release of the Tool is installed in the system
-func (ta *toolActions) IsInstalled() (bool, error) {
+func (ta *ToolActions) IsInstalled() (bool, error) {
 	if ta.forwardError != nil {
 		return false, ta.forwardError
 	}
@@ -284,27 +284,27 @@ func (ta *toolActions) IsInstalled() (bool, error) {
 	return false, nil
 }
 
-func (ta *toolActions) Release(version *semver.RelaxedVersion) *toolReleaseActions {
+func (ta *ToolActions) Release(version *semver.RelaxedVersion) *ToolReleaseActions {
 	if ta.forwardError != nil {
-		return &toolReleaseActions{forwardError: ta.forwardError}
+		return &ToolReleaseActions{forwardError: ta.forwardError}
 	}
 	release := ta.tool.GetRelease(version)
 	if release == nil {
-		return &toolReleaseActions{forwardError: fmt.Errorf("release %s not found for tool %s", version, ta.tool.String())}
+		return &ToolReleaseActions{forwardError: fmt.Errorf("release %s not found for tool %s", version, ta.tool.String())}
 	}
-	return &toolReleaseActions{release: release}
+	return &ToolReleaseActions{release: release}
 }
 
 // END -- Actions that can be done on a Tool
 
-// toolReleaseActions defines what actions can be performed on the specific ToolRelease
+// ToolReleaseActions defines what actions can be performed on the specific ToolRelease
 // It serves as a status container for the fluent APIs
-type toolReleaseActions struct {
+type ToolReleaseActions struct {
 	release      *cores.ToolRelease
 	forwardError error
 }
 
-func (tr *toolReleaseActions) Get() (*cores.ToolRelease, error) {
+func (tr *ToolReleaseActions) Get() (*cores.ToolRelease, error) {
 	if tr.forwardError != nil {
 		return nil, tr.forwardError
 	}

--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -288,7 +288,7 @@ func (ta *ToolActions) Release(version *semver.RelaxedVersion) *ToolReleaseActio
 	if ta.forwardError != nil {
 		return &ToolReleaseActions{forwardError: ta.forwardError}
 	}
-	release := ta.tool.GetRelease(version)
+	release := ta.tool.GetReleaseRelaxedVersion(version)
 	if release == nil {
 		return &ToolReleaseActions{forwardError: fmt.Errorf("release %s not found for tool %s", version, ta.tool.String())}
 	}

--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -288,7 +288,7 @@ func (ta *ToolActions) Release(version *semver.RelaxedVersion) *ToolReleaseActio
 	if ta.forwardError != nil {
 		return &ToolReleaseActions{forwardError: ta.forwardError}
 	}
-	release := ta.tool.GetReleaseRelaxedVersion(version)
+	release := ta.tool.FindReleaseWithRelaxedVersion(version)
 	if release == nil {
 		return &ToolReleaseActions{forwardError: fmt.Errorf("release %s not found for tool %s", version, ta.tool.String())}
 	}

--- a/arduino/cores/status.go
+++ b/arduino/cores/status.go
@@ -113,11 +113,11 @@ func (targetPackage *Package) String() string {
 func (tdep ToolDependency) extractTool(sc Packages) (*Tool, error) {
 	pkg, exists := sc.Packages[tdep.ToolPackager]
 	if !exists {
-		return nil, errors.New("Package not found")
+		return nil, errors.New("package not found")
 	}
 	tool, exists := pkg.Tools[tdep.ToolName]
 	if !exists {
-		return nil, errors.New("Tool not found")
+		return nil, errors.New("tool not found")
 	}
 	return tool, nil
 }
@@ -129,7 +129,7 @@ func (tdep ToolDependency) extractRelease(sc Packages) (*ToolRelease, error) {
 	}
 	release, exists := tool.Releases[tdep.ToolVersion.String()]
 	if !exists {
-		return nil, errors.New("Release Not Found")
+		return nil, errors.New("release Not Found")
 	}
 	return release, nil
 }
@@ -143,15 +143,15 @@ func (packages *Packages) GetDepsOfPlatformRelease(release *PlatformRelease) ([]
 	for _, dep := range release.Dependencies {
 		pkg, exists := packages.Packages[dep.ToolPackager]
 		if !exists {
-			return nil, fmt.Errorf("Package %s not found", dep.ToolPackager)
+			return nil, fmt.Errorf("package %s not found", dep.ToolPackager)
 		}
 		tool, exists := pkg.Tools[dep.ToolName]
 		if !exists {
-			return nil, fmt.Errorf("Tool %s not found", dep.ToolName)
+			return nil, fmt.Errorf("tool %s not found", dep.ToolName)
 		}
 		toolRelease, exists := tool.Releases[dep.ToolVersion.String()]
 		if !exists {
-			return nil, fmt.Errorf("Tool version %s not found", dep.ToolVersion)
+			return nil, fmt.Errorf("tool version %s not found", dep.ToolVersion)
 		}
 		ret = append(ret, toolRelease)
 	}

--- a/arduino/cores/status.go
+++ b/arduino/cores/status.go
@@ -129,7 +129,7 @@ func (tdep ToolDependency) extractRelease(sc Packages) (*ToolRelease, error) {
 	}
 	release, exists := tool.Releases[tdep.ToolVersion.String()]
 	if !exists {
-		return nil, errors.New("release Not Found")
+		return nil, errors.New("release not found")
 	}
 	return release, nil
 }

--- a/arduino/cores/tools.go
+++ b/arduino/cores/tools.go
@@ -37,14 +37,14 @@ type Tool struct {
 // ToolRelease represents a single release of a tool
 type ToolRelease struct {
 	Version    *semver.RelaxedVersion `json:"version,required"` // The version number of this Release.
-	Flavours   []*Flavour             `json:"systems"`          // Maps OS to Flavour
+	Flavors    []*Flavor              `json:"systems"`          // Maps OS to Flavor
 	Tool       *Tool                  `json:"-"`
 	InstallDir *paths.Path            `json:"-"`
 }
 
-// Flavour represents a flavour of a Tool version.
-type Flavour struct {
-	OS       string `json:"os,required"` // The OS Supported by this flavour.
+// Flavor represents a flavor of a Tool version.
+type Flavor struct {
+	OS       string `json:"os,required"` // The OS Supported by this flavor.
 	Resource *resources.DownloadResource
 }
 
@@ -150,11 +150,11 @@ var (
 	regexpArmBSD   = regexp.MustCompile("arm.*-freebsd[0-9]*")
 )
 
-func (f *Flavour) isCompatibleWithCurrentMachine() bool {
+func (f *Flavor) isCompatibleWithCurrentMachine() bool {
 	return f.isCompatibleWith(runtime.GOOS, runtime.GOARCH)
 }
 
-func (f *Flavour) isCompatibleWith(osName, osArch string) bool {
+func (f *Flavor) isCompatibleWith(osName, osArch string) bool {
 	if f.OS == "all" {
 		return true
 	}
@@ -183,7 +183,7 @@ func (f *Flavour) isCompatibleWith(osName, osArch string) bool {
 
 // GetCompatibleFlavour returns the downloadable resource compatible with the running O.S.
 func (tr *ToolRelease) GetCompatibleFlavour() *resources.DownloadResource {
-	for _, flavour := range tr.Flavours {
+	for _, flavour := range tr.Flavors {
 		if flavour.isCompatibleWithCurrentMachine() {
 			return flavour.Resource
 		}

--- a/arduino/cores/tools.go
+++ b/arduino/cores/tools.go
@@ -81,11 +81,12 @@ func (tool *Tool) GetAllReleasesVersions() []*semver.RelaxedVersion {
 
 // LatestRelease obtains latest version of a core package.
 func (tool *Tool) LatestRelease() *ToolRelease {
-	if latest := tool.latestReleaseVersion(); latest == nil {
+	latest := tool.latestReleaseVersion()
+	if latest == nil {
 		return nil
-	} else {
-		return tool.GetRelease(latest)
 	}
+
+	return tool.GetRelease(latest)
 }
 
 // latestReleaseVersion obtains latest version number.

--- a/arduino/cores/tools.go
+++ b/arduino/cores/tools.go
@@ -62,9 +62,9 @@ func (tool *Tool) GetOrCreateRelease(version *semver.RelaxedVersion) *ToolReleas
 	return release
 }
 
-// GetRelease returns the specified release corresponding the provided version,
+// GetReleaseRelaxedVersion returns the specified release corresponding the provided version,
 // or nil if not found.
-func (tool *Tool) GetRelease(version *semver.RelaxedVersion) *ToolRelease {
+func (tool *Tool) GetReleaseRelaxedVersion(version *semver.RelaxedVersion) *ToolRelease {
 	return tool.Releases[version.String()]
 }
 
@@ -86,7 +86,7 @@ func (tool *Tool) LatestRelease() *ToolRelease {
 		return nil
 	}
 
-	return tool.GetRelease(latest)
+	return tool.GetReleaseRelaxedVersion(latest)
 }
 
 // latestReleaseVersion obtains latest version number.

--- a/arduino/cores/tools.go
+++ b/arduino/cores/tools.go
@@ -62,9 +62,9 @@ func (tool *Tool) GetOrCreateRelease(version *semver.RelaxedVersion) *ToolReleas
 	return release
 }
 
-// GetReleaseRelaxedVersion returns the specified release corresponding the provided version,
+// FindReleaseWithRelaxedVersion returns the specified release corresponding the provided version,
 // or nil if not found.
-func (tool *Tool) GetReleaseRelaxedVersion(version *semver.RelaxedVersion) *ToolRelease {
+func (tool *Tool) FindReleaseWithRelaxedVersion(version *semver.RelaxedVersion) *ToolRelease {
 	return tool.Releases[version.String()]
 }
 
@@ -86,7 +86,7 @@ func (tool *Tool) LatestRelease() *ToolRelease {
 		return nil
 	}
 
-	return tool.GetReleaseRelaxedVersion(latest)
+	return tool.FindReleaseWithRelaxedVersion(latest)
 }
 
 // latestReleaseVersion obtains latest version number.

--- a/arduino/cores/tools_test.go
+++ b/arduino/cores/tools_test.go
@@ -56,9 +56,9 @@ func TestFlavorCompatibility(t *testing.T) {
 		Positives []*os
 	}
 	tests := []*test{
-		&test{&Flavor{OS: "i686-mingw32"}, []*os{windowsi386, windowsx8664}},
-		&test{&Flavor{OS: "i386-apple-darwin11"}, []*os{darwini386, darwinamd646}},
-		&test{&Flavor{OS: "x86_64-apple-darwin"}, []*os{darwinamd646}},
+		{&Flavor{OS: "i686-mingw32"}, []*os{windowsi386, windowsx8664}},
+		{&Flavor{OS: "i386-apple-darwin11"}, []*os{darwini386, darwinamd646}},
+		{&Flavor{OS: "x86_64-apple-darwin"}, []*os{darwinamd646}},
 
 		// Raspberry PI, BBB or other ARM based host
 		// PI: "arm-linux-gnueabihf"
@@ -66,14 +66,14 @@ func TestFlavorCompatibility(t *testing.T) {
 		// Ubuntu Mate on PI2: "arm-linux-gnueabihf"
 		// Debian 7.9 on BBB: "arm-linux-gnueabihf"
 		// Raspbian on PI Zero: "arm-linux-gnueabihf"
-		&test{&Flavor{OS: "arm-linux-gnueabihf"}, []*os{linuxarm, linuxarmbe}},
+		{&Flavor{OS: "arm-linux-gnueabihf"}, []*os{linuxarm, linuxarmbe}},
 		// Arch-linux on PI2: "armv7l-unknown-linux-gnueabihf"
-		&test{&Flavor{OS: "armv7l-unknown-linux-gnueabihf"}, []*os{linuxarm, linuxarmbe}},
+		{&Flavor{OS: "armv7l-unknown-linux-gnueabihf"}, []*os{linuxarm, linuxarmbe}},
 
-		&test{&Flavor{OS: "i686-linux-gnu"}, []*os{linuxi386}},
-		&test{&Flavor{OS: "i686-pc-linux-gnu"}, []*os{linuxi386}},
-		&test{&Flavor{OS: "x86_64-linux-gnu"}, []*os{linuxamd64}},
-		&test{&Flavor{OS: "x86_64-pc-linux-gnu"}, []*os{linuxamd64}},
+		{&Flavor{OS: "i686-linux-gnu"}, []*os{linuxi386}},
+		{&Flavor{OS: "i686-pc-linux-gnu"}, []*os{linuxi386}},
+		{&Flavor{OS: "x86_64-linux-gnu"}, []*os{linuxamd64}},
+		{&Flavor{OS: "x86_64-pc-linux-gnu"}, []*os{linuxamd64}},
 	}
 
 	check := func(test *test, os *os) {

--- a/arduino/cores/tools_test.go
+++ b/arduino/cores/tools_test.go
@@ -52,13 +52,13 @@ func TestFlavorCompatibility(t *testing.T) {
 	}
 
 	type test struct {
-		Flavour   *Flavour
+		Flavour   *Flavor
 		Positives []*os
 	}
 	tests := []*test{
-		&test{&Flavour{OS: "i686-mingw32"}, []*os{windowsi386, windowsx8664}},
-		&test{&Flavour{OS: "i386-apple-darwin11"}, []*os{darwini386, darwinamd646}},
-		&test{&Flavour{OS: "x86_64-apple-darwin"}, []*os{darwinamd646}},
+		&test{&Flavor{OS: "i686-mingw32"}, []*os{windowsi386, windowsx8664}},
+		&test{&Flavor{OS: "i386-apple-darwin11"}, []*os{darwini386, darwinamd646}},
+		&test{&Flavor{OS: "x86_64-apple-darwin"}, []*os{darwinamd646}},
 
 		// Raspberry PI, BBB or other ARM based host
 		// PI: "arm-linux-gnueabihf"
@@ -66,14 +66,14 @@ func TestFlavorCompatibility(t *testing.T) {
 		// Ubuntu Mate on PI2: "arm-linux-gnueabihf"
 		// Debian 7.9 on BBB: "arm-linux-gnueabihf"
 		// Raspbian on PI Zero: "arm-linux-gnueabihf"
-		&test{&Flavour{OS: "arm-linux-gnueabihf"}, []*os{linuxarm, linuxarmbe}},
+		&test{&Flavor{OS: "arm-linux-gnueabihf"}, []*os{linuxarm, linuxarmbe}},
 		// Arch-linux on PI2: "armv7l-unknown-linux-gnueabihf"
-		&test{&Flavour{OS: "armv7l-unknown-linux-gnueabihf"}, []*os{linuxarm, linuxarmbe}},
+		&test{&Flavor{OS: "armv7l-unknown-linux-gnueabihf"}, []*os{linuxarm, linuxarmbe}},
 
-		&test{&Flavour{OS: "i686-linux-gnu"}, []*os{linuxi386}},
-		&test{&Flavour{OS: "i686-pc-linux-gnu"}, []*os{linuxi386}},
-		&test{&Flavour{OS: "x86_64-linux-gnu"}, []*os{linuxamd64}},
-		&test{&Flavour{OS: "x86_64-pc-linux-gnu"}, []*os{linuxamd64}},
+		&test{&Flavor{OS: "i686-linux-gnu"}, []*os{linuxi386}},
+		&test{&Flavor{OS: "i686-pc-linux-gnu"}, []*os{linuxi386}},
+		&test{&Flavor{OS: "x86_64-linux-gnu"}, []*os{linuxamd64}},
+		&test{&Flavor{OS: "x86_64-pc-linux-gnu"}, []*os{linuxamd64}},
 	}
 
 	check := func(test *test, os *os) {

--- a/arduino/libraries/libraries.go
+++ b/arduino/libraries/libraries.go
@@ -108,7 +108,7 @@ func (library *Library) IsOptimizedForArchitecture(arch string) bool {
 }
 
 // IsArchitectureIndependent returns true if the library declares to be
-// compatibile with all architectures (the `architecture` field in
+// compatible with all architectures (the `architecture` field in
 // library.properties contains the `*` item)
 func (library *Library) IsArchitectureIndependent() bool {
 	return library.IsOptimizedForArchitecture("*")

--- a/arduino/libraries/libraries_layout.go
+++ b/arduino/libraries/libraries_layout.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 )
 
-// LibraryLayout represents how the library source code is layed out in the library
+// LibraryLayout represents how the library source code is laid out in the library
 type LibraryLayout uint16
 
 const (

--- a/arduino/libraries/librariesresolver/cpp.go
+++ b/arduino/libraries/librariesresolver/cpp.go
@@ -106,7 +106,7 @@ func computePriority(lib *libraries.Library, header, arch string) int {
 	header = simplify(header)
 	name := simplify(lib.Name)
 
-	priority := int(lib.PriorityForArchitecture(arch)) // bewteen 0..255
+	priority := int(lib.PriorityForArchitecture(arch)) // between 0..255
 	if name == header {
 		priority += 0x500
 	} else if name == header+"-master" {

--- a/arduino/resources/helpers.go
+++ b/arduino/resources/helpers.go
@@ -41,12 +41,12 @@ func (r *DownloadResource) IsCached(downloadDir *paths.Path) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("getting archive path: %s", err)
 	}
-
-	if exist, err := archivePath.Exist(); err != nil {
+	exist, err := archivePath.Exist()
+	if err != nil {
 		return false, fmt.Errorf("checking archive existence: %s", err)
-	} else {
-		return exist, nil
 	}
+
+	return exist, nil
 }
 
 // Download a DownloadResource.

--- a/arduino/resources/install.go
+++ b/arduino/resources/install.go
@@ -96,11 +96,11 @@ func (release *DownloadResource) Install(downloadDir, tempPath, destDir *paths.P
 
 // IsDirEmpty returns true if the directory specified by path is empty.
 func IsDirEmpty(path *paths.Path) (bool, error) {
-	if files, err := path.ReadDir(); err != nil {
+	files, err := path.ReadDir()
+	if err != nil {
 		return false, err
-	} else {
-		return len(files) == 0, nil
 	}
+	return len(files) == 0, nil
 }
 
 func findPackageRoot(parent *paths.Path) (*paths.Path, error) {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -54,7 +54,8 @@ type Config struct {
 	// ClientID is the client id you are using
 	ClientID string
 
-	// RedirectURI is the redirectURI where the oauth process will redirect. It's only required since the oauth system checks for it, but we intercept the redirect before hitting it
+	// RedirectURI is the redirectURI where the oauth process will redirect.
+	// It's only required since the oauth system checks for it, but we intercept the redirect before hitting it
 	RedirectURI string
 
 	// Scopes is a space-separated list of scopes to require
@@ -157,7 +158,8 @@ func (c *Config) Refresh(token string) (*Token, error) {
 // cookies keeps track of the cookies for each request
 type cookies map[string][]*http.Cookie
 
-// requestAuth calls hydra and follows the redirects until it reaches the authentication page. It saves the cookie it finds so it can apply them to subsequent requests
+// requestAuth calls hydra and follows the redirects until it reaches the authentication page.
+// It saves the cookie it finds so it can apply them to subsequent requests
 func (c *Config) requestAuth(client *http.Client) (string, cookies, error) {
 	uri, err := url.Parse(c.CodeURL)
 	if err != nil {

--- a/builder_client_helpers/alive.go
+++ b/builder_client_helpers/alive.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 import (
 	"context"

--- a/builder_client_helpers/boards.go
+++ b/builder_client_helpers/boards.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 import (
 	"context"

--- a/builder_client_helpers/boards_v2.go
+++ b/builder_client_helpers/boards_v2.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 import (
 	"context"

--- a/builder_client_helpers/client.go
+++ b/builder_client_helpers/client.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 import (
 	"github.com/goadesign/goa"

--- a/builder_client_helpers/compilations.go
+++ b/builder_client_helpers/compilations.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 import (
 	"bytes"

--- a/builder_client_helpers/compilations.go
+++ b/builder_client_helpers/compilations.go
@@ -30,7 +30,10 @@ func StartCompilationsPath() string {
 	return fmt.Sprintf("/builder/v1/compile")
 }
 
-// Start a compilation for the given user and saves the request (but not the generated files) on the database. requires authentication. Can return PreconditionFailed if the user has reached their maximum number of compilations per day. If the compilation failed it returns UnprocessableEntity
+// Start a compilation for the given user and saves the request (but not the generated files) on the database.
+// requires authentication.
+// Can return PreconditionFailed if the user has reached their maximum number of compilations per day.
+// If the compilation failed it returns UnprocessableEntity
 func (c *Client) StartCompilations(ctx context.Context, path string, payload *Compilation) (*http.Response, error) {
 	req, err := c.NewStartCompilationsRequest(ctx, path, payload)
 	if err != nil {

--- a/builder_client_helpers/examples.go
+++ b/builder_client_helpers/examples.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 import (
 	"context"
@@ -30,8 +30,8 @@ func ListExamplesPath() string {
 }
 
 // ListExamples provides a list of all the builtin examples
-func (c *Client) ListExamples(ctx context.Context, path string, maintainer *string, type_ *string) (*http.Response, error) {
-	req, err := c.NewListExamplesRequest(ctx, path, maintainer, type_)
+func (c *Client) ListExamples(ctx context.Context, path string, maintainer *string, type1 *string) (*http.Response, error) {
+	req, err := c.NewListExamplesRequest(ctx, path, maintainer, type1)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (c *Client) ListExamples(ctx context.Context, path string, maintainer *stri
 }
 
 // NewListExamplesRequest create the request corresponding to the list action endpoint of the examples resource.
-func (c *Client) NewListExamplesRequest(ctx context.Context, path string, maintainer *string, type_ *string) (*http.Request, error) {
+func (c *Client) NewListExamplesRequest(ctx context.Context, path string, maintainer *string, type1 *string) (*http.Request, error) {
 	scheme := c.Scheme
 	if scheme == "" {
 		scheme = "http"
@@ -49,8 +49,8 @@ func (c *Client) NewListExamplesRequest(ctx context.Context, path string, mainta
 	if maintainer != nil {
 		values.Set("maintainer", *maintainer)
 	}
-	if type_ != nil {
-		values.Set("type", *type_)
+	if type1 != nil {
+		values.Set("type", *type1)
 	}
 	u.RawQuery = values.Encode()
 	req, err := http.NewRequest("GET", u.String(), nil)

--- a/builder_client_helpers/examples.go
+++ b/builder_client_helpers/examples.go
@@ -30,8 +30,8 @@ func ListExamplesPath() string {
 }
 
 // ListExamples provides a list of all the builtin examples
-func (c *Client) ListExamples(ctx context.Context, path string, maintainer *string, type1 *string) (*http.Response, error) {
-	req, err := c.NewListExamplesRequest(ctx, path, maintainer, type1)
+func (c *Client) ListExamples(ctx context.Context, path string, maintainer *string, libType *string) (*http.Response, error) {
+	req, err := c.NewListExamplesRequest(ctx, path, maintainer, libType)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (c *Client) ListExamples(ctx context.Context, path string, maintainer *stri
 }
 
 // NewListExamplesRequest create the request corresponding to the list action endpoint of the examples resource.
-func (c *Client) NewListExamplesRequest(ctx context.Context, path string, maintainer *string, type1 *string) (*http.Request, error) {
+func (c *Client) NewListExamplesRequest(ctx context.Context, path string, maintainer *string, libType *string) (*http.Request, error) {
 	scheme := c.Scheme
 	if scheme == "" {
 		scheme = "http"
@@ -49,8 +49,8 @@ func (c *Client) NewListExamplesRequest(ctx context.Context, path string, mainta
 	if maintainer != nil {
 		values.Set("maintainer", *maintainer)
 	}
-	if type1 != nil {
-		values.Set("type", *type1)
+	if libType != nil {
+		values.Set("type", *libType)
 	}
 	u.RawQuery = values.Encode()
 	req, err := http.NewRequest("GET", u.String(), nil)

--- a/builder_client_helpers/files.go
+++ b/builder_client_helpers/files.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 import (
 	"context"

--- a/builder_client_helpers/libraries.go
+++ b/builder_client_helpers/libraries.go
@@ -29,8 +29,12 @@ func ListLibrariesPath() string {
 	return fmt.Sprintf("/builder/v1/libraries")
 }
 
-// ListLibraries provides a list of all the latest versions of the libraries supported by Arduino Create. Doesn't require any authentication.
-func (c *Client) ListLibraries(ctx context.Context, path string, maintainer *string, type1 *string, withoutType *string) (*http.Response, error) {
+// ListLibraries provides a list of all the latest versions of the libraries supported by Arduino Create.
+// Doesn't require any authentication.
+func (c *Client) ListLibraries(
+	ctx context.Context,
+	path string, maintainer *string, type1 *string, withoutType *string) (*http.Response, error) {
+
 	req, err := c.NewListLibrariesRequest(ctx, path, maintainer, type1, withoutType)
 	if err != nil {
 		return nil, err
@@ -68,7 +72,8 @@ func ShowLibrariesPath(id string) string {
 	return fmt.Sprintf("/builder/v1/libraries/%s", id)
 }
 
-// ShowLibraries provides the library identified by the :id and :pid param. Doesn't require authentication. Also contains a list of other versions of the library
+// ShowLibraries provides the library identified by the :id and :pid param. Doesn't require authentication.
+// Also contains a list of other versions of the library
 func (c *Client) ShowLibraries(ctx context.Context, path string) (*http.Response, error) {
 	req, err := c.NewShowLibrariesRequest(ctx, path)
 	if err != nil {

--- a/builder_client_helpers/libraries.go
+++ b/builder_client_helpers/libraries.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 import (
 	"context"
@@ -30,8 +30,8 @@ func ListLibrariesPath() string {
 }
 
 // ListLibraries provides a list of all the latest versions of the libraries supported by Arduino Create. Doesn't require any authentication.
-func (c *Client) ListLibraries(ctx context.Context, path string, maintainer *string, type_ *string, withoutType *string) (*http.Response, error) {
-	req, err := c.NewListLibrariesRequest(ctx, path, maintainer, type_, withoutType)
+func (c *Client) ListLibraries(ctx context.Context, path string, maintainer *string, type1 *string, withoutType *string) (*http.Response, error) {
+	req, err := c.NewListLibrariesRequest(ctx, path, maintainer, type1, withoutType)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (c *Client) ListLibraries(ctx context.Context, path string, maintainer *str
 }
 
 // NewListLibrariesRequest create the request corresponding to the list action endpoint of the libraries resource.
-func (c *Client) NewListLibrariesRequest(ctx context.Context, path string, maintainer *string, type_ *string, withoutType *string) (*http.Request, error) {
+func (c *Client) NewListLibrariesRequest(ctx context.Context, path string, maintainer *string, type1 *string, withoutType *string) (*http.Request, error) {
 	scheme := c.Scheme
 	if scheme == "" {
 		scheme = "http"
@@ -49,8 +49,8 @@ func (c *Client) NewListLibrariesRequest(ctx context.Context, path string, maint
 	if maintainer != nil {
 		values.Set("maintainer", *maintainer)
 	}
-	if type_ != nil {
-		values.Set("type", *type_)
+	if type1 != nil {
+		values.Set("type", *type1)
 	}
 	if withoutType != nil {
 		values.Set("without_type", *withoutType)

--- a/builder_client_helpers/libraries.go
+++ b/builder_client_helpers/libraries.go
@@ -43,7 +43,7 @@ func (c *Client) ListLibraries(
 }
 
 // NewListLibrariesRequest create the request corresponding to the list action endpoint of the libraries resource.
-func (c *Client) NewListLibrariesRequest(ctx context.Context, path string, maintainer *string, type1 *string, withoutType *string) (*http.Request, error) {
+func (c *Client) NewListLibrariesRequest(ctx context.Context, path string, maintainer *string, libType *string, withoutType *string) (*http.Request, error) {
 	scheme := c.Scheme
 	if scheme == "" {
 		scheme = "http"
@@ -53,8 +53,8 @@ func (c *Client) NewListLibrariesRequest(ctx context.Context, path string, maint
 	if maintainer != nil {
 		values.Set("maintainer", *maintainer)
 	}
-	if type1 != nil {
-		values.Set("type", *type1)
+	if libType != nil {
+		values.Set("type", *libType)
 	}
 	if withoutType != nil {
 		values.Set("without_type", *withoutType)

--- a/builder_client_helpers/media_types.go
+++ b/builder_client_helpers/media_types.go
@@ -24,7 +24,11 @@ import (
 	"github.com/goadesign/goa"
 )
 
-// ArduinoBuilderBoard is a physical board belonging to a certain architecture in a package. The most obvious package is arduino, which contains architectures avr, sam and samd. It can contain multiple versions of the upload commands and options. If there is a default version it means that it's the only version officially supported. Of course if there is only one version it will be called default (default view)
+// ArduinoBuilderBoard is a physical board belonging to a certain architecture in a package.
+// The most obvious package is arduino, which contains architectures avr, sam and samd.
+// It can contain multiple versions of the upload commands and options.
+// If there is a default version it means that it's the only version officially supported.
+// Of course if there is only one version it will be called default (default view)
 //
 // Identifier: application/vnd.arduino.builder.board+json; view=default
 type ArduinoBuilderBoard struct {
@@ -160,7 +164,11 @@ func (c *Client) DecodeArduinoBuilderBoardsv2(resp *http.Response) (*ArduinoBuil
 	return &decoded, err
 }
 
-// ArduinoBuilderBoardv2 is a physical board belonging to a certain architecture in a package. The most obvious package is arduino, which contains architectures avr, sam and samd. It can contain multiple versions of the upload commands and options. If there is a default version it means that it's the only version officially supported. Of course if there is only one version it will be called default (default view)
+// ArduinoBuilderBoardv2 is a physical board belonging to a certain architecture in a package.
+// The most obvious package is arduino, which contains architectures avr, sam and samd.
+// It can contain multiple versions of the upload commands and options.
+// If there is a default version it means that it's the only version officially supported.
+// Of course if there is only one version it will be called default (default view)
 //
 // Identifier: application/vnd.arduino.builder.boardv2+json; view=default
 type ArduinoBuilderBoardv2 struct {
@@ -177,7 +185,11 @@ type ArduinoBuilderBoardv2 struct {
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 }
 
-// ArduinoBuilderBoardv2Full is a physical board belonging to a certain architecture in a package. The most obvious package is arduino, which contains architectures avr, sam and samd. It can contain multiple versions of the upload commands and options. If there is a default version it means that it's the only version officially supported. Of course if there is only one version it will be called default (full view)
+// ArduinoBuilderBoardv2Full is a physical board belonging to a certain architecture in a package.
+// The most obvious package is arduino, which contains architectures avr, sam and samd.
+// It can contain multiple versions of the upload commands and options.
+// If there is a default version it means that it's the only version officially supported.
+// Of course if there is only one version it will be called default (full view)
 //
 // Identifier: application/vnd.arduino.builder.boardv2+json; view=full
 type ArduinoBuilderBoardv2Full struct {
@@ -343,7 +355,9 @@ func (c *Client) DecodeArduinoBuilderBoardv2FullCollection(resp *http.Response) 
 	return decoded, err
 }
 
-// ArduinoBuilderCompilationResult is the result of a compilation. It contains the output and the eventual errors. If successful it contains the generated files. (default view)
+// ArduinoBuilderCompilationResult is the result of a compilation.
+// It contains the output and the eventual errors.
+// If successful it contains the generated files. (default view)
 //
 // Identifier: application/vnd.arduino.builder.compilation.result; view=default
 type ArduinoBuilderCompilationResult struct {
@@ -388,8 +402,8 @@ type ArduinoBuilderExample struct {
 	Types []string `form:"types,omitempty" json:"types,omitempty" xml:"types,omitempty"`
 }
 
-// An ArduinoBuilderExampleLink is a simple sketch with the purpose of demonstrating the capabilities of the language. (link view)
-//
+// An ArduinoBuilderExampleLink is a simple sketch with the purpose of demonstrating the capabilities of the language.
+// (link view)
 // Identifier: application/vnd.arduino.builder.example+json; view=link
 type ArduinoBuilderExampleLink struct {
 	// The url where to find the details
@@ -471,7 +485,9 @@ func (c *Client) DecodeArduinoBuilderFileCollection(resp *http.Response) (Arduin
 	return decoded, err
 }
 
-// ArduinoBuilderLibrary is a collection of header files containing arduino reusable code and functions. It typically contains its info in a library.properties files. The examples property contains a list of examples that use that library. (default view)
+// ArduinoBuilderLibrary is a collection of header files containing arduino reusable code and functions.
+// It typically contains its info in a library.properties files.
+// The examples property contains a list of examples that use that library. (default view)
 //
 // Identifier: application/vnd.arduino.builder.library+json; view=default
 type ArduinoBuilderLibrary struct {
@@ -489,7 +505,8 @@ type ArduinoBuilderLibrary struct {
 	Files []*ArduinoBuilderFile `form:"files,omitempty" json:"files,omitempty" xml:"files,omitempty"`
 	// The url where to find the details
 	Href *string `form:"href,omitempty" json:"href,omitempty" xml:"href,omitempty"`
-	// The id of the library. It could be a combination of name and version, a combination of the package and architecture, or an uuid id
+	// The id of the library.
+	// It could be a combination of name and version, a combination of the package and architecture, or an uuid id
 	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
 	// The maintainer of the library
 	Maintainer *string `form:"maintainer,omitempty" json:"maintainer,omitempty" xml:"maintainer,omitempty"`
@@ -507,7 +524,9 @@ type ArduinoBuilderLibrary struct {
 	Version *string `form:"version,omitempty" json:"version,omitempty" xml:"version,omitempty"`
 }
 
-// ArduinoBuilderLibraryLink is a collection of header files containing arduino reusable code and functions. It typically contains its info in a library.properties files. The examples property contains a list of examples that use that library. (link view)
+// ArduinoBuilderLibraryLink is a collection of header files containing arduino reusable code and functions.
+// It typically contains its info in a library.properties files.
+// The examples property contains a list of examples that use that library. (link view)
 //
 // Identifier: application/vnd.arduino.builder.library+json; view=link
 type ArduinoBuilderLibraryLink struct {
@@ -542,7 +561,8 @@ type ArduinoBuilderSlimlibrary struct {
 	// The number of examples that it contains
 	ExamplesNumber *int    `form:"examples_number,omitempty" json:"examples_number,omitempty" xml:"examples_number,omitempty"`
 	Href           *string `form:"href,omitempty" json:"href,omitempty" xml:"href,omitempty"`
-	// The id of the library. It could be a combination of name and version, a combination of the package and architecture, or an uuid id
+	// The id of the library.
+	// It could be a combination of name and version, a combination of the package and architecture, or an uuid id
 	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
 	// The maintainer of the library
 	Maintainer *string `form:"maintainer,omitempty" json:"maintainer,omitempty" xml:"maintainer,omitempty"`

--- a/builder_client_helpers/media_types.go
+++ b/builder_client_helpers/media_types.go
@@ -32,7 +32,7 @@ type ArduinoBuilderBoard struct {
 	Architecture *string                          `form:"architecture,omitempty" json:"architecture,omitempty" xml:"architecture,omitempty"`
 	Bootloader   []*ArduinoBuilderBoardBootloader `form:"bootloader,omitempty" json:"bootloader,omitempty" xml:"bootloader,omitempty"`
 	Build        []*ArduinoBuilderBoardBuild      `form:"build,omitempty" json:"build,omitempty" xml:"build,omitempty"`
-	// The default flavour of the board
+	// The default flavor of the board
 	DefaultFlavour *string `form:"default_flavour,omitempty" json:"default_flavour,omitempty" xml:"default_flavour,omitempty"`
 	// An identifier used by the tools to determine which tools to use on it
 	Fqbn *string `form:"fqbn,omitempty" json:"fqbn,omitempty" xml:"fqbn,omitempty"`
@@ -62,7 +62,7 @@ func (c *Client) DecodeArduinoBuilderBoard(resp *http.Response) (*ArduinoBuilder
 type ArduinoBuilderBoardBootloader struct {
 	// The commandline used to bootload
 	Commandline *string `form:"commandline,omitempty" json:"commandline,omitempty" xml:"commandline,omitempty"`
-	// The flavour of the board. Usually it's default
+	// The flavor of the board. Usually it's default
 	Flavour *string `form:"flavour,omitempty" json:"flavour,omitempty" xml:"flavour,omitempty"`
 	// The signature of the commandline
 	Signature *string `form:"signature,omitempty" json:"signature,omitempty" xml:"signature,omitempty"`
@@ -75,11 +75,11 @@ func (c *Client) DecodeArduinoBuilderBoardBootloader(resp *http.Response) (*Ardu
 	return &decoded, err
 }
 
-// ArduinoBuilderBoardBuild contains the info used to compile for a certain flavour of board. (default view)
+// ArduinoBuilderBoardBuild contains the info used to compile for a certain flavor of board. (default view)
 //
 // Identifier: application/vnd.arduino.builder.board.build; view=default
 type ArduinoBuilderBoardBuild struct {
-	// The flavour of the board. Usually it's default
+	// The flavor of the board. Usually it's default
 	Flavour *string `form:"flavour,omitempty" json:"flavour,omitempty" xml:"flavour,omitempty"`
 	// An identifier used by the tools to determine which tools to use on it
 	Fqbn *string `form:"fqbn,omitempty" json:"fqbn,omitempty" xml:"fqbn,omitempty"`
@@ -92,7 +92,7 @@ func (c *Client) DecodeArduinoBuilderBoardBuild(resp *http.Response) (*ArduinoBu
 	return &decoded, err
 }
 
-// ArduinoBuilderBoardUpload contains the info used to upload a certain flavour of board. (default view)
+// ArduinoBuilderBoardUpload contains the info used to upload a certain flavor of board. (default view)
 //
 // Identifier: application/vnd.arduino.builder.board.upload; view=default
 type ArduinoBuilderBoardUpload struct {
@@ -102,7 +102,7 @@ type ArduinoBuilderBoardUpload struct {
 	Ext *string `form:"ext,omitempty" json:"ext,omitempty" xml:"ext,omitempty"`
 	// Files used by the programmer
 	Files ArduinoBuilderFileCollection `form:"files,omitempty" json:"files,omitempty" xml:"files,omitempty"`
-	// The flavour of the board. Usually it's default
+	// The flavor of the board. Usually it's default
 	Flavour *string `form:"flavour,omitempty" json:"flavour,omitempty" xml:"flavour,omitempty"`
 	// Some options used for uploading, like the speed.
 	Options map[string]string `form:"options,omitempty" json:"options,omitempty" xml:"options,omitempty"`
@@ -167,7 +167,7 @@ type ArduinoBuilderBoardv2 struct {
 	// The architecture of the board
 	Architecture *string                              `form:"architecture,omitempty" json:"architecture,omitempty" xml:"architecture,omitempty"`
 	Build        ArduinoBuilderBoardv2BuildCollection `form:"build,omitempty" json:"build,omitempty" xml:"build,omitempty"`
-	// The default flavour of the board
+	// The default flavor of the board
 	DefaultFlavour *string `form:"default_flavour,omitempty" json:"default_flavour,omitempty" xml:"default_flavour,omitempty"`
 	// An identifier used by the tools to determine which tools to use on it
 	Fqbn *string `form:"fqbn,omitempty" json:"fqbn,omitempty" xml:"fqbn,omitempty"`
@@ -185,7 +185,7 @@ type ArduinoBuilderBoardv2Full struct {
 	Architecture *string                                   `form:"architecture,omitempty" json:"architecture,omitempty" xml:"architecture,omitempty"`
 	Bootloader   ArduinoBuilderBoardv2BootloaderCollection `form:"bootloader,omitempty" json:"bootloader,omitempty" xml:"bootloader,omitempty"`
 	Build        ArduinoBuilderBoardv2BuildCollection      `form:"build,omitempty" json:"build,omitempty" xml:"build,omitempty"`
-	// The default flavour of the board
+	// The default flavor of the board
 	DefaultFlavour *string `form:"default_flavour,omitempty" json:"default_flavour,omitempty" xml:"default_flavour,omitempty"`
 	// An identifier used by the tools to determine which tools to use on it
 	Fqbn *string `form:"fqbn,omitempty" json:"fqbn,omitempty" xml:"fqbn,omitempty"`
@@ -224,7 +224,7 @@ func (c *Client) DecodeArduinoBuilderBoardv2Full(resp *http.Response) (*ArduinoB
 type ArduinoBuilderBoardv2Bootloader struct {
 	// The commandline used to bootload
 	Commandline *string `form:"commandline,omitempty" json:"commandline,omitempty" xml:"commandline,omitempty"`
-	// The flavour of the board. Usually it's default
+	// The flavor of the board. Usually it's default
 	Flavour *string `form:"flavour,omitempty" json:"flavour,omitempty" xml:"flavour,omitempty"`
 	// The signature of the commandline
 	Signature *string `form:"signature,omitempty" json:"signature,omitempty" xml:"signature,omitempty"`
@@ -249,11 +249,11 @@ func (c *Client) DecodeArduinoBuilderBoardv2BootloaderCollection(resp *http.Resp
 	return decoded, err
 }
 
-// Build contains the info used to compile for a certain flavour of board. (default view)
+// Build contains the info used to compile for a certain flavor of board. (default view)
 //
 // Identifier: application/vnd.arduino.builder.boardv2.build; view=default
 type ArduinoBuilderBoardv2Build struct {
-	// The flavour of the board. Usually it's default
+	// The flavor of the board. Usually it's default
 	Flavour *string `form:"flavour,omitempty" json:"flavour,omitempty" xml:"flavour,omitempty"`
 	// An identifier used by the tools to determine which tools to use on it
 	Fqbn *string `form:"fqbn,omitempty" json:"fqbn,omitempty" xml:"fqbn,omitempty"`
@@ -278,7 +278,7 @@ func (c *Client) DecodeArduinoBuilderBoardv2BuildCollection(resp *http.Response)
 	return decoded, err
 }
 
-// ArduinoBuilderBoardv2Upload contains the info used to upload a certain flavour of board. (default view)
+// ArduinoBuilderBoardv2Upload contains the info used to upload a certain flavor of board. (default view)
 //
 // Identifier: application/vnd.arduino.builder.boardv2.upload; view=default
 type ArduinoBuilderBoardv2Upload struct {
@@ -288,7 +288,7 @@ type ArduinoBuilderBoardv2Upload struct {
 	Ext *string `form:"ext,omitempty" json:"ext,omitempty" xml:"ext,omitempty"`
 	// Files used by the programmer
 	Files ArduinoBuilderFileCollection `form:"files,omitempty" json:"files,omitempty" xml:"files,omitempty"`
-	// The flavour of the board. Usually it's default
+	// The flavor of the board. Usually it's default
 	Flavour *string `form:"flavour,omitempty" json:"flavour,omitempty" xml:"flavour,omitempty"`
 	// Some options used for uploading, like the speed.
 	Options map[string]string `form:"options,omitempty" json:"options,omitempty" xml:"options,omitempty"`

--- a/builder_client_helpers/media_types.go
+++ b/builder_client_helpers/media_types.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 import (
 	"net/http"

--- a/builder_client_helpers/pinned_libraries.go
+++ b/builder_client_helpers/pinned_libraries.go
@@ -40,7 +40,8 @@ func (c *Client) AddPinnedLibraries(ctx context.Context, path string) (*http.Res
 	return c.Client.Do(ctx, req)
 }
 
-// NewAddPinnedLibrariesRequest create the request corresponding to the add action endpoint of the pinnedLibraries resource.
+// NewAddPinnedLibrariesRequest create the request
+// corresponding to the add action endpoint of the pinnedLibraries resource.
 func (c *Client) NewAddPinnedLibrariesRequest(ctx context.Context, path string) (*http.Request, error) {
 	scheme := c.Scheme
 	if scheme == "" {

--- a/builder_client_helpers/pinned_libraries.go
+++ b/builder_client_helpers/pinned_libraries.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 import (
 	"context"

--- a/builder_client_helpers/public.go
+++ b/builder_client_helpers/public.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 /*
 import (

--- a/builder_client_helpers/user_types.go
+++ b/builder_client_helpers/user_types.go
@@ -21,7 +21,9 @@ import (
 	"github.com/goadesign/goa"
 )
 
-// A compilation is made up of a sketch (or a path to a sketch) and an fqbn. Eventual libraries are automatically determined and linked. NOTE: swagger will force you to define the files inside the sketch because of a bug. But they are not mandatory.
+// A compilation is made up of a sketch (or a path to a sketch) and an fqbn.
+// Eventual libraries are automatically determined and linked.
+// NOTE: swagger will force you to define the files inside the sketch because of a bug. But they are not mandatory.
 type compilation struct {
 	// The fully qualified board name
 	Fqbn *string `form:"fqbn,omitempty" json:"fqbn,omitempty" xml:"fqbn,omitempty"`
@@ -72,7 +74,9 @@ func (ut *compilation) Publicize() *Compilation {
 	return &pub
 }
 
-// A Compilation is made up of a sketch (or a path to a sketch) and an fqbn. Eventual libraries are automatically determined and linked. NOTE: swagger will force you to define the files inside the sketch because of a bug. But they are not mandatory.
+// A Compilation is made up of a sketch (or a path to a sketch) and an fqbn.
+// Eventual libraries are automatically determined and linked.
+// NOTE: swagger will force you to define the files inside the sketch because of a bug. But they are not mandatory.
 type Compilation struct {
 	// The fully qualified board name
 	Fqbn string `form:"fqbn" json:"fqbn" xml:"fqbn"`
@@ -275,7 +279,8 @@ func (ut *filemeta) Publicize() *Filemeta {
 	return &pub
 }
 
-// FileMeta represent a file in the filesystem, belonging to a sketch, a library or an example. Can contain a data property with the content of the file.
+// FileMeta represent a file in the filesystem, belonging to a sketch, a library or an example.
+// Can contain a data property with the content of the file.
 type Filemeta struct {
 	// The contents of the file, in base64
 	Data *string `form:"data,omitempty" json:"data,omitempty" xml:"data,omitempty"`
@@ -291,7 +296,9 @@ func (ut *Filemeta) Validate() (err error) {
 	return
 }
 
-// Library is a collection of header files containing arduino reusable code and functions. It typically contains its info in a library.properties files. The examples property contains a list of examples that use that library.
+// Library is a collection of header files containing arduino reusable code and functions.
+// It typically contains its info in a library.properties files.
+// The examples property contains a list of examples that use that library.
 type library struct {
 	// The architectures supported by the library.
 	Architectures []string `form:"architectures,omitempty" json:"architectures,omitempty" xml:"architectures,omitempty"`
@@ -391,7 +398,9 @@ func (ut *library) Publicize() *Library {
 	return &pub
 }
 
-// Library is a collection of header files containing arduino reusable code and functions. It typically contains its info in a library.properties files. The examples property contains a list of examples that use that library.
+// Library is a collection of header files containing arduino reusable code and functions.
+// It typically contains its info in a library.properties files.
+// The examples property contains a list of examples that use that library.
 type Library struct {
 	// The architectures supported by the library.
 	Architectures []string `form:"architectures,omitempty" json:"architectures,omitempty" xml:"architectures,omitempty"`
@@ -468,7 +477,9 @@ type PinnedLib struct {
 	Version *string `form:"version,omitempty" json:"version,omitempty" xml:"version,omitempty"`
 }
 
-// A sketch is a program intended to run on an arduino board. It's composed by a main .ino file and optional other files. You should upload only .ino and .h files.
+// A sketch is a program intended to run on an arduino board.
+// It's composed by a main .ino file and optional other files.
+// You should upload only .ino and .h files.
 type sketch struct {
 	// Other files contained in the example
 	Files []*filefull `form:"files,omitempty" json:"files,omitempty" xml:"files,omitempty"`
@@ -527,7 +538,8 @@ func (ut *sketch) Publicize() *Sketch {
 	return &pub
 }
 
-// A sketch is a program intended to run on an arduino board. It's composed by a main .ino file and optional other files. You should upload only .ino and .h files.
+// A sketch is a program intended to run on an arduino board.
+// It's composed by a main .ino file and optional other files. You should upload only .ino and .h files.
 type Sketch struct {
 	// Other files contained in the example
 	Files []*Filefull `form:"files,omitempty" json:"files,omitempty" xml:"files,omitempty"`

--- a/builder_client_helpers/user_types.go
+++ b/builder_client_helpers/user_types.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package builderClient
+package builderclient
 
 import (
 	"github.com/goadesign/goa"

--- a/commands/board/attach.go
+++ b/commands/board/attach.go
@@ -46,8 +46,10 @@ func initAttachCommand() *cobra.Command {
 		Args: cobra.RangeArgs(1, 2),
 		Run:  runAttachCommand,
 	}
-	attachCommand.Flags().StringVar(&attachFlags.boardFlavour, "flavour", "default", "The Name of the CPU flavour, it is required for some boards (e.g. Arduino Nano).")
-	attachCommand.Flags().StringVar(&attachFlags.searchTimeout, "timeout", "5s", "The timeout of the search of connected devices, try to high it if your board is not found (e.g. to 10s).")
+	attachCommand.Flags().StringVar(&attachFlags.boardFlavour, "flavour", "default",
+		"The Name of the CPU flavour, it is required for some boards (e.g. Arduino Nano).")
+	attachCommand.Flags().StringVar(&attachFlags.searchTimeout, "timeout", "5s",
+		"The timeout of the search of connected devices, try to high it if your board is not found (e.g. to 10s).")
 	return attachCommand
 }
 

--- a/commands/board/attach.go
+++ b/commands/board/attach.go
@@ -52,7 +52,7 @@ func initAttachCommand() *cobra.Command {
 }
 
 var attachFlags struct {
-	boardFlavour  string // The flavour of the chipset of the cpu of the connected board, if not specified it is set to "default".
+	boardFlavour  string // The flavor of the chipset of the cpu of the connected board, if not specified it is set to "default".
 	searchTimeout string // Expressed in a parsable duration, is the timeout for the list and attach commands.
 }
 

--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -39,7 +39,8 @@ func initListCommand() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Run:     runListCommand,
 	}
-	listCommand.Flags().StringVar(&listFlags.timeout, "timeout", "5s", "The timeout of the search of connected devices, try to high it if your board is not found (e.g. to 10s).")
+	usage := "The timeout of the search of connected devices, try to high it if your board is not found (e.g. to 10s)."
+	listCommand.Flags().StringVar(&listFlags.timeout, "timeout", "5s", usage)
 	return listCommand
 }
 

--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -39,8 +39,9 @@ func initListCommand() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Run:     runListCommand,
 	}
-	usage := "The timeout of the search of connected devices, try to high it if your board is not found (e.g. to 10s)."
-	listCommand.Flags().StringVar(&listFlags.timeout, "timeout", "5s", usage)
+
+	listCommand.Flags().StringVar(&listFlags.timeout, "timeout", "5s",
+		"The timeout of the search of connected devices, try to high it if your board is not found (e.g. to 10s).")
 	return listCommand
 }
 

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -35,7 +35,7 @@ import (
 
 // Redirecting stdOut so we can analyze output line by
 // line and check with what we want.
-var stdOut *os.File = os.Stdout
+var stdOut = os.Stdout // *os.File
 
 type stdOutRedirect struct {
 	tempFile *os.File

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -102,7 +102,7 @@ func executeWithArgs(t *testing.T, args ...string) (exitCode int, output []byte)
 	cmd.SetArgs(args)
 	cmd.Execute()
 
-	return
+	return exitCode, output
 }
 
 var currDataDir *paths.Path

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -206,8 +206,10 @@ func TestUserLibs(t *testing.T) {
 func TestLibDownloadAndInstall(t *testing.T) {
 	defer makeTempDataDir(t)()
 	defer makeTempSketchbookDir(t)()
+	var d []byte
+	var exitCode int
 
-	exitCode, d := executeWithArgs(t, "core", "update-index")
+	exitCode, _ = executeWithArgs(t, "core", "update-index")
 	require.Zero(t, exitCode, "exit code")
 
 	// Download inexistent

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -35,7 +35,7 @@ import (
 
 // Redirecting stdOut so we can analyze output line by
 // line and check with what we want.
-var stdOut = os.Stdout // *os.File
+var stdOut = os.Stdout
 
 type stdOutRedirect struct {
 	tempFile *os.File

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -67,7 +67,9 @@ func (grabber *stdOutRedirect) Close() {
 
 // executeWithArgs executes the Cobra Command with the given arguments
 // and intercepts any errors (even `os.Exit()` ones), returning the exit code
-func executeWithArgs(t *testing.T, args ...string) (exitCode int, output []byte) {
+func executeWithArgs(t *testing.T, args ...string) (int, []byte) {
+	var output []byte
+	var exitCode int
 	fmt.Printf("RUNNING: %s\n", args)
 
 	redirect := &stdOutRedirect{}

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -70,7 +70,7 @@ var flags struct {
 	buildProperties []string // List of custom build properties separated by commas. Or can be used multiple times for multiple properties.
 	warnings        string   // Used to tell gcc which warning level to use.
 	verbose         bool     // Turns on verbose mode.
-	quiet           bool     // Supresses almost every output.
+	quiet           bool     // Suppresses almost every output.
 	vidPid          string   // VID/PID specific build properties.
 }
 

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -48,16 +48,26 @@ func InitCommand() *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		Run:     run,
 	}
-	command.Flags().StringVarP(&flags.fqbn, "fqbn", "b", "", "Fully Qualified Board Name, e.g.: arduino:avr:uno")
-	command.Flags().BoolVar(&flags.showProperties, "show-properties", false, "Show all build properties used instead of compiling.")
-	command.Flags().BoolVar(&flags.preprocess, "preprocess", false, "Print preprocessed code to stdout instead of compiling.")
-	command.Flags().StringVar(&flags.buildCachePath, "build-cache-path", "", "Builds of 'core.a' are saved into this path to be cached and reused.")
-	command.Flags().StringVar(&flags.buildPath, "build-path", "", "Path where to save compiled files. If omitted, a directory will be created in the default temporary path of your OS.")
-	command.Flags().StringSliceVar(&flags.buildProperties, "build-properties", []string{}, "List of custom build properties separated by commas. Or can be used multiple times for multiple properties.")
-	command.Flags().StringVar(&flags.warnings, "warnings", "none", `Optional, can be "none", "default", "more" and "all". Defaults to "none". Used to tell gcc which warning level to use (-W flag).`)
-	command.Flags().BoolVarP(&flags.verbose, "verbose", "v", false, "Optional, turns on verbose mode.")
-	command.Flags().BoolVar(&flags.quiet, "quiet", false, "Optional, supresses almost every output.")
-	command.Flags().StringVar(&flags.vidPid, "vid-pid", "", "When specified, VID/PID specific build properties are used, if boards supports them.")
+	command.Flags().StringVarP(&flags.fqbn, "fqbn", "b", "",
+		"Fully Qualified Board Name, e.g.: arduino:avr:uno")
+	command.Flags().BoolVar(&flags.showProperties, "show-properties", false,
+		"Show all build properties used instead of compiling.")
+	command.Flags().BoolVar(&flags.preprocess, "preprocess", false,
+		"Print preprocessed code to stdout instead of compiling.")
+	command.Flags().StringVar(&flags.buildCachePath, "build-cache-path", "",
+		"Builds of 'core.a' are saved into this path to be cached and reused.")
+	command.Flags().StringVar(&flags.buildPath, "build-path", "",
+		"Path where to save compiled files. If omitted, a directory will be created in the default temporary path of your OS.")
+	command.Flags().StringSliceVar(&flags.buildProperties, "build-properties", []string{},
+		"List of custom build properties separated by commas. Or can be used multiple times for multiple properties.")
+	command.Flags().StringVar(&flags.warnings, "warnings", "none",
+		`Optional, can be "none", "default", "more" and "all". Defaults to "none". Used to tell gcc which warning level to use (-W flag).`)
+	command.Flags().BoolVarP(&flags.verbose, "verbose", "v", false,
+		"Optional, turns on verbose mode.")
+	command.Flags().BoolVar(&flags.quiet, "quiet", false,
+		"Optional, supresses almost every output.")
+	command.Flags().StringVar(&flags.vidPid, "vid-pid", "",
+		"When specified, VID/PID specific build properties are used, if boards supports them.")
 	return command
 }
 
@@ -128,7 +138,10 @@ func run(cmd *cobra.Command, args []string) {
 		PlatformArchitecture: coreName,
 	})
 	if targetPlatform == nil || targetPlatform.GetInstalled() == nil {
-		formatter.PrintErrorMessage(fmt.Sprintf("\"%[1]s:%[2]s\" platform is not installed, please install it by running \""+commands.AppName+" core install %[1]s:%[2]s\".", packageName, coreName))
+		errorMessage := fmt.Sprintf(
+			"\"%[1]s:%[2]s\" platform is not installed, please install it by running \""+
+				commands.AppName+" core install %[1]s:%[2]s\".", packageName, coreName)
+		formatter.PrintErrorMessage(errorMessage)
 		os.Exit(commands.ErrCoreConfig)
 	}
 

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -106,7 +106,7 @@ func run(cmd *cobra.Command, args []string) {
 
 	// Check for ctags tool
 	loadBuiltinCtagsMetadata(pm)
-	ctags, err := getBuiltinCtagsTool(pm)
+	ctags, _ := getBuiltinCtagsTool(pm)
 	if !ctags.IsInstalled() {
 		formatter.Print("Downloading and installing missing tool: " + ctags.String())
 		core.DownloadToolRelease(pm, ctags)
@@ -116,7 +116,7 @@ func run(cmd *cobra.Command, args []string) {
 			formatter.PrintError(err, "Could not load hardware packages.")
 			os.Exit(commands.ErrCoreConfig)
 		}
-		ctags, err = getBuiltinCtagsTool(pm)
+		ctags, _ = getBuiltinCtagsTool(pm)
 		if !ctags.IsInstalled() {
 			formatter.PrintErrorMessage("Missing ctags tool.")
 			os.Exit(commands.ErrCoreConfig)

--- a/commands/compile/ctags.go
+++ b/commands/compile/ctags.go
@@ -29,7 +29,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 	ctagsTool := builtinPackage.GetOrCreateTool("ctags")
 	ctagsRel := ctagsTool.GetOrCreateRelease(semver.ParseRelaxed("5.8-arduino11"))
 	ctagsRel.Flavors = []*cores.Flavor{
-		&cores.Flavor{
+		{
 			OS: "i686-pc-linux-gnu",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-i686-pc-linux-gnu.tar.bz2",
@@ -39,7 +39,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 				CachePath:       "tools",
 			},
 		},
-		&cores.Flavor{
+		{
 			OS: "x86_64-pc-linux-gnu",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-x86_64-pc-linux-gnu.tar.bz2",
@@ -49,7 +49,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 				CachePath:       "tools",
 			},
 		},
-		&cores.Flavor{
+		{
 			OS: "i686-mingw32",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-i686-mingw32.zip",
@@ -59,7 +59,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 				CachePath:       "tools",
 			},
 		},
-		&cores.Flavor{
+		{
 			OS: "x86_64-apple-darwin",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-x86_64-apple-darwin.zip",
@@ -69,7 +69,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 				CachePath:       "tools",
 			},
 		},
-		&cores.Flavor{
+		{
 			OS: "arm-linux-gnueabihf",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-armv6-linux-gnueabihf.tar.bz2",

--- a/commands/compile/ctags.go
+++ b/commands/compile/ctags.go
@@ -28,8 +28,8 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 	builtinPackage := pm.GetPackages().GetOrCreatePackage("builtin")
 	ctagsTool := builtinPackage.GetOrCreateTool("ctags")
 	ctagsRel := ctagsTool.GetOrCreateRelease(semver.ParseRelaxed("5.8-arduino11"))
-	ctagsRel.Flavours = []*cores.Flavour{
-		&cores.Flavour{
+	ctagsRel.Flavors = []*cores.Flavor{
+		&cores.Flavor{
 			OS: "i686-pc-linux-gnu",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-i686-pc-linux-gnu.tar.bz2",
@@ -39,7 +39,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 				CachePath:       "tools",
 			},
 		},
-		&cores.Flavour{
+		&cores.Flavor{
 			OS: "x86_64-pc-linux-gnu",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-x86_64-pc-linux-gnu.tar.bz2",
@@ -49,7 +49,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 				CachePath:       "tools",
 			},
 		},
-		&cores.Flavour{
+		&cores.Flavor{
 			OS: "i686-mingw32",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-i686-mingw32.zip",
@@ -59,7 +59,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 				CachePath:       "tools",
 			},
 		},
-		&cores.Flavour{
+		&cores.Flavor{
 			OS: "x86_64-apple-darwin",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-x86_64-apple-darwin.zip",
@@ -69,7 +69,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 				CachePath:       "tools",
 			},
 		},
-		&cores.Flavour{
+		&cores.Flavor{
 			OS: "arm-linux-gnueabihf",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-armv6-linux-gnueabihf.tar.bz2",

--- a/commands/config/dump.go
+++ b/commands/config/dump.go
@@ -38,10 +38,11 @@ func initDumpCommand() *cobra.Command {
 	}
 }
 
-var dumpFlags struct {
-	_default bool   // If false, ask questions to the user about setting configuration properties, otherwise use default configuration.
-	location string // The custom location of the file to create.
-}
+// This struct is unused
+//var dumpFlags struct {
+//	_default bool   // If false, ask questions to the user about setting configuration properties, otherwise use default configuration.
+//	location string // The custom location of the file to create.
+//}
 
 func runDumpCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino config dump`")

--- a/commands/config/dump.go
+++ b/commands/config/dump.go
@@ -38,12 +38,6 @@ func initDumpCommand() *cobra.Command {
 	}
 }
 
-// This struct is unused
-//var dumpFlags struct {
-//	_default bool   // If false, ask questions to the user about setting configuration properties, otherwise use default configuration.
-//	location string // The custom location of the file to create.
-//}
-
 func runDumpCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino config dump`")
 

--- a/commands/config/init.go
+++ b/commands/config/init.go
@@ -39,8 +39,14 @@ func initInitCommand() *cobra.Command {
 		Args: cobra.NoArgs,
 		Run:  runInitCommand,
 	}
-	initCommand.Flags().BoolVar(&initFlags._default, "default", false, "If omitted, ask questions to the user about setting configuration properties, otherwise use default configuration.")
-	initCommand.Flags().StringVar(&initFlags.location, "save-as", "", "Sets where to save the configuration file [default is ./.cli-config.yml].")
+	initCommand.Flags().BoolVar(&initFlags._default,
+		"default",
+		false,
+		"If omitted, ask questions to the user about setting configuration properties, otherwise use default configuration.")
+	initCommand.Flags().StringVar(&initFlags.location,
+		"save-as",
+		"",
+		"Sets where to save the configuration file [default is ./.cli-config.yml].")
 	return initCommand
 }
 

--- a/commands/config/init.go
+++ b/commands/config/init.go
@@ -39,13 +39,9 @@ func initInitCommand() *cobra.Command {
 		Args: cobra.NoArgs,
 		Run:  runInitCommand,
 	}
-	initCommand.Flags().BoolVar(&initFlags._default,
-		"default",
-		false,
+	initCommand.Flags().BoolVar(&initFlags._default, "default", false,
 		"If omitted, ask questions to the user about setting configuration properties, otherwise use default configuration.")
-	initCommand.Flags().StringVar(&initFlags.location,
-		"save-as",
-		"",
+	initCommand.Flags().StringVar(&initFlags.location, "save-as", "",
 		"Sets where to save the configuration file [default is ./.cli-config.yml].")
 	return initCommand
 }

--- a/commands/core/download.go
+++ b/commands/core/download.go
@@ -60,7 +60,7 @@ func downloadPlatformByRef(pm *packagemanager.PackageManager, platformsRef *pack
 		os.Exit(commands.ErrBadCall)
 	}
 
-	// Check if all tools have a flavour available for the current OS
+	// Check if all tools have a flavor available for the current OS
 	for _, tool := range tools {
 		if tool.GetCompatibleFlavour() == nil {
 			formatter.PrintErrorMessage("The tool " + tool.String() + " is not available for the current OS")

--- a/commands/lib/uninstall.go
+++ b/commands/lib/uninstall.go
@@ -27,10 +27,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	versionAll    string = "all"
-	versionLatest string = "latest"
-)
+// These const are unused
+//const (
+//	versionAll    string = "all"
+//	versionLatest string = "latest"
+//)
 
 func initUninstallCommand() *cobra.Command {
 	uninstallCommand := &cobra.Command{

--- a/commands/lib/uninstall.go
+++ b/commands/lib/uninstall.go
@@ -27,12 +27,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// These const are unused
-//const (
-//	versionAll    string = "all"
-//	versionLatest string = "latest"
-//)
-
 func initUninstallCommand() *cobra.Command {
 	uninstallCommand := &cobra.Command{
 		Use:     "uninstall LIBRARY_NAME(S)",

--- a/commands/login/login.go
+++ b/commands/login/login.go
@@ -80,7 +80,7 @@ func run(cmd *cobra.Command, args []string) {
 
 	if passwordEmpty {
 		fmt.Print("Password: ")
-		pass, err := terminal.ReadPassword(int(syscall.Stdin))
+		pass, err := terminal.ReadPassword(syscall.Stdin)
 		if err != nil {
 			formatter.PrintError(err, "Cannot read password, login aborted.")
 			return

--- a/commands/sketch/sync.go
+++ b/commands/sketch/sync.go
@@ -129,9 +129,9 @@ func runSyncCommand(cmd *cobra.Command, args []string) {
 	sketchMap := sketches.Find(sketchbook.String(), "libraries") // Exclude libraries dirs.
 
 	logrus.Info("Finding online sketches")
-	client := createClient.New(nil)
+	client := createclient.New(nil)
 	tok := "Bearer " + bearerToken
-	resp, err := client.SearchSketches(context.Background(), createClient.SearchSketchesPath(), nil, &username, &tok)
+	resp, err := client.SearchSketches(context.Background(), createclient.SearchSketchesPath(), nil, &username, &tok)
 	if err != nil {
 		stopSpinner()
 		formatter.PrintError(err, "Cannot get create sketches, sync failed.")
@@ -146,7 +146,7 @@ func runSyncCommand(cmd *cobra.Command, args []string) {
 		os.Exit(commands.ErrGeneric)
 	}
 
-	onlineSketchesMap := make(map[string]*createClient.ArduinoCreateSketch, len(onlineSketches.Sketches))
+	onlineSketchesMap := make(map[string]*createclient.ArduinoCreateSketch, len(onlineSketches.Sketches))
 	for _, item := range onlineSketches.Sketches {
 		onlineSketchesMap[*item.Name] = item
 	}
@@ -271,9 +271,9 @@ func runSyncCommand(cmd *cobra.Command, args []string) {
 }
 
 func pushSketch(sketch sketches.Sketch, sketchbook *paths.Path, bearerToken string) error {
-	client := createClient.New(nil)
+	client := createclient.New(nil)
 
-	resp, err := client.CreateSketches(context.Background(), createClient.CreateSketchesPath(), createClient.ConvertFrom(sketch), "Bearer "+bearerToken)
+	resp, err := client.CreateSketches(context.Background(), createclient.CreateSketchesPath(), createclient.ConvertFrom(sketch), "Bearer "+bearerToken)
 	if err != nil {
 		return err
 	}
@@ -295,8 +295,8 @@ func pushSketch(sketch sketches.Sketch, sketchbook *paths.Path, bearerToken stri
 }
 
 func editSketch(sketch sketches.Sketch, sketchbook *paths.Path, bearerToken string) error {
-	client := createClient.New(nil)
-	resp, err := client.EditSketches(context.Background(), createClient.EditSketchesPath(sketch.ID), createClient.ConvertFrom(sketch), "Bearer "+bearerToken)
+	client := createclient.New(nil)
+	resp, err := client.EditSketches(context.Background(), createclient.EditSketchesPath(sketch.ID), createclient.ConvertFrom(sketch), "Bearer "+bearerToken)
 	if err != nil {
 		return err
 	}
@@ -317,11 +317,11 @@ func editSketch(sketch sketches.Sketch, sketchbook *paths.Path, bearerToken stri
 	return nil
 }
 
-func pullSketch(sketch *createClient.ArduinoCreateSketch, sketchbook *paths.Path, bearerToken string) error {
-	client := createClient.New(nil)
+func pullSketch(sketch *createclient.ArduinoCreateSketch, sketchbook *paths.Path, bearerToken string) error {
+	client := createclient.New(nil)
 	bearer := "Bearer " + bearerToken
 
-	resp, err := client.ShowSketches(context.Background(), createClient.ShowSketchesPath(fmt.Sprint(sketch.ID)), &bearer)
+	resp, err := client.ShowSketches(context.Background(), createclient.ShowSketchesPath(fmt.Sprint(sketch.ID)), &bearer)
 	if err != nil {
 		return err
 	}
@@ -356,7 +356,7 @@ func pullSketch(sketch *createClient.ArduinoCreateSketch, sketchbook *paths.Path
 			return err
 		}
 
-		resp, err = client.ShowFiles(context.Background(), createClient.ShowFilesPath("sketch", sketch.ID.String(), path))
+		resp, err = client.ShowFiles(context.Background(), createclient.ShowFilesPath("sketch", sketch.ID.String(), path))
 		if err != nil {
 			return err
 		}
@@ -379,7 +379,7 @@ func pullSketch(sketch *createClient.ArduinoCreateSketch, sketchbook *paths.Path
 		destFile := sketchDir.Join(path)
 		err = destFile.WriteFile(decodedData)
 		if err != nil {
-			return errors.New("Copy of a file of the downloaded sketch failed, sync failed.")
+			return errors.New("copy of a file of the downloaded sketch failed, sync failed")
 		}
 	}
 
@@ -431,7 +431,7 @@ func login() (string, string, error) {
 	arduinoMachine := NetRC.FindMachine("arduino.cc")
 	if arduinoMachine == nil || arduinoMachine.Name != "arduino.cc" {
 		logrus.WithError(err).Error("Credentials not found")
-		return "", "", errors.New("Credentials not found, try typing `arduino login` to login")
+		return "", "", errors.New("credentials not found, try typing `arduino login` to login")
 	}
 
 	logrus.Info("Refreshing user session")

--- a/commands/sketch/sync.go
+++ b/commands/sketch/sync.go
@@ -57,7 +57,8 @@ func initSyncCommand() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Run:     runSyncCommand,
 	}
-	syncCommand.Flags().StringVar(&syncFlags.priority, "conflict-policy", prioritySkip, "The decision made by default on conflicting sketches. Can be push-local, pull-remote, skip, ask-once, ask-always.")
+	usage := "The decision made by default on conflicting sketches. Can be push-local, pull-remote, skip, ask-once, ask-always."
+	syncCommand.Flags().StringVar(&syncFlags.priority, "conflict-policy", prioritySkip, usage)
 	return syncCommand
 }
 
@@ -296,7 +297,11 @@ func pushSketch(sketch sketches.Sketch, sketchbook *paths.Path, bearerToken stri
 
 func editSketch(sketch sketches.Sketch, sketchbook *paths.Path, bearerToken string) error {
 	client := createclient.New(nil)
-	resp, err := client.EditSketches(context.Background(), createclient.EditSketchesPath(sketch.ID), createclient.ConvertFrom(sketch), "Bearer "+bearerToken)
+	resp, err := client.EditSketches(
+		context.Background(),
+		createclient.EditSketchesPath(sketch.ID),
+		createclient.ConvertFrom(sketch),
+		"Bearer "+bearerToken)
 	if err != nil {
 		return err
 	}

--- a/commands/sketch/sync.go
+++ b/commands/sketch/sync.go
@@ -400,7 +400,7 @@ func findPathOf(sketchName string, path string) string {
 	for i := len(list) - 1; i > -1; i-- {
 		//fmt.Println(list[i], "==", sketchName, "?", list[i] == sketchName)
 		if list[i] == sketchName {
-			return filepath.Join(list[i+1 : len(list)]...)
+			return filepath.Join(list[i+1:]...)
 		}
 	}
 	return ""

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -45,10 +45,14 @@ func InitCommand() *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		Run:     run,
 	}
-	uploadCommand.Flags().StringVarP(&flags.fqbn, "fqbn", "b", "", "Fully Qualified Board Name, e.g.: arduino:avr:uno")
-	uploadCommand.Flags().StringVarP(&flags.port, "port", "p", "", "Upload port, e.g.: COM10 or /dev/ttyACM0")
-	uploadCommand.Flags().BoolVarP(&flags.verbose, "verify", "t", false, "Verify uploaded binary after the upload.")
-	uploadCommand.Flags().BoolVarP(&flags.verbose, "verbose", "v", false, "Optional, turns on verbose mode.")
+	uploadCommand.Flags().StringVarP(&flags.fqbn, "fqbn", "b", "",
+		"Fully Qualified Board Name, e.g.: arduino:avr:uno")
+	uploadCommand.Flags().StringVarP(&flags.port, "port", "p", "",
+		"Upload port, e.g.: COM10 or /dev/ttyACM0")
+	uploadCommand.Flags().BoolVarP(&flags.verbose, "verify", "t", false,
+		"Verify uploaded binary after the upload.")
+	uploadCommand.Flags().BoolVarP(&flags.verbose, "verbose", "v", false,
+		"Optional, turns on verbose mode.")
 	return uploadCommand
 }
 

--- a/common/formatter/examples_test.go
+++ b/common/formatter/examples_test.go
@@ -49,7 +49,7 @@ func ExampleJSONFormatter_Format() {
 	var jf formatter.JSONFormatter
 	fmt.Println(jf.Format(example))
 
-	var example2 float64 = 3.14
+	var example2 = 3.14
 	fmt.Println(jf.Format(example2))
 
 	var example3 float32 = 3.14

--- a/common/formatter/formatter.go
+++ b/common/formatter/formatter.go
@@ -42,8 +42,6 @@ var defaultFormatter Formatter
 
 var logger *logrus.Logger
 
-var debug bool
-
 func init() {
 	formatters = make(map[string]Formatter, 2)
 	AddCustomFormatter("text", &TextFormatter{})

--- a/common/formatter/formatter.go
+++ b/common/formatter/formatter.go
@@ -54,7 +54,7 @@ func init() {
 // SetFormatter sets the defaults format to the one specified, if valid. Otherwise it returns an error.
 func SetFormatter(formatName string) error {
 	if !IsSupported(formatName) {
-		return fmt.Errorf("Formatter for %s format not implemented", formatName)
+		return fmt.Errorf("formatter for %s format not implemented", formatName)
 	}
 	defaultFormatter = formatters[formatName]
 	return nil
@@ -91,7 +91,7 @@ func AddCustomFormatter(formatName string, form Formatter) Formatter {
 // Format formats a message formatted using a Formatter specified by SetFormatter(...) function.
 func Format(msg interface{}) (string, error) {
 	if defaultFormatter == nil {
-		return "", errors.New("No formatter set")
+		return "", errors.New("no formatter set")
 	}
 	return defaultFormatter.Format(msg)
 }

--- a/configs/preferences_txt_serializer.go
+++ b/configs/preferences_txt_serializer.go
@@ -105,7 +105,7 @@ func proxyConfigsFromIDEPrefs(props properties.Map) error {
 		manualConfig := proxy.SubTree("manual")
 		hostname, exists := manualConfig["hostname"]
 		if !exists {
-			return errors.New("Proxy hostname not found in preferences.txt")
+			return errors.New("proxy hostname not found in preferences.txt")
 		}
 		username := manualConfig["username"]
 		password := manualConfig["password"]
@@ -119,7 +119,7 @@ func proxyConfigsFromIDEPrefs(props properties.Map) error {
 		// No proxy
 		break
 	default:
-		return errors.New("Unsupported proxy config")
+		return errors.New("unsupported proxy config")
 	}
 	return nil
 }

--- a/create_client_helpers/alive.go
+++ b/create_client_helpers/alive.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package createClient
+package createclient
 
 import (
 	"context"

--- a/create_client_helpers/client.go
+++ b/create_client_helpers/client.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package createClient
+package createclient
 
 import (
 	"github.com/goadesign/goa"

--- a/create_client_helpers/files.go
+++ b/create_client_helpers/files.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package createClient
+package createclient
 
 import (
 	"context"
@@ -25,8 +25,8 @@ import (
 )
 
 // ShowFilesPath computes a request path to the show action of files.
-func ShowFilesPath(type_ string, id string, name string) string {
-	param0 := type_
+func ShowFilesPath(fileType string, id string, name string) string {
+	param0 := fileType
 	param1 := id
 	param2 := name
 

--- a/create_client_helpers/media_types.go
+++ b/create_client_helpers/media_types.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package createClient
+package createclient
 
 import (
 	"net/http"

--- a/create_client_helpers/media_types.go
+++ b/create_client_helpers/media_types.go
@@ -77,7 +77,9 @@ func (c *Client) DecodeArduinoCreateLibraries(resp *http.Response) (*ArduinoCrea
 	return &decoded, err
 }
 
-// Library is a collection of header files containing arduino reusable code and functions. It typically contains its info in a library.properties files. The examples property contains a list of examples that use that library. (default view)
+// Library is a collection of header files containing arduino reusable code and functions.
+// It typically contains its info in a library.properties files.
+// The examples property contains a list of examples that use that library. (default view)
 //
 // Identifier: application/vnd.arduino.create.library+json; view=default
 type ArduinoCreateLibrary struct {
@@ -115,7 +117,9 @@ type ArduinoCreateLibrary struct {
 	Version *string `form:"version,omitempty" json:"version,omitempty" xml:"version,omitempty"`
 }
 
-// Library is a collection of header files containing arduino reusable code and functions. It typically contains its info in a library.properties files. The examples property contains a list of examples that use that library. (link view)
+// Library is a collection of header files containing arduino reusable code and functions.
+// It typically contains its info in a library.properties files.
+// The examples property contains a list of examples that use that library. (link view)
 //
 // Identifier: application/vnd.arduino.create.library+json; view=link
 type ArduinoCreateLibraryLink struct {

--- a/create_client_helpers/sketches.go
+++ b/create_client_helpers/sketches.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package createClient
+package createclient
 
 import (
 	"bytes"

--- a/create_client_helpers/user_types.go
+++ b/create_client_helpers/user_types.go
@@ -15,7 +15,7 @@
  * a commercial license, send an email to license@arduino.cc.
  */
 
-package createClient
+package createclient
 
 import (
 	"encoding/base64"


### PR DESCRIPTION
This PR introduce golangci-lint in the pipeline to improve the code quality through the code static analysis.
I fixed the problems reported by the linters:
- misspell
- gofmt
- unconvert
- nakedret
- ineffassign
- interfacer
- varcheck
- lll
- golint except one problem where I have to modify also vendor dependencies 

These linters should be enable after fix the problems 
 - deadcode
  - dupl
  - errcheck
  - goconst
  - gocyclo
  - govet
  - maligned
  - megacheck
  - unparam