### PR TITLE
Fixed commands used as examples for CLI board commands

### DIFF
--- a/commands/board/attach.go
+++ b/commands/board/attach.go
@@ -40,7 +40,7 @@ func initAttachCommand() *cobra.Command {
 		Use:   "attach <port>|<FQBN> [sketchPath]",
 		Short: "Attaches a sketch to a board.",
 		Long:  "Attaches a sketch to a board.",
-		Example: "arduino board attach serial:///dev/tty/ACM0\n" +
+		Example: "  arduino board attach serial:///dev/tty/ACM0\n" +
 			"  " + commands.AppName + " board attach serial:///dev/tty/ACM0 HelloWorld\n" +
 			"  " + commands.AppName + " board attach arduino:samd:mkr1000",
 		Args: cobra.RangeArgs(1, 2),

--- a/commands/board/board.go
+++ b/commands/board/board.go
@@ -31,7 +31,7 @@ func InitCommand() *cobra.Command {
 		Example: "  # Lists all connected boards.\n" +
 			"  " + commands.AppName + " board list\n\n" +
 			"  # Attaches a sketch to a board.\n" +
-			"  " + commands.AppName + " board attach --board serial:///dev/tty/ACM0 --sketch mySketch",
+			"  " + commands.AppName + " board attach serial:///dev/tty/ACM0 mySketch",
 	}
 	boardCommand.AddCommand(initAttachCommand())
 	boardCommand.AddCommand(initListCommand())


### PR DESCRIPTION
This commit fixes the text for the examples used when typing '`arduino-cli board attach`' and '`arduino-cli board`' as they shown the wrong commands:

1. wrong AppName in the 'board attach' command
2. non-existing '--board' and '--sketch' arguments in 'board' command