### PR TITLE
Moved LibraryIndexURL over HTTPS endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ This is **not yet available** until the first stable version is released.
 
 Please note that these are **preview** build, they may have bugs, some features may not work or may be changed without notice:
 
-- [Linux 64 bit 0.2.2-alpha.preview](http://downloads.arduino.cc/arduino-cli/arduino-cli-0.2.2-alpha.preview-linux64.tar.bz2)
-- [Linux 32 bit 0.2.2-alpha.preview](http://downloads.arduino.cc/arduino-cli/arduino-cli-0.2.2-alpha.preview-linux32.tar.bz2)
-- [Linux ARM 0.2.2-alpha.preview](http://downloads.arduino.cc/arduino-cli/arduino-cli-0.2.2-alpha.preview-linuxarm.tar.bz2)
-- [Windows 0.2.2-alpha.preview](http://downloads.arduino.cc/arduino-cli/arduino-cli-0.2.2-alpha.preview-windows.zip)
-- [Mac OSX 0.2.2-alpha.preview](http://downloads.arduino.cc/arduino-cli/arduino-cli-0.2.2-alpha.preview-osx.zip)
+- [Linux 64 bit 0.2.2-alpha.preview](https://downloads.arduino.cc/arduino-cli/arduino-cli-0.2.2-alpha.preview-linux64.tar.bz2)
+- [Linux 32 bit 0.2.2-alpha.preview](https://downloads.arduino.cc/arduino-cli/arduino-cli-0.2.2-alpha.preview-linux32.tar.bz2)
+- [Linux ARM 0.2.2-alpha.preview](https://downloads.arduino.cc/arduino-cli/arduino-cli-0.2.2-alpha.preview-linuxarm.tar.bz2)
+- [Windows 0.2.2-alpha.preview](https://downloads.arduino.cc/arduino-cli/arduino-cli-0.2.2-alpha.preview-windows.zip)
+- [Mac OSX 0.2.2-alpha.preview](https://downloads.arduino.cc/arduino-cli/arduino-cli-0.2.2-alpha.preview-osx.zip)
 
 ### Build the latest "bleeding-edge" from source
 

--- a/arduino/libraries/librariesmanager/download.go
+++ b/arduino/libraries/librariesmanager/download.go
@@ -25,7 +25,7 @@ import (
 )
 
 // LibraryIndexURL is the URL where to get library index.
-var LibraryIndexURL, _ = url.Parse("http://downloads.arduino.cc/libraries/library_index.json")
+var LibraryIndexURL, _ = url.Parse("https://downloads.arduino.cc/libraries/library_index.json")
 
 // UpdateIndex downloads the libraries index file from Arduino repository.
 func (lm *LibrariesManager) UpdateIndex() (*grab.Response, error) {

--- a/commands/compile/ctags.go
+++ b/commands/compile/ctags.go
@@ -33,7 +33,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 			OS: "i686-pc-linux-gnu",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-i686-pc-linux-gnu.tar.bz2",
-				URL:             "http://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-i686-pc-linux-gnu.tar.bz2",
+				URL:             "https://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-i686-pc-linux-gnu.tar.bz2",
 				Size:            106930,
 				Checksum:        "SHA-256:3e219116f54d9035f6c49c600d0bb358710dcce139798ad237de0eef7998d0e2",
 				CachePath:       "tools",
@@ -43,7 +43,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 			OS: "x86_64-pc-linux-gnu",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-x86_64-pc-linux-gnu.tar.bz2",
-				URL:             "http://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-x86_64-pc-linux-gnu.tar.bz2",
+				URL:             "https://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-x86_64-pc-linux-gnu.tar.bz2",
 				Size:            111604,
 				Checksum:        "SHA-256:62b514f3aaf37b5429ef703853bb46365fb91b4754c1916d085bf134004886e3",
 				CachePath:       "tools",
@@ -53,7 +53,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 			OS: "i686-mingw32",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-i686-mingw32.zip",
-				URL:             "http://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-i686-mingw32.zip",
+				URL:             "https://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-i686-mingw32.zip",
 				Size:            116455,
 				Checksum:        "SHA-256:106c9f074a3e2ec55bd8a461c1522bb4c90488275f061c3d51942862c99b8ba7",
 				CachePath:       "tools",
@@ -63,7 +63,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 			OS: "x86_64-apple-darwin",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-x86_64-apple-darwin.zip",
-				URL:             "http://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-x86_64-apple-darwin.zip",
+				URL:             "https://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-x86_64-apple-darwin.zip",
 				Size:            107801,
 				Checksum:        "SHA-256:e8c5db45867fb5987ad0fc429d8bbbcf5549f4b7c2b5ade863e76ac77255144d",
 				CachePath:       "tools",
@@ -73,7 +73,7 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 			OS: "arm-linux-gnueabihf",
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-armv6-linux-gnueabihf.tar.bz2",
-				URL:             "http://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-armv6-linux-gnueabihf.tar.bz2",
+				URL:             "https://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-armv6-linux-gnueabihf.tar.bz2",
 				Size:            95271,
 				Checksum:        "SHA-256:098e8dc6a7dc0ddf09ef28e6e2e81d2ae181d12f41fb182dd78ff1387d4eb285",
 				CachePath:       "tools",


### PR DESCRIPTION
Let's continue to prepare for our http->https migration by updating pieces that shouldn't break. 