### PR TITLE
Various improvements in compile / upload

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -390,14 +390,40 @@ func TestCompileCommands(t *testing.T) {
 	require.Contains(t, string(d), "Sketch created")
 
 	// Build sketch for arduino:avr:uno
-	exitCode, d = executeWithArgs(t, "compile", "-b", "arduino:avr:uno", currSketchbookDir.Join("Test1").String())
+	test1 := currSketchbookDir.Join("Test1").String()
+	exitCode, d = executeWithArgs(t, "compile", "-b", "arduino:avr:uno", test1)
 	require.Zero(t, exitCode, "exit code")
 	require.Contains(t, string(d), "Sketch uses")
+	require.True(t, paths.New(test1).Join("Test1.arduino.avr.uno.hex").Exist())
 
 	// Build sketch for arduino:avr:nano (without options)
-	exitCode, d = executeWithArgs(t, "compile", "-b", "arduino:avr:nano", currSketchbookDir.Join("Test1").String())
+	exitCode, d = executeWithArgs(t, "compile", "-b", "arduino:avr:nano", test1)
 	require.Zero(t, exitCode, "exit code")
 	require.Contains(t, string(d), "Sketch uses")
+	require.True(t, paths.New(test1).Join("Test1.arduino.avr.nano.hex").Exist())
+
+	// Build sketch with --output path
+	require.NoError(t, os.Chdir(tmp))
+	exitCode, d = executeWithArgs(t, "compile", "-b", "arduino:avr:nano", "-o", "test", test1)
+	require.Zero(t, exitCode, "exit code")
+	require.Contains(t, string(d), "Sketch uses")
+	require.True(t, paths.New("test.hex").Exist())
+
+	exitCode, d = executeWithArgs(t, "compile", "-b", "arduino:avr:nano", "-o", "test2.hex", test1)
+	require.Zero(t, exitCode, "exit code")
+	require.Contains(t, string(d), "Sketch uses")
+	require.True(t, paths.New("test2.hex").Exist())
+	require.NoError(t, paths.New(tmp, "anothertest").MkdirAll())
+
+	exitCode, d = executeWithArgs(t, "compile", "-b", "arduino:avr:nano", "-o", "anothertest/test", test1)
+	require.Zero(t, exitCode, "exit code")
+	require.Contains(t, string(d), "Sketch uses")
+	require.True(t, paths.New("anothertest", "test.hex").Exist())
+
+	exitCode, d = executeWithArgs(t, "compile", "-b", "arduino:avr:nano", "-o", tmp+"/anothertest/test2", test1)
+	require.Zero(t, exitCode, "exit code")
+	require.Contains(t, string(d), "Sketch uses")
+	require.True(t, paths.New("anothertest", "test2.hex").Exist())
 }
 
 func TestCoreCommands(t *testing.T) {

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -47,25 +47,35 @@ func InitCommand() *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		Run:     run,
 	}
-	command.Flags().StringVarP(&flags.fqbn, "fqbn", "b", "",
+	command.Flags().StringVarP(
+		&flags.fqbn, "fqbn", "b", "",
 		"Fully Qualified Board Name, e.g.: arduino:avr:uno")
-	command.Flags().BoolVar(&flags.showProperties, "show-properties", false,
+	command.Flags().BoolVar(
+		&flags.showProperties, "show-properties", false,
 		"Show all build properties used instead of compiling.")
-	command.Flags().BoolVar(&flags.preprocess, "preprocess", false,
+	command.Flags().BoolVar(
+		&flags.preprocess, "preprocess", false,
 		"Print preprocessed code to stdout instead of compiling.")
-	command.Flags().StringVar(&flags.buildCachePath, "build-cache-path", "",
+	command.Flags().StringVar(
+		&flags.buildCachePath, "build-cache-path", "",
 		"Builds of 'core.a' are saved into this path to be cached and reused.")
-	command.Flags().StringVar(&flags.buildPath, "build-path", "",
+	command.Flags().StringVar(
+		&flags.buildPath, "build-path", "",
 		"Path where to save compiled files. If omitted, a directory will be created in the default temporary path of your OS.")
-	command.Flags().StringSliceVar(&flags.buildProperties, "build-properties", []string{},
+	command.Flags().StringSliceVar(
+		&flags.buildProperties, "build-properties", []string{},
 		"List of custom build properties separated by commas. Or can be used multiple times for multiple properties.")
-	command.Flags().StringVar(&flags.warnings, "warnings", "none",
+	command.Flags().StringVar(
+		&flags.warnings, "warnings", "none",
 		`Optional, can be "none", "default", "more" and "all". Defaults to "none". Used to tell gcc which warning level to use (-W flag).`)
-	command.Flags().BoolVarP(&flags.verbose, "verbose", "v", false,
+	command.Flags().BoolVarP(
+		&flags.verbose, "verbose", "v", false,
 		"Optional, turns on verbose mode.")
-	command.Flags().BoolVar(&flags.quiet, "quiet", false,
+	command.Flags().BoolVar(
+		&flags.quiet, "quiet", false,
 		"Optional, supresses almost every output.")
-	command.Flags().StringVar(&flags.vidPid, "vid-pid", "",
+	command.Flags().StringVar(
+		&flags.vidPid, "vid-pid", "",
 		"When specified, VID/PID specific build properties are used, if boards supports them.")
 	return command
 }

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -236,6 +236,8 @@ func run(cmd *cobra.Command, args []string) {
 	ext := filepath.Ext(outputPath)
 
 	// FIXME: Make a function to produce a better name...
+	// Make the filename without the FQBN configs part
+	fqbn.Configs = properties.NewMap()
 	fqbnSuffix := strings.Replace(fqbn.String(), ":", ".", -1)
 
 	// Copy .hex file to sketch directory


### PR DESCRIPTION
- The exported compiled binary now does not contains the FQBN "config" part anymore. This means that, for example, the default exported file for `arduino:avr:mega:cpu=atmega1280` will be called `Blink.arduino.avr.mega.hex` instead of `Blink.arduino.avr.mega.cpu=atmega1280.hex`.

The change above should fix #64

- The `compile` command now has a `-o, --output` to manually specifiy the output filename for the compiled binary.
- The `upload` command now has a `-i, --input` to manually specify the input filename of the binary to upload to the board.