### PR TITLE
Fixed wrong capitalization in JSON output for 'lib' related commands

### DIFF
--- a/arduino/libraries/librariesindex/index.go
+++ b/arduino/libraries/librariesindex/index.go
@@ -22,34 +22,34 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino/libraries"
 	"github.com/arduino/arduino-cli/arduino/resources"
-	"go.bug.st/relaxed-semver"
+	semver "go.bug.st/relaxed-semver"
 )
 
 // Index represents the list of libraries available for download
 type Index struct {
-	Libraries map[string]*Library
+	Libraries map[string]*Library `json:"libraries"`
 }
 
 // Library is a library available for download
 type Library struct {
-	Name     string
-	Releases map[string]*Release
-	Latest   *Release `json:"-"`
-	Index    *Index   `json:"-"`
+	Name     string              `json:"name"`
+	Releases map[string]*Release `json:"releases"`
+	Latest   *Release            `json:"-"`
+	Index    *Index              `json:"-"`
 }
 
 // Release is a release of a library available for download
 type Release struct {
-	Author        string
-	Version       *semver.Version
-	Maintainer    string
-	Sentence      string
-	Paragraph     string
-	Website       string
-	Category      string
-	Architectures []string
-	Types         []string
-	Resource      *resources.DownloadResource
+	Author        string                      `json:"author"`
+	Version       *semver.Version             `json:"version"`
+	Maintainer    string                      `json:"maintainer"`
+	Sentence      string                      `json:"sentence"`
+	Paragraph     string                      `json:"paragraph"`
+	Website       string                      `json:"website"`
+	Category      string                      `json:"category"`
+	Architectures []string                    `json:"architectures"`
+	Types         []string                    `json:"types"`
+	Resource      *resources.DownloadResource `json:"resource"`
 
 	Library *Library `json:"-"`
 }

--- a/arduino/resources/structs.go
+++ b/arduino/resources/structs.go
@@ -19,11 +19,11 @@ package resources
 
 // DownloadResource has all the information to download a file
 type DownloadResource struct {
-	URL             string
-	ArchiveFileName string
-	Checksum        string
-	Size            int64
-	CachePath       string
+	URL             string `json:"url"`
+	ArchiveFileName string `json:"archiveFileName"`
+	Checksum        string `json:"checksum"`
+	Size            int64  `json:"size"`
+	CachePath       string `json:"cachePath"`
 }
 
 // DownloadResult contains the result of a download


### PR DESCRIPTION
before:

```
{
   "libraries" : [
      {
         "Name" : "AudioZero",
         "Releases" : {
            "1.0.0" : {
               "Paragraph" : "With this library you can use the Arduino Zero DAC outputs to play audio files.<br />The audio files must be in the raw .wav format.",
               "Category" : "Signal Input/Output",
               "Types" : [
                  "Arduino"
               ],
               "Website" : "http://arduino.cc/en/Reference/Audio",
               "Version" : "1.0.0",
               "Architectures" : [
                  "samd"
               ],
               "Sentence" : "Allows playing audio files from an SD card. For Arduino Zero only.",
               "Resource" : {
                  "ArchiveFileName" : "AudioZero-1.0.0.zip",
                  "CachePath" : "libraries",
                  "Size" : 4962,
                  "URL" : "http://downloads.arduino.cc/libraries/github.com/arduino-libraries/AudioZero-1.0.0.zip",
                  "Checksum" : "SHA-256:0bc3847eab13222c53ff5ab094dcd92f8b293ba897ffccd457e5b68b5d1e8117"
               },
               "Author" : "Arduino",
               "Maintainer" : "Arduino <info@arduino.cc>"
            },
```

after:

```
{
   "libraries" : [
      {
         "name" : "AudioZero",
         "releases" : {
            "1.0.0" : {
               "types" : [
                  "Arduino"
               ],
               "author" : "Arduino",
               "architectures" : [
                  "samd"
               ],
               "maintainer" : "Arduino <info@arduino.cc>",
               "sentence" : "Allows playing audio files from an SD card. For Arduino Zero only.",
               "category" : "Signal Input/Output",
               "version" : "1.0.0",
               "website" : "http://arduino.cc/en/Reference/Audio",
               "resource" : {
                  "archiveFileName" : "AudioZero-1.0.0.zip",
                  "url" : "http://downloads.arduino.cc/libraries/github.com/arduino-libraries/AudioZero-1.0.0.zip",
                  "cachePath" : "libraries",
                  "checksum" : "SHA-256:0bc3847eab13222c53ff5ab094dcd92f8b293ba897ffccd457e5b68b5d1e8117",
                  "size" : 4962
               },
               "paragraph" : "With this library you can use the Arduino Zero DAC outputs to play audio files.<br />The audio files must be in the raw .wav format."
            },
```
