### PR TITLE
Global build vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /cmd/formatter/debug.test
 /arduino-cli.yaml
 /wiki
+.idea

--- a/cli/arduino-cli.yaml
+++ b/cli/arduino-cli.yaml
@@ -1,0 +1,2 @@
+board_manager:
+  additional_urls:

--- a/cli/arduino-cli.yaml
+++ b/cli/arduino-cli.yaml
@@ -1,2 +1,0 @@
-board_manager:
-  additional_urls:

--- a/cli/board/attach.go
+++ b/cli/board/attach.go
@@ -19,12 +19,12 @@ package board
 
 import (
 	"context"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/spf13/cobra"
 )

--- a/cli/board/attach.go
+++ b/cli/board/attach.go
@@ -19,6 +19,7 @@ package board
 
 import (
 	"context"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -33,9 +34,9 @@ func initAttachCommand() *cobra.Command {
 		Use:   "attach <port>|<FQBN> [sketchPath]",
 		Short: "Attaches a sketch to a board.",
 		Long:  "Attaches a sketch to a board.",
-		Example: "  " + cli.AppName + " board attach serial:///dev/tty/ACM0\n" +
-			"  " + cli.AppName + " board attach serial:///dev/tty/ACM0 HelloWorld\n" +
-			"  " + cli.AppName + " board attach arduino:samd:mkr1000",
+		Example: "  " + global.GetAppName() + " board attach serial:///dev/tty/ACM0\n" +
+			"  " + global.GetAppName() + " board attach serial:///dev/tty/ACM0 HelloWorld\n" +
+			"  " + global.GetAppName() + " board attach arduino:samd:mkr1000",
 		Args: cobra.RangeArgs(1, 2),
 		Run:  runAttachCommand,
 	}

--- a/cli/board/board.go
+++ b/cli/board/board.go
@@ -18,7 +18,7 @@
 package board
 
 import (
-	"github.com/arduino/arduino-cli/cli"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/spf13/cobra"
 )
 
@@ -29,9 +29,9 @@ func InitCommand() *cobra.Command {
 		Short: "Arduino board commands.",
 		Long:  "Arduino board commands.",
 		Example: "  # Lists all connected boards.\n" +
-			"  " + cli.AppName + " board list\n\n" +
+			"  " + global.GetAppName() + " board list\n\n" +
 			"  # Attaches a sketch to a board.\n" +
-			"  " + cli.AppName + " board attach serial:///dev/tty/ACM0 mySketch",
+			"  " + global.GetAppName() + " board attach serial:///dev/tty/ACM0 mySketch",
 	}
 	boardCommand.AddCommand(initAttachCommand())
 	boardCommand.AddCommand(initDetailsCommand())

--- a/cli/board/details.go
+++ b/cli/board/details.go
@@ -20,6 +20,7 @@ package board
 import (
 	"context"
 	"fmt"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -35,7 +36,7 @@ func initDetailsCommand() *cobra.Command {
 		Use:     "details <FQBN>",
 		Short:   "Print details about a board.",
 		Long:    "Show information about a board, in particular if the board has options to be specified in the FQBN.",
-		Example: "  " + cli.AppName + " board details arduino:avr:nano",
+		Example: "  " + global.GetAppName() + " board details arduino:avr:nano",
 		Args:    cobra.ExactArgs(1),
 		Run:     runDetailsCommand,
 	}

--- a/cli/board/details.go
+++ b/cli/board/details.go
@@ -20,12 +20,12 @@ package board
 import (
 	"context"
 	"fmt"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/output"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/spf13/cobra"

--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -20,7 +20,6 @@ package board
 import (
 	"context"
 	"fmt"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 	"sort"
 	"time"
@@ -28,6 +27,7 @@ import (
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/output"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/spf13/cobra"

--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -20,6 +20,7 @@ package board
 import (
 	"context"
 	"fmt"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 	"sort"
 	"time"
@@ -37,7 +38,7 @@ func initListCommand() *cobra.Command {
 		Use:     "list",
 		Short:   "List connected boards.",
 		Long:    "Detects and displays a list of connected boards to the current computer.",
-		Example: "  " + cli.AppName + " board list --timeout 10s",
+		Example: "  " + global.GetAppName() + " board list --timeout 10s",
 		Args:    cobra.NoArgs,
 		Run:     runListCommand,
 	}

--- a/cli/board/listall.go
+++ b/cli/board/listall.go
@@ -20,13 +20,13 @@ package board
 import (
 	"context"
 	"fmt"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 	"sort"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/output"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/spf13/cobra"

--- a/cli/board/listall.go
+++ b/cli/board/listall.go
@@ -20,6 +20,7 @@ package board
 import (
 	"context"
 	"fmt"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 	"sort"
 
@@ -39,8 +40,8 @@ func initListAllCommand() *cobra.Command {
 			"List all boards that have the support platform installed. You can search\n" +
 			"for a specific board if you specify the board name",
 		Example: "" +
-			"  " + cli.AppName + " board listall\n" +
-			"  " + cli.AppName + " board listall zero",
+			"  " + global.GetAppName() + " board listall\n" +
+			"  " + global.GetAppName() + " board listall zero",
 		Args: cobra.ArbitraryArgs,
 		Run:  runListAllCommand,
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -20,17 +20,16 @@ package cli
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesmanager"
 	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/common/formatter"
 	"github.com/arduino/arduino-cli/configs"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
-	paths "github.com/arduino/go-paths-helper"
+	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
+	"os"
 )
 
 // Error codes to be used for os.Exit().
@@ -60,9 +59,6 @@ var GlobalFlags struct {
 	Debug      bool // If true, dump debug output to stderr.
 	OutputJSON bool // true output in JSON, false output as Text
 }
-
-// AppName is the command line name of the Arduino CLI executable
-var AppName = filepath.Base(os.Args[0])
 
 var Config *configs.Configuration
 
@@ -116,7 +112,7 @@ func CreateInstance() *rpc.Instance {
 		for _, err := range resp.GetPlatformsIndexErrors() {
 			formatter.PrintError(errors.New(err), "Error loading index")
 		}
-		formatter.PrintErrorMessage("Launch '" + AppName + " core update-index' to fix or download indexes.")
+		formatter.PrintErrorMessage("Launch '" + global.GetAppName() + " core update-index' to fix or download indexes.")
 		os.Exit(ErrGeneric)
 	}
 	return resp.GetInstance()

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -20,6 +20,8 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
+
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesmanager"
 	"github.com/arduino/arduino-cli/commands"
@@ -29,7 +31,6 @@ import (
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
-	"os"
 )
 
 // Error codes to be used for os.Exit().

--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -19,12 +19,12 @@ package compile
 
 import (
 	"context"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/compile"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/arduino/go-paths-helper"
 	"github.com/spf13/cobra"

--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -19,6 +19,7 @@ package compile
 
 import (
 	"context"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -35,7 +36,7 @@ func InitCommand() *cobra.Command {
 		Use:     "compile",
 		Short:   "Compiles Arduino sketches.",
 		Long:    "Compiles Arduino sketches.",
-		Example: "  " + cli.AppName + " compile -b arduino:avr:uno /home/user/Arduino/MySketch",
+		Example: "  " + global.GetAppName() + " compile -b arduino:avr:uno /home/user/Arduino/MySketch",
 		Args:    cobra.MaximumNArgs(1),
 		Run:     run,
 	}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -18,7 +18,7 @@
 package config
 
 import (
-	"github.com/arduino/arduino-cli/cli"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +27,7 @@ func InitCommand() *cobra.Command {
 	configCommand := &cobra.Command{
 		Use:     "config",
 		Short:   "Arduino Configuration Commands.",
-		Example: "  " + cli.AppName + " config init",
+		Example: "  " + global.GetAppName() + " config init",
 	}
 	configCommand.AddCommand(initDumpCommand())
 	configCommand.AddCommand(initInitCommand())

--- a/cli/config/dump.go
+++ b/cli/config/dump.go
@@ -19,11 +19,11 @@ package config
 
 import (
 	"fmt"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cli/config/dump.go
+++ b/cli/config/dump.go
@@ -19,6 +19,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -32,7 +33,7 @@ func initDumpCommand() *cobra.Command {
 		Use:     "dump",
 		Short:   "Prints the current configuration",
 		Long:    "Prints the current configuration.",
-		Example: "  " + cli.AppName + " config dump",
+		Example: "  " + global.GetAppName() + " config dump",
 		Args:    cobra.NoArgs,
 		Run:     runDumpCommand,
 	}

--- a/cli/config/init.go
+++ b/cli/config/init.go
@@ -18,11 +18,11 @@
 package config
 
 import (
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cli/config/init.go
+++ b/cli/config/init.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -33,9 +34,9 @@ func initInitCommand() *cobra.Command {
 		Long:  "Initializes a new config file into the default location ($EXE_DIR/cli-config.yml).",
 		Example: "" +
 			"  # Creates a config file by asking questions to the user into the default location.\n" +
-			"  " + cli.AppName + " config init\n\n" +
+			"  " + global.GetAppName() + " config init\n\n" +
 			"  # Creates a config file with default configuration into default location.\n" +
-			"  " + cli.AppName + " config init --default\n",
+			"  " + global.GetAppName() + " config init --default\n",
 		Args: cobra.NoArgs,
 		Run:  runInitCommand,
 	}

--- a/cli/core/core.go
+++ b/cli/core/core.go
@@ -18,7 +18,7 @@
 package core
 
 import (
-	"github.com/arduino/arduino-cli/cli"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +28,7 @@ func InitCommand() *cobra.Command {
 		Use:     "core",
 		Short:   "Arduino Core operations.",
 		Long:    "Arduino Core operations.",
-		Example: "  " + cli.AppName + " core update-index",
+		Example: "  " + global.GetAppName() + " core update-index",
 	}
 	coreCommand.AddCommand(initDownloadCommand())
 	coreCommand.AddCommand(initInstallCommand())

--- a/cli/core/download.go
+++ b/cli/core/download.go
@@ -19,12 +19,12 @@ package core
 
 import (
 	"context"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/core"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cli/core/download.go
+++ b/cli/core/download.go
@@ -19,6 +19,7 @@ package core
 
 import (
 	"context"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -35,8 +36,8 @@ func initDownloadCommand() *cobra.Command {
 		Short: "Downloads one or more cores and corresponding tool dependencies.",
 		Long:  "Downloads one or more cores and corresponding tool dependencies.",
 		Example: "" +
-			"  " + cli.AppName + " core download arduino:samd       # to download the latest version of arduino SAMD core.\n" +
-			"  " + cli.AppName + " core download arduino:samd=1.6.9 # for a specific version (in this case 1.6.9).",
+			"  " + global.GetAppName() + " core download arduino:samd       # to download the latest version of arduino SAMD core.\n" +
+			"  " + global.GetAppName() + " core download arduino:samd=1.6.9 # for a specific version (in this case 1.6.9).",
 		Args: cobra.MinimumNArgs(1),
 		Run:  runDownloadCommand,
 	}

--- a/cli/core/install.go
+++ b/cli/core/install.go
@@ -24,6 +24,7 @@ import (
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/core"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -35,9 +36,9 @@ func initInstallCommand() *cobra.Command {
 		Short: "Installs one or more cores and corresponding tool dependencies.",
 		Long:  "Installs one or more cores and corresponding tool dependencies.",
 		Example: "  # download the latest version of arduino SAMD core.\n" +
-			"  " + cli.AppName + " core install arduino:samd\n\n" +
+			"  " + global.GetAppName() + " core install arduino:samd\n\n" +
 			"  # download a specific version (in this case 1.6.9).\n" +
-			"  " + cli.AppName + " core install arduino:samd@1.6.9",
+			"  " + global.GetAppName() + " core install arduino:samd@1.6.9",
 		Args: cobra.MinimumNArgs(1),
 		Run:  runInstallCommand,
 	}

--- a/cli/core/list.go
+++ b/cli/core/list.go
@@ -20,13 +20,13 @@ package core
 import (
 	"context"
 	"fmt"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 	"sort"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/core"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/output"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/sirupsen/logrus"

--- a/cli/core/list.go
+++ b/cli/core/list.go
@@ -20,6 +20,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 	"sort"
 
@@ -37,7 +38,7 @@ func initListCommand() *cobra.Command {
 		Use:     "list",
 		Short:   "Shows the list of installed platforms.",
 		Long:    "Shows the list of installed platforms.",
-		Example: "  " + cli.AppName + " core list",
+		Example: "  " + global.GetAppName() + " core list",
 		Args:    cobra.NoArgs,
 		Run:     runListCommand,
 	}

--- a/cli/core/search.go
+++ b/cli/core/search.go
@@ -20,6 +20,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 	"sort"
 	"strings"
@@ -38,7 +39,7 @@ func initSearchCommand() *cobra.Command {
 		Use:     "search <keywords...>",
 		Short:   "Search for a core in the package index.",
 		Long:    "Search for a core in the package index using the specified keywords.",
-		Example: "  " + cli.AppName + " core search MKRZero -v",
+		Example: "  " + global.GetAppName() + " core search MKRZero -v",
 		Args:    cobra.MinimumNArgs(1),
 		Run:     runSearchCommand,
 	}

--- a/cli/core/search.go
+++ b/cli/core/search.go
@@ -20,7 +20,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 	"sort"
 	"strings"
@@ -28,6 +27,7 @@ import (
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/core"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/output"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/sirupsen/logrus"

--- a/cli/core/uninstall.go
+++ b/cli/core/uninstall.go
@@ -19,6 +19,7 @@ package core
 
 import (
 	"context"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -35,7 +36,7 @@ func initUninstallCommand() *cobra.Command {
 		Use:     "uninstall PACKAGER:ARCH ...",
 		Short:   "Uninstalls one or more cores and corresponding tool dependencies if no more used.",
 		Long:    "Uninstalls one or more cores and corresponding tool dependencies if no more used.",
-		Example: "  " + cli.AppName + " core uninstall arduino:samd\n",
+		Example: "  " + global.GetAppName() + " core uninstall arduino:samd\n",
 		Args:    cobra.MinimumNArgs(1),
 		Run:     runUninstallCommand,
 	}

--- a/cli/core/uninstall.go
+++ b/cli/core/uninstall.go
@@ -19,12 +19,12 @@ package core
 
 import (
 	"context"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/core"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/output"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/sirupsen/logrus"

--- a/cli/core/update_index.go
+++ b/cli/core/update_index.go
@@ -19,12 +19,12 @@ package core
 
 import (
 	"context"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cli/core/update_index.go
+++ b/cli/core/update_index.go
@@ -19,6 +19,7 @@ package core
 
 import (
 	"context"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -34,7 +35,7 @@ func initUpdateIndexCommand() *cobra.Command {
 		Use:     "update-index",
 		Short:   "Updates the index of cores.",
 		Long:    "Updates the index of cores to the latest version.",
-		Example: "  " + cli.AppName + " core update-index",
+		Example: "  " + global.GetAppName() + " core update-index",
 		Args:    cobra.NoArgs,
 		Run:     runUpdateIndexCommand,
 	}

--- a/cli/core/upgrade.go
+++ b/cli/core/upgrade.go
@@ -19,6 +19,7 @@ package core
 
 import (
 	"context"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -36,9 +37,9 @@ func initUpgradeCommand() *cobra.Command {
 		Long:  "Upgrades one or all installed platforms to the latest version.",
 		Example: "" +
 			"  # upgrade everything to the latest version\n" +
-			"  " + cli.AppName + " core upgrade\n\n" +
+			"  " + global.GetAppName() + " core upgrade\n\n" +
 			"  # upgrade arduino:samd to the latest version\n" +
-			"  " + cli.AppName + " core upgrade arduino:samd",
+			"  " + global.GetAppName() + " core upgrade arduino:samd",
 		Run: runUpgradeCommand,
 	}
 	return upgradeCommand

--- a/cli/core/upgrade.go
+++ b/cli/core/upgrade.go
@@ -19,12 +19,12 @@ package core
 
 import (
 	"context"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/core"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -19,10 +19,10 @@ package daemon
 
 import (
 	"fmt"
+	"github.com/arduino/arduino-cli/global"
 	"log"
 	"net"
 
-	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/daemon"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/spf13/cobra"
@@ -35,7 +35,7 @@ func InitCommand() *cobra.Command {
 		Use:     "daemon",
 		Short:   "Run as a daemon",
 		Long:    "Running as a daemon the initialization of cores and libraries is done only once.",
-		Example: "  " + cli.AppName + " daemon",
+		Example: "  " + global.GetAppName() + " daemon",
 		Args:    cobra.NoArgs,
 		Run:     runDaemonCommand,
 		Hidden:  true,

--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -19,11 +19,11 @@ package daemon
 
 import (
 	"fmt"
-	"github.com/arduino/arduino-cli/global"
 	"log"
 	"net"
 
 	"github.com/arduino/arduino-cli/daemon"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"

--- a/cli/generatedocs/generatedocs.go
+++ b/cli/generatedocs/generatedocs.go
@@ -18,11 +18,11 @@
 package generatedocs
 
 import (
-	"github.com/arduino/arduino-cli/global"
 	"os"
 	"path/filepath"
 
 	"github.com/arduino/arduino-cli/cli"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"

--- a/cli/generatedocs/generatedocs.go
+++ b/cli/generatedocs/generatedocs.go
@@ -18,6 +18,7 @@
 package generatedocs
 
 import (
+	"github.com/arduino/arduino-cli/global"
 	"os"
 	"path/filepath"
 
@@ -33,7 +34,7 @@ func InitCommand() *cobra.Command {
 		Use:     "generate-docs",
 		Short:   "Generates bash completion and command manpages.",
 		Long:    "Generates bash completion and command manpages.",
-		Example: "  " + cli.AppName + " generate-docs bash-completions",
+		Example: "  " + global.GetAppName() + " generate-docs bash-completions",
 	}
 	command.PersistentFlags().StringVarP(&outputDir, "output-dir", "o", "",
 		"Directory where to save generated files. Default is './docs', the directory must exist.")

--- a/cli/lib/download.go
+++ b/cli/lib/download.go
@@ -19,6 +19,7 @@ package lib
 
 import (
 	"context"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/common/formatter"
@@ -36,8 +37,8 @@ func initDownloadCommand() *cobra.Command {
 		Short: "Downloads one or more libraries without installing them.",
 		Long:  "Downloads one or more libraries without installing them.",
 		Example: "" +
-			"  " + cli.AppName + " lib download AudioZero       # for the latest version.\n" +
-			"  " + cli.AppName + " lib download AudioZero@1.0.0 # for a specific version.",
+			"  " + global.GetAppName() + " lib download AudioZero       # for the latest version.\n" +
+			"  " + global.GetAppName() + " lib download AudioZero@1.0.0 # for a specific version.",
 		Args: cobra.MinimumNArgs(1),
 		Run:  runDownloadCommand,
 	}

--- a/cli/lib/download.go
+++ b/cli/lib/download.go
@@ -19,14 +19,13 @@ package lib
 
 import (
 	"context"
-	"github.com/arduino/arduino-cli/global"
 	"os"
-
-	"github.com/arduino/arduino-cli/common/formatter"
 
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesindex"
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/lib"
+	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/spf13/cobra"
 )

--- a/cli/lib/install.go
+++ b/cli/lib/install.go
@@ -19,6 +19,7 @@ package lib
 
 import (
 	"context"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/commands/lib"
@@ -36,8 +37,8 @@ func initInstallCommand() *cobra.Command {
 		Short: "Installs one of more specified libraries into the system.",
 		Long:  "Installs one or more specified libraries into the system.",
 		Example: "" +
-			"  " + cli.AppName + " lib install AudioZero       # for the latest version.\n" +
-			"  " + cli.AppName + " lib install AudioZero@1.0.0 # for the specific version.",
+			"  " + global.GetAppName() + " lib install AudioZero       # for the latest version.\n" +
+			"  " + global.GetAppName() + " lib install AudioZero@1.0.0 # for the specific version.",
 		Args: cobra.MinimumNArgs(1),
 		Run:  runInstallCommand,
 	}

--- a/cli/lib/install.go
+++ b/cli/lib/install.go
@@ -19,15 +19,14 @@ package lib
 
 import (
 	"context"
-	"github.com/arduino/arduino-cli/global"
 	"os"
-
-	"github.com/arduino/arduino-cli/commands/lib"
-	"github.com/arduino/arduino-cli/rpc"
 
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesindex"
 	"github.com/arduino/arduino-cli/cli"
+	"github.com/arduino/arduino-cli/commands/lib"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
+	"github.com/arduino/arduino-cli/rpc"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/lib/lib.go
+++ b/cli/lib/lib.go
@@ -18,7 +18,7 @@
 package lib
 
 import (
-	"github.com/arduino/arduino-cli/cli"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/spf13/cobra"
 )
 
@@ -29,8 +29,8 @@ func InitCommand() *cobra.Command {
 		Short: "Arduino commands about libraries.",
 		Long:  "Arduino commands about libraries.",
 		Example: "" +
-			"  " + cli.AppName + " lib install AudioZero\n" +
-			"  " + cli.AppName + " lib update-index",
+			"  " + global.GetAppName() + " lib install AudioZero\n" +
+			"  " + global.GetAppName() + " lib update-index",
 	}
 	libCommand.AddCommand(initDownloadCommand())
 	libCommand.AddCommand(initInstallCommand())

--- a/cli/lib/list.go
+++ b/cli/lib/list.go
@@ -19,12 +19,12 @@ package lib
 
 import (
 	"fmt"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/lib"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/gosuri/uitable"
 	"github.com/sirupsen/logrus"

--- a/cli/lib/list.go
+++ b/cli/lib/list.go
@@ -19,6 +19,7 @@ package lib
 
 import (
 	"fmt"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -36,7 +37,7 @@ func initListCommand() *cobra.Command {
 		Use:     "list",
 		Short:   "Shows a list of all installed libraries.",
 		Long:    "Shows a list of all installed libraries.",
-		Example: "  " + cli.AppName + " lib list",
+		Example: "  " + global.GetAppName() + " lib list",
 		Args:    cobra.NoArgs,
 		Run:     runListCommand,
 	}

--- a/cli/lib/search.go
+++ b/cli/lib/search.go
@@ -20,6 +20,7 @@ package lib
 import (
 	"context"
 	"fmt"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 	"sort"
 
@@ -39,7 +40,7 @@ func initSearchCommand() *cobra.Command {
 		Use:     "search [LIBRARY_NAME]",
 		Short:   "Searchs for one or more libraries data.",
 		Long:    "Search for one or more libraries data (case insensitive search).",
-		Example: "  " + cli.AppName + " lib search audio",
+		Example: "  " + global.GetAppName() + " lib search audio",
 		Args:    cobra.ArbitraryArgs,
 		Run:     runSearchCommand,
 	}

--- a/cli/lib/search.go
+++ b/cli/lib/search.go
@@ -20,15 +20,14 @@ package lib
 import (
 	"context"
 	"fmt"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 	"sort"
-
 	"strings"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/lib"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cli/lib/uninstall.go
+++ b/cli/lib/uninstall.go
@@ -19,13 +19,13 @@ package lib
 
 import (
 	"context"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesindex"
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/lib"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cli/lib/uninstall.go
+++ b/cli/lib/uninstall.go
@@ -19,6 +19,7 @@ package lib
 
 import (
 	"context"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesindex"
@@ -35,7 +36,7 @@ func initUninstallCommand() *cobra.Command {
 		Use:     "uninstall LIBRARY_NAME(S)",
 		Short:   "Uninstalls one or more libraries.",
 		Long:    "Uninstalls one or more libraries.",
-		Example: "  " + cli.AppName + " lib uninstall AudioZero",
+		Example: "  " + global.GetAppName() + " lib uninstall AudioZero",
 		Args:    cobra.MinimumNArgs(1),
 		Run:     runUninstallCommand,
 	}

--- a/cli/lib/update_index.go
+++ b/cli/lib/update_index.go
@@ -19,12 +19,12 @@ package lib
 
 import (
 	"context"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/spf13/cobra"
 )

--- a/cli/lib/update_index.go
+++ b/cli/lib/update_index.go
@@ -19,6 +19,7 @@ package lib
 
 import (
 	"context"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -33,7 +34,7 @@ func initUpdateIndexCommand() *cobra.Command {
 		Use:     "update-index",
 		Short:   "Updates the libraries index.",
 		Long:    "Updates the libraries index to the latest version.",
-		Example: "  " + cli.AppName + " lib update-index",
+		Example: "  " + global.GetAppName() + " lib update-index",
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			instance := cli.CreateInstaceIgnorePlatformIndexErrors()

--- a/cli/lib/upgrade.go
+++ b/cli/lib/upgrade.go
@@ -18,6 +18,7 @@
 package lib
 
 import (
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -35,7 +36,7 @@ func initUpgradeCommand() *cobra.Command {
 		Short: "Upgrades installed libraries.",
 		Long: "This command ungrades all installed libraries to the latest available version." +
 			"To upgrade a single library use the 'install' command.",
-		Example: "  " + cli.AppName + " lib upgrade",
+		Example: "  " + global.GetAppName() + " lib upgrade",
 		Args:    cobra.NoArgs,
 		Run:     runUpgradeCommand,
 	}

--- a/cli/lib/upgrade.go
+++ b/cli/lib/upgrade.go
@@ -18,12 +18,12 @@
 package lib
 
 import (
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/lib"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cli/output.go
+++ b/cli/output.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/arduino/arduino-cli/output"
-
 	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/output"
 	"github.com/arduino/arduino-cli/rpc"
 )
 

--- a/cli/root/root.go
+++ b/cli/root/root.go
@@ -19,6 +19,7 @@ package root
 
 import (
 	"fmt"
+	"github.com/arduino/arduino-cli/global"
 	"io/ioutil"
 	"os"
 
@@ -48,7 +49,7 @@ func Init() *cobra.Command {
 		Use:              "arduino-cli",
 		Short:            "Arduino CLI.",
 		Long:             "Arduino Command Line Interface (arduino-cli).",
-		Example:          "  " + cli.AppName + " <command> [flags...]",
+		Example:          "  " + global.GetAppName() + " <command> [flags...]",
 		PersistentPreRun: preRun,
 	}
 	command.PersistentFlags().BoolVar(&cli.GlobalFlags.Debug, "debug", false, "Enables debug output (super verbose, used to debug the CLI).")
@@ -91,7 +92,7 @@ func preRun(cmd *cobra.Command, args []string) {
 	}
 	initConfigs()
 
-	logrus.Info(cli.AppName + "-" + cli.Version)
+	logrus.Info(global.GetAppName() + "-" + cli.Version)
 	logrus.Info("Starting root command preparation (`arduino`)")
 	switch outputFormat {
 	case "text":

--- a/cli/root/root.go
+++ b/cli/root/root.go
@@ -19,7 +19,6 @@ package root
 
 import (
 	"fmt"
-	"github.com/arduino/arduino-cli/global"
 	"io/ioutil"
 	"os"
 
@@ -36,6 +35,7 @@ import (
 	"github.com/arduino/arduino-cli/cli/version"
 	"github.com/arduino/arduino-cli/common/formatter"
 	"github.com/arduino/arduino-cli/configs"
+	"github.com/arduino/arduino-cli/global"
 	paths "github.com/arduino/go-paths-helper"
 	"github.com/mattn/go-colorable"
 	"github.com/sirupsen/logrus"
@@ -92,7 +92,7 @@ func preRun(cmd *cobra.Command, args []string) {
 	}
 	initConfigs()
 
-	logrus.Info(global.GetAppName() + "-" + cli.Version)
+	logrus.Info(global.GetAppName() + "-" + global.GetVersion())
 	logrus.Info("Starting root command preparation (`arduino`)")
 	switch outputFormat {
 	case "text":

--- a/cli/sketch/new.go
+++ b/cli/sketch/new.go
@@ -18,6 +18,7 @@
 package sketch
 
 import (
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -30,7 +31,7 @@ func initNewCommand() *cobra.Command {
 		Use:     "new",
 		Short:   "Create a new Sketch",
 		Long:    "Create a new Sketch",
-		Example: "  " + cli.AppName + " sketch new MultiBlinker",
+		Example: "  " + global.GetAppName() + " sketch new MultiBlinker",
 		Args:    cobra.ExactArgs(1),
 		Run:     runNewCommand,
 	}

--- a/cli/sketch/new.go
+++ b/cli/sketch/new.go
@@ -18,11 +18,11 @@
 package sketch
 
 import (
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/sketch/sketch.go
+++ b/cli/sketch/sketch.go
@@ -18,7 +18,7 @@
 package sketch
 
 import (
-	"github.com/arduino/arduino-cli/cli"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +28,7 @@ func InitCommand() *cobra.Command {
 		Use:     "sketch",
 		Short:   "Arduino CLI Sketch Commands.",
 		Long:    "Arduino CLI Sketch Commands.",
-		Example: "  " + cli.AppName + " sketch new MySketch",
+		Example: "  " + global.GetAppName() + " sketch new MySketch",
 	}
 	sketchCommand.AddCommand(initNewCommand())
 	//sketchCommand.AddCommand(initSyncCommand())

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -19,12 +19,12 @@ package upload
 
 import (
 	"context"
-	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands/upload"
 	"github.com/arduino/arduino-cli/common/formatter"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/arduino/go-paths-helper"
 	"github.com/spf13/cobra"

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -19,6 +19,7 @@ package upload
 
 import (
 	"context"
+	"github.com/arduino/arduino-cli/global"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
@@ -35,7 +36,7 @@ func InitCommand() *cobra.Command {
 		Use:     "upload",
 		Short:   "Upload Arduino sketches.",
 		Long:    "Upload Arduino sketches.",
-		Example: "  " + cli.AppName + " upload /home/user/Arduino/MySketch",
+		Example: "  " + global.GetAppName() + " upload /home/user/Arduino/MySketch",
 		Args:    cobra.MaximumNArgs(1),
 		Run:     run,
 	}

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -19,6 +19,7 @@ package version
 
 import (
 	"fmt"
+	"github.com/arduino/arduino-cli/global"
 
 	"github.com/arduino/arduino-cli/cli"
 	"github.com/spf13/cobra"
@@ -30,7 +31,7 @@ func InitCommand() *cobra.Command {
 		Use:     "version",
 		Short:   "Shows version number of arduino CLI.",
 		Long:    "Shows version number of arduino CLI which is installed on your system.",
-		Example: "  " + cli.AppName + " version",
+		Example: "  " + global.GetAppName() + " version",
 		Args:    cobra.NoArgs,
 		Run:     run,
 	}

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -19,9 +19,9 @@ package version
 
 import (
 	"fmt"
-	"github.com/arduino/arduino-cli/global"
 
 	"github.com/arduino/arduino-cli/cli"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +46,7 @@ type versionOutput struct {
 func run(cmd *cobra.Command, args []string) {
 	res := &versionOutput{
 		Command: cmd.Parent().Name(),
-		Version: cli.Version,
+		Version: global.GetVersion(),
 	}
 	if cli.OutputJSONOrElse(res) {
 		fmt.Printf("%s version %s\n", res.Command, res.Version)

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -76,7 +76,7 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream io.Writer, errS
 		// TODO: Move this error message in `cli` module
 		// errorMessage := fmt.Sprintf(
 		// 	"\"%[1]s:%[2]s\" platform is not installed, please install it by running \""+
-		// 		cli.AppName+" core install %[1]s:%[2]s\".", fqbn.Package, fqbn.PlatformArch)
+		// 		global.GetAppName()+" core install %[1]s:%[2]s\".", fqbn.Package, fqbn.PlatformArch)
 		// formatter.PrintErrorMessage(errorMessage)
 		return nil, fmt.Errorf("platform not installed")
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -26,13 +26,13 @@ import (
 	"log"
 	"net"
 
-	"github.com/arduino/arduino-cli/cli"
 	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/commands/compile"
 	"github.com/arduino/arduino-cli/commands/core"
 	"github.com/arduino/arduino-cli/commands/lib"
 	"github.com/arduino/arduino-cli/commands/upload"
+	"github.com/arduino/arduino-cli/global"
 	"github.com/arduino/arduino-cli/rpc"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -121,7 +121,7 @@ func (s *ArduinoCoreServerImpl) Init(req *rpc.InitReq, stream rpc.ArduinoCore_In
 }
 
 func (s *ArduinoCoreServerImpl) Version(ctx context.Context, req *rpc.VersionReq) (*rpc.VersionResp, error) {
-	return &rpc.VersionResp{Version: cli.Version}, nil
+	return &rpc.VersionResp{Version: global.GetVersion()}, nil
 }
 
 func (s *ArduinoCoreServerImpl) Compile(req *rpc.CompileReq, stream rpc.ArduinoCore_CompileServer) error {

--- a/global/global.go
+++ b/global/global.go
@@ -27,7 +27,7 @@ var appName = filepath.Base(os.Args[0])
 
 var (
 	application = "arduino-cli"
-	version     = "missing"
+	version     = "0.3.6-alpha.preview"
 	commit      = "missing"
 	cvsRef      = "missing"
 	buildDate   = "missing"

--- a/global/global.go
+++ b/global/global.go
@@ -9,14 +9,13 @@ import (
 var appName = filepath.Base(os.Args[0])
 
 var (
-	application= "arduino-cli"
-	version    = "missing"
-	commit     = "missing"
-	cvsRef     = "missing"
-	buildDate  = "missing"
-	repository = "missing"
+	application = "arduino-cli"
+	version     = "missing"
+	commit      = "missing"
+	cvsRef      = "missing"
+	buildDate   = "missing"
+	repository  = "missing"
 )
-
 
 func GetAppName() string {
 	return appName
@@ -54,4 +53,3 @@ type Info struct {
 	BuildDate   string `json:"buildDate"`
 	Repository  string `json:"repository"`
 }
-

--- a/global/global.go
+++ b/global/global.go
@@ -1,3 +1,20 @@
+/*
+ * This file is part of arduino-cli.
+ *
+ * Copyright 2018 ARDUINO SA (http://www.arduino.cc/)
+ *
+ * This software is released under the GNU General Public License version 3,
+ * which covers the main part of arduino-cli.
+ * The terms of this license can be found at:
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * You can be released from the requirements of the above licenses by purchasing
+ * a commercial license. Buying such a license is mandatory if you want to modify or
+ * otherwise use the software for commercial activities involving the Arduino
+ * software without disclosing the source code of your own applications. To purchase
+ * a commercial license, send an email to license@arduino.cc.
+ */
+
 package global
 
 import (

--- a/global/global.go
+++ b/global/global.go
@@ -1,0 +1,57 @@
+package global
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// appName is the command line name of the Arduino CLI executable on the user system (users may change it)
+var appName = filepath.Base(os.Args[0])
+
+var (
+	application= "arduino-cli"
+	version    = "missing"
+	commit     = "missing"
+	cvsRef     = "missing"
+	buildDate  = "missing"
+	repository = "missing"
+)
+
+
+func GetAppName() string {
+	return appName
+}
+
+func GetApplication() string {
+	return application
+}
+
+func GetVersion() string {
+	return version
+}
+
+func GetCommit() string {
+	return commit
+}
+
+func GetCvsRef() string {
+	return cvsRef
+}
+
+func GetBuildDate() string {
+	return buildDate
+}
+
+func GetRepository() string {
+	return repository
+}
+
+type Info struct {
+	Application string `json:"application"`
+	Version     string `json:"version"`
+	Commit      string `json:"commit"`
+	CvsRef      string `json:"cvsRef"`
+	BuildDate   string `json:"buildDate"`
+	Repository  string `json:"repository"`
+}
+

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,12 @@ module github.com/arduino/arduino-cli
 go 1.12
 
 require (
-	bou.ke/monkey v1.0.1 // indirect
+	bou.ke/monkey v1.0.1
 	github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c
 	github.com/arduino/go-paths-helper v0.0.0-20190214132331-c3c98d1bf2e1
 	github.com/arduino/go-properties-orderedmap v0.0.0-20181003091528-89278049acd3
 	github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b
 	github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b
-	github.com/bouk/monkey v1.0.1
 	github.com/cmaglie/pb v1.0.27
 	github.com/codeclysm/cc v1.2.2 // indirect
 	github.com/codeclysm/extract v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b/go.mod h1:uwG
 github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b h1:3PjgYG5gVPA7cipp7vIR2lF96KkEJIFBJ+ANnuv6J20=
 github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b/go.mod h1:iIPnclBMYm1g32Q5kXoqng4jLhMStReIP7ZxaoUC2y8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/bouk/monkey v1.0.1 h1:82kWEtyEjyfkRZb0DaQ5+7O5dJfe3GzF/o97+yUo5d0=
-github.com/bouk/monkey v1.0.1/go.mod h1:PG/63f4XEUlVyW1ttIeOJmJhhe1+t9EC/je3eTjvFhE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cmaglie/pb v1.0.27 h1:ynGj8vBXR+dtj4B7Q/W/qGt31771Ux5iFfRQBnwdQiA=
 github.com/cmaglie/pb v1.0.27/go.mod h1:GilkKZMXYjBA4NxItWFfO+lwkp59PLHQ+IOW/b/kmZI=


### PR DESCRIPTION
This PR aims to refactor a group of global variables in a `global` package in order to inject values at build time and use them in the CLI section of the cli

In order to have the values injected the use of `-ldflags` param is required in the `go build` phase otherwise a `missing` value will be shown (so an update in our CI is mandatory)

i.e. to inject the version value 

```
go build -ldflags "-X github.com/arduino/arduino-cli/global.version=0.3.6-alpha.preview"
```