### PR TITLE
Introduce new testing layout

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,23 @@
+version: '2'
+
+tasks:
+  build:
+    desc: Build the project
+    cmds:
+      - go build -v -i
+
+  test:
+    desc: Run the full testsuite
+    cmds:
+      - task: test-unit
+      - task: test-integration
+
+  test-unit:
+    desc: Run unit tests only
+    cmds:
+      - go test -short {{ default "-v" .GOFLAGS }} {{ default "./..." .TARGETS }}
+
+  test-integration:
+    desc: Run integration tests only
+    cmds:
+      - go test -run Integration {{ default "-v" .GOFLAGS }} {{ default "./..." .TARGETS }}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -57,7 +57,7 @@ func TestTokenIntegration(t *testing.T) {
 	}
 
 	// Obtain info
-	req, err := http.NewRequest("GET", "https://ddauth.arduino.cc/v1/users/byID/me", nil)
+	req, err := http.NewRequest("GET", "https://auth.arduino.cc/v1/users/byID/me", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -19,13 +19,13 @@ package auth_test
 
 import (
 	"encoding/json"
-	"flag"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
 
 	"github.com/arduino/arduino-cli/auth"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -33,12 +33,20 @@ var (
 	testPass = os.Getenv("TEST_PASSWORD")
 )
 
-func TestMain(m *testing.M) {
-	flag.Parse()
-	os.Exit(m.Run())
+func TestNewConfig(t *testing.T) {
+	conf := auth.New()
+	require.Equal(t, "https://hydra.arduino.cc/oauth2/auth", conf.CodeURL)
+	require.Equal(t, "https://hydra.arduino.cc/oauth2/token", conf.TokenURL)
+	require.Equal(t, "cli", conf.ClientID)
+	require.Equal(t, "http://localhost:5000", conf.RedirectURI)
+	require.Equal(t, "profile:core offline", conf.Scopes)
 }
 
-func TestToken(t *testing.T) {
+func TestTokenIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test")
+	}
+
 	if testUser == "" || testPass == "" {
 		t.Skip("Skipped because user and pass were not provided")
 	}
@@ -49,7 +57,7 @@ func TestToken(t *testing.T) {
 	}
 
 	// Obtain info
-	req, err := http.NewRequest("GET", "https://auth.arduino.cc/v1/users/byID/me", nil)
+	req, err := http.NewRequest("GET", "https://ddauth.arduino.cc/v1/users/byID/me", nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Overview

The project currently has a robust test suite that exercises most of the functionalities against the actual http API. This is not very suitable to iterate fast on the code, thus this PR introduces the concept of unit tests in addition to the existing suite that will stay as it is but will be marked as "integration tests".

## Implementation

Integration test functions will contain the string `Integration` in the name, so that the suite can be run with `go test -run integration ./...`. Integration tests will be skipped when running unit tests and we use the `short` option from the Go standard lib to make this easy: each test function will begin like this:
```
	if testing.Short() {
		t.Skip("skip integration test")
	}
```
This way, unit tests will be run with just `go test -short ./...`

To make easier for contributors and the CI to run either of the suites, or both in sequence, a task runner was added. `task` is written in Go and can be easily installed by just `go get` so it should be fair to ask developers to have it in their dev env. Available tasks are defined in the `Taskfile.yml` file, with this PR you can do `task test-unit` to run all the unit tests, or (for example) `task test-unit TARGETS=./auth` to run all the unit tests for the `auth` package only. `task test-integration` is symmetric while `task test` will run both integration and unit tests.

Note that `go test ./...` will keep running all the tests so the use of `task` is not mandatory.