### PR TITLE
Fix core upgrade

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,7 +30,7 @@ tasks:
   test-legacy:
     desc: Run tests for the `legacy` package
     cmds:
-      - go test {{ default "-v" .GOFLAGS }} ./legacy/...
+      - go test {{ default "-v -failfast" .GOFLAGS }} ./legacy/...
 
   test-unit-race:
     desc: Run unit tests only with race condition detection

--- a/arduino/cores/cores.go
+++ b/arduino/cores/cores.go
@@ -18,6 +18,7 @@
 package cores
 
 import (
+	"encoding/json"
 	"strings"
 
 	paths "github.com/arduino/go-paths-helper"
@@ -41,14 +42,13 @@ type PlatformRelease struct {
 	Resource       *resources.DownloadResource
 	Version        *semver.Version
 	BoardsManifest []*BoardManifest
-	Dependencies   ToolDependencies // The Dependency entries to load tools.
-	Platform       *Platform        `json:"-"`
-
-	Properties  *properties.Map            `json:"-"`
-	Boards      map[string]*Board          `json:"-"`
-	Programmers map[string]*properties.Map `json:"-"`
-	Menus       *properties.Map            `json:"-"`
-	InstallDir  *paths.Path                `json:"-"`
+	Dependencies   ToolDependencies           // The Dependency entries to load tools.
+	Platform       *Platform                  `json:"-"`
+	Properties     *properties.Map            `json:"-"`
+	Boards         map[string]*Board          `json:"-"`
+	Programmers    map[string]*properties.Map `json:"-"`
+	Menus          *properties.Map            `json:"-"`
+	InstallDir     *paths.Path                `json:"-"`
 }
 
 // BoardManifest contains information about a board. These metadata are usually
@@ -225,4 +225,26 @@ func (release *PlatformRelease) String() string {
 		version = release.Version.String()
 	}
 	return release.Platform.String() + "@" + version
+}
+
+// MarshalJSON provides a more user friendly serialization for
+// PlatformRelease objects.
+func (release *PlatformRelease) MarshalJSON() ([]byte, error) {
+	latestStr := ""
+	latest := release.Platform.GetLatestRelease()
+	if latest != nil {
+		latestStr = latest.Version.String()
+	}
+
+	return json.Marshal(&struct {
+		ID        string `json:"ID,omitempty"`
+		Installed string `json:"Installed,omitempty"`
+		Latest    string `json:"Latest,omitempty"`
+		Name      string `json:"Name,omitempty"`
+	}{
+		ID:        release.Platform.String(),
+		Installed: release.Version.String(),
+		Latest:    latestStr,
+		Name:      release.Platform.Name,
+	})
 }

--- a/arduino/cores/packageindex/index.go
+++ b/arduino/cores/packageindex/index.go
@@ -24,7 +24,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/resources"
 	"github.com/arduino/go-paths-helper"
-	"go.bug.st/relaxed-semver"
+	semver "go.bug.st/relaxed-semver"
 )
 
 // Index represents Cores and Tools struct as seen from package_index.json file.
@@ -97,13 +97,13 @@ type indexHelp struct {
 
 // MergeIntoPackages converts the Index data into a cores.Packages and merge them
 // with the existing conents of the cores.Packages passed as parameter.
-func (index Index) MergeIntoPackages(outPackages *cores.Packages) {
+func (index Index) MergeIntoPackages(outPackages cores.Packages) {
 	for _, inPackage := range index.Packages {
 		inPackage.extractPackageIn(outPackages)
 	}
 }
 
-func (inPackage indexPackage) extractPackageIn(outPackages *cores.Packages) {
+func (inPackage indexPackage) extractPackageIn(outPackages cores.Packages) {
 	outPackage := outPackages.GetOrCreatePackage(inPackage.Name)
 	outPackage.Maintainer = inPackage.Maintainer
 	outPackage.WebsiteURL = inPackage.WebsiteURL

--- a/arduino/cores/packagemanager/download.go
+++ b/arduino/cores/packagemanager/download.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"go.bug.st/downloader"
-	"go.bug.st/relaxed-semver"
+	semver "go.bug.st/relaxed-semver"
 )
 
 // PlatformReference represents a tuple to identify a Platform
@@ -44,7 +44,7 @@ func (platform *PlatformReference) String() string {
 // FindPlatform returns the Platform matching the PlatformReference or nil if not found.
 // The PlatformVersion field of the reference is ignored.
 func (pm *PackageManager) FindPlatform(ref *PlatformReference) *cores.Platform {
-	targetPackage, ok := pm.GetPackages().Packages[ref.Package]
+	targetPackage, ok := pm.Packages[ref.Package]
 	if !ok {
 		return nil
 	}
@@ -71,7 +71,7 @@ func (pm *PackageManager) FindPlatformRelease(ref *PlatformReference) *cores.Pla
 // FindPlatformReleaseDependencies takes a PlatformReference and returns a set of items to download and
 // a set of outputs for non existing platforms.
 func (pm *PackageManager) FindPlatformReleaseDependencies(item *PlatformReference) (*cores.PlatformRelease, []*cores.ToolRelease, error) {
-	targetPackage, exists := pm.packages.Packages[item.Package]
+	targetPackage, exists := pm.Packages[item.Package]
 	if !exists {
 		return nil, nil, fmt.Errorf("package %s not found", item.Package)
 	}
@@ -94,7 +94,7 @@ func (pm *PackageManager) FindPlatformReleaseDependencies(item *PlatformReferenc
 	}
 
 	// replaces "latest" with latest version too
-	toolDeps, err := pm.packages.GetDepsOfPlatformRelease(release)
+	toolDeps, err := pm.Packages.GetDepsOfPlatformRelease(release)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting tool dependencies for platform %s: %s", release.String(), err)
 	}

--- a/arduino/cores/packagemanager/install_uninstall.go
+++ b/arduino/cores/packagemanager/install_uninstall.go
@@ -127,7 +127,7 @@ func (pm *PackageManager) UninstallTool(toolRelease *cores.ToolRelease) error {
 // passed as parameter
 func (pm *PackageManager) IsToolRequired(toolRelease *cores.ToolRelease) bool {
 	// Search in all installed platforms
-	for _, targetPackage := range pm.packages.Packages {
+	for _, targetPackage := range pm.Packages {
 		for _, platform := range targetPackage.Platforms {
 			if platformRelease := pm.GetInstalledPlatformRelease(platform); platformRelease != nil {
 				if platformRelease.RequiresToolRelease(toolRelease) {

--- a/arduino/cores/packagemanager/loader.go
+++ b/arduino/cores/packagemanager/loader.go
@@ -112,7 +112,7 @@ func (pm *PackageManager) LoadHardwareFromDirectory(path *paths.Path) error {
 			continue
 		}
 
-		targetPackage := pm.packages.GetOrCreatePackage(packager)
+		targetPackage := pm.Packages.GetOrCreatePackage(packager)
 		if err := pm.loadPlatforms(targetPackage, architectureParentPath); err != nil {
 			return fmt.Errorf("loading package %s: %s", packager, err)
 		}
@@ -419,7 +419,7 @@ func (pm *PackageManager) LoadToolsFromBundleDirectory(toolsPath *paths.Path) er
 		}
 
 		for packager, toolsData := range all.FirstLevelOf() {
-			targetPackage := pm.packages.GetOrCreatePackage(packager)
+			targetPackage := pm.Packages.GetOrCreatePackage(packager)
 
 			for toolName, toolVersion := range toolsData.AsMap() {
 				tool := targetPackage.GetOrCreateTool(toolName)
@@ -431,7 +431,7 @@ func (pm *PackageManager) LoadToolsFromBundleDirectory(toolsPath *paths.Path) er
 		}
 	} else {
 		// otherwise load the tools inside the unnamed package
-		unnamedPackage := pm.packages.GetOrCreatePackage("")
+		unnamedPackage := pm.Packages.GetOrCreatePackage("")
 		pm.loadToolsFromPackage(unnamedPackage, toolsPath)
 	}
 	return nil

--- a/cli/core/upgrade.go
+++ b/cli/core/upgrade.go
@@ -19,6 +19,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli/errorcodes"
@@ -51,21 +52,42 @@ func runUpgradeCommand(cmd *cobra.Command, args []string) {
 	instance := instance.CreateInstance()
 	logrus.Info("Executing `arduino core upgrade`")
 
+	// if no platform was passed, upgrade allthethings
+	if len(args) == 0 {
+		targets, err := core.GetPlatforms(instance.Id, true)
+		if err != nil {
+			formatter.PrintError(err, "Error retrieving core list")
+			os.Exit(errorcodes.ErrGeneric)
+		}
+
+		if len(targets) == 0 {
+			formatter.PrintResult("All the cores are already at the latest version")
+			return
+		}
+
+		for _, t := range targets {
+			args = append(args, t.Platform.String())
+		}
+	}
+
+	// proceed upgrading, if anything is upgradable
 	platformsRefs := parsePlatformReferenceArgs(args)
 	for i, platformRef := range platformsRefs {
 		if platformRef.Version != "" {
 			formatter.PrintErrorMessage(("Invalid item " + args[i]))
-			os.Exit(errorcodes.ErrBadArgument)
+			continue
 		}
-	}
-	for _, platformRef := range platformsRefs {
-		_, err := core.PlatformUpgrade(context.Background(), &rpc.PlatformUpgradeReq{
+
+		r := &rpc.PlatformUpgradeReq{
 			Instance:        instance,
 			PlatformPackage: platformRef.Package,
 			Architecture:    platformRef.Architecture,
-		}, output.ProgressBar(), output.TaskProgress(),
-			globals.HTTPClientHeader)
-		if err != nil {
+		}
+
+		_, err := core.PlatformUpgrade(context.Background(), r, output.ProgressBar(), output.TaskProgress(), globals.HTTPClientHeader)
+		if err == core.ErrAlreadyLatest {
+			formatter.PrintResult(fmt.Sprintf("Platform %s is already at the latest version", platformRef))
+		} else if err != nil {
 			formatter.PrintError(err, "Error during upgrade")
 			os.Exit(errorcodes.ErrGeneric)
 		}

--- a/cli/core/upgrade.go
+++ b/cli/core/upgrade.go
@@ -71,10 +71,12 @@ func runUpgradeCommand(cmd *cobra.Command, args []string) {
 	}
 
 	// proceed upgrading, if anything is upgradable
+	exitErr := false
 	platformsRefs := parsePlatformReferenceArgs(args)
 	for i, platformRef := range platformsRefs {
 		if platformRef.Version != "" {
 			formatter.PrintErrorMessage(("Invalid item " + args[i]))
+			exitErr = true
 			continue
 		}
 
@@ -91,5 +93,9 @@ func runUpgradeCommand(cmd *cobra.Command, args []string) {
 			formatter.PrintError(err, "Error during upgrade")
 			os.Exit(errorcodes.ErrGeneric)
 		}
+	}
+
+	if exitErr {
+		os.Exit(errorcodes.ErrBadArgument)
 	}
 }

--- a/commands/board/listall.go
+++ b/commands/board/listall.go
@@ -48,7 +48,7 @@ func ListAll(ctx context.Context, req *rpc.BoardListAllReq) (*rpc.BoardListAllRe
 	}
 
 	list := &rpc.BoardListAllResp{Boards: []*rpc.BoardListItem{}}
-	for _, targetPackage := range pm.GetPackages().Packages {
+	for _, targetPackage := range pm.Packages {
 		for _, platform := range targetPackage.Platforms {
 			platformRelease := pm.GetInstalledPlatformRelease(platform)
 			if platformRelease == nil {

--- a/commands/bundled_tools_ctags.go
+++ b/commands/bundled_tools_ctags.go
@@ -25,7 +25,7 @@ import (
 )
 
 func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
-	builtinPackage := pm.GetPackages().GetOrCreatePackage("builtin")
+	builtinPackage := pm.Packages.GetOrCreatePackage("builtin")
 	ctagsTool := builtinPackage.GetOrCreateTool("ctags")
 	ctagsRel := ctagsTool.GetOrCreateRelease(semver.ParseRelaxed("5.8-arduino11"))
 	ctagsRel.Flavors = []*cores.Flavor{

--- a/commands/bundled_tools_serial_discovery.go
+++ b/commands/bundled_tools_serial_discovery.go
@@ -30,7 +30,7 @@ import (
 var serialDiscoveryVersion = semver.ParseRelaxed("0.5.0")
 
 func loadBuiltinSerialDiscoveryMetadata(pm *packagemanager.PackageManager) {
-	builtinPackage := pm.GetPackages().GetOrCreatePackage("builtin")
+	builtinPackage := pm.Packages.GetOrCreatePackage("builtin")
 	ctagsTool := builtinPackage.GetOrCreateTool("serial-discovery")
 	ctagsRel := ctagsTool.GetOrCreateRelease(serialDiscoveryVersion)
 	ctagsRel.Flavors = []*cores.Flavor{

--- a/commands/core/core.go
+++ b/commands/core/core.go
@@ -22,10 +22,10 @@ import (
 	rpc "github.com/arduino/arduino-cli/rpc/commands"
 )
 
-// platformReleaseToRPC converts our internal structure to the RPC structure.
+// PlatformReleaseToRPC converts our internal structure to the RPC structure.
 // Note: this function does not touch the "Installed" field of rpc.Platform as it's not always clear that the
 // platformRelease we're currently converting is actually installed.
-func platformReleaseToRPC(platformRelease *cores.PlatformRelease) *rpc.Platform {
+func PlatformReleaseToRPC(platformRelease *cores.PlatformRelease) *rpc.Platform {
 	boards := make([]*rpc.Board, len(platformRelease.Boards))
 	i := 0
 	for _, b := range platformRelease.Boards {

--- a/commands/core/search.go
+++ b/commands/core/search.go
@@ -45,7 +45,7 @@ func PlatformSearch(ctx context.Context, req *rpc.PlatformSearchReq) (*rpc.Platf
 		match := func(line string) bool {
 			return strings.Contains(strings.ToLower(line), search)
 		}
-		for _, targetPackage := range pm.GetPackages().Packages {
+		for _, targetPackage := range pm.Packages {
 			for _, platform := range targetPackage.Platforms {
 				platformRelease := platform.GetLatestRelease()
 				if platformRelease == nil {
@@ -67,7 +67,7 @@ func PlatformSearch(ctx context.Context, req *rpc.PlatformSearchReq) (*rpc.Platf
 
 	out := make([]*rpc.Platform, len(res))
 	for i, platformRelease := range res {
-		out[i] = platformReleaseToRPC(platformRelease)
+		out[i] = PlatformReleaseToRPC(platformRelease)
 	}
 	return &rpc.PlatformSearchResp{SearchOutput: out}, nil
 }

--- a/commands/core/upgrade.go
+++ b/commands/core/upgrade.go
@@ -28,6 +28,12 @@ import (
 	rpc "github.com/arduino/arduino-cli/rpc/commands"
 )
 
+var (
+	// ErrAlreadyLatest is returned when an upgrade is not possible because
+	// already at latest version.
+	ErrAlreadyLatest = errors.New("platform already at latest version")
+)
+
 // PlatformUpgrade FIXMEDOC
 func PlatformUpgrade(ctx context.Context, req *rpc.PlatformUpgradeReq,
 	downloadCB commands.DownloadProgressCB, taskCB commands.TaskProgressCB, downloaderHeaders http.Header) (*rpc.PlatformUpgradeResp, error) {
@@ -71,7 +77,7 @@ func upgradePlatform(pm *packagemanager.PackageManager, platformRef *packagemana
 	}
 	latest := platform.GetLatestRelease()
 	if !latest.Version.GreaterThan(installed.Version) {
-		return fmt.Errorf("platform %s is already at the latest version", platformRef)
+		return ErrAlreadyLatest
 	}
 	platformRef.PlatformVersion = latest.Version
 	toInstallRefs = append(toInstallRefs, platformRef)

--- a/commands/daemon/daemon.go
+++ b/commands/daemon/daemon.go
@@ -194,7 +194,19 @@ func (s *ArduinoCoreServerImpl) PlatformSearch(ctx context.Context, req *rpc.Pla
 
 // PlatformList FIXMEDOC
 func (s *ArduinoCoreServerImpl) PlatformList(ctx context.Context, req *rpc.PlatformListReq) (*rpc.PlatformListResp, error) {
-	return core.PlatformList(ctx, req)
+	platforms, err := core.GetPlatforms(req.Instance.Id, req.UpdatableOnly)
+	if err != nil {
+		return nil, err
+	}
+
+	installed := []*rpc.Platform{}
+	for _, p := range platforms {
+		rpcPlatform := core.PlatformReleaseToRPC(p)
+		rpcPlatform.Installed = p.Version.String()
+		installed = append(installed, rpcPlatform)
+	}
+
+	return &rpc.PlatformListResp{InstalledPlatform: installed}, nil
 }
 
 // Upload FIXMEDOC

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -93,7 +93,7 @@ func Upload(ctx context.Context, req *rpc.UploadReq, outStream io.Writer, errStr
 		uploadToolPattern = split[1]
 		architecture := board.PlatformRelease.Platform.Architecture
 
-		if referencedPackage := pm.GetPackages().Packages[referencedPackageName]; referencedPackage == nil {
+		if referencedPackage := pm.Packages[referencedPackageName]; referencedPackage == nil {
 			return nil, fmt.Errorf("required platform %s:%s not installed", referencedPackageName, architecture)
 		} else if referencedPlatform := referencedPackage.Platforms[architecture]; referencedPlatform == nil {
 			return nil, fmt.Errorf("required platform %s:%s not installed", referencedPackageName, architecture)

--- a/legacy/builder/add_build_board_property_if_missing.go
+++ b/legacy/builder/add_build_board_property_if_missing.go
@@ -43,7 +43,7 @@ func (*AddBuildBoardPropertyIfMissing) Run(ctx *types.Context) error {
 	packages := ctx.Hardware
 	logger := ctx.GetLogger()
 
-	for _, aPackage := range packages.Packages {
+	for _, aPackage := range packages {
 		for _, platform := range aPackage.Platforms {
 			for _, platformRelease := range platform.Releases {
 				for _, board := range platformRelease.Boards {

--- a/legacy/builder/hardware_loader.go
+++ b/legacy/builder/hardware_loader.go
@@ -45,6 +45,6 @@ func (s *HardwareLoader) Run(ctx *types.Context) error {
 		}
 		ctx.PackageManager = pm
 	}
-	ctx.Hardware = ctx.PackageManager.GetPackages()
+	ctx.Hardware = ctx.PackageManager.Packages
 	return nil
 }

--- a/legacy/builder/rewrite_hardware_keys.go
+++ b/legacy/builder/rewrite_hardware_keys.go
@@ -46,7 +46,7 @@ func (s *RewriteHardwareKeys) Run(ctx *types.Context) error {
 	platformKeysRewrite := ctx.PlatformKeyRewrites
 	hardwareRewriteResults := ctx.HardwareRewriteResults
 
-	for _, aPackage := range packages.Packages {
+	for _, aPackage := range packages {
 		for _, platform := range aPackage.Platforms {
 			for _, platformRelease := range platform.Releases {
 				if platformRelease.Properties.Get(constants.REWRITING) != constants.REWRITING_DISABLED {

--- a/legacy/builder/setup_build_properties.go
+++ b/legacy/builder/setup_build_properties.go
@@ -90,7 +90,7 @@ func (s *SetupBuildProperties) Run(ctx *types.Context) error {
 		var variantPlatformRelease *cores.PlatformRelease
 		variantParts := strings.Split(variant, ":")
 		if len(variantParts) > 1 {
-			variantPlatform := packages.Packages[variantParts[0]].Platforms[targetPlatform.Platform.Architecture]
+			variantPlatform := packages[variantParts[0]].Platforms[targetPlatform.Platform.Architecture]
 			variantPlatformRelease = ctx.PackageManager.GetInstalledPlatformRelease(variantPlatform)
 			variant = variantParts[1]
 		} else {

--- a/legacy/builder/test/hardware_loader_test.go
+++ b/legacy/builder/test/hardware_loader_test.go
@@ -55,23 +55,23 @@ func TestLoadHardware(t *testing.T) {
 	}
 
 	packages := ctx.Hardware
-	require.Equal(t, 2, len(packages.Packages))
-	require.NotNil(t, packages.Packages["arduino"])
-	require.Equal(t, 2, len(packages.Packages["arduino"].Platforms))
+	require.Equal(t, 2, len(packages))
+	require.NotNil(t, packages["arduino"])
+	require.Equal(t, 2, len(packages["arduino"].Platforms))
 
-	require.Equal(t, "uno", packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards["uno"].BoardID)
-	require.Equal(t, "uno", packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards["uno"].Properties.Get("_id"))
+	require.Equal(t, "uno", packages["arduino"].Platforms["avr"].Releases[""].Boards["uno"].BoardID)
+	require.Equal(t, "uno", packages["arduino"].Platforms["avr"].Releases[""].Boards["uno"].Properties.Get("_id"))
 
-	require.Equal(t, "yun", packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards["yun"].BoardID)
-	require.Equal(t, "true", packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards["yun"].Properties.Get("upload.wait_for_upload_port"))
+	require.Equal(t, "yun", packages["arduino"].Platforms["avr"].Releases[""].Boards["yun"].BoardID)
+	require.Equal(t, "true", packages["arduino"].Platforms["avr"].Releases[""].Boards["yun"].Properties.Get("upload.wait_for_upload_port"))
 
-	require.Equal(t, "{build.usb_flags}", packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards["robotMotor"].Properties.Get("build.extra_flags"))
+	require.Equal(t, "{build.usb_flags}", packages["arduino"].Platforms["avr"].Releases[""].Boards["robotMotor"].Properties.Get("build.extra_flags"))
 
-	require.Equal(t, "arduino_due_x", packages.Packages["arduino"].Platforms["sam"].Releases[""].Boards["arduino_due_x"].BoardID)
+	require.Equal(t, "arduino_due_x", packages["arduino"].Platforms["sam"].Releases[""].Boards["arduino_due_x"].BoardID)
 
-	require.Equal(t, "ATmega123", packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards["diecimila"].Properties.Get("menu.cpu.atmega123"))
+	require.Equal(t, "ATmega123", packages["arduino"].Platforms["avr"].Releases[""].Boards["diecimila"].Properties.Get("menu.cpu.atmega123"))
 
-	avrPlatform := packages.Packages["arduino"].Platforms["avr"]
+	avrPlatform := packages["arduino"].Platforms["avr"]
 	require.Equal(t, "Arduino AVR Boards", avrPlatform.Releases[""].Properties.Get("name"))
 	require.Equal(t, "-v", avrPlatform.Releases[""].Properties.Get("tools.avrdude.bootloader.params.verbose"))
 	require.Equal(t, "/my/personal/avrdude", avrPlatform.Releases[""].Properties.Get("tools.avrdude.cmd.path"))
@@ -105,25 +105,25 @@ func TestLoadHardwareMixingUserHardwareFolder(t *testing.T) {
 
 	if runtime.GOOS == "windows" {
 		//a package is a symlink, and windows does not support them
-		require.Equal(t, 3, len(packages.Packages))
+		require.Equal(t, 3, len(packages))
 	} else {
-		require.Equal(t, 4, len(packages.Packages))
+		require.Equal(t, 4, len(packages))
 	}
 
-	require.NotNil(t, packages.Packages["arduino"])
-	require.Equal(t, 2, len(packages.Packages["arduino"].Platforms))
+	require.NotNil(t, packages["arduino"])
+	require.Equal(t, 2, len(packages["arduino"].Platforms))
 
-	require.Equal(t, "uno", packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards["uno"].BoardID)
-	require.Equal(t, "uno", packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards["uno"].Properties.Get("_id"))
+	require.Equal(t, "uno", packages["arduino"].Platforms["avr"].Releases[""].Boards["uno"].BoardID)
+	require.Equal(t, "uno", packages["arduino"].Platforms["avr"].Releases[""].Boards["uno"].Properties.Get("_id"))
 
-	require.Equal(t, "yun", packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards["yun"].BoardID)
-	require.Equal(t, "true", packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards["yun"].Properties.Get("upload.wait_for_upload_port"))
+	require.Equal(t, "yun", packages["arduino"].Platforms["avr"].Releases[""].Boards["yun"].BoardID)
+	require.Equal(t, "true", packages["arduino"].Platforms["avr"].Releases[""].Boards["yun"].Properties.Get("upload.wait_for_upload_port"))
 
-	require.Equal(t, "{build.usb_flags}", packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards["robotMotor"].Properties.Get("build.extra_flags"))
+	require.Equal(t, "{build.usb_flags}", packages["arduino"].Platforms["avr"].Releases[""].Boards["robotMotor"].Properties.Get("build.extra_flags"))
 
-	require.Equal(t, "arduino_due_x", packages.Packages["arduino"].Platforms["sam"].Releases[""].Boards["arduino_due_x"].BoardID)
+	require.Equal(t, "arduino_due_x", packages["arduino"].Platforms["sam"].Releases[""].Boards["arduino_due_x"].BoardID)
 
-	avrPlatform := packages.Packages["arduino"].Platforms["avr"].Releases[""]
+	avrPlatform := packages["arduino"].Platforms["avr"].Releases[""]
 	require.Equal(t, "Arduino AVR Boards", avrPlatform.Properties.Get("name"))
 	require.Equal(t, "-v", avrPlatform.Properties.Get("tools.avrdude.bootloader.params.verbose"))
 	require.Equal(t, "/my/personal/avrdude", avrPlatform.Properties.Get("tools.avrdude.cmd.path"))
@@ -135,8 +135,8 @@ func TestLoadHardwareMixingUserHardwareFolder(t *testing.T) {
 	require.Equal(t, "\"{compiler.path}{compiler.cpp.cmd}\" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} \"{source_file}\"", avrPlatform.Properties.Get("recipe.preproc.includes"))
 	require.False(t, avrPlatform.Properties.ContainsKey("preproc.macros.compatibility_flags"))
 
-	require.NotNil(t, packages.Packages["my_avr_platform"])
-	myAVRPlatform := packages.Packages["my_avr_platform"]
+	require.NotNil(t, packages["my_avr_platform"])
+	myAVRPlatform := packages["my_avr_platform"]
 	//require.Equal(t, "hello world", myAVRPlatform.Properties.Get("example"))
 	myAVRPlatformAvrArch := myAVRPlatform.Platforms["avr"].Releases[""]
 	require.Equal(t, "custom_yun", myAVRPlatformAvrArch.Boards["custom_yun"].BoardID)
@@ -149,8 +149,8 @@ func TestLoadHardwareMixingUserHardwareFolder(t *testing.T) {
 	//require.Equal(t, "-w -x c++ -E -CC", packages.Properties.Get("preproc.macros.flags"))
 
 	if runtime.GOOS != "windows" {
-		require.NotNil(t, packages.Packages["my_symlinked_avr_platform"])
-		require.NotNil(t, packages.Packages["my_symlinked_avr_platform"].Platforms["avr"])
+		require.NotNil(t, packages["my_symlinked_avr_platform"])
+		require.NotNil(t, packages["my_symlinked_avr_platform"].Platforms["avr"])
 	}
 }
 
@@ -169,15 +169,15 @@ func TestLoadHardwareWithBoardManagerFolderStructure(t *testing.T) {
 	}
 
 	packages := ctx.Hardware
-	require.Equal(t, 3, len(packages.Packages))
-	require.NotNil(t, packages.Packages["arduino"])
-	require.Equal(t, 1, len(packages.Packages["arduino"].Platforms))
-	require.NotNil(t, packages.Packages["RedBearLab"])
-	require.Equal(t, 1, len(packages.Packages["RedBearLab"].Platforms))
-	require.NotNil(t, packages.Packages["RFduino"])
-	require.Equal(t, 0, len(packages.Packages["RFduino"].Platforms))
+	require.Equal(t, 3, len(packages))
+	require.NotNil(t, packages["arduino"])
+	require.Equal(t, 1, len(packages["arduino"].Platforms))
+	require.NotNil(t, packages["RedBearLab"])
+	require.Equal(t, 1, len(packages["RedBearLab"].Platforms))
+	require.NotNil(t, packages["RFduino"])
+	require.Equal(t, 0, len(packages["RFduino"].Platforms))
 
-	samdPlatform := packages.Packages["arduino"].Platforms["samd"].Releases["1.6.5"]
+	samdPlatform := packages["arduino"].Platforms["samd"].Releases["1.6.5"]
 	require.Equal(t, 3, len(samdPlatform.Boards))
 
 	require.Equal(t, "arduino_zero_edbg", samdPlatform.Boards["arduino_zero_edbg"].BoardID)
@@ -194,7 +194,7 @@ func TestLoadHardwareWithBoardManagerFolderStructure(t *testing.T) {
 	require.Equal(t, "Atmel EDBG", samdPlatform.Programmers["edbg"].Get("name"))
 	require.Equal(t, "openocd", samdPlatform.Programmers["edbg"].Get("program.tool"))
 
-	avrRedBearPlatform := packages.Packages["RedBearLab"].Platforms["avr"].Releases["1.0.0"]
+	avrRedBearPlatform := packages["RedBearLab"].Platforms["avr"].Releases["1.0.0"]
 	require.Equal(t, 3, len(avrRedBearPlatform.Boards))
 
 	require.Equal(t, "blend", avrRedBearPlatform.Boards["blend"].BoardID)
@@ -220,24 +220,24 @@ func TestLoadLotsOfHardware(t *testing.T) {
 
 	if runtime.GOOS == "windows" {
 		//a package is a symlink, and windows does not support them
-		require.Equal(t, 5, len(packages.Packages))
+		require.Equal(t, 5, len(packages))
 	} else {
-		require.Equal(t, 6, len(packages.Packages))
+		require.Equal(t, 6, len(packages))
 	}
 
-	require.NotNil(t, packages.Packages["arduino"])
-	require.NotNil(t, packages.Packages["my_avr_platform"])
+	require.NotNil(t, packages["arduino"])
+	require.NotNil(t, packages["my_avr_platform"])
 
-	require.Equal(t, 3, len(packages.Packages["arduino"].Platforms))
-	require.Equal(t, 20, len(packages.Packages["arduino"].Platforms["avr"].Releases[""].Boards))
-	require.Equal(t, 2, len(packages.Packages["arduino"].Platforms["sam"].Releases[""].Boards))
-	require.Equal(t, 3, len(packages.Packages["arduino"].Platforms["samd"].Releases["1.6.5"].Boards))
+	require.Equal(t, 3, len(packages["arduino"].Platforms))
+	require.Equal(t, 20, len(packages["arduino"].Platforms["avr"].Releases[""].Boards))
+	require.Equal(t, 2, len(packages["arduino"].Platforms["sam"].Releases[""].Boards))
+	require.Equal(t, 3, len(packages["arduino"].Platforms["samd"].Releases["1.6.5"].Boards))
 
-	require.Equal(t, 1, len(packages.Packages["my_avr_platform"].Platforms))
-	require.Equal(t, 2, len(packages.Packages["my_avr_platform"].Platforms["avr"].Releases[""].Boards))
+	require.Equal(t, 1, len(packages["my_avr_platform"].Platforms))
+	require.Equal(t, 2, len(packages["my_avr_platform"].Platforms["avr"].Releases[""].Boards))
 
 	if runtime.GOOS != "windows" {
-		require.Equal(t, 1, len(packages.Packages["my_symlinked_avr_platform"].Platforms))
-		require.Equal(t, 2, len(packages.Packages["my_symlinked_avr_platform"].Platforms["avr"].Releases[""].Boards))
+		require.Equal(t, 1, len(packages["my_symlinked_avr_platform"].Platforms))
+		require.Equal(t, 2, len(packages["my_symlinked_avr_platform"].Platforms["avr"].Releases[""].Boards))
 	}
 }

--- a/legacy/builder/test/rewrite_hardware_keys_test.go
+++ b/legacy/builder/test/rewrite_hardware_keys_test.go
@@ -42,10 +42,9 @@ import (
 func TestRewriteHardwareKeys(t *testing.T) {
 	ctx := &types.Context{}
 
-	packages := &cores.Packages{}
-	packages.Packages = map[string]*cores.Package{}
+	packages := cores.Packages{}
 	aPackage := &cores.Package{Name: "dummy"}
-	packages.Packages["dummy"] = aPackage
+	packages["dummy"] = aPackage
 	aPackage.Platforms = map[string]*cores.Platform{}
 
 	platform := &cores.PlatformRelease{
@@ -83,10 +82,9 @@ func TestRewriteHardwareKeys(t *testing.T) {
 func TestRewriteHardwareKeysWithRewritingDisabled(t *testing.T) {
 	ctx := &types.Context{}
 
-	packages := &cores.Packages{}
-	packages.Packages = make(map[string]*cores.Package)
+	packages := cores.Packages{}
 	aPackage := &cores.Package{Name: "dummy"}
-	packages.Packages["dummy"] = aPackage
+	packages["dummy"] = aPackage
 	aPackage.Platforms = make(map[string]*cores.Platform)
 
 	platform := &cores.PlatformRelease{

--- a/legacy/builder/types/context.go
+++ b/legacy/builder/types/context.go
@@ -39,7 +39,7 @@ type Context struct {
 	BuildOptionsJsonPrevious string
 
 	PackageManager *packagemanager.PackageManager
-	Hardware       *cores.Packages
+	Hardware       cores.Packages
 	AllTools       []*cores.ToolRelease
 	RequiredTools  []*cores.ToolRelease
 	TargetBoard    *cores.Board


### PR DESCRIPTION
This PR fixes the case where no args are passed to the upgrade command, like:
```
arduino-cli core upgrade
```
Now an upgrade will be performed to any core that is up to date. If all the cores are at the latest version, command is a no op and will exit without errors, providing and info message.

Fixes ~#285~ #273  

## Additional notes

I took the opportunity to review the design of the code that lists all the available cores that was depending on the `rpc` package for no reason. Also the api of the old `PlatformList` required a `context` that was never used.

Other minor improvements are commented inline.