### PR TITLE
Assert output is empty

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -33,11 +33,14 @@ def test_command_help():
 
 
 def test_command_lib_list():
+    """
+    When ouput is empty, nothing is printed out, no matter the output format
+    """
     result = run_command('lib list')
     assert result.ok
     assert result.stderr == ''
     result = run_command('lib list', '--format json')
-    assert '{}' == result.stdout
+    assert '' == result.stdout
 
 
 def test_command_lib_install():

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -38,7 +38,7 @@ def test_command_lib_list():
     """
     result = run_command('lib list')
     assert result.ok
-    assert result.stderr == ''
+    assert '' == result.stderr
     result = run_command('lib list', '--format json')
     assert '' == result.stdout
 


### PR DESCRIPTION
Following up discussion at https://github.com/arduino/arduino-cli/issues/96 we ensure that when command has no output nothing will be printed out, even if the selected format was JSON (`docker` cli style).