### PR TITLE
Do not exit with an error if lib is not present

### DIFF
--- a/commands/lib/uninstall.go
+++ b/commands/lib/uninstall.go
@@ -28,15 +28,20 @@ import (
 // LibraryUninstall FIXMEDOC
 func LibraryUninstall(ctx context.Context, req *rpc.LibraryUninstallReq, taskCB commands.TaskProgressCB) error {
 	lm := commands.GetLibraryManager(req)
-
-	lib, err := findLibrary(lm, req)
+	ref, err := createLibIndexReference(lm, req)
 	if err != nil {
-		return fmt.Errorf("looking for library: %s", err)
+		return err
 	}
 
-	taskCB(&rpc.TaskProgress{Name: "Uninstalling " + lib.String()})
-	lm.Uninstall(lib)
-	taskCB(&rpc.TaskProgress{Completed: true})
+	lib := lm.FindByReference(ref)
+
+	if lib == nil {
+		taskCB(&rpc.TaskProgress{Message: fmt.Sprintf("Library %s is not installed", req.Name), Completed: true})
+	} else {
+		taskCB(&rpc.TaskProgress{Name: "Uninstalling " + lib.String()})
+		lm.Uninstall(lib)
+		taskCB(&rpc.TaskProgress{Completed: true})
+	}
 
 	return nil
 }

--- a/commands/lib/utils.go
+++ b/commands/lib/utils.go
@@ -20,7 +20,6 @@ package lib
 import (
 	"fmt"
 
-	"github.com/arduino/arduino-cli/arduino/libraries"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesindex"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesmanager"
 	"github.com/arduino/arduino-cli/commands"
@@ -48,18 +47,6 @@ func findLibraryIndexRelease(lm *librariesmanager.LibrariesManager, req libraryR
 	lib := lm.Index.FindRelease(ref)
 	if lib == nil {
 		return nil, fmt.Errorf("library %s not found", ref)
-	}
-	return lib, nil
-}
-
-func findLibrary(lm *librariesmanager.LibrariesManager, req libraryReferencer) (*libraries.Library, error) {
-	ref, err := createLibIndexReference(lm, req)
-	if err != nil {
-		return nil, err
-	}
-	lib := lm.FindByReference(ref)
-	if lib == nil {
-		return nil, fmt.Errorf("library %s is not installed", ref)
 	}
 	return lib, nil
 }


### PR DESCRIPTION
Cli doesn't fail anymore if a library scheduled for removal is not actually installed.