### PR TITLE
Remove build date from the version

### DIFF
--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -55,8 +55,8 @@ func runDaemonCommand(cmd *cobra.Command, args []string) {
 	}
 	s := grpc.NewServer()
 
-	userAgentValue := fmt.Sprintf("%s/%s daemon (%s; %s; %s) Commit:%s/Build:%s", globals.VersionInfo.Application,
-		globals.VersionInfo.VersionString, runtime.GOARCH, runtime.GOOS, runtime.Version(), globals.VersionInfo.Commit, globals.VersionInfo.BuildDate)
+	userAgentValue := fmt.Sprintf("%s/%s daemon (%s; %s; %s) Commit:%s", globals.VersionInfo.Application,
+		globals.VersionInfo.VersionString, runtime.GOARCH, runtime.GOOS, runtime.Version(), globals.VersionInfo.Commit)
 	headers := http.Header{"User-Agent": []string{userAgentValue}}
 
 	coreServer := daemon.ArduinoCoreServerImpl{

--- a/cli/globals/globals.go
+++ b/cli/globals/globals.go
@@ -42,8 +42,8 @@ var (
 )
 
 func getHTTPClientHeader() http.Header {
-	userAgentValue := fmt.Sprintf("%s/%s (%s; %s; %s) Commit:%s/Build:%s", VersionInfo.Application,
-		VersionInfo.VersionString, runtime.GOARCH, runtime.GOOS, runtime.Version(), VersionInfo.Commit, VersionInfo.BuildDate)
+	userAgentValue := fmt.Sprintf("%s/%s (%s; %s; %s) Commit:%s", VersionInfo.Application,
+		VersionInfo.VersionString, runtime.GOARCH, runtime.GOOS, runtime.Version(), VersionInfo.Commit)
 	downloaderHeaders := http.Header{"User-Agent": []string{userAgentValue}}
 	return downloaderHeaders
 }

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -106,4 +106,3 @@ def test_command_version():
     assert parsed_out.get('Application', False) == 'arduino-cli'
     assert isinstance(semver.parse(parsed_out.get('VersionString', False)), dict)
     assert isinstance(parsed_out.get('Commit', False), str)
-    assert datetime.strptime(parsed_out.get('BuildDate')[:-2], '%Y-%m-%dT%H:%M:%S.%f')

--- a/version/version.go
+++ b/version/version.go
@@ -19,34 +19,19 @@ package version
 
 import (
 	"fmt"
-	"time"
 )
 
 var (
 	defaultVersionString = "0.3.7-alpha.preview"
 	versionString        = ""
 	commit               = ""
-	buildDate            = rfc3339Time{}
 )
-
-type rfc3339Time struct {
-	time.Time
-}
-
-func (r rfc3339Time) format() string {
-	return r.Time.Format(time.RFC3339)
-}
-
-func (r rfc3339Time) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + r.format() + `"`), nil
-}
 
 // Info FIXMEDOC
 type Info struct {
-	Application   string      `json:"Application"`
-	VersionString string      `json:"VersionString"`
-	Commit        string      `json:"Commit"`
-	BuildDate     rfc3339Time `json:"BuildDate"`
+	Application   string `json:"Application"`
+	VersionString string `json:"VersionString"`
+	Commit        string `json:"Commit"`
 }
 
 // NewInfo FIXMEDOC
@@ -55,12 +40,11 @@ func NewInfo(application string) *Info {
 		Application:   application,
 		VersionString: versionString,
 		Commit:        commit,
-		BuildDate:     buildDate,
 	}
 }
 
 func (i *Info) String() string {
-	return fmt.Sprintf("%s Version: %s Commit: %s BuildDate: %s", i.Application, i.VersionString, i.Commit, i.BuildDate.format())
+	return fmt.Sprintf("%s Version: %s Commit: %s", i.Application, i.VersionString, i.Commit)
 }
 
 //nolint:gochecknoinits
@@ -68,5 +52,4 @@ func init() {
 	if versionString == "" {
 		versionString = defaultVersionString
 	}
-	buildDate = rfc3339Time{time.Now().UTC()}
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -19,7 +19,6 @@ package version
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -35,12 +34,9 @@ func TestBuildInjectedInfo(t *testing.T) {
 		Application:   goldenAppName,
 		VersionString: "0.0.0-test.preview",
 		Commit:        "deadbeef",
-		BuildDate:     rfc3339Time{time.Time{}},
 	}
 	info := NewInfo(goldenAppName)
 	require.Equal(t, goldenInfo.Application, info.Application)
 	require.Equal(t, goldenInfo.VersionString, info.VersionString)
 	require.Equal(t, goldenInfo.Commit, info.Commit)
-	require.IsType(t, rfc3339Time{time.Time{}}, info.BuildDate)
-	require.False(t, info.BuildDate.IsZero())
 }


### PR DESCRIPTION
This proved to be problematic when playing with repeatable builds and the value added is very little.