### PR TITLE
ctags arm64 osx64 support

### DIFF
--- a/commands/bundled_tools_ctags.go
+++ b/commands/bundled_tools_ctags.go
@@ -64,8 +64,8 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 			Resource: &resources.DownloadResource{
 				ArchiveFileName: "ctags-5.8-arduino11-pm-x86_64-apple-darwin.zip",
 				URL:             "https://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-x86_64-apple-darwin.zip",
-				Size:            107801,
-				Checksum:        "SHA-256:e8c5db45867fb5987ad0fc429d8bbbcf5549f4b7c2b5ade863e76ac77255144d",
+				Size:            118296,
+				Checksum:        "SHA-256:bf74807260ddf0e1fc94d67e9cd8a41b7c0a2f0bee03e254e6975139b37ef250",
 				CachePath:       "tools",
 			},
 		},

--- a/commands/bundled_tools_ctags.go
+++ b/commands/bundled_tools_ctags.go
@@ -79,6 +79,16 @@ func loadBuiltinCtagsMetadata(pm *packagemanager.PackageManager) {
 				CachePath:       "tools",
 			},
 		},
+		{
+			OS: "aarch64-linux-gnu",
+			Resource: &resources.DownloadResource{
+				ArchiveFileName: "ctags-5.8-arduino11-pm-aarch64-linux-gnu.tar.bz2",
+				URL:             "https://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-aarch64-linux-gnu.tar.bz2",
+				Size:            100819,
+				Checksum:        "SHA-256:89b6f8adb7b7124ebe2eb30970ea77c754cd2239e0d8a6b0102ae2a36416c6ef",
+				CachePath:       "tools",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
This PR updates the ctags metadata for the following platforms:
- `aarch64-linux` (arm 64 bit)
- `x86_64-apple` (macOS 64 bit)
In order to force the arduino-cli to download the correct version of the Arduino ctags binary tool (https://github.com/arduino/ctags) for each platform

***regarding the arm 64 bit platforms***
The PR completes the arm64 support effort started in https://github.com/arduino/arduino-cli/pull/204, solving the following error that happened when using the cli built and executed on an arm64 board (i.e. NVIDIA Jetson) 

```
downloading builtin:ctags@5.8-arduino11 tool: tool not available for your OS
```

This PR also solves https://github.com/arduino/arduino-cli/issues/292 together with Arduino CI pipeline configuration to enable the arm64 build.

***regarding the macOS 64 bit platforms***
This PR updates also the metadata for the macOS platform in order to download a ctag binary that complies with the 64bit transition for this OS, and stopping the "optimization" popup warning during the arduino-cli utilization on macOS High Sierra 10.13.4 and later. 
![image](https://user-images.githubusercontent.com/35916119/61731881-b2461c80-ad7c-11e9-8322-7370d3707696.png)
