### PR TITLE
updated README.md download links with linuxarm32 and linuxarm64 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ the latest preview version is `0.3.7-alpha.preview`:
 
 - [Linux 64 bit](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-linux64.tar.bz2)
 - [Linux 32 bit](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-linux32.tar.bz2)
-- [Linux ARM](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-linuxarm.tar.bz2)
+- [Linux ARM 64 bit](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-linuxarm32.tar.bz2)
+- [Linux ARM 32 bit](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-linuxarm64.tar.bz2)
 - [Windows](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-windows.zip)
 - [Mac OSX](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-macosx.zip)
 
@@ -33,7 +34,8 @@ These builds are generated once a day from `master` branch starting at 23:00 UTC
 
 - [Linux 64 bit](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli-nightly-latest-linux64.tar.bz2)
 - [Linux 32 bit](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli-nightly-latest-linux32.tar.bz2)
-- [Linux ARM](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli-nightly-latest-linuxarm.tar.bz2)
+- [Linux ARM 64 bit](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli-nightly-latest-linuxarm32.tar.bz2)
+- [Linux ARM 32 bit](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli-nightly-latest-linuxarm64.tar.bz2)
 - [Windows](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli-nightly-latest-windows.zip)
 - [Mac OSX](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli-nightly-latest-macosx.zip)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the latest preview version is `0.3.7-alpha.preview`:
 - [Windows](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-windows.zip)
 - [Mac OSX](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-macosx.zip)
 
-Once downloaded, place the executable into a directory which is in your `PATH` environment variable. To use the tool as it is presented in the Getting started guide below (`arduino-cli`), you should rename the executable from _arduino-cli-X.Y.Z-alpha.preview-XYZ_ to _arduino-cli_.
+Once downloaded, place the executable `arduino-cli` into a directory which is in your `PATH` environment variable.
 
 #### Download the nightly build
 
@@ -39,7 +39,7 @@ These builds are generated once a day from `master` branch starting at 23:00 UTC
 - [Windows](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli-nightly-latest-windows.zip)
 - [Mac OSX](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli-nightly-latest-macosx.zip)
 
-Once downloaded, place the executable into a directory which is in your `PATH` environment variable. Launch the tool as it is presented in the Getting started guide below (`arduino-cli`).
+Once downloaded, place the executable `arduino-cli` into a directory which is in your `PATH` environment variable.
 
 ### Build the latest "bleeding-edge" from source
 


### PR DESCRIPTION
This PR follows https://github.com/arduino/arduino-cli/pull/304

Readme links updated to include `linuxarm64` binaries links and renaming `linuxarm` to `linuxarm32` to have a clear distinction between the two architectures

Updated also instructions as the binaries in the archive are, from now on, always named `arduino-cli`