### PR TITLE
Skip tests we cannot run on Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,6 @@ steps:
 
 - name: integration
   image: arduino/arduino-cli:drone-1.0
-  failure: ignore  # work in progress, we know some tests will fail at the moment
   commands:
     - pip install -r test/requirements.txt
     - task test-integration

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -7,7 +7,8 @@ from datetime import datetime
 
 
 def running_on_ci():
-    return os.getenv('APPVEYOR') or os.getenv('DRONE')
+    val = os.getenv('APPVEYOR') or os.getenv('DRONE')
+    return val is not None
 
 
 def test_command_help(run_command):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -6,6 +6,10 @@ import semver
 from datetime import datetime
 
 
+def running_on_ci():
+    return os.getenv('APPVEYOR') or os.getenv('DRONE')
+
+
 def test_command_help(run_command):
     result = run_command('help')
     assert result.ok
@@ -62,7 +66,7 @@ def test_command_lib_search(run_command):
     assert number_of_libs == number_of_libs_from_json
 
 
-@pytest.mark.skipif(os.getenv('APPVEYOR'), reason="Appveyor VMs have no serial ports")
+@pytest.mark.skipif(running_on_ci(), reason="VMs have no serial ports")
 def test_command_board_list(run_command):
     result = run_command('core update-index')
     assert result.ok
@@ -76,7 +80,7 @@ def test_command_board_list(run_command):
         assert 'protocol_label' in port
 
 
-@pytest.mark.skipif(os.getenv('APPVEYOR'), reason="Appveyor VMs have no serial ports")
+@pytest.mark.skipif(running_on_ci(), reason="VMs have no serial ports")
 def test_command_board_listall(run_command):
     result = run_command('board listall')
     assert result.ok


### PR DESCRIPTION
Integration tests were allowed to fail until now, this PR makes them mandatory by skipping tests requiring a serial port (like `board list`) since VMs on drone.io have no serial ports attached.