### PR TITLE
Use same default data dir as the IDE on OSX

### DIFF
--- a/commands/.test-config.yml
+++ b/commands/.test-config.yml
@@ -1,3 +1,0 @@
-proxy_type: auto
-sketchbook_path: /home/bcmi/Arduino
-arduino_data: /home/bcmi/.arduino15

--- a/configs/directories.go
+++ b/configs/directories.go
@@ -44,7 +44,7 @@ func getDefaultArduinoDataDir() (*paths.Path, error) {
 	case "linux":
 		return paths.New(userHomeDir).Join(".arduino15"), nil
 	case "darwin":
-		return paths.New(userHomeDir).Join("Library", "arduino15"), nil
+		return paths.New(userHomeDir).Join("Library", "Arduino15"), nil
 	case "windows":
 		localAppDataPath, err := win32.GetLocalAppDataFolder()
 		if err != nil {


### PR DESCRIPTION
Fixes #290.
Also removed an hidden, unused file I've found while searching for references to the default dir.