### PR TITLE
Goreleaser S3 upload support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -61,6 +61,11 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
+    AWS_ACCESS_KEY_ID:
+      from_secret: downloads_drone_io_aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: downloads_drone_io_aws_secret_access_key
+    AWS_DEFAULT_REGION: 'us-east-1'
   commands:
     - goreleaser
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -92,3 +92,11 @@ archives:
     files:
       - README.md
       - LICENSE.txt
+
+blob:
+  -
+    provider: s3
+    bucket: arduino-downloads-prod-beagle
+    ids:
+      - arduino_cli
+    folder: "{{ .ProjectName }}"


### PR DESCRIPTION
This PR adds s3 upload support in .goreleaser.yml via `blob` configuration.

`arduino-downloads-prod-beagle` is the Arduino artifact repository bucket that is configured to allow public download

Used `blob` configuration instead of deprecated` s3` one. 
This requires adding a AWS_DEFAULT_REGION env var to the drone step (together with
the IAM credentials), because this property is missing in the blob config

TODO:

- [x] create drone.io secret `downloads_drone_io_aws_access_key_id` and `downloads_drone_io_aws_secret_access_key`