### PR TITLE
Update single libraries

### DIFF
--- a/cli/instance/instance.go
+++ b/cli/instance/instance.go
@@ -45,7 +45,7 @@ func initInstance() *rpc.InitResp {
 	if resp.GetLibrariesIndexError() != "" {
 		commands.UpdateLibrariesIndex(context.Background(),
 			&rpc.UpdateLibrariesIndexReq{Instance: resp.GetInstance()}, output.ProgressBar())
-		rescResp, err := commands.Rescan(context.Background(), &rpc.RescanReq{Instance: resp.GetInstance()})
+		rescResp, err := commands.Rescan(resp.GetInstance().GetId())
 		if rescResp.GetLibrariesIndexError() != "" {
 			formatter.PrintErrorMessage("Error loading library index: " + rescResp.GetLibrariesIndexError())
 			os.Exit(errorcodes.ErrGeneric)

--- a/cli/lib/upgrade.go
+++ b/cli/lib/upgrade.go
@@ -34,11 +34,14 @@ func initUpgradeCommand() *cobra.Command {
 	listCommand := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrades installed libraries.",
-		Long: "This command ungrades all installed libraries to the latest available version." +
-			"To upgrade a single library use the 'install' command.",
-		Example: "  " + os.Args[0] + " lib upgrade",
-		Args:    cobra.ArbitraryArgs,
-		Run:     runUpgradeCommand,
+		Long: "This command upgrades an installed library to the latest available version. " +
+			"If no arguments are provided, the command will upgrade all the installed libraries " +
+			"where an update is available.",
+		Example: "  " + os.Args[0] + " lib upgrade \n" +
+			"  " + os.Args[0] + " lib upgrade Audio\n" +
+			"  " + os.Args[0] + " lib upgrade Audio ArduinoJson",
+		Args: cobra.ArbitraryArgs,
+		Run:  runUpgradeCommand,
 	}
 	return listCommand
 }

--- a/cli/lib/upgrade.go
+++ b/cli/lib/upgrade.go
@@ -26,10 +26,8 @@ import (
 	"github.com/arduino/arduino-cli/cli/output"
 	"github.com/arduino/arduino-cli/commands/lib"
 	"github.com/arduino/arduino-cli/common/formatter"
-	rpc "github.com/arduino/arduino-cli/rpc/commands"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 func initUpgradeCommand() *cobra.Command {
@@ -39,7 +37,7 @@ func initUpgradeCommand() *cobra.Command {
 		Long: "This command ungrades all installed libraries to the latest available version." +
 			"To upgrade a single library use the 'install' command.",
 		Example: "  " + os.Args[0] + " lib upgrade",
-		Args:    cobra.NoArgs,
+		Args:    cobra.ArbitraryArgs,
 		Run:     runUpgradeCommand,
 	}
 	return listCommand
@@ -49,9 +47,13 @@ func runUpgradeCommand(cmd *cobra.Command, args []string) {
 	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
 
 	if len(args) == 0 {
-		err := lib.LibraryUpgradeAll(context.Background(), &rpc.LibraryUpgradeAllReq{
-			Instance: instance,
-		}, output.ProgressBar(), output.TaskProgress(), globals.HTTPClientHeader)
+		err := lib.LibraryUpgradeAll(instance.Id, output.ProgressBar(), output.TaskProgress(), globals.HTTPClientHeader)
+		if err != nil {
+			formatter.PrintError(err, "Error upgrading libraries")
+			os.Exit(errorcodes.ErrGeneric)
+		}
+	} else {
+		err := lib.LibraryUpgrade(instance.Id, args, output.ProgressBar(), output.TaskProgress(), globals.HTTPClientHeader)
 		if err != nil {
 			formatter.PrintError(err, "Error upgrading libraries")
 			os.Exit(errorcodes.ErrGeneric)

--- a/cli/lib/upgrade.go
+++ b/cli/lib/upgrade.go
@@ -48,12 +48,14 @@ func initUpgradeCommand() *cobra.Command {
 func runUpgradeCommand(cmd *cobra.Command, args []string) {
 	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
 
-	err := lib.LibraryUpgradeAll(context.Background(), &rpc.LibraryUpgradeAllReq{
-		Instance: instance,
-	}, output.ProgressBar(), output.TaskProgress(), globals.HTTPClientHeader)
-	if err != nil {
-		formatter.PrintError(err, "Error upgrading libraries")
-		os.Exit(errorcodes.ErrGeneric)
+	if len(args) == 0 {
+		err := lib.LibraryUpgradeAll(context.Background(), &rpc.LibraryUpgradeAllReq{
+			Instance: instance,
+		}, output.ProgressBar(), output.TaskProgress(), globals.HTTPClientHeader)
+		if err != nil {
+			formatter.PrintError(err, "Error upgrading libraries")
+			os.Exit(errorcodes.ErrGeneric)
+		}
 	}
 
 	logrus.Info("Done")

--- a/cli/lib/upgrade.go
+++ b/cli/lib/upgrade.go
@@ -35,8 +35,8 @@ func initUpgradeCommand() *cobra.Command {
 		Use:   "upgrade",
 		Short: "Upgrades installed libraries.",
 		Long: "This command upgrades an installed library to the latest available version. " +
-			"If no arguments are provided, the command will upgrade all the installed libraries " +
-			"where an update is available.",
+			"Multiple libraries can be passed separated by a space. If no arguments are provided, " +
+			"the command will upgrade all the installed libraries where an update is available.",
 		Example: "  " + os.Args[0] + " lib upgrade \n" +
 			"  " + os.Args[0] + " lib upgrade Audio\n" +
 			"  " + os.Args[0] + " lib upgrade Audio ArduinoJson",

--- a/commands/core/install.go
+++ b/commands/core/install.go
@@ -57,7 +57,7 @@ func PlatformInstall(ctx context.Context, req *rpc.PlatformInstallReq,
 		return nil, err
 	}
 
-	_, err = commands.Rescan(ctx, &rpc.RescanReq{Instance: req.Instance})
+	_, err = commands.Rescan(req.GetInstance().GetId())
 	if err != nil {
 		return nil, err
 	}

--- a/commands/core/uninstall.go
+++ b/commands/core/uninstall.go
@@ -69,7 +69,7 @@ func PlatformUninstall(ctx context.Context, req *rpc.PlatformUninstallReq, taskC
 		}
 	}
 
-	_, err = commands.Rescan(ctx, &rpc.RescanReq{Instance: req.Instance})
+	_, err = commands.Rescan(req.GetInstance().GetId())
 	if err != nil {
 		return nil, err
 	}

--- a/commands/core/upgrade.go
+++ b/commands/core/upgrade.go
@@ -52,7 +52,7 @@ func PlatformUpgrade(ctx context.Context, req *rpc.PlatformUpgradeReq,
 		return nil, err
 	}
 
-	if _, err := commands.Rescan(ctx, &rpc.RescanReq{Instance: req.Instance}); err != nil {
+	if _, err := commands.Rescan(req.GetInstance().GetId()); err != nil {
 		return nil, err
 	}
 

--- a/commands/daemon/daemon.go
+++ b/commands/daemon/daemon.go
@@ -76,7 +76,7 @@ func (s *ArduinoCoreServerImpl) Destroy(ctx context.Context, req *rpc.DestroyReq
 
 // Rescan FIXMEDOC
 func (s *ArduinoCoreServerImpl) Rescan(ctx context.Context, req *rpc.RescanReq) (*rpc.RescanResp, error) {
-	return commands.Rescan(ctx, req)
+	return commands.Rescan(req.GetInstance().GetId())
 }
 
 // UpdateIndex FIXMEDOC
@@ -277,7 +277,7 @@ func (s *ArduinoCoreServerImpl) LibraryUninstall(req *rpc.LibraryUninstallReq, s
 
 // LibraryUpgradeAll FIXMEDOC
 func (s *ArduinoCoreServerImpl) LibraryUpgradeAll(req *rpc.LibraryUpgradeAllReq, stream rpc.ArduinoCore_LibraryUpgradeAllServer) error {
-	err := lib.LibraryUpgradeAll(stream.Context(), req,
+	err := lib.LibraryUpgradeAll(req.GetInstance().GetId(),
 		func(p *rpc.DownloadProgress) { stream.Send(&rpc.LibraryUpgradeAllResp{Progress: p}) },
 		func(p *rpc.TaskProgress) { stream.Send(&rpc.LibraryUpgradeAllResp{TaskProgress: p}) },
 		s.DownloaderHeaders,

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -243,7 +243,7 @@ func UpdateLibrariesIndex(ctx context.Context, req *rpc.UpdateLibrariesIndexReq,
 	if d.Error() != nil {
 		return d.Error()
 	}
-	if _, err := Rescan(ctx, &rpc.RescanReq{Instance: req.Instance}); err != nil {
+	if _, err := Rescan(req.GetInstance().GetId()); err != nil {
 		return fmt.Errorf("rescanning filesystem: %s", err)
 	}
 	return nil
@@ -293,21 +293,20 @@ func UpdateIndex(ctx context.Context, req *rpc.UpdateIndexReq, downloadCB Downlo
 			return nil, fmt.Errorf("saving downloaded index %s: %s", URL, err)
 		}
 	}
-	if _, err := Rescan(ctx, &rpc.RescanReq{Instance: req.Instance}); err != nil {
+	if _, err := Rescan(id); err != nil {
 		return nil, fmt.Errorf("rescanning filesystem: %s", err)
 	}
 	return &rpc.UpdateIndexResp{}, nil
 }
 
-// Rescan FIXMEDOC
-func Rescan(ctx context.Context, req *rpc.RescanReq) (*rpc.RescanResp, error) {
-	id := req.GetInstance().GetId()
-	coreInstance, ok := instances[id]
+// Rescan restart discoveries for the given instance
+func Rescan(instanceID int32) (*rpc.RescanResp, error) {
+	coreInstance, ok := instances[instanceID]
 	if !ok {
 		return nil, fmt.Errorf("invalid handle")
 	}
 
-	pm, lm, reqPltIndex, reqLibIndex, err := createInstance(ctx, coreInstance.config, coreInstance.getLibOnly)
+	pm, lm, reqPltIndex, reqLibIndex, err := createInstance(context.Background(), coreInstance.config, coreInstance.getLibOnly)
 	if err != nil {
 		return nil, fmt.Errorf("rescanning filesystem: %s", err)
 	}

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -75,9 +75,9 @@ func GetPackageManager(req InstanceContainer) *packagemanager.PackageManager {
 	return i.PackageManager
 }
 
-// GetLibraryManager FIXMEDOC
-func GetLibraryManager(req InstanceContainer) *librariesmanager.LibrariesManager {
-	i, ok := instances[req.GetInstance().GetId()]
+// GetLibraryManager returns the library manager for the given instance ID
+func GetLibraryManager(instanceID int32) *librariesmanager.LibrariesManager {
+	i, ok := instances[instanceID]
 	if !ok {
 		return nil
 	}
@@ -231,7 +231,7 @@ func Destroy(ctx context.Context, req *rpc.DestroyReq) (*rpc.DestroyResp, error)
 // UpdateLibrariesIndex updates the library_index.json
 func UpdateLibrariesIndex(ctx context.Context, req *rpc.UpdateLibrariesIndexReq, downloadCB func(*rpc.DownloadProgress)) error {
 	logrus.Info("Updating libraries index")
-	lm := GetLibraryManager(req)
+	lm := GetLibraryManager(req.GetInstance().GetId())
 	if lm == nil {
 		return fmt.Errorf("invalid handle")
 	}

--- a/commands/lib/download.go
+++ b/commands/lib/download.go
@@ -34,7 +34,7 @@ func LibraryDownload(ctx context.Context, req *rpc.LibraryDownloadReq, downloadC
 	downloaderHeaders http.Header) (*rpc.LibraryDownloadResp, error) {
 	logrus.Info("Executing `arduino lib download`")
 
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance().GetId())
 
 	logrus.Info("Preparing download")
 

--- a/commands/lib/install.go
+++ b/commands/lib/install.go
@@ -33,7 +33,7 @@ import (
 func LibraryInstall(ctx context.Context, req *rpc.LibraryInstallReq,
 	downloadCB commands.DownloadProgressCB, taskCB commands.TaskProgressCB, downloaderHeaders http.Header) error {
 
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance().GetId())
 
 	libRelease, err := findLibraryIndexRelease(lm, req)
 	if err != nil {

--- a/commands/lib/install.go
+++ b/commands/lib/install.go
@@ -48,7 +48,7 @@ func LibraryInstall(ctx context.Context, req *rpc.LibraryInstallReq,
 		return err
 	}
 
-	if _, err := commands.Rescan(ctx, &rpc.RescanReq{Instance: req.Instance}); err != nil {
+	if _, err := commands.Rescan(req.GetInstance().GetId()); err != nil {
 		return fmt.Errorf("rescanning libraries: %s", err)
 	}
 	return nil

--- a/commands/lib/list.go
+++ b/commands/lib/list.go
@@ -34,7 +34,7 @@ type installedLib struct {
 
 // LibraryList FIXMEDOC
 func LibraryList(ctx context.Context, req *rpc.LibraryListReq) (*rpc.LibraryListResp, error) {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance().GetId())
 
 	instaledLib := []*rpc.InstalledLibrary{}
 	res := listLibraries(lm, req.GetUpdatable(), req.GetAll())

--- a/commands/lib/list.go
+++ b/commands/lib/list.go
@@ -64,12 +64,9 @@ func listLibraries(lm *librariesmanager.LibrariesManager, updatable bool, all bo
 					continue
 				}
 			}
-			var available *librariesindex.Release
-			if updatable {
-				available = lm.Index.FindLibraryUpdate(lib)
-				if available == nil {
-					continue
-				}
+			available := lm.Index.FindLibraryUpdate(lib)
+			if updatable && available == nil {
+				continue
 			}
 			res = append(res, &installedLib{
 				Library:   lib,

--- a/commands/lib/search.go
+++ b/commands/lib/search.go
@@ -29,7 +29,7 @@ import (
 
 // LibrarySearch FIXMEDOC
 func LibrarySearch(ctx context.Context, req *rpc.LibrarySearchReq) (*rpc.LibrarySearchResp, error) {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance().GetId())
 	if lm == nil {
 		return nil, errors.New("invalid instance")
 	}

--- a/commands/lib/uninstall.go
+++ b/commands/lib/uninstall.go
@@ -27,7 +27,7 @@ import (
 
 // LibraryUninstall FIXMEDOC
 func LibraryUninstall(ctx context.Context, req *rpc.LibraryUninstallReq, taskCB commands.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance().GetId())
 	ref, err := createLibIndexReference(lm, req)
 	if err != nil {
 		return err

--- a/commands/lib/upgrade.go
+++ b/commands/lib/upgrade.go
@@ -29,7 +29,7 @@ import (
 // LibraryUpgradeAll FIXMEDOC
 func LibraryUpgradeAll(ctx context.Context, req *rpc.LibraryUpgradeAllReq, downloadCB commands.DownloadProgressCB,
 	taskCB commands.TaskProgressCB, downloaderHeaders http.Header) error {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance().GetId())
 
 	// Obtain the list of upgradable libraries
 	list := listLibraries(lm, true, true)

--- a/commands/lib/upgrade.go
+++ b/commands/lib/upgrade.go
@@ -18,33 +18,78 @@
 package lib
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
+	"github.com/arduino/arduino-cli/arduino/libraries/librariesmanager"
 	"github.com/arduino/arduino-cli/commands"
-	rpc "github.com/arduino/arduino-cli/rpc/commands"
 )
 
-// LibraryUpgradeAll FIXMEDOC
-func LibraryUpgradeAll(ctx context.Context, req *rpc.LibraryUpgradeAllReq, downloadCB commands.DownloadProgressCB,
+// LibraryUpgradeAll upgrades all the available libraries
+func LibraryUpgradeAll(instanceID int32, downloadCB commands.DownloadProgressCB,
+	taskCB commands.TaskProgressCB, headers http.Header) error {
+	// get the library manager
+	lm := commands.GetLibraryManager(instanceID)
+
+	if err := upgrade(lm, listLibraries(lm, true, true), downloadCB, taskCB, headers); err != nil {
+		return err
+	}
+
+	if _, err := commands.Rescan(instanceID); err != nil {
+		return fmt.Errorf("rescanning libraries: %s", err)
+	}
+
+	return nil
+}
+
+// LibraryUpgrade upgrades only the given libraries
+func LibraryUpgrade(instanceID int32, libraryNames []string, downloadCB commands.DownloadProgressCB,
+	taskCB commands.TaskProgressCB, headers http.Header) error {
+	// get the library manager
+	lm := commands.GetLibraryManager(instanceID)
+
+	// get the libs to upgrade
+	libs := filterByName(listLibraries(lm, true, true), libraryNames)
+
+	// do it
+	return upgrade(lm, libs, downloadCB, taskCB, headers)
+}
+
+func upgrade(lm *librariesmanager.LibrariesManager, libs []*installedLib, downloadCB commands.DownloadProgressCB,
 	taskCB commands.TaskProgressCB, downloaderHeaders http.Header) error {
-	lm := commands.GetLibraryManager(req.GetInstance().GetId())
 
-	// Obtain the list of upgradable libraries
-	list := listLibraries(lm, true, true)
+	// Go through the list and download them
 
-	for _, upgradeDesc := range list {
-		if err := downloadLibrary(lm, upgradeDesc.Available, downloadCB, taskCB, downloaderHeaders); err != nil {
+	for _, lib := range libs {
+		if err := downloadLibrary(lm, lib.Available, downloadCB, taskCB, downloaderHeaders); err != nil {
 			return err
 		}
 	}
-	for _, upgradeDesc := range list {
-		installLibrary(lm, upgradeDesc.Available, taskCB)
+
+	// Go through the list and install them
+	for _, lib := range libs {
+		if err := installLibrary(lm, lib.Available, taskCB); err != nil {
+			return err
+		}
 	}
 
-	if _, err := commands.Rescan(ctx, &rpc.RescanReq{Instance: req.Instance}); err != nil {
-		return fmt.Errorf("rescanning libraries: %s", err)
-	}
 	return nil
+}
+
+func filterByName(libs []*installedLib, names []string) []*installedLib {
+	// put the names in a map to ease lookup
+	queryMap := make(map[string]struct{})
+	for _, name := range names {
+		queryMap[name] = struct{}{}
+	}
+
+	ret := []*installedLib{}
+	for _, lib := range libs {
+		// skip if library name wasn't in the query
+		if _, found := queryMap[lib.Library.Name]; found {
+			ret = append(ret, lib)
+		}
+	}
+
+	return ret
 }


### PR DESCRIPTION
Adding the ability to upgrade single libs vs. just upgrading all or nothing. This will be now possible:
```
arduino-cli lib upgrade WiFiNINA
```

Also in this PR (sorry it got too large)
* fix a bug preventing to show the latest version in `arduino-cli lib list` (an integration test will be added separately to avoid regressions)
* changed the API to avoid passing around useless parameters
