### PR TITLE
Add install script and update install instructions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,7 @@ indent_size = 4
 [*.yml,*.tmpl]
 indent_style = space
 indent_size = 2
+
+[*.sh]
+indent_style = tab
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the current source tree.
 
 If you're familiar with Golang or if you want to contribute to the project, you will probably
 build the `arduino-cli` locally with your Go compiler. Please refer to the
-[contritubing](CONTRIBUTING.md) doc for setup instructions.
+[contributing](CONTRIBUTING.md) doc for setup instructions.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@
 `arduino-cli` is an all-in-one solution that provides builder, boards/library manager, uploader,
 discovery and many other tools needed to use any Arduino compatible board and platforms.
 
-This software is currently in alpha state: new features will be added and some may be changed.
-
-It will be soon used as a building block in the Arduino IDE and Arduino Create.
+This software is currently under active development: anything can change at any time, API and UI
+must be considered unstable.
 
 ## How to contribute
 
@@ -19,26 +18,27 @@ build the source code, run the tests, and contribute your changes to the project
 
 ## How to install
 
-### Download the latest stable release
+### Get the latest package
 
-This is **not yet available** until the first stable version is released.
+The easiest way to get the latest version of `arduino-cli` on any supported platform is using the
+`install.sh` script:
 
-#### Download the latest unstable "alpha" preview
+```console
+curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
+```
 
-Please note that these are **preview** builds, they may have bugs, some features may not work or may
-be changed without notice, the latest preview version is `0.3.7-alpha.preview`:
+The script will install `arduino-cli` at `$PWD/bin`, if you want to target a different directory,
+for example `~/local/bin`, set the `BINDIR` environment variable like this:
 
-- [Linux 64 bit](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-linux64.tar.bz2)
-- [Linux 32 bit](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-linux32.tar.bz2)
-- [Linux ARM 64 bit](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-linuxarm32.tar.bz2)
-- [Linux ARM 32 bit](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-linuxarm64.tar.bz2)
-- [Windows](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-windows.zip)
-- [Mac OSX](https://downloads.arduino.cc/arduino-cli/arduino-cli-latest-macosx.zip)
+```console
+curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=~/local/bin sh
+```
 
-Once downloaded, place the executable `arduino-cli` into a directory which is in your `PATH`
-environment variable.
+Alternatively you can download one of the pre-built binaries for the supported platforms from the
+[release page](https://github.com/arduino/arduino-cli/releases). Once downloaded, place the executable
+`arduino-cli` into a directory which is in your `PATH`.
 
-#### Download the nightly build
+### Download a nightly build
 
 These builds are generated once a day from `master` branch starting at 23:00 UTC
 
@@ -49,70 +49,85 @@ These builds are generated once a day from `master` branch starting at 23:00 UTC
 - [Windows](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli-nightly-latest-windows.zip)
 - [Mac OSX](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli-nightly-latest-macosx.zip)
 
-Once downloaded, place the executable `arduino-cli` into a directory which is in your `PATH`
-environment variable.
+Once downloaded, place the executable `arduino-cli` into a directory which is in your `PATH`.
 
-### Build the latest "bleeding-edge" from source
+### Build from source with Docker
 
-- You should have a recent Go compiler installed.
-- Run `go get -u github.com/arduino/arduino-cli`
-- The `arduino-cli` executable will be produced in `$GOPATH/bin/arduino-cli`
+If you don't have a working Golang environment or if you want to build `arduino-cli` targeting
+different platforms, you can use Docker to get a binary directly from sources. From the project
+folder run:
 
-You may want to copy the executable into a directory which is in your `PATH` environment variable
-(such as `/usr/local/bin/`).
+```console
+docker run -v $PWD:/arduino-cli -w /arduino-cli arduino/arduino-cli:builder-0.1 goreleaser --rm-dist --snapshot --skip-publish
+```
 
-## Usage
+Once the build is over, you will find a `./dist/` folder containing the packages built out of
+the current source tree.
+
+### Build from source
+
+If you're familiar with Golang or if you want to contribute to the project, you will probably
+build the `arduino-cli` locally with your Go compiler. Please refer to the
+[contritubing](CONTRIBUTING.md) doc for setup instructions.
+
+## Getting Started
 
 The goal of the Arduino CLI is to be used by either including it in Makefile or in any kind of
 script for the Command Line. The Arduino CLI aims to replace the majority of features the Arduino
 IDE has without the graphical UI.
 
-## Getting Started
-
 ### Step 1. Create a new sketch
 
 The command will create a new empty sketch named MyFirstSketch in the default directory under \$HOME/Arduino/
 
-    $ arduino-cli sketch new MyFirstSketch
-    Sketch created in: /home/luca/Arduino/MyFirstSketch
+```console
+$ arduino-cli sketch new MyFirstSketch
+Sketch created in: /home/luca/Arduino/MyFirstSketch
 
-    $ cat /home/luca/Arduino/MyFirstSketch/MyFirstSketch.ino
-    void setup() {
-    }
+$ cat /home/luca/Arduino/MyFirstSketch/MyFirstSketch.ino
+void setup() {
+}
 
-    void loop() {
-    }
+void loop() {
+}
+```
 
 ### Step 2. Modify your sketch
 
 Use your favourite file editor or IDE to modify the .ino file under: `$HOME/Arduino/MyFirstSketch/MyFirstSketch.ino`
 and change the file to look like this one:
 
-    void setup() {
-      pinMode(LED_BUILTIN, OUTPUT);
-    }
+```C
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT);
+}
 
-    void loop() {
-      digitalWrite(LED_BUILTIN, HIGH);
-      delay(1000);
-      digitalWrite(LED_BUILTIN, LOW);
-      delay(1000);
-    }
+void loop() {
+  digitalWrite(LED_BUILTIN, HIGH);
+  delay(1000);
+  digitalWrite(LED_BUILTIN, LOW);
+  delay(1000);
+}
+```
 
 ### Step 3. Connect the board to your PC
 
 If you are running a fresh install of the arduino-cli you probably need to update the platform
 indexes by running:
 
-    $ arduino-cli core update-index
-    Updating index: package_index.json downloaded
+```console
+$ arduino-cli core update-index
+Updating index: package_index.json downloaded
+```
 
 Now, just connect the board to your PCs by using the USB cable. In this example we will use the
 MKR1000 board:
 
-    $ arduino-cli board list
-    FQBN    Port            ID              Board Name
-            /dev/ttyACM0    2341:804E       unknown
+```console
+$ arduino-cli board list
+FQBN    Port            ID              Board Name
+        /dev/ttyACM0    2341:804E       unknown
+```
 
 the board has been discovered but we do not have the correct core to program it yet.
 Let's install it!
@@ -122,72 +137,84 @@ Let's install it!
 We have to look at the core available with the `core search` command. It will provide a list of
 available cores matching the name arduino:
 
-    $ arduino-cli core search arduino
-    Searching for platforms matching 'arduino'
+```console
+$ arduino-cli core search arduino
+Searching for platforms matching 'arduino'
 
-    ID              Version Installed       Name
-    Intel:arc32     2.0.2   No              Intel Curie Boards
-    arduino:avr     1.6.21  No              Arduino AVR Boards
-    arduino:nrf52   1.0.2   No              Arduino nRF52 Boards
-    arduino:sam     1.6.11  No              Arduino SAM Boards (32-bits ARM Cortex-M3)
-    arduino:samd    1.6.18  No              Arduino SAMD Boards (32-bits ARM Cortex-M0+)
-    arduino:stm32f4 1.0.1   No              Arduino STM32F4 Boards
-    littleBits:avr  1.0.0   No              littleBits Arduino AVR Modules
+ID              Version Installed       Name
+Intel:arc32     2.0.2   No              Intel Curie Boards
+arduino:avr     1.6.21  No              Arduino AVR Boards
+arduino:nrf52   1.0.2   No              Arduino nRF52 Boards
+arduino:sam     1.6.11  No              Arduino SAM Boards (32-bits ARM Cortex-M3)
+arduino:samd    1.6.18  No              Arduino SAMD Boards (32-bits ARM Cortex-M0+)
+arduino:stm32f4 1.0.1   No              Arduino STM32F4 Boards
+littleBits:avr  1.0.0   No              littleBits Arduino AVR Modules
+```
 
 If you're unsure you can try to refine the search with the board name
 
-    $ arduino-cli core search mkr1000
-    Searching for platforms matching 'mkr1000'
+```console
+$ arduino-cli core search mkr1000
+Searching for platforms matching 'mkr1000'
 
-    ID              Version Installed   Name
-    arduino:samd    1.6.19  No          Arduino SAMD Boards (32-bits ARM Cortex-M0+)
+ID              Version Installed   Name
+arduino:samd    1.6.19  No          Arduino SAMD Boards (32-bits ARM Cortex-M0+)
+```
 
 So, the right platform for the Arduino MKR1000 is arduino:samd, now we can install it
 
-    $ arduino-cli core install arduino:samd
-    Downloading tools...
-    arduino:arm-none-eabi-gcc@4.8.3-2014q1 downloaded
-    arduino:bossac@1.7.0 downloaded
-    arduino:openocd@0.9.0-arduino6-static downloaded
-    arduino:CMSIS@4.5.0 downloaded
-    arduino:CMSIS-Atmel@1.1.0 downloaded
-    arduino:arduinoOTA@1.2.0 downloaded
-    Downloading cores...
-    arduino:samd@1.6.19 downloaded
-    Installing tools...
-    Installing platforms...
-    Results:
-    arduino:samd@1.6.19 - Installed
-    arduino:arm-none-eabi-gcc@4.8.3-2014q1 - Installed
-    arduino:bossac@1.7.0 - Installed
-    arduino:openocd@0.9.0-arduino6-static - Installed
-    arduino:CMSIS@4.5.0 - Installed
-    arduino:CMSIS-Atmel@1.1.0 - Installed
-    arduino:arduinoOTA@1.2.0 - Installed
+```console
+$ arduino-cli core install arduino:samd
+Downloading tools...
+arduino:arm-none-eabi-gcc@4.8.3-2014q1 downloaded
+arduino:bossac@1.7.0 downloaded
+arduino:openocd@0.9.0-arduino6-static downloaded
+arduino:CMSIS@4.5.0 downloaded
+arduino:CMSIS-Atmel@1.1.0 downloaded
+arduino:arduinoOTA@1.2.0 downloaded
+Downloading cores...
+arduino:samd@1.6.19 downloaded
+Installing tools...
+Installing platforms...
+Results:
+arduino:samd@1.6.19 - Installed
+arduino:arm-none-eabi-gcc@4.8.3-2014q1 - Installed
+arduino:bossac@1.7.0 - Installed
+arduino:openocd@0.9.0-arduino6-static - Installed
+arduino:CMSIS@4.5.0 - Installed
+arduino:CMSIS-Atmel@1.1.0 - Installed
+arduino:arduinoOTA@1.2.0 - Installed
+```
 
 Now verify we have installed the core properly by running
 
-    $ arduino-cli core list
-    ID              Installed       Latest  Name
-    arduino:samd    1.6.19          1.6.19  Arduino SAMD Boards (32-bits ARM Cortex-M0+)
+```console
+$ arduino-cli core list
+ID              Installed       Latest  Name
+arduino:samd    1.6.19          1.6.19  Arduino SAMD Boards (32-bits ARM Cortex-M0+)
+```
 
 We can finally check if the board is now recognized as a MKR1000
 
-    $ arduino-cli board list
-    FQBN                    Port            ID              Board Name
-    arduino:samd:mkr1000    /dev/ttyACM0    2341:804E       Arduino/Genuino MKR1000
+```console
+$ arduino-cli board list
+FQBN                    Port            ID              Board Name
+arduino:samd:mkr1000    /dev/ttyACM0    2341:804E       Arduino/Genuino MKR1000
+```
 
 If the board is not detected for any reason, you can list all the supported boards
 with `arduino-cli board listall` and also search for a specific board:
 
-    $ arduino-cli board listall mkr
-    Board Name              FQBN
-    Arduino MKR FOX 1200    arduino:samd:mkrfox1200
-    Arduino MKR GSM 1400    arduino:samd:mkrgsm1400
-    Arduino MKR WAN 1300    arduino:samd:mkrwan1300
-    Arduino MKR WiFi 1010   arduino:samd:mkrwifi1010
-    Arduino MKRZERO         arduino:samd:mkrzero
-    Arduino/Genuino MKR1000 arduino:samd:mkr1000
+```console
+$ arduino-cli board listall mkr
+Board Name              FQBN
+Arduino MKR FOX 1200    arduino:samd:mkrfox1200
+Arduino MKR GSM 1400    arduino:samd:mkrgsm1400
+Arduino MKR WAN 1300    arduino:samd:mkrwan1300
+Arduino MKR WiFi 1010   arduino:samd:mkrwifi1010
+Arduino MKRZERO         arduino:samd:mkrzero
+Arduino/Genuino MKR1000 arduino:samd:mkr1000
+```
 
 Great! Now we have the Board FQBN (Fully Qualified Board Name) `arduino:samd:mkr1000`
 and the Board Name look good, we are ready to compile and upload the sketch
@@ -198,146 +225,178 @@ To add 3rd party core packages add a link of the additional package to the file 
 
 If you want to add the ESP8266 core, for example:
 
-    board_manager:
-      additional_urls:
-        - http://arduino.esp8266.com/stable/package_esp8266com_index.json
+```yaml
+board_manager:
+  additional_urls:
+    - http://arduino.esp8266.com/stable/package_esp8266com_index.json
+```
 
 And then run:
 
-    arduino-cli core update-index
-    arduino-cli core install esp8266:esp8266
+```console
+$ arduino-cli core update-index
+Updating index: package_index.json downloaded
+Updating index: package_esp8266com_index.json downloaded
+Updating index: package_index.json downloaded
+
+$ arduino-cli core search esp8266
+ID              Version Name
+esp8266:esp8266 2.5.2   esp8266
+```
+
+Alternatively, you can pass the `--additional-urls` to any command involving the additional cores:
+
+```console
+$ arduino-cli core update-index --additional-urls http://arduino.esp8266.com/stable/package_esp8266com_index.json
+$
+$ arduino-cli core search esp8266 --additional-urls http://arduino.esp8266.com/stable/package_esp8266com_index.json
+ID              Version Name
+esp8266:esp8266 2.5.2   esp8266
+```
 
 ### Step 5. Compile the sketch
 
 To compile the sketch we have to run the `compile` command with the proper FQBN we just got in the
 previous command.
 
-    $ arduino-cli compile --fqbn arduino:samd:mkr1000 Arduino/MyFirstSketch
-    Sketch uses 9600 bytes (3%) of program storage space. Maximum is 262144 bytes.
+```console
+$ arduino-cli compile --fqbn arduino:samd:mkr1000 Arduino/MyFirstSketch
+Sketch uses 9600 bytes (3%) of program storage space. Maximum is 262144 bytes.
+```
 
 ### Step 6. Upload your sketch
 
 We can finally upload the sketch and see our board blinking, we now have to specify the serial port
 used by our board other than the FQBN:
 
-    $ arduino-cli upload -p /dev/ttyACM0 --fqbn arduino:samd:mkr1000 Arduino/MyFirstSketch
-    No new serial port detected.
-    Atmel SMART device 0x10010005 found
-    Device       : ATSAMD21G18A
-    Chip ID      : 10010005
-    Version      : v2.0 [Arduino:XYZ] Dec 20 2016 15:36:43
-    Address      : 8192
-    Pages        : 3968
-    Page Size    : 64 bytes
-    Total Size   : 248KB
-    Planes       : 1
-    Lock Regions : 16
-    Locked       : none
-    Security     : false
-    Boot Flash   : true
-    BOD          : true
-    BOR          : true
-    Arduino      : FAST_CHIP_ERASE
-    Arduino      : FAST_MULTI_PAGE_WRITE
-    Arduino      : CAN_CHECKSUM_MEMORY_BUFFER
-    Erase flash
-    done in 0.784 seconds
+```console
+$ arduino-cli upload -p /dev/ttyACM0 --fqbn arduino:samd:mkr1000 Arduino/MyFirstSketch
+No new serial port detected.
+Atmel SMART device 0x10010005 found
+Device       : ATSAMD21G18A
+Chip ID      : 10010005
+Version      : v2.0 [Arduino:XYZ] Dec 20 2016 15:36:43
+Address      : 8192
+Pages        : 3968
+Page Size    : 64 bytes
+Total Size   : 248KB
+Planes       : 1
+Lock Regions : 16
+Locked       : none
+Security     : false
+Boot Flash   : true
+BOD          : true
+BOR          : true
+Arduino      : FAST_CHIP_ERASE
+Arduino      : FAST_MULTI_PAGE_WRITE
+Arduino      : CAN_CHECKSUM_MEMORY_BUFFER
+Erase flash
+done in 0.784 seconds
 
-    Write 9856 bytes to flash (154 pages)
-    [==============================] 100% (154/154 pages)
-    done in 0.069 seconds
+Write 9856 bytes to flash (154 pages)
+[==============================] 100% (154/154 pages)
+done in 0.069 seconds
 
-    Verify 9856 bytes of flash with checksum.
-    Verify successful
-    done in 0.009 seconds
-    CPU reset.
+Verify 9856 bytes of flash with checksum.
+Verify successful
+done in 0.009 seconds
+CPU reset.
+```
 
 ### Step 7. Add libraries
 
 Now we can try to add a useful library to our sketch. We can at first look at the name of a library,
 our favourite one is the wifi101, here the command to get more info:
 
-    $ arduino-cli lib search wifi101
-    Name: "WiFi101OTA"
-      Author:  Arduino
-      Maintainer:  Arduino <info@arduino.cc>
-      Sentence:  Update sketches to your board over WiFi
-      Paragraph:  Requires an SD card and SAMD board
-      Website:  http://www.arduino.cc/en/Reference/WiFi101OTA
-      Category:  Other
-      Architecture:  samd
-      Types:  Arduino
-      Versions:  [1.0.2, 1.0.0, 1.0.1]
-    Name: "WiFi101"
-      Author:  Arduino
-      Maintainer:  Arduino <info@arduino.cc>
-      Sentence:  Network driver for ATMEL WINC1500 module (used on Arduino/Genuino Wifi Shield 101 and MKR1000 boards)
-      Paragraph:  This library implements a network driver for devices based on the ATMEL WINC1500 wifi module
-      Website:  http://www.arduino.cc/en/Reference/WiFi101
-      Category:  Communication
-      Architecture:  *
-      Types:  Arduino
-      Versions:  [0.5.0, 0.6.0, 0.10.0, 0.11.0, 0.11.1, 0.11.2, 0.12.0, 0.15.2, 0.8.0, 0.9.0, 0.12.1, 0.14.1, 0.14.4, 0.14.5, 0.15.1, 0.7.0, 0.14.0, 0.14.2, 0.14.3, 0.9.1, 0.13.0, 0.15.0, 0.5.1]
+```console
+$ arduino-cli lib search wifi101
+Name: "WiFi101OTA"
+  Author:  Arduino
+  Maintainer:  Arduino <info@arduino.cc>
+  Sentence:  Update sketches to your board over WiFi
+  Paragraph:  Requires an SD card and SAMD board
+  Website:  http://www.arduino.cc/en/Reference/WiFi101OTA
+  Category:  Other
+  Architecture:  samd
+  Types:  Arduino
+  Versions:  [1.0.2, 1.0.0, 1.0.1]
+Name: "WiFi101"
+  Author:  Arduino
+  Maintainer:  Arduino <info@arduino.cc>
+  Sentence:  Network driver for ATMEL WINC1500 module (used on Arduino/Genuino Wifi Shield 101 and MKR1000 boards)
+  Paragraph:  This library implements a network driver for devices based on the ATMEL WINC1500 wifi module
+  Website:  http://www.arduino.cc/en/Reference/WiFi101
+  Category:  Communication
+  Architecture:  *
+  Types:  Arduino
+  Versions:  [0.5.0, 0.6.0, 0.10.0, 0.11.0, 0.11.1, 0.11.2, 0.12.0, 0.15.2, 0.8.0, 0.9.0, 0.12.1, 0.14.1, 0.14.4, 0.14.5, 0.15.1, 0.7.0, 0.14.0, 0.14.2, 0.14.3, 0.9.1, 0.13.0, 0.15.0, 0.5.1]
+```
 
 We are now ready to install it! Please be sure to use the full name of the lib as specified in the
 "Name:" section previously seen:
 
-    $ arduino-cli lib install "WiFi101"
-    Downloading libraries...
-    WiFi101@0.15.2 downloaded
-    Installed WiFi101@0.15.2
+```console
+$ arduino-cli lib install "WiFi101"
+Downloading libraries...
+WiFi101@0.15.2 downloaded
+Installed WiFi101@0.15.2
+```
 
 ## Inline Help
 
 `arduino-cli` is a container of commands, to see the full list just run:
 
-    $ arduino-cli
-    Arduino Command Line Interface (arduino-cli).
+```console
+$ arduino-cli
+Arduino Command Line Interface (arduino-cli).
 
-    Usage:
-      arduino-cli [command]
+Usage:
+  arduino-cli [command]
 
-    Examples:
-    arduino <command> [flags...]
+Examples:
+arduino <command> [flags...]
 
-    Available Commands:
-      board         Arduino board commands.
-      compile       Compiles Arduino sketches.
-      config        Arduino Configuration Commands.
-      core          Arduino Core operations.
-      help          Help about any command
-      lib           Arduino commands about libraries.
-      sketch        Arduino CLI Sketch Commands.
-      upload        Upload Arduino sketches.
-      version       Shows version number of Arduino CLI.
-    ....
+Available Commands:
+  board         Arduino board commands.
+  compile       Compiles Arduino sketches.
+  config        Arduino Configuration Commands.
+  core          Arduino Core operations.
+  help          Help about any command
+  lib           Arduino commands about libraries.
+  sketch        Arduino CLI Sketch Commands.
+  upload        Upload Arduino sketches.
+  version       Shows version number of Arduino CLI.
+  ....
+```
 
 Each command has his own specific help that can be obtained with the `help` command, for example:
 
-    $ arduino-cli help core
-    Arduino Core operations.
+```console
+$ arduino-cli help core
+Arduino Core operations.
 
-    Usage:
-      arduino-cli core [command]
+Usage:
+  arduino-cli core [command]
 
-    Examples:
-    arduino-cli core update-index # to update the package index file.
+Examples:
+arduino-cli core update-index # to update the package index file.
 
-    Available Commands:
-      download     Downloads one or more cores and corresponding tool dependencies.
-      install      Installs one or more cores and corresponding tool dependencies.
-      list         Shows the list of installed cores.
-      update-index Updates the index of cores.
+Available Commands:
+  download     Downloads one or more cores and corresponding tool dependencies.
+  install      Installs one or more cores and corresponding tool dependencies.
+  list         Shows the list of installed cores.
+  update-index Updates the index of cores.
 
-    Flags:
-      -h, --help   help for core
+Flags:
+  -h, --help   help for core
 
-    Global Flags:
-          --config-file string   The custom config file (if not specified the default one will be used).
-          --debug                Enables debug output (super verbose, used to debug the CLI).
-          --format string        The output format, can be [text|json]. (default "text")
+Global Flags:
+      --config-file string   The custom config file (if not specified the default one will be used).
+      --debug                Enables debug output (super verbose, used to debug the CLI).
+      --format string        The output format, can be [text|json]. (default "text")
 
-    Use "arduino-cli core [command] --help" for more information about a command.
+Use "arduino-cli core [command] --help" for more information about a command.
+```
 
 ## FAQ
 
@@ -364,8 +423,10 @@ specific USB2Serial chip, but we don't know which board is.
 
 Update the core index to have latest boards informations:
 
-    $ arduino-cli core update-index
-    Updating index: package_index.json downloaded
+```console
+$ arduino-cli core update-index
+Updating index: package_index.json downloaded
+```
 
 See: <https://github.com/arduino/arduino-cli#step-4-find-and-install-the-right-core>
 

--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,7 @@ downloadFile() {
 	httpStatusCode=$(getFile "$DOWNLOAD_URL" "$CLI_TMP_FILE")
 	if [ "$httpStatusCode" -ne 200 ]; then
 		echo "Did not find a release for your system: $OS $ARCH"
-		echo "Trying to find a release on the github api."
+		echo "Trying to find a release using the GitHub API."
 		LATEST_RELEASE_URL="https://api.github.com/repos/arduino/$PROJECT_NAME/releases/tags/$TAG"
 		echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
 		get LATEST_RELEASE_JSON $LATEST_RELEASE_URL

--- a/install.sh
+++ b/install.sh
@@ -82,7 +82,7 @@ get() {
 		httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
 	fi
 	if [ "$httpStatusCode" != 200 ]; then
-		echo "Request fail with http status code $httpStatusCode"
+		echo "Request failed with HTTP status code $httpStatusCode"
 		fail "Body: $body"
 	fi
 	eval "$1='$body'"

--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ initDownloadTool() {
 	elif type "wget" > /dev/null; then
 		DOWNLOAD_TOOL="wget"
 	else
-		fail "You need curl or wget as download tool. Please install it first before continue"
+		fail "You need curl or wget as download tool. Please install it first before continuing"
 	fi
 	echo "Using $DOWNLOAD_TOOL as download tool"
 }

--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ getFile() {
 
 downloadFile() {
 	get TAG_JSON https://api.github.com/repos/arduino/arduino-cli/releases/latest
-	TAG=$(echo $TAG_JSON | python -c 'import json,sys;obj=json.load(sys.stdin);sys.stdout.write(obj["tag_name"])')
+	TAG=$(echo $TAG_JSON | python -c 'import json,sys;obj=json.load(sys.stdin, strict=False);sys.stdout.write(obj["tag_name"])')
 	echo "TAG=$TAG"
 	#  arduino-cli_0.4.0-rc1_Linux_64bit.tar.gz
 	CLI_DIST="arduino-cli_${TAG}_${OS}_${ARCH}.tar.gz"

--- a/install.sh
+++ b/install.sh
@@ -142,7 +142,7 @@ installFile() {
 bye() {
 	result=$?
 	if [ "$result" != "0" ]; then
-		echo "Fail to install $PROJECT_NAME"
+		echo "Failed to install $PROJECT_NAME"
 	fi
 	exit $result
 }

--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ downloadFile() {
 	if [ "$httpStatusCode" -ne 200 ]; then
 		echo "Did not find a release for your system: $OS $ARCH"
 		echo "Trying to find a release on the github api."
-		LATEST_RELEASE_URL="https://api.github.com/repos/Masterminds/$PROJECT_NAME/releases/tags/$TAG"
+		LATEST_RELEASE_URL="https://api.github.com/repos/arduino/$PROJECT_NAME/releases/tags/$TAG"
 		echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
 		get LATEST_RELEASE_JSON $LATEST_RELEASE_URL
 		# || true forces this command to not catch error if grep does not find anything

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,176 @@
+#!/bin/sh
+
+# The original version of this script is licensed under the MIT license.
+# See https://github.com/Masterminds/glide/blob/master/LICENSE for more details
+# and copyright notice.
+
+PROJECT_NAME="arduino-cli"
+
+# BINDIR represents the local bin location, defaults to ./bin.
+LBINDIR=""
+DEFAULT_BINDIR="$PWD/bin"
+
+fail() {
+	echo "$1"
+	exit 1
+}
+
+initDestination() {
+	if [ -n "$BINDIR" ]; then
+		if [ ! -d "$BINDIR" ]; then
+			fail "$BINDIR "'($BINDIR)'" folder not found. Please create it before continue."
+		fi
+		LBINDIR="$BINDIR"
+	else
+		if [ ! -d "$DEFAULT_BINDIR" ]; then
+		mkdir "$DEFAULT_BINDIR"
+		fi
+		LBINDIR="$DEFAULT_BINDIR"
+	fi
+	echo "Installing in $LBINDIR"
+}
+
+initArch() {
+	ARCH=$(uname -m)
+	case $ARCH in
+		armv5*) ARCH="armv5";;
+		armv6*) ARCH="armv6";;
+		armv7*) ARCH="ARM";;
+		aarch64) ARCH="ARM64";;
+		x86) ARCH="32bit";;
+		x86_64) ARCH="64bit";;
+		i686) ARCH="32bit";;
+		i386) ARCH="32bit";;
+	esac
+	echo "ARCH=$ARCH"
+}
+
+initOS() {
+	OS=$(uname -s)
+	case "$OS" in
+		Linux*) OS='Linux' ;;
+		Darwin*) OS='macOS' ;;
+		MINGW*) OS='Windows';;
+		MSYS*) OS='Windows';;
+	esac
+	echo "OS=$OS"
+}
+
+initDownloadTool() {
+	if type "curl" > /dev/null; then
+		DOWNLOAD_TOOL="curl"
+	elif type "wget" > /dev/null; then
+		DOWNLOAD_TOOL="wget"
+	else
+		fail "You need curl or wget as download tool. Please install it first before continue"
+	fi
+	echo "Using $DOWNLOAD_TOOL as download tool"
+}
+
+get() {
+	local url="$2"
+	local body
+	local httpStatusCode
+	echo "Getting $url"
+	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
+		httpResponse=$(curl -sL --write-out HTTPSTATUS:%{http_code} "$url")
+		httpStatusCode=$(echo $httpResponse | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+		body=$(echo "$httpResponse" | sed -e 's/HTTPSTATUS\:.*//g')
+	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
+		tmpFile=$(mktemp)
+		body=$(wget --server-response --content-on-error -q -O - "$url" 2> $tmpFile || true)
+		httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
+	fi
+	if [ "$httpStatusCode" != 200 ]; then
+		echo "Request fail with http status code $httpStatusCode"
+		fail "Body: $body"
+	fi
+	eval "$1='$body'"
+}
+
+getFile() {
+	local url="$1"
+	local filePath="$2"
+	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
+		httpStatusCode=$(curl -s -w '%{http_code}' -L "$url" -o "$filePath")
+	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
+		body=$(wget --server-response --content-on-error -q -O "$filePath" "$url")
+		httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
+	fi
+	echo "$httpStatusCode"
+}
+
+downloadFile() {
+	get TAG_JSON https://api.github.com/repos/arduino/arduino-cli/releases/latest
+	TAG=$(echo $TAG_JSON | python -c 'import json,sys;obj=json.load(sys.stdin);sys.stdout.write(obj["tag_name"])')
+	echo "TAG=$TAG"
+	#  arduino-cli_0.4.0-rc1_Linux_64bit.tar.gz
+	CLI_DIST="arduino-cli_${TAG}_${OS}_${ARCH}.tar.gz"
+	echo "CLI_DIST=$CLI_DIST"
+	DOWNLOAD_URL="https://downloads.arduino.cc/arduino-cli/$CLI_DIST"
+	CLI_TMP_FILE="/tmp/$CLI_DIST"
+	echo "Downloading $DOWNLOAD_URL"
+	httpStatusCode=$(getFile "$DOWNLOAD_URL" "$CLI_TMP_FILE")
+	if [ "$httpStatusCode" -ne 200 ]; then
+		echo "Did not find a release for your system: $OS $ARCH"
+		echo "Trying to find a release on the github api."
+		LATEST_RELEASE_URL="https://api.github.com/repos/Masterminds/$PROJECT_NAME/releases/tags/$TAG"
+		echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
+		get LATEST_RELEASE_JSON $LATEST_RELEASE_URL
+		# || true forces this command to not catch error if grep does not find anything
+		DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | grep 'browser_' | cut -d\" -f4 | grep "$CLI_DIST") || true
+		if [ -z "$DOWNLOAD_URL" ]; then
+			echo "Sorry, we dont have a dist for your system: $OS $ARCH"
+			fail "You can ask one here: https://github.com/Arduino/$PROJECT_NAME/issues"
+		else
+			echo "Downloading $DOWNLOAD_URL"
+			getFile "$DOWNLOAD_URL" "$CLI_TMP_FILE"
+		fi
+	fi
+}
+
+installFile() {
+	CLI_TMP="/tmp/$PROJECT_NAME"
+	mkdir -p "$CLI_TMP"
+	tar xf "$CLI_TMP_FILE" -C "$CLI_TMP"
+	CLI_TMP_BIN="$CLI_TMP/$PROJECT_NAME"
+	cp "$CLI_TMP_BIN" "$LBINDIR"
+	rm -rf $CLI_TMP
+	rm -f $CLI_TMP_FILE
+}
+
+bye() {
+	result=$?
+	if [ "$result" != "0" ]; then
+		echo "Fail to install $PROJECT_NAME"
+	fi
+	exit $result
+}
+
+testVersion() {
+	set +e
+	CLI="$(which $PROJECT_NAME)"
+	if [ "$?" = "1" ]; then
+		fail "$PROJECT_NAME not found. Did you add "$LBINDIR" to your "'$PATH?'
+	fi
+	if [ $CLI != "$LBINDIR/$PROJECT_NAME" ]; then
+		fail "An existing $PROJECT_NAME was found at $CLI. Please prepend "$LBINDIR" to your "'$PATH'" or remove the existing one."
+	fi
+	set -e
+	CLI_VERSION=$($PROJECT_NAME version)
+	echo "$CLI_VERSION installed successfully"
+}
+
+
+# Execution
+
+#Stop execution on any error
+trap "bye" EXIT
+initDestination
+set -e
+initArch
+initOS
+initDownloadTool
+downloadFile
+installFile
+testVersion

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ fail() {
 initDestination() {
 	if [ -n "$BINDIR" ]; then
 		if [ ! -d "$BINDIR" ]; then
-			fail "$BINDIR "'($BINDIR)'" folder not found. Please create it before continue."
+			fail "$BINDIR "'($BINDIR)'" folder not found. Please create it before continuing."
 		fi
 		LBINDIR="$BINDIR"
 	else

--- a/install.sh
+++ b/install.sh
@@ -121,7 +121,7 @@ downloadFile() {
 		DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | grep 'browser_' | cut -d\" -f4 | grep "$CLI_DIST") || true
 		if [ -z "$DOWNLOAD_URL" ]; then
 			echo "Sorry, we dont have a dist for your system: $OS $ARCH"
-			fail "You can ask one here: https://github.com/Arduino/$PROJECT_NAME/issues"
+			fail "You can request one here: https://github.com/Arduino/$PROJECT_NAME/issues"
 		else
 			echo "Downloading $DOWNLOAD_URL"
 			getFile "$DOWNLOAD_URL" "$CLI_TMP_FILE"


### PR DESCRIPTION
This PR adds an `install.sh` script based on the one from `https://github.com/Masterminds/glide` to allow newcomers to simply do:
```
curl https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
```
to install the CLI.

It also updates the README accordingly, showing the various supported install methods. The markdown was also fixed to leverage Github's rendering helpers and show a nice output in the examples.