### PR TITLE
[skip changelog] Remove protobuf workaround on AppVeyor 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: test
 
 steps:
 - name: lint
-  image: arduino/arduino-cli:drone-1.0
+  image: arduino/arduino-cli:drone-1.1.0
   commands:
     # Check if the Go code is properly formatted and run the linter
     - task check
@@ -12,18 +12,18 @@ steps:
     - task protoc
 
 - name: build
-  image: arduino/arduino-cli:drone-1.0
+  image: arduino/arduino-cli:drone-1.1.0
   commands:
     - task build
 
 - name: test
-  image: arduino/arduino-cli:drone-1.0
+  image: arduino/arduino-cli:drone-1.1.0
   commands:
     - task test-unit
     - task test-legacy
 
 - name: integration
-  image: arduino/arduino-cli:drone-1.0
+  image: arduino/arduino-cli:drone-1.1.0
   commands:
     - pip install -r test/requirements.txt
     - task test-integration
@@ -32,7 +32,7 @@ steps:
   # Contrary to other CI platforms, uploading reports to Codecov requires Drone to provide a token.
   # To avoid exposing the Codecov token to external PRs, we only upload coverage when we merge on
   # `master`.
-  image: arduino/arduino-cli:drone-1.0
+  image: arduino/arduino-cli:drone-1.1.0
   environment:
     CODECOV_TOKEN:
       from_secret: codecov_token

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
   # protobuf tooling needed at test time. We use a very old version of the compiler
   # because of this: https://github.com/protocolbuffers/protobuf/issues/3957
   - go get github.com/golang/protobuf/protoc-gen-go
-  - curl -o protoc.zip -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.4.0/protoc-3.4.0-win32.zip
+  - curl -o protoc.zip -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-win32.zip
   - 7z x protoc.zip -o%PROTOC_PATH%
 
 test_script:


### PR DESCRIPTION
We can now switch back to a current version of the protocol since the
PR https://github.com/protocolbuffers/protobuf/pull/5044 has been
merged to master a released.