### PR TITLE
Fix compile error when --preprocess or --show-properties were passed

### DIFF
--- a/legacy/builder/wipeout_build_path_if_build_options_changed.go
+++ b/legacy/builder/wipeout_build_path_if_build_options_changed.go
@@ -49,7 +49,6 @@ func (s *WipeoutBuildPathIfBuildOptionsChanged) Run(ctx *types.Context) error {
 	}
 	buildOptionsJson := ctx.BuildOptionsJson
 	previousBuildOptionsJson := ctx.BuildOptionsJsonPrevious
-	logger := ctx.GetLogger()
 
 	var opts *properties.Map
 	var prevOpts *properties.Map

--- a/legacy/builder/wipeout_build_path_if_build_options_changed.go
+++ b/legacy/builder/wipeout_build_path_if_build_options_changed.go
@@ -79,7 +79,9 @@ func (s *WipeoutBuildPathIfBuildOptionsChanged) Run(ctx *types.Context) error {
 		}
 	}
 
-	logger.Println(constants.LOG_LEVEL_INFO, constants.MSG_BUILD_OPTIONS_CHANGED)
+	// FIXME: this should go outside legacy and behind a `logrus` call so users can
+	// control when this should be printed.
+	// logger.Println(constants.LOG_LEVEL_INFO, constants.MSG_BUILD_OPTIONS_CHANGED)
 
 	buildPath := ctx.BuildPath
 	files, err := gohasissues.ReadDir(buildPath.String())


### PR DESCRIPTION
The command should exit early when `--preprocess` or `--show-properties` are passed, since binary artifacts are not produced and command would fail.

EDIT: Now that #337 was merged, this PR fixes #333