### PR TITLE
[skip changelog] Upgrade protobuf on the CI

### DIFF
--- a/Dockerfiles/CI/Dockerfile
+++ b/Dockerfiles/CI/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PROTOBUF_VER 3.8.0
+ENV PROTOBUF_VER 3.9.1
 ENV PATH="/miniconda/bin:${PATH}"
 
 # NOTE: most of the following assume WORDKIR is '/'


### PR DESCRIPTION
Now we can have the same version on both drone.io and AppVeyor, see PR #329 for the details.