### PR TITLE
Query the backend to get the fqbn when a core is not installed

### DIFF
--- a/arduino/cores/packagemanager/identify.go
+++ b/arduino/cores/packagemanager/identify.go
@@ -24,7 +24,7 @@ import (
 	properties "github.com/arduino/go-properties-orderedmap"
 )
 
-// IdentifyBoard returns a list of baords matching the provided identification properties.
+// IdentifyBoard returns a list of boards matching the provided identification properties.
 func (pm *PackageManager) IdentifyBoard(idProps *properties.Map) []*cores.Board {
 	if idProps.Size() == 0 {
 		return []*cores.Board{}

--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -60,19 +60,18 @@ func runListCommand(cmd *cobra.Command, args []string) {
 		time.Sleep(timeout)
 	}
 
-	resp, err := board.List(instance.CreateInstance().GetId())
+	ports, err := board.List(instance.CreateInstance().GetId())
 	if err != nil {
 		formatter.PrintError(err, "Error detecting boards")
 		os.Exit(errorcodes.ErrNetwork)
 	}
 
-	if output.JSONOrElse(resp) {
-		outputListResp(resp)
+	if output.JSONOrElse(ports) {
+		outputListResp(ports)
 	}
 }
 
-func outputListResp(resp *rpc.BoardListResp) {
-	ports := resp.GetPorts()
+func outputListResp(ports []*rpc.DetectedPort) {
 	if len(ports) == 0 {
 		formatter.Print("No boards found.")
 		return
@@ -84,7 +83,7 @@ func outputListResp(resp *rpc.BoardListResp) {
 	})
 	table := output.NewTable()
 	table.SetHeader("Port", "Type", "Board Name", "FQBN")
-	for _, port := range resp.GetPorts() {
+	for _, port := range ports {
 		address := port.GetProtocol() + "://" + port.GetAddress()
 		if port.GetProtocol() == "serial" {
 			address = port.GetAddress()

--- a/cli/output/table.go
+++ b/cli/output/table.go
@@ -71,9 +71,9 @@ func (t *Table) makeTableRow(columns ...interface{}) *TableRow {
 		case TextBox:
 			cells[i] = text
 		case string:
-			cells[i] = Sprintf("%s", text)
+			cells[i] = sprintf("%s", text)
 		case fmt.Stringer:
-			cells[i] = Sprintf("%s", text.String())
+			cells[i] = sprintf("%s", text.String())
 		default:
 			panic(fmt.Sprintf("invalid column argument type: %t", col))
 		}

--- a/cli/output/text.go
+++ b/cli/output/text.go
@@ -121,8 +121,7 @@ func spaces(n int) string {
 	return res
 }
 
-// Sprintf FIXMEDOC
-func Sprintf(format string, args ...interface{}) TextBox {
+func sprintf(format string, args ...interface{}) TextBox {
 	cleanArgs := make([]interface{}, len(args))
 	for i, arg := range args {
 		if text, ok := arg.(*Text); ok {

--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -121,7 +121,7 @@ func List(instanceID int32) ([]*rpc.DetectedPort, error) {
 				continue
 			} else if err != nil {
 				// this is bad, bail out
-				return nil, errors.Wrap(err, "error getting bard info from Arduino Cloud")
+				return nil, errors.Wrap(err, "error getting board info from Arduino Cloud")
 			}
 
 			b = items

--- a/commands/board/list_test.go
+++ b/commands/board/list_test.go
@@ -1,0 +1,64 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package board
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetByVidPid(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `
+{
+	"architecture": "samd",
+	"fqbn": "arduino:samd:mkr1000",
+	"href": "/v3/boards/arduino:samd:mkr1000",
+	"id": "mkr1000",
+	"name": "Arduino/Genuino MKR1000",
+	"package": "arduino",
+	"plan": "create-free"
+}
+		`)
+	}))
+	defer ts.Close()
+
+	res, err := apiByVidPid(ts.URL)
+	require.Nil(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, "Arduino/Genuino MKR1000", res[0].Name)
+	require.Equal(t, "arduino:samd:mkr1000", res[0].FQBN)
+
+	// wrong url
+	res, err = apiByVidPid("http://0.0.0.0")
+	require.NotNil(t, err)
+}
+
+func TestGetByVidPidMalformedResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "{}")
+	}))
+	defer ts.Close()
+
+	res, err := apiByVidPid(ts.URL)
+	require.NotNil(t, err)
+	require.Equal(t, "wrong format in server response", err.Error())
+	require.Len(t, res, 0)
+}

--- a/commands/board/list_test.go
+++ b/commands/board/list_test.go
@@ -51,6 +51,31 @@ func TestGetByVidPid(t *testing.T) {
 	require.NotNil(t, err)
 }
 
+func TestGetByVidPidNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	res, err := apiByVidPid(ts.URL)
+	require.NotNil(t, err)
+	require.Equal(t, "board not found", err.Error())
+	require.Len(t, res, 0)
+}
+
+func TestGetByVidPid5xx(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("500 - Ooooops!"))
+	}))
+	defer ts.Close()
+
+	res, err := apiByVidPid(ts.URL)
+	require.NotNil(t, err)
+	require.Equal(t, "the server responded with status 500 Internal Server Error", err.Error())
+	require.Len(t, res, 0)
+}
+
 func TestGetByVidPidMalformedResponse(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "{}")

--- a/commands/daemon/daemon.go
+++ b/commands/daemon/daemon.go
@@ -49,7 +49,14 @@ func (s *ArduinoCoreServerImpl) BoardDetails(ctx context.Context, req *rpc.Board
 
 // BoardList FIXMEDOC
 func (s *ArduinoCoreServerImpl) BoardList(ctx context.Context, req *rpc.BoardListReq) (*rpc.BoardListResp, error) {
-	return board.List(req.GetInstance().GetId())
+	ports, err := board.List(req.GetInstance().GetId())
+	if err != nil {
+		return nil, err
+	}
+
+	return &rpc.BoardListResp{
+		Ports: ports,
+	}, nil
 }
 
 // BoardListAll FIXMEDOC


### PR DESCRIPTION
This PR makes the command `arduino-cli board list` properly work even when a core for the connected board is not installed. It works by querying the Arduino Cloud backend passing VID and PID, hence the CLI must be able to access the Internet for this to work.