### PR TITLE
Add support for ARM v6

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,22 @@ builds:
     binary: arduino-cli
     env:
       - CGO_ENABLED=1
+      - CC=/usr/arm-linux-gnueabi/bin/cc
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 6
+    ldflags:
+      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit=={{ .ShortCommit }}
+      - "-extldflags '-static'"
+  -
+    # ARMv7
+    id: arduino_cli_armv7
+    binary: arduino-cli
+    env:
+      - CGO_ENABLED=1
       - CC=/usr/arm-linux-gnueabihf/bin/cc
     goos:
       - linux

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ initArch() {
 	ARCH=$(uname -m)
 	case $ARCH in
 		armv5*) ARCH="armv5";;
-		armv6*) ARCH="armv6";;
+		armv6*) ARCH="ARMv6";;
 		armv7*) ARCH="ARMv7";;
 		aarch64) ARCH="ARM64";;
 		x86) ARCH="32bit";;


### PR DESCRIPTION
Fixes #340

Nightly will be available in the archive `arduino-cli_nightly-20190812_Linux_ARMv6.tar.gz`