### PR TITLE
Fix panic when board attach args are incomplete

### DIFF
--- a/cli/board/attach.go
+++ b/cli/board/attach.go
@@ -32,13 +32,13 @@ import (
 
 func initAttachCommand() *cobra.Command {
 	attachCommand := &cobra.Command{
-		Use:   "attach <port>|<FQBN> [sketchPath]",
+		Use:   "attach <port>|<FQBN> <sketchPath>",
 		Short: "Attaches a sketch to a board.",
 		Long:  "Attaches a sketch to a board.",
-		Example: "  " + os.Args[0] + " board attach serial:///dev/tty/ACM0\n" +
+		Example: "  " + os.Args[0] + " board attach serial:///dev/tty/ACM0 HelloWorld\n" +
 			"  " + os.Args[0] + " board attach serial:///dev/tty/ACM0 HelloWorld\n" +
-			"  " + os.Args[0] + " board attach arduino:samd:mkr1000",
-		Args: cobra.RangeArgs(1, 2),
+			"  " + os.Args[0] + " board attach arduino:samd:mkr1000 HelloWorld",
+		Args: cobra.ExactArgs(2),
 		Run:  runAttachCommand,
 	}
 	attachCommand.Flags().StringVar(&attachFlags.searchTimeout, "timeout", "5s",
@@ -52,16 +52,15 @@ var attachFlags struct {
 
 func runAttachCommand(cmd *cobra.Command, args []string) {
 	instance := instance.CreateInstance()
-	var path string
-	if len(args) > 0 {
-		path = args[1]
-	}
+	path := args[1]
+
 	_, err := board.Attach(context.Background(), &rpc.BoardAttachReq{
 		Instance:      instance,
 		BoardUri:      args[0],
 		SketchPath:    path,
 		SearchTimeout: attachFlags.searchTimeout,
 	}, output.TaskProgress())
+
 	if err != nil {
 		formatter.PrintError(err, "attach board error")
 		os.Exit(errorcodes.ErrGeneric)

--- a/commands/board/attach.go
+++ b/commands/board/attach.go
@@ -36,15 +36,16 @@ import (
 
 // Attach FIXMEDOC
 func Attach(ctx context.Context, req *rpc.BoardAttachReq, taskCB commands.TaskProgressCB) (*rpc.BoardAttachResp, error) {
-
 	pm := commands.GetPackageManager(req.GetInstance().GetId())
 	if pm == nil {
 		return nil, errors.New("invalid instance")
 	}
-	var sketchPath *paths.Path
-	if req.GetSketchPath() != "" {
-		sketchPath = paths.New(req.GetSketchPath())
+
+	if req.GetSketchPath() == "" {
+		return nil, errors.New("sketch path can't be empty")
 	}
+
+	sketchPath := paths.New(req.GetSketchPath())
 	sketch, err := sketches.NewSketchFromPath(sketchPath)
 	if err != nil {
 		return nil, fmt.Errorf("opening sketch: %s", err)


### PR DESCRIPTION
Fixes #165 

The command `board attach` was configured to optionally take only one argument (the FQBN) but it's actually missing any logic to fill the gap (figuring out sketch name and path) when a sketch is not passed.

This PR enforces the sketch to be passed and fixes the command documentation accordingly.