### PR TITLE
Fix logging from low level operations

### DIFF
--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -73,7 +73,6 @@ func NewCommand() *cobra.Command {
 		"List of custom build properties separated by commas. Or can be used multiple times for multiple properties.")
 	command.Flags().StringVar(&warnings, "warnings", "none",
 		`Optional, can be "none", "default", "more" and "all". Defaults to "none". Used to tell gcc which warning level to use (-W flag).`)
-	command.Flags().BoolVarP(&verbose, "verbose", "v", false, "Optional, turns on verbose mode.")
 	command.Flags().BoolVar(&quiet, "quiet", false, "Optional, supresses almost every output.")
 	command.Flags().BoolVarP(&uploadAfterCompile, "upload", "u", false, "Upload the binary after the compilation.")
 	command.Flags().StringVarP(&port, "port", "p", "", "Upload port, e.g.: COM10 or /dev/ttyACM0")

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -32,7 +32,6 @@ import (
 	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/configs"
 	"github.com/arduino/arduino-cli/legacy/builder"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	rpc "github.com/arduino/arduino-cli/rpc/commands"
 	paths "github.com/arduino/go-paths-helper"
@@ -159,7 +158,7 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 
 	builderCtx.ExecStdout = outStream
 	builderCtx.ExecStderr = errStream
-	builderCtx.SetLogger(i18n.LoggerToCustomStreams{Stdout: outStream, Stderr: errStream})
+	builderCtx.SetLogger(commands.LegacyLogger{})
 
 	// if --preprocess or --show-properties were passed, we can stop here
 	if req.GetShowProperties() {

--- a/commands/legacy_logger.go
+++ b/commands/legacy_logger.go
@@ -1,0 +1,78 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to modify or
+// otherwise use the software for commercial activities involving the Arduino
+// software without disclosing the source code of your own applications. To purchase
+// a commercial license, send an email to license@arduino.cc.
+
+package commands
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/arduino/arduino-cli/legacy/builder/constants"
+	"github.com/arduino/arduino-cli/legacy/builder/i18n"
+	"github.com/sirupsen/logrus"
+)
+
+// LegacyLogger wraps logrus but can be used within the `legacy` package
+type LegacyLogger struct{}
+
+// Fprintln is supposed to let the caller decide the target, let's not do it
+// and just forward to Println
+func (l LegacyLogger) Fprintln(w io.Writer, level string, format string, a ...interface{}) {
+	l.Println(level, format, a...)
+}
+
+// Println is a regular log call
+func (l LegacyLogger) Println(level string, format string, a ...interface{}) {
+	msg := legacyFormat(format, a...)
+
+	switch level {
+	case constants.LOG_LEVEL_INFO:
+		logrus.Info(msg)
+	case constants.LOG_LEVEL_DEBUG:
+		logrus.Debug(msg)
+	case constants.LOG_LEVEL_ERROR:
+		logrus.Error(msg)
+	case constants.LOG_LEVEL_WARN:
+		logrus.Warn(msg)
+	default:
+		logrus.Trace(msg)
+	}
+}
+
+// UnformattedFprintln will do the same as Fprintln
+func (l LegacyLogger) UnformattedFprintln(w io.Writer, str string) {
+	l.Println(constants.LOG_LEVEL_INFO, str)
+}
+
+// UnformattedWrite will do the same as Fprintln
+func (l LegacyLogger) UnformattedWrite(w io.Writer, data []byte) {
+	l.Println(constants.LOG_LEVEL_INFO, string(data))
+}
+
+// Flush is a noop
+func (l LegacyLogger) Flush() string {
+	return ""
+}
+
+// Name doesn't matter
+func (l LegacyLogger) Name() string {
+	return "legacy"
+}
+
+func legacyFormat(format string, a ...interface{}) string {
+	format = i18n.FromJavaToGoSyntax(format)
+	message := fmt.Sprintf(format, a...)
+	return message
+}


### PR DESCRIPTION
Fixes #174 

This PR provides a wrapper around logrus to be used by the legacy package. This way, the global `-v` and `--log-level` options will be actually used by the low level packages under `legacy`, along with all the logging setup we already do at the CLI level.