### PR TITLE
Make the serial discovery execution atomic

### DIFF
--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -98,7 +98,7 @@ func List(instanceID int32) ([]*rpc.DetectedPort, error) {
 		b := []*rpc.BoardListItem{}
 
 		// first query installed cores through the Package Manager
-		logrus.Info("Querying installed cores for board identification...")
+		logrus.Debug("Querying installed cores for board identification...")
 		for _, board := range pm.IdentifyBoard(port.IdentificationPrefs) {
 			b = append(b, &rpc.BoardListItem{
 				Name: board.Name(),
@@ -109,14 +109,14 @@ func List(instanceID int32) ([]*rpc.DetectedPort, error) {
 		// if installed cores didn't recognize the board, try querying
 		// the builder API
 		if len(b) == 0 {
-			logrus.Info("Querying builder API for board identification...")
+			logrus.Debug("Querying builder API for board identification...")
 			url := fmt.Sprintf("https://builder.arduino.cc/v3/boards/byVidPid/%s/%s",
 				port.IdentificationPrefs.Get("vid"),
 				port.IdentificationPrefs.Get("pid"))
 			items, err := apiByVidPid(url)
 			if err == ErrNotFound {
 				// the board couldn't be detected, keep going with the next port
-				logrus.Info("Board not recognized")
+				logrus.Debug("Board not recognized")
 				continue
 			} else if err != nil {
 				// this is bad, bail out

--- a/commands/bundled_tools_serial_discovery.go
+++ b/commands/bundled_tools_serial_discovery.go
@@ -206,7 +206,7 @@ func (d *SerialDiscovery) List() ([]*BoardPort, error) {
 		return nil, fmt.Errorf("decoding LIST command: %s", err)
 	}
 	done <- true
-	return event.Ports, nil
+	return event.Ports, d.close()
 }
 
 // Close stops the Discovery and free the resources

--- a/commands/bundled_tools_serial_discovery.go
+++ b/commands/bundled_tools_serial_discovery.go
@@ -194,7 +194,7 @@ func (d *SerialDiscovery) List() ([]*BoardPort, error) {
 	go func() {
 		select {
 		case <-done:
-		case <-time.After(2000 * time.Millisecond):
+		case <-time.After(10 * time.Second):
 			timeout = true
 			d.close()
 		}


### PR DESCRIPTION
Attempt to fix a concurrency issue surfacing when multiple clients at once use the CLI from the gRPC Api. Instead of having the client code calling `Start`, `List` and `Close` in sequence, we only export `List` that will take care of the entire workflow.