### PR TITLE
Don't scan hidden directories in arduino-builder (.git, etc.)

### DIFF
--- a/legacy/builder/builder_utils/utils.go
+++ b/legacy/builder/builder_utils/utils.go
@@ -155,6 +155,7 @@ func findAllFilesInFolder(sourcePath string, recurse bool) ([]string, error) {
 
 		for _, folder := range folders {
 			if !utils.IsSCCSOrHiddenFile(folder) {
+				// Skip SCCS directories as they do not influence the build and can be very large
 				otherSources, err := findAllFilesInFolder(filepath.Join(sourcePath, folder.Name()), recurse)
 				if err != nil {
 					return nil, i18n.WrapError(err)

--- a/legacy/builder/builder_utils/utils.go
+++ b/legacy/builder/builder_utils/utils.go
@@ -154,11 +154,13 @@ func findAllFilesInFolder(sourcePath string, recurse bool) ([]string, error) {
 		}
 
 		for _, folder := range folders {
-			otherSources, err := findAllFilesInFolder(filepath.Join(sourcePath, folder.Name()), recurse)
-			if err != nil {
-				return nil, i18n.WrapError(err)
+			if !utils.IsSCCSOrHiddenFile(folder) {
+				otherSources, err := findAllFilesInFolder(filepath.Join(sourcePath, folder.Name()), recurse)
+				if err != nil {
+					return nil, i18n.WrapError(err)
+				}
+				sources = append(sources, otherSources...)
 			}
-			sources = append(sources, otherSources...)
 		}
 	}
 


### PR DESCRIPTION
Port of https://github.com/arduino/arduino-builder/pull/328

When checking for updated core files, don't scan inside UNIX hidden
directories like .git.  Scanning inside a GIT tree for a large project
with many branches could take many minutes of runtime and multiple GB of
RAM.  This was seen in the Arduino core for the ESP8266, but is probably
also an issue for other core development teams.

Fixes https://github.com/arduino/arduino-builder/issues/327

Signed-off-by: Earle F. Philhower, III <earlephilhower@yahoo.com>