### PR TITLE
[skip changelog] Upload coverage only on push events

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,7 +71,13 @@ jobs:
           flags: unit
 
       - name: Send integration tests coverage to Codecov
-        if: matrix.operating-system != 'windows-2019'
+        # Since secrets aren't available on forks, we only
+        # upload coverage on `push`. This might change if
+        # Codecov whitelists GitHub, lifting the need
+        # for a token.
+        if: >
+          matrix.operating-system != 'windows-2019' &&
+          github.event_name == 'push'
         uses: codecov/codecov-action@v1.0.2
         with:
           token: ${{secrets.CODECOV_TOKEN}}


### PR DESCRIPTION
Workflows run on PRs coming from forks are currently broken.

Since secrets aren't available on forks, we only upload coverage on `push`. This might change if Codecov whitelists GitHub, lifting the need for a token.