### PR TITLE
Add an option to format logs with JSON

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -12,7 +12,9 @@
 # otherwise use the software for commercial activities involving the Arduino
 # software without disclosing the source code of your own applications. To purchase
 # a commercial license, send an email to license@arduino.cc.
+import os
 import json
+
 import semver
 
 
@@ -36,3 +38,37 @@ def test_version(run_command):
     assert parsed_out.get("Application", False) == "arduino-cli"
     assert isinstance(semver.parse(parsed_out.get("VersionString", False)), dict)
     assert isinstance(parsed_out.get("Commit", False), str)
+
+
+def test_log_options(run_command, data_dir):
+    """
+    using `version` as a test command
+    """
+
+    # no logs
+    out_lines = run_command("version").stdout.strip().split("\n")
+    assert len(out_lines) == 1
+
+    # plain text logs on stdoud
+    out_lines = run_command("version -v").stdout.strip().split("\n")
+    assert len(out_lines) > 1
+    assert out_lines[0].startswith("\x1b[36mINFO\x1b[0m")  # account for the colors
+
+    # plain text logs on file
+    log_file = os.path.join(data_dir, "log.txt")
+    run_command("version --log-file " + log_file)
+    with open(log_file) as f:
+        lines = f.readlines()
+        assert lines[0].startswith('time="')  # file format is different from console
+
+    # json on stdout
+    out_lines = run_command("version -v --log-format JSON").stdout.strip().split("\n")
+    lg = json.loads(out_lines[0])
+    assert "level" in lg
+
+    # json on file
+    log_file = os.path.join(data_dir, "log.json")
+    run_command("version --log-format json --log-file " + log_file)
+    with open(log_file) as f:
+        for line in f.readlines():
+            json.loads(line)


### PR DESCRIPTION
This PR adds the `--log-format` option.

Same as you can do with output, let users choose the format of the logged informations to ease parsing the CLI output.

Also accepts uppercase strings when parsing format args, i.e. `--format JSON` will work as good as `--format json`.