### PR TITLE
Rewrite the serial discovery logic

### DIFF
--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -83,12 +83,7 @@ func List(instanceID int32) ([]*rpc.DetectedPort, error) {
 		return nil, errors.New("invalid instance")
 	}
 
-	serialDiscovery, err := commands.NewBuiltinSerialDiscovery(pm)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to instance serial-discovery")
-	}
-
-	ports, err := serialDiscovery.List()
+	ports, err := commands.ListBoards(pm)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting port list from serial-discovery")
 	}


### PR DESCRIPTION
This PR fixes some concurrency issues we faced when connecting multiple gRPC client to the same CLI daemon. We don't really know the root cause but the problems went away by making really atomic the execution of the external tool. With this PR, only one function is called by the clients, and this function is responsible for:

* creating the command
* launching the process
* setting up the pipes
* send and receive commands
* closing the pipes
* shutting down (or kill if needed) the process

The function operates within a mutex.