### PR TITLE
[skip changelog] Fix changelog filters

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,10 +9,12 @@ release:
   prerelease: auto
 
 changelog:
-  sort: asc
   filters:
     exclude:
-    - '^[skip changelog]'
+      - '^\[skip changelog\].*'
+      - '^\[changelog skip\].*'
+      - '^\[skip ci\].*'
+      - '^\[ci skip\].*'
 
 # We have multiple builds in order to fine tune
 # cross compilations.


### PR DESCRIPTION
Fix the regex we use to exclude commits from the changelog and add more rules to skip `[ci skip]` and `[skip ci]` that likely you don't want to be on the changelog.

Also removed the sorting by commit message, so commits will be sorted by commit sequence (useful to manually redact the changelog).