### PR TITLE
Make commands output agnostic

### DIFF
--- a/cli/board/details.go
+++ b/cli/board/details.go
@@ -54,7 +54,7 @@ func runDetailsCommand(cmd *cobra.Command, args []string) {
 	feedback.PrintResult(detailsResult{details: res})
 }
 
-// ouput from this command requires special formatting, let's create a dedicated
+// output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type detailsResult struct {
 	details *rpc.BoardDetailsResp

--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -18,10 +18,12 @@
 package board
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"time"
 
+	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/arduino/arduino-cli/cli/instance"

--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -70,7 +70,7 @@ func runListCommand(cmd *cobra.Command, args []string) {
 	feedback.PrintResult(result{ports})
 }
 
-// ouput from this command requires special formatting, let's create a dedicated
+// output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type result struct {
 	ports []*rpc.DetectedPort

--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -18,15 +18,12 @@
 package board
 
 import (
-	"fmt"
 	"os"
 	"sort"
 	"time"
 
-	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
-	"github.com/arduino/arduino-cli/cli/globals"
 	"github.com/arduino/arduino-cli/cli/instance"
 	"github.com/arduino/arduino-cli/commands/board"
 	rpc "github.com/arduino/arduino-cli/rpc/commands"
@@ -68,27 +65,33 @@ func runListCommand(cmd *cobra.Command, args []string) {
 		os.Exit(errorcodes.ErrNetwork)
 	}
 
-	if globals.OutputFormat == "json" {
-		feedback.PrintJSON(ports)
-	} else {
-		outputListResp(ports)
-	}
+	feedback.PrintResult(result{ports})
 }
 
-func outputListResp(ports []*rpc.DetectedPort) {
-	if len(ports) == 0 {
-		feedback.Print("No boards found.")
-		return
+// ouput from this command requires special formatting, let's create a dedicated
+// feedback.Result implementation
+type result struct {
+	ports []*rpc.DetectedPort
+}
+
+func (dr result) Data() interface{} {
+	return dr.ports
+}
+
+func (dr result) String() string {
+	if len(dr.ports) == 0 {
+		return "No boards found."
 	}
-	sort.Slice(ports, func(i, j int) bool {
-		x, y := ports[i], ports[j]
+
+	sort.Slice(dr.ports, func(i, j int) bool {
+		x, y := dr.ports[i], dr.ports[j]
 		return x.GetProtocol() < y.GetProtocol() ||
 			(x.GetProtocol() == y.GetProtocol() && x.GetAddress() < y.GetAddress())
 	})
 
 	t := table.New()
 	t.SetHeader("Port", "Type", "Board Name", "FQBN", "Core")
-	for _, port := range ports {
+	for _, port := range dr.ports {
 		address := port.GetProtocol() + "://" + port.GetAddress()
 		if port.GetProtocol() == "serial" {
 			address = port.GetAddress()
@@ -123,5 +126,5 @@ func outputListResp(ports []*rpc.DetectedPort) {
 			t.AddRow(address, protocol, board, fqbn, coreName)
 		}
 	}
-	feedback.Print(t.Render())
+	return t.Render()
 }

--- a/cli/board/listall.go
+++ b/cli/board/listall.go
@@ -60,7 +60,7 @@ func runListAllCommand(cmd *cobra.Command, args []string) {
 	feedback.PrintResult(resultAll{list})
 }
 
-// ouput from this command requires special formatting, let's create a dedicated
+// output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type resultAll struct {
 	list *rpc.BoardListAllResp

--- a/cli/config/dump.go
+++ b/cli/config/dump.go
@@ -58,6 +58,21 @@ var dumpCmd = &cobra.Command{
 	Run:     runDumpCommand,
 }
 
+// ouput from this command requires special formatting, let's create a dedicated
+// feedback.Result implementation
+type dumpResult struct {
+	structured *jsonConfig
+	plain      string
+}
+
+func (dr dumpResult) Data() interface{} {
+	return dr.structured
+}
+
+func (dr dumpResult) String() string {
+	return dr.plain
+}
+
 func runDumpCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino config dump`")
 
@@ -69,23 +84,23 @@ func runDumpCommand(cmd *cobra.Command, args []string) {
 
 	c := globals.Config
 
-	if globals.OutputFormat == "json" {
-		sketchbookDir := ""
-		if c.SketchbookDir != nil {
-			sketchbookDir = c.SketchbookDir.String()
-		}
+	sketchbookDir := ""
+	if c.SketchbookDir != nil {
+		sketchbookDir = c.SketchbookDir.String()
+	}
 
-		arduinoDataDir := ""
-		if c.DataDir != nil {
-			arduinoDataDir = c.DataDir.String()
-		}
+	arduinoDataDir := ""
+	if c.DataDir != nil {
+		arduinoDataDir = c.DataDir.String()
+	}
 
-		arduinoDownloadsDir := ""
-		if c.ArduinoDownloadsDir != nil {
-			arduinoDownloadsDir = c.ArduinoDownloadsDir.String()
-		}
+	arduinoDownloadsDir := ""
+	if c.ArduinoDownloadsDir != nil {
+		arduinoDownloadsDir = c.ArduinoDownloadsDir.String()
+	}
 
-		feedback.PrintJSON(jsonConfig{
+	feedback.PrintResult(&dumpResult{
+		structured: &jsonConfig{
 			ProxyType: c.ProxyType,
 			ProxyManualConfig: &jsonProxyConfig{
 				Hostname: c.ProxyHostname,
@@ -98,8 +113,7 @@ func runDumpCommand(cmd *cobra.Command, args []string) {
 			BoardsManager: &jsonBoardsManagerConfig{
 				AdditionalURLS: c.BoardManagerAdditionalUrls,
 			},
-		})
-	} else {
-		feedback.Print(string(data))
-	}
+		},
+		plain: string(data),
+	})
 }

--- a/cli/config/dump.go
+++ b/cli/config/dump.go
@@ -58,7 +58,7 @@ var dumpCmd = &cobra.Command{
 	Run:     runDumpCommand,
 }
 
-// ouput from this command requires special formatting, let's create a dedicated
+// output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type dumpResult struct {
 	structured *jsonConfig

--- a/cli/config/init.go
+++ b/cli/config/init.go
@@ -40,8 +40,6 @@ func initInitCommand() *cobra.Command {
 		Args: cobra.NoArgs,
 		Run:  runInitCommand,
 	}
-	initCommand.Flags().BoolVar(&initFlags._default, "default", false,
-		"If omitted, ask questions to the user about setting configuration properties, otherwise use default configuration.")
 	initCommand.Flags().StringVar(&initFlags.location, "save-as", "",
 		"Sets where to save the configuration file [default is ./arduino-cli.yaml].")
 	return initCommand
@@ -54,13 +52,6 @@ var initFlags struct {
 
 func runInitCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino config init`")
-
-	if !initFlags._default {
-		if globals.OutputFormat != "text" {
-			feedback.Error("The interactive mode is supported only in text mode.")
-			os.Exit(errorcodes.ErrBadCall)
-		}
-	}
 
 	filepath := initFlags.location
 	if filepath == "" {

--- a/cli/core/list.go
+++ b/cli/core/list.go
@@ -61,7 +61,7 @@ func runListCommand(cmd *cobra.Command, args []string) {
 	feedback.PrintResult(installedResult{platforms})
 }
 
-// ouput from this command requires special formatting, let's create a dedicated
+// output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type installedResult struct {
 	platforms []*cores.PlatformRelease

--- a/cli/core/search.go
+++ b/cli/core/search.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
-	"github.com/arduino/arduino-cli/cli/globals"
 	"github.com/arduino/arduino-cli/cli/instance"
 	"github.com/arduino/arduino-cli/commands/core"
 	rpc "github.com/arduino/arduino-cli/rpc/commands"
@@ -51,11 +50,6 @@ func runSearchCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino core search`")
 
 	arguments := strings.ToLower(strings.Join(args, " "))
-
-	if globals.OutputFormat != "json" {
-		feedback.Printf("Searching for platforms matching '%s'", arguments)
-	}
-
 	resp, err := core.PlatformSearch(context.Background(), &rpc.PlatformSearchReq{
 		Instance:   instance,
 		SearchArgs: arguments,

--- a/cli/core/search.go
+++ b/cli/core/search.go
@@ -66,25 +66,30 @@ func runSearchCommand(cmd *cobra.Command, args []string) {
 	}
 
 	coreslist := resp.GetSearchOutput()
-	if globals.OutputFormat == "json" {
-		feedback.PrintJSON(coreslist)
-	} else {
-		outputSearchCores(coreslist)
-	}
+	feedback.PrintResult(searchResults{coreslist})
 }
 
-func outputSearchCores(cores []*rpc.Platform) {
-	if len(cores) > 0 {
+// ouput from this command requires special formatting, let's create a dedicated
+// feedback.Result implementation
+type searchResults struct {
+	platforms []*rpc.Platform
+}
+
+func (sr searchResults) Data() interface{} {
+	return sr.platforms
+}
+
+func (sr searchResults) String() string {
+	if len(sr.platforms) > 0 {
 		t := table.New()
 		t.SetHeader("ID", "Version", "Name")
-		sort.Slice(cores, func(i, j int) bool {
-			return cores[i].ID < cores[j].ID
+		sort.Slice(sr.platforms, func(i, j int) bool {
+			return sr.platforms[i].ID < sr.platforms[j].ID
 		})
-		for _, item := range cores {
+		for _, item := range sr.platforms {
 			t.AddRow(item.GetID(), item.GetLatest(), item.GetName())
 		}
-		feedback.Print(t.Render())
-	} else {
-		feedback.Print("No platforms matching your search.")
+		return t.Render()
 	}
+	return "No platforms matching your search."
 }

--- a/cli/core/search.go
+++ b/cli/core/search.go
@@ -63,7 +63,7 @@ func runSearchCommand(cmd *cobra.Command, args []string) {
 	feedback.PrintResult(searchResults{coreslist})
 }
 
-// ouput from this command requires special formatting, let's create a dedicated
+// output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type searchResults struct {
 	platforms []*rpc.Platform

--- a/cli/feedback/exported.go
+++ b/cli/feedback/exported.go
@@ -52,8 +52,8 @@ func Printf(format string, v ...interface{}) {
 }
 
 // Print behaves like fmt.Print but writes on the out writer and adds a newline.
-func Print(v ...interface{}) {
-	fb.Print(v...)
+func Print(v interface{}) {
+	fb.Print(v)
 }
 
 // Errorf behaves like fmt.Printf but writes on the error writer and adds a
@@ -74,7 +74,9 @@ func PrintJSON(v interface{}) {
 	fb.PrintJSON(v)
 }
 
-// PrintResult is a convenient wrapper...
+// PrintResult is a convenient wrapper to provide feedback for complex data,
+// where the contents can't be just serialized to JSON but requires more
+// structure.
 func PrintResult(res Result) {
 	fb.PrintResult(res)
 }

--- a/cli/feedback/exported.go
+++ b/cli/feedback/exported.go
@@ -68,12 +68,6 @@ func Error(v ...interface{}) {
 	fb.Error(v...)
 }
 
-// PrintJSON is a convenient wrapper to provide feedback by printing the
-// desired output in a pretty JSON format. It adds a newline to the output.
-func PrintJSON(v interface{}) {
-	fb.PrintJSON(v)
-}
-
 // PrintResult is a convenient wrapper to provide feedback for complex data,
 // where the contents can't be just serialized to JSON but requires more
 // structure.

--- a/cli/feedback/feedback.go
+++ b/cli/feedback/feedback.go
@@ -86,8 +86,12 @@ func (fb *Feedback) Printf(format string, v ...interface{}) {
 }
 
 // Print behaves like fmt.Print but writes on the out writer and adds a newline.
-func (fb *Feedback) Print(v ...interface{}) {
-	fmt.Fprintln(fb.out, v...)
+func (fb *Feedback) Print(v interface{}) {
+	if fb.format == JSON {
+		fb.PrintJSON(v)
+	} else {
+		fmt.Fprintln(fb.out, v)
+	}
 }
 
 // Errorf behaves like fmt.Printf but writes on the error writer and adds a
@@ -109,18 +113,16 @@ func (fb *Feedback) PrintJSON(v interface{}) {
 	if d, err := json.MarshalIndent(v, "", "  "); err != nil {
 		fb.Errorf("Error during JSON encoding of the output: %v", err)
 	} else {
-		fb.Print(string(d))
+		fmt.Fprint(fb.out, string(d))
 	}
 }
 
-// PrintResult is a convenient wrapper...
+// PrintResult is a convenient wrapper to provide feedback for complex data,
+// where the contents can't be just serialized to JSON but requires more
+// structure.
 func (fb *Feedback) PrintResult(res Result) {
 	if fb.format == JSON {
-		if d, err := json.MarshalIndent(res.Data(), "", "  "); err != nil {
-			fb.Errorf("Error during JSON encoding of the output: %v", err)
-		} else {
-			fb.Print(string(d))
-		}
+		fb.PrintJSON(res.Data())
 	} else {
 		fb.Print(fmt.Sprintf("%s", res))
 	}

--- a/cli/feedback/feedback.go
+++ b/cli/feedback/feedback.go
@@ -88,7 +88,7 @@ func (fb *Feedback) Printf(format string, v ...interface{}) {
 // Print behaves like fmt.Print but writes on the out writer and adds a newline.
 func (fb *Feedback) Print(v interface{}) {
 	if fb.format == JSON {
-		fb.PrintJSON(v)
+		fb.printJSON(v)
 	} else {
 		fmt.Fprintln(fb.out, v)
 	}
@@ -107,9 +107,9 @@ func (fb *Feedback) Error(v ...interface{}) {
 	logrus.Error(fmt.Sprint(v...))
 }
 
-// PrintJSON is a convenient wrapper to provide feedback by printing the
+// printJSON is a convenient wrapper to provide feedback by printing the
 // desired output in a pretty JSON format. It adds a newline to the output.
-func (fb *Feedback) PrintJSON(v interface{}) {
+func (fb *Feedback) printJSON(v interface{}) {
 	if d, err := json.MarshalIndent(v, "", "  "); err != nil {
 		fb.Errorf("Error during JSON encoding of the output: %v", err)
 	} else {
@@ -122,7 +122,7 @@ func (fb *Feedback) PrintJSON(v interface{}) {
 // structure.
 func (fb *Feedback) PrintResult(res Result) {
 	if fb.format == JSON {
-		fb.PrintJSON(res.Data())
+		fb.printJSON(res.Data())
 	} else {
 		fb.Print(fmt.Sprintf("%s", res))
 	}

--- a/cli/globals/globals.go
+++ b/cli/globals/globals.go
@@ -29,8 +29,6 @@ import (
 var (
 	// Debug determines whether to dump debug output to stderr or not
 	Debug bool
-	// OutputFormat can be "text" or "json"
-	OutputFormat string
 	// HTTPClientHeader is the object that will be propagated to configure the clients inside the downloaders
 	HTTPClientHeader = getHTTPClientHeader()
 	// VersionInfo contains all info injected during build

--- a/cli/lib/list.go
+++ b/cli/lib/list.go
@@ -82,7 +82,7 @@ func (ir installedResult) Data() interface{} {
 
 func (ir installedResult) String() string {
 	if ir.installedLibs == nil || len(ir.installedLibs) == 0 {
-		return ""
+		return "No libraries installed."
 	}
 
 	t := table.New()

--- a/cli/lib/list.go
+++ b/cli/lib/list.go
@@ -70,7 +70,7 @@ func runListCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Done")
 }
 
-// ouput from this command requires special formatting, let's create a dedicated
+// output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type installedResult struct {
 	installedLibs []*rpc.InstalledLibrary

--- a/cli/lib/search.go
+++ b/cli/lib/search.go
@@ -71,7 +71,7 @@ func runSearchCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Done")
 }
 
-// ouput from this command requires special formatting, let's create a dedicated
+// output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type result struct {
 	results   *rpc.LibrarySearchResp

--- a/cli/output/rpc_progress.go
+++ b/cli/output/rpc_progress.go
@@ -20,16 +20,18 @@ package output
 import (
 	"fmt"
 
-	"github.com/arduino/arduino-cli/cli/globals"
 	"github.com/arduino/arduino-cli/commands"
 	rpc "github.com/arduino/arduino-cli/rpc/commands"
 	"github.com/cmaglie/pb"
 )
 
+// OutputFormat can be "text" or "json"
+var OutputFormat string
+
 // ProgressBar returns a DownloadProgressCB that prints a progress bar.
 // If JSON output format has been selected, the callback outputs nothing.
 func ProgressBar() commands.DownloadProgressCB {
-	if globals.OutputFormat != "json" {
+	if OutputFormat != "json" {
 		return NewDownloadProgressBarCB()
 	}
 	return func(curr *rpc.DownloadProgress) {
@@ -40,7 +42,7 @@ func ProgressBar() commands.DownloadProgressCB {
 // TaskProgress returns a TaskProgressCB that prints the task progress.
 // If JSON output format has been selected, the callback outputs nothing.
 func TaskProgress() commands.TaskProgressCB {
-	if globals.OutputFormat != "json" {
+	if OutputFormat != "json" {
 		return NewTaskProgressCB()
 	}
 	return func(curr *rpc.TaskProgress) {

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -38,9 +38,5 @@ func NewCommand() *cobra.Command {
 }
 
 func run(cmd *cobra.Command, args []string) {
-	if globals.OutputFormat == "json" {
-		feedback.PrintJSON(globals.VersionInfo)
-	} else {
-		feedback.Print(globals.VersionInfo)
-	}
+	feedback.Print(globals.VersionInfo)
 }

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	golang.org/x/text v0.3.0
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190327125643-d831d65fe17d // indirect
 	google.golang.org/grpc v1.21.1
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -23,11 +23,11 @@ def test_list(run_command):
     result = run_command("lib list")
     assert result.ok
     assert "" == result.stderr
-    assert "" == result.stdout
+    assert "No libraries installed." == result.stdout.strip()
     result = run_command("lib list --format json")
     assert result.ok
     assert "" == result.stderr
-    assert "" == result.stdout
+    assert "null" == result.stdout
 
     # Install something we can list at a version older than latest
     result = run_command("lib install ArduinoJson@6.11.0")
@@ -83,7 +83,7 @@ def test_search(run_command):
 
     result = run_command("lib search --names")
     assert result.ok
-    out_lines = result.stdout.splitlines()
+    out_lines = result.stdout.strip().splitlines()
     # Create an array with just the name of the vars
     libs = []
     for line in out_lines:

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -19,7 +19,7 @@ def test_list(run_command):
     # Init the environment explicitly
     assert run_command("core update-index")
 
-    # When ouput is empty, nothing is printed out, no matter the output format
+    # When output is empty, nothing is printed out, no matter the output format
     result = run_command("lib list")
     assert result.ok
     assert "" == result.stderr


### PR DESCRIPTION
Continuation of #345, extend the `PrintResult` API usage to all those commands that need a complex output rendering.

To reduce boilerplate, `feedback.Print` was changed so that it will serialize strings to JSON when needed; this way, all those commands that don't need to provide a complex output can simply do `feedback.Print("message")` without caring of the output format, see `version` for example.