### PR TITLE
Check json logs entries in compile and upload python integration tests

### DIFF
--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -47,7 +47,7 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 		return nil, errors.New("invalid instance")
 	}
 
-	logrus.Info("Executing `arduino compile`")
+	logrus.Tracef("Compile %s for %s started", req.GetSketchPath(), req.GetFqbn())
 	if req.GetSketchPath() == "" {
 		return nil, fmt.Errorf("missing sketchPath")
 	}
@@ -202,7 +202,7 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 	// Copy .hex file to sketch directory
 	srcHex := paths.New(outputPath)
 	dstHex := exportPath.Join(exportFile + ext)
-	logrus.WithField("from", srcHex).WithField("to", dstHex).Print("copying sketch build output")
+	logrus.WithField("from", srcHex).WithField("to", dstHex).Debug("copying sketch build output")
 	if err = srcHex.CopyTo(dstHex); err != nil {
 		return nil, fmt.Errorf("copying output file: %s", err)
 	}
@@ -210,12 +210,12 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 	// Copy .elf file to sketch directory
 	srcElf := paths.New(outputPath[:len(outputPath)-3] + "elf")
 	dstElf := exportPath.Join(exportFile + ".elf")
-	logrus.WithField("from", srcElf).WithField("to", dstElf).Print("copying sketch build output")
+	logrus.WithField("from", srcElf).WithField("to", dstElf).Debug("copying sketch build output")
 	if err = srcElf.CopyTo(dstElf); err != nil {
 		return nil, fmt.Errorf("copying elf file: %s", err)
 	}
 
-	logrus.Infof("Compile %s for %s successful", sketch.Name, fqbnIn)
+	logrus.Tracef("Compile %s for %s successful", sketch.Name, fqbnIn)
 
 	return &rpc.CompileResp{}, nil
 }

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -215,5 +215,7 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 		return nil, fmt.Errorf("copying elf file: %s", err)
 	}
 
+	logrus.Infof("Compile %s for %s successful", sketch.Name, fqbnIn)
+
 	return &rpc.CompileResp{}, nil
 }

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -40,7 +40,7 @@ import (
 
 // Upload FIXMEDOC
 func Upload(ctx context.Context, req *rpc.UploadReq, outStream io.Writer, errStream io.Writer) (*rpc.UploadResp, error) {
-	logrus.Info("Executing `arduino upload`")
+	logrus.Tracef("Upload %s on %s started", req.GetSketchPath(), req.GetFqbn())
 
 	// TODO: make a generic function to extract sketch from request
 	// and remove duplication in commands/compile.go
@@ -249,7 +249,7 @@ func Upload(ctx context.Context, req *rpc.UploadReq, outStream io.Writer, errStr
 		return nil, fmt.Errorf("uploading error: %s", err)
 	}
 
-	logrus.Infof("Upload %s on %s successful", sketch.Name, fqbnIn)
+	logrus.Tracef("Upload %s on %s successful", sketch.Name, fqbnIn)
 
 	return &rpc.UploadResp{}, nil
 }

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -248,6 +248,9 @@ func Upload(ctx context.Context, req *rpc.UploadReq, outStream io.Writer, errStr
 	if err := cmd.Wait(); err != nil {
 		return nil, fmt.Errorf("uploading error: %s", err)
 	}
+
+	logrus.Infof("Upload %s on %s successful", sketch.Name, fqbnIn)
+
 	return &rpc.UploadResp{}, nil
 }
 

--- a/test/.flake8
+++ b/test/.flake8
@@ -1,2 +1,3 @@
 [flake8]
+exclude = venv
 max-line-length = 120

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,14 @@
+# This file is part of arduino-cli.
+#
+# Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
+#
+# This software is released under the GNU General Public License version 3,
+# which covers the main part of arduino-cli.
+# The terms of this license can be found at:
+# https://www.gnu.org/licenses/gpl-3.0.en.html
+#
+# You can be released from the requirements of the above licenses by purchasing
+# a commercial license. Buying such a license is mandatory if you want to modify or
+# otherwise use the software for commercial activities involving the Arduino
+# software without disclosing the source code of your own applications. To purchase
+# a commercial license, send an email to license@arduino.cc.

--- a/test/common.py
+++ b/test/common.py
@@ -1,12 +1,12 @@
 # This file is part of arduino-cli.
-
+#
 # Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
-
+#
 # This software is released under the GNU General Public License version 3,
 # which covers the main part of arduino-cli.
 # The terms of this license can be found at:
 # https://www.gnu.org/licenses/gpl-3.0.en.html
-
+#
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to modify or
 # otherwise use the software for commercial activities involving the Arduino

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,12 +1,12 @@
 # This file is part of arduino-cli.
-
+#
 # Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
-
+#
 # This software is released under the GNU General Public License version 3,
 # which covers the main part of arduino-cli.
 # The terms of this license can be found at:
 # https://www.gnu.org/licenses/gpl-3.0.en.html
-
+#
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to modify or
 # otherwise use the software for commercial activities involving the Arduino

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -1,12 +1,12 @@
 # This file is part of arduino-cli.
-
+#
 # Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
-
+#
 # This software is released under the GNU General Public License version 3,
 # which covers the main part of arduino-cli.
 # The terms of this license can be found at:
 # https://www.gnu.org/licenses/gpl-3.0.en.html
-
+#
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to modify or
 # otherwise use the software for commercial activities involving the Arduino

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1,20 +1,20 @@
 # This file is part of arduino-cli.
-
+#
 # Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
-
+#
 # This software is released under the GNU General Public License version 3,
 # which covers the main part of arduino-cli.
 # The terms of this license can be found at:
 # https://www.gnu.org/licenses/gpl-3.0.en.html
-
+#
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to modify or
 # otherwise use the software for commercial activities involving the Arduino
 # software without disclosing the source code of your own applications. To purchase
 # a commercial license, send an email to license@arduino.cc.
-import pytest
 import json
 import os
+import pytest
 
 from .common import running_on_ci
 
@@ -62,11 +62,11 @@ def test_compile_with_simple_sketch(run_command, data_dir):
     # let's test from the logs if the hex file produced by successful compile is moved to our sketch folder
     log_json = open(log_file_path, 'r')
     json_log_lines = log_json.readlines()
-    assert is_message_in_json_log_lines("Executing `arduino compile`", json_log_lines)
-    assert is_message_in_json_log_lines(
-        "Compile {sketch} for {fqbn} successful".format(sketch=sketch_name,
-                                                        fqbn=fqbn),
-        json_log_lines)
+    expected_trace_sequence = [
+        "Compile {sketch} for {fqbn} started".format(sketch=sketch_path, fqbn=fqbn),
+        "Compile {sketch} for {fqbn} successful".format(sketch=sketch_name, fqbn=fqbn)
+    ]
+    assert is_message_sequence_in_json_log_traces(expected_trace_sequence, json_log_lines)
 
 
 @pytest.mark.skipif(running_on_ci(), reason="VMs have no serial ports")
@@ -77,7 +77,7 @@ def test_compile_and_compile_combo(run_command, data_dir):
 
     # Install required core(s)
     result = run_command("core install arduino:avr")
-    # result = run_command("core install arduino:samd")
+    result = run_command("core install arduino:samd")
     assert result.ok
 
     # Create a test sketch
@@ -126,31 +126,31 @@ def test_compile_and_compile_combo(run_command, data_dir):
     for board in detected_boards:
         log_file_name = "{fqbn}-compile.log".format(fqbn=board.get('fqbn'))
         log_file_path = os.path.join(data_dir, log_file_name)
-        result = run_command(
-            "compile -b {fqbn} --upload -p {address} {sketch_path} --log-format json --log-file {log_file} --log-level trace".format(
-                fqbn=board.get('fqbn'),
-                address=board.get('address'),
-                sketch_path=sketch_path,
-                log_file=log_file_path
-            )
-        )
+        command_log_flags = "--log-format json --log-file {} --log-level trace".format(log_file_path)
+        result = run_command("compile -b {fqbn} --upload -p {address} {sketch_path} {log_flags}".format(
+            fqbn=board.get('fqbn'),
+            address=board.get('address'),
+            sketch_path=sketch_path,
+            log_flags=command_log_flags
+        ))
         assert result.ok
         # check from the logs if the bin file were uploaded on the current board
         log_json = open(log_file_path, 'r')
         json_log_lines = log_json.readlines()
-        assert is_message_in_json_log_lines("Executing `arduino compile`", json_log_lines)
-        assert is_message_in_json_log_lines(
-            "Compile {sketch} for {fqbn} successful".format(sketch=sketch_name,
-                                                            fqbn=board.get(
-                                                                'fqbn')),
-            json_log_lines)
-        assert is_message_in_json_log_lines("Executing `arduino upload`", json_log_lines)
-        assert is_message_in_json_log_lines(
-            "Upload {sketch} on {fqbn} successful".format(sketch=sketch_name,
-                                                          fqbn=board.get(
-                                                              'fqbn')),
-            json_log_lines)
+        expected_trace_sequence = [
+            "Compile {sketch} for {fqbn} started".format(sketch=sketch_path, fqbn=board.get('fqbn')),
+            "Compile {sketch} for {fqbn} successful".format(sketch=sketch_name, fqbn=board.get('fqbn')),
+            "Upload {sketch} on {fqbn} started".format(sketch=sketch_path, fqbn=board.get('fqbn')),
+            "Upload {sketch} on {fqbn} successful".format(sketch=sketch_name, fqbn=board.get('fqbn'))
+        ]
+        assert is_message_sequence_in_json_log_traces(expected_trace_sequence, json_log_lines)
 
 
-def is_message_in_json_log_lines(message, log_json_lines):
-    return len([index for index, entry in enumerate(log_json_lines) if json.loads(entry).get("msg") == message]) == 1
+def is_message_sequence_in_json_log_traces(message_sequence, log_json_lines):
+    trace_entries = []
+    for entry in log_json_lines:
+        entry = json.loads(entry)
+        if entry.get("level") == "trace":
+            if entry.get("msg") in message_sequence:
+                trace_entries.append(entry.get("msg"))
+    return message_sequence == trace_entries

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -1,12 +1,12 @@
 # This file is part of arduino-cli.
-
+#
 # Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
-
+#
 # This software is released under the GNU General Public License version 3,
 # which covers the main part of arduino-cli.
 # The terms of this license can be found at:
 # https://www.gnu.org/licenses/gpl-3.0.en.html
-
+#
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to modify or
 # otherwise use the software for commercial activities involving the Arduino

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,12 +1,12 @@
 # This file is part of arduino-cli.
-
+#
 # Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
-
+#
 # This software is released under the GNU General Public License version 3,
 # which covers the main part of arduino-cli.
 # The terms of this license can be found at:
 # https://www.gnu.org/licenses/gpl-3.0.en.html
-
+#
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to modify or
 # otherwise use the software for commercial activities involving the Arduino


### PR DESCRIPTION
This PR adds log lines assertions in a "white box" fashion in the python integration testing suite to allow a more flexible testing

The ~~`is_message_in_json_log_lines`~~ `is_message_sequence_in_json_log_traces` function is not optimized as the log produced for each test is currently very small