### PR TITLE
Show core name when listing boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Alternatively you can download one of the pre-built binaries for the supported p
 
 These builds are generated once a day from `master` branch starting at 01:00 GMT
 
-In order to get the latest nightly build for your platform use the following links: 
+In order to get the latest nightly build for your platform use the following links:
 
 - [Linux 64 bit](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_64bit.tar.gz)
 - [Linux 32 bit](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_32bit.tar.gz)
@@ -55,7 +55,7 @@ In order to get the latest nightly build for your platform use the following lin
 - [Windows 32 bit](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Windows_32bit.zip)
 - [Mac OSX](https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_macOS_64bit.tar.gz)
 
-These links return a `302: Found` response, redirecting to latest generated builds by replacing `latest` with the latest 
+These links return a `302: Found` response, redirecting to latest generated builds by replacing `latest` with the latest
 available build date, using the format YYYYMMDD (i.e for 2019/Aug/06 `latest` is replaced with `20190806` )
 
 Checksums for the nightly builds are available at
@@ -137,44 +137,17 @@ MKR1000 board:
 
 ```console
 $ arduino-cli board list
-FQBN    Port            ID              Board Name
-        /dev/ttyACM0    2341:804E       unknown
+Port         Type              Board Name              FQBN                 Core
+/dev/ttyACM1 Serial Port (USB) Arduino/Genuino MKR1000 arduino:samd:mkr1000 arduino:samd
 ```
 
-the board has been discovered but we do not have the correct core to program it yet.
-Let's install it!
+the board has been discovered but we need the correct core to program it, let's
+install it!
 
-### Step 4. Find and install the right core
+### Step 4. Install the core for your board
 
-We have to look at the core available with the `core search` command. It will provide a list of
-available cores matching the name arduino:
-
-```console
-$ arduino-cli core search arduino
-Searching for platforms matching 'arduino'
-ID                Version Name
-Intel:arc32       2.0.4   Intel Curie Boards
-arduino:avr       1.6.23  Arduino AVR Boards
-arduino:mbed      1.1.0   Arduino nRF528x Boards (Mbed OS)
-arduino:megaavr   1.8.3   Arduino megaAVR Boards
-arduino:nrf52     1.0.2   Arduino nRF52 Boards
-arduino:sam       1.6.12  Arduino SAM Boards (32-bits ARM Cortex-M3)
-arduino:samd      1.8.3   Arduino SAMD Boards (32-bits ARM Cortex-M0+)
-arduino:samd_beta 1.6.25  Arduino SAMD Beta Boards (32-bits ARM Cortex-M0+)
-arduino:stm32f4   1.0.1   Arduino STM32F4 Boards
-littleBits:avr    1.0.0   littleBits Arduino AVR Modules
-```
-
-If you're unsure you can try to refine the search with the board name
-
-```console
-$ arduino-cli core search mkr1000
-Searching for platforms matching 'mkr1000'
-ID           Version Name
-arduino:samd 1.8.3   Arduino SAMD Boards (32-bits ARM Cortex-M0+)
-```
-
-So, the right platform for the Arduino MKR1000 is arduino:samd, now we can install it
+From the output of the `board list` command, the right platform for the Arduino
+MKR1000 is `arduino:samd`, we can install it with:
 
 ```console
 $ arduino-cli core install arduino:samd
@@ -207,14 +180,6 @@ ID              Installed       Latest  Name
 arduino:samd    1.6.19          1.6.19  Arduino SAMD Boards (32-bits ARM Cortex-M0+)
 ```
 
-We can finally check if the board is now recognized as a MKR1000
-
-```console
-$ arduino-cli board list
-FQBN                    Port            ID              Board Name
-arduino:samd:mkr1000    /dev/ttyACM0    2341:804E       Arduino/Genuino MKR1000
-```
-
 If the board is not detected for any reason, you can list all the supported boards
 with `arduino-cli board listall` and also search for a specific board:
 
@@ -229,8 +194,7 @@ Arduino MKRZERO         arduino:samd:mkrzero
 Arduino/Genuino MKR1000 arduino:samd:mkr1000
 ```
 
-Great! Now we have the Board FQBN (Fully Qualified Board Name) `arduino:samd:mkr1000`
-and the Board Name look good, we are ready to compile and upload the sketch
+Great! Now we are ready to compile and upload the sketch.
 
 #### Adding 3rd party cores
 

--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -20,6 +20,7 @@ package board
 import (
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/arduino/arduino-cli/cli/errorcodes"
@@ -85,7 +86,7 @@ func outputListResp(ports []*rpc.DetectedPort) {
 	})
 
 	t := table.New()
-	t.SetHeader("Port", "Type", "Board Name", "FQBN")
+	t.SetHeader("Port", "Type", "Board Name", "FQBN", "Core")
 	for _, port := range ports {
 		address := port.GetProtocol() + "://" + port.GetAddress()
 		if port.GetProtocol() == "serial" {
@@ -100,7 +101,8 @@ func outputListResp(ports []*rpc.DetectedPort) {
 			for _, b := range boards {
 				board := b.GetName()
 				fqbn := b.GetFQBN()
-				t.AddRow(address, protocol, board, fqbn)
+				core := fqbn[:strings.LastIndex(fqbn, ":")]
+				t.AddRow(address, protocol, board, fqbn, core)
 				// show address and protocol only on the first row
 				address = ""
 				protocol = ""
@@ -108,7 +110,8 @@ func outputListResp(ports []*rpc.DetectedPort) {
 		} else {
 			board := "Unknown"
 			fqbn := ""
-			t.AddRow(address, protocol, board, fqbn)
+			core := ""
+			t.AddRow(address, protocol, board, fqbn, core)
 		}
 	}
 	feedback.Print(t.Render())

--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -18,11 +18,12 @@
 package board
 
 import (
+	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
+	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/arduino/arduino-cli/cli/globals"
@@ -100,18 +101,26 @@ func outputListResp(ports []*rpc.DetectedPort) {
 			})
 			for _, b := range boards {
 				board := b.GetName()
-				fqbn := b.GetFQBN()
-				core := fqbn[:strings.LastIndex(fqbn, ":")]
-				t.AddRow(address, protocol, board, fqbn, core)
-				// show address and protocol only on the first row
+
+				// to improve the user experience, show on a dedicated column
+				// the name of the core supporting the board detected
+				var coreName = ""
+				fqbn, err := cores.ParseFQBN(b.GetFQBN())
+				if err == nil {
+					coreName = fmt.Sprintf("%s:%s", fqbn.Package, fqbn.PlatformArch)
+				}
+
+				t.AddRow(address, protocol, board, fqbn, coreName)
+
+				// reset address and protocol, we only show them on the first row
 				address = ""
 				protocol = ""
 			}
 		} else {
 			board := "Unknown"
 			fqbn := ""
-			core := ""
-			t.AddRow(address, protocol, board, fqbn, core)
+			coreName := ""
+			t.AddRow(address, protocol, board, fqbn, coreName)
 		}
 	}
 	feedback.Print(t.Render())


### PR DESCRIPTION
Fixes #191

Now that #336 has been released, the vicious cycle of not knowing the board name if the corresponding core is not available, and not knowing which core to install without the board name, is finally broken.

To help users who are not familiar with the FQBN concept to better understand which core has to be installed, a new column in the output of `board list` was added to show the name of the core that  supports the detected board.

The README was updated accordingly. 

Note: the core name wasn't added to the JSON output because that would require a non trivial amount of code - provided that the JSON output is supposed to be read by a machine and provided that the name of the core can be easily deduced from the data the CLI already provides, my advice is to avoid making the code too complex and let client applications do a little extra work when needed.