### PR TITLE
Add a stale bot to help grooming issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,106 @@
+name: stale-bot
+
+on:
+  schedule:
+    # run every day at midnight
+    - cron:  '0 0 * * *'
+  issue_comment:
+    types: ['created']
+
+jobs:
+  stale-bot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark stale
+        if: github.event_name == 'schedule'
+        uses: actions/github-script@0.2.0
+        with:
+          github-token: ${{github.token}}
+          script: |
+            // Get a list of all open issues labeled `waiting for feedback`
+            const opts = github.issues.listForRepo.endpoint.merge({
+              ...context.repo,
+              state: 'open',
+              labels: ['waiting for feedback'],
+            });
+            const issues = await github.paginate(opts);
+
+            // Set this value to whatever makes sense for the repo.
+            let elapsedDays = 15
+
+            let elapsed = elapsedDays * 24 * 60 * 60 * 1000;
+            let now = new Date();
+            for (const issue of issues) {
+              // If an issue was active in the past 15 days, leave it alone.
+              if (now - new Date(issue.updated_at).getTime() < elapsedDays) {
+                continue;
+              }
+
+              // If we're here, we've been waiting for feedback for more than
+              // 15 days, mark as stale.
+              github.issues.addLabels({
+                ...context.repo,
+                issue_number: issue.number,
+                labels: ['stale']
+              });
+            }
+
+      - name: Mark active
+        uses: actions/github-script@0.2.0
+        with:
+          github-token: ${{github.token}}
+          script: |
+            // Every time a comment is added to an issue, close it if it contains
+            // the `stale` label.
+
+            // Load issue's labels.
+            const opts = github.issues.listLabelsOnIssue.endpoint.merge({
+              ...context.repo,
+              issue_number: context.issue.number
+            });
+            const labels = await github.paginate(opts);
+
+            // Search for `stale`.
+            for (const label of labels) {
+              if (label.name === 'stale') {
+                await github.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: context.issue.number,
+                  name: 'stale'
+                })
+                return;
+              }
+            }
+
+      - name: Close stale
+        if: github.event_name == 'schedule'
+        uses: actions/github-script@0.2.0
+        with:
+          github-token: ${{github.token}}
+          script: |
+            // Load all the `stale` issues
+            const opts = github.issues.listForRepo.endpoint.merge({
+              ...context.repo,
+              state: 'open',
+              labels: ['stale'],
+            });
+            const issues = await github.paginate(opts);
+
+            // Set this value to whatever makes sense for the repo.
+            let elapsedDays = 30;
+
+            let elapsed = elapsedDays * 24 * 60 * 60 * 1000;
+            let now = new Date();
+            for (const issue of issues) {
+              // If an issue was stale for less than elapsed time, leave it alone.
+              if (now - new Date(issue.updated_at).getTime() < elapsed) {
+                continue;
+              }
+
+              // Close the stale issue.
+              await github.issues.update({
+                ...context.repo,
+                issue_number: issue.number,
+                state: 'closed'
+              });
+            }


### PR DESCRIPTION
This workflow will:

* Mark an issue with the `stale` label after 15 days of no activity on issues labelled with `waiting for feedback`
* Close an issue after 30 days with the label `stale` attached.

The `stale` labels is automatically removed as soon as somebody leaves a comment on the issue.