### PR TITLE
[skip changelog] Only run job on comments activity

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -46,6 +46,7 @@ jobs:
             }
 
       - name: Mark active
+        if: github.event_name == 'issue_comment'
         uses: actions/github-script@0.2.0
         with:
           github-token: ${{github.token}}


### PR DESCRIPTION
Scheduled runs are failing because `Mark active` can only work when the trigger event is a comment added to an issue.