### PR TITLE
Do not fail if install folder is not in PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -172,14 +172,14 @@ testVersion() {
 	set +e
 	CLI="$(which $PROJECT_NAME)"
 	if [ "$?" = "1" ]; then
-		fail "$PROJECT_NAME not found. Did you add "$LBINDIR" to your "'$PATH?'
-	fi
-	if [ $CLI != "$LBINDIR/$PROJECT_NAME" ]; then
+		echo "$PROJECT_NAME not found. You might want to add "$LBINDIR" to your "'$PATH'
+	elif [ $CLI != "$LBINDIR/$PROJECT_NAME" ]; then
 		fail "An existing $PROJECT_NAME was found at $CLI. Please prepend "$LBINDIR" to your "'$PATH'" or remove the existing one."
 	fi
+
 	set -e
-	CLI_VERSION=$($PROJECT_NAME version)
-	echo "$CLI_VERSION installed successfully"
+	CLI_VERSION=$($LBINDIR/$PROJECT_NAME version)
+	echo "$CLI_VERSION installed successfully in $LBINDIR"
 }
 
 


### PR DESCRIPTION
Failing the install script because the target folder isn't in the PATH is misleading and not always a problem (for example in a CI where you might launch the cli with a full path).

With this change, if the target folder is not in the PATH, a message is printed to warn the user but the install will succeed nevertheless.

It mitigates #407 