### PR TITLE
Replace default dummy version

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,12 +63,10 @@ vars:
     sh: echo `go list ./... | grep -v legacy | tr '\n' ' '`
 
   # build vars
-  VERSIONSTRING: "0.0.0-git"
   COMMIT:
     sh: echo ${TRAVIS_COMMIT:-`git log -n 1 --format=%h`}
   LDFLAGS: >
-      -ldflags '-X github.com/arduino/arduino-cli/version.versionString={{.VERSIONSTRING}}
-      -X github.com/arduino/arduino-cli/version.commit={{.COMMIT}}'
+      -ldflags '-X github.com/arduino/arduino-cli/version.commit={{.COMMIT}}'
 
   # test vars
   GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,7 +63,7 @@ vars:
     sh: echo `go list ./... | grep -v legacy | tr '\n' ' '`
 
   # build vars
-  VERSIONSTRING: "0.3.7-alpha.preview"
+  VERSIONSTRING: "0.0.0-git"
   COMMIT:
     sh: echo ${TRAVIS_COMMIT:-`git log -n 1 --format=%h`}
   LDFLAGS: >

--- a/version/version.go
+++ b/version/version.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	defaultVersionString = "0.3.7-alpha.preview"
+	defaultVersionString = "0.0.0-git"
 	versionString        = ""
 	commit               = ""
 )


### PR DESCRIPTION
 The default dummy version `0.3.7-alpha.preview` overlaps with a real version and this creates confusion to developers and contributors.

This PR replaces the default version with an explicit dummy version `0.0.0-git`