### PR TITLE
Disable e2e test on Github Actions windows agent

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,6 +58,11 @@ jobs:
           architecture: 'x64'
 
       - name: Run integration tests
+        # Since we are investigating issues emerged
+        # with python integration tests on windows
+        # this step is disabled for windows-2019
+        # platform ATM
+        if: matrix.operating-system != 'windows-2019'
         run: |
           pip install -r test/requirements.txt
           task test-integration


### PR DESCRIPTION
Windows End to End testing evidenced CLI return codes issues that are currently under investigation.

This is an example of the error reported by the `test` pipeline
```
================================== FAILURES ===================================
_________________________________ test_search _________________________________
##[error]test\test_lib.py:82: in test_search
    assert run_command("lib update-index")
E   AssertionError: assert <Result cmd='cd C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\ArduinoTestWork7 && D:\\a\\arduino-cli\\arduino-cli\\test\\..\\arduino-cli lib update-index' exited=None>
E    +  where <Result cmd='cd C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\ArduinoTestWork7 && D:\\a\\arduino-cli\\arduino-cli\\test\\..\\arduino-cli lib update-index' exited=None> = <function run_command.<locals>._run at 0x0000024CD533FCA8>('lib update-index')
=============== 1 failed, 7 passed, 3 skipped in 46.30 seconds ================
 task: Failed to run task "test-integration": exit status 1
##[error]Process completed with exit code 1.
```


This PR temporarily disables E2E tests (currently improperly labeled as `integration`) until a solution is implemented