### PR TITLE
Replace ctx.ToolsDirs with ctx.BuiltInToolsDirs

### DIFF
--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -95,7 +95,7 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 	}
 
 	if toolsDir, err := config.BundleToolsDirectories(); err == nil {
-		builderCtx.ToolsDirs = toolsDir
+		builderCtx.BuiltInToolsDirs = toolsDir
 	} else {
 		return nil, fmt.Errorf("cannot get bundled tools directories: %s", err)
 	}

--- a/legacy/builder/grpc/rpc.go
+++ b/legacy/builder/grpc/rpc.go
@@ -57,7 +57,7 @@ type builderServer struct {
 }
 
 func (s *builderServer) watch() {
-	folders := []paths.PathList{s.ctx.HardwareDirs, s.ctx.ToolsDirs, s.ctx.BuiltInLibrariesDirs, s.ctx.OtherLibrariesDirs}
+	folders := []paths.PathList{s.ctx.HardwareDirs, s.ctx.BuiltInToolsDirs, s.ctx.BuiltInLibrariesDirs, s.ctx.OtherLibrariesDirs}
 
 	for _, category := range folders {
 		for _, folder := range category {
@@ -84,7 +84,7 @@ func (s *builderServer) DropCache(ctx context.Context, args *pb.VerboseParams) (
 func (s *builderServer) Autocomplete(ctx context.Context, args *pb.BuildParams) (*pb.Response, error) {
 
 	s.ctx.HardwareDirs = paths.NewPathList(strings.Split(args.HardwareFolders, ",")...)
-	s.ctx.ToolsDirs = paths.NewPathList(strings.Split(args.ToolsFolders, ",")...)
+	s.ctx.BuiltInToolsDirs = paths.NewPathList(strings.Split(args.ToolsFolders, ",")...)
 	s.ctx.BuiltInLibrariesDirs = paths.NewPathList(strings.Split(args.BuiltInLibrariesFolders, ",")...)
 	s.ctx.OtherLibrariesDirs = paths.NewPathList(strings.Split(args.OtherLibrariesFolders, ",")...)
 	s.ctx.SketchLocation = paths.New(args.SketchLocation)
@@ -128,7 +128,7 @@ func (s *builderServer) Autocomplete(ctx context.Context, args *pb.BuildParams) 
 func (s *builderServer) Build(args *pb.BuildParams, stream pb.Builder_BuildServer) error {
 
 	s.ctx.HardwareDirs = paths.NewPathList(strings.Split(args.HardwareFolders, ",")...)
-	s.ctx.ToolsDirs = paths.NewPathList(strings.Split(args.ToolsFolders, ",")...)
+	s.ctx.BuiltInToolsDirs = paths.NewPathList(strings.Split(args.ToolsFolders, ",")...)
 	s.ctx.BuiltInLibrariesDirs = paths.NewPathList(strings.Split(args.BuiltInLibrariesFolders, ",")...)
 	s.ctx.OtherLibrariesDirs = paths.NewPathList(strings.Split(args.OtherLibrariesFolders, ",")...)
 	s.ctx.SketchLocation = paths.New(args.SketchLocation)

--- a/legacy/builder/test/builder_test.go
+++ b/legacy/builder/test/builder_test.go
@@ -242,7 +242,7 @@ func TestBuilderBridgeRedBearLab(t *testing.T) {
 
 	ctx := prepareBuilderTestContext(t, paths.New("downloaded_libraries", "Bridge", "examples", "Bridge", "Bridge.ino"), "RedBearLab:avr:blend")
 	ctx.HardwareDirs = append(ctx.HardwareDirs, paths.New("downloaded_board_manager_stuff"))
-	ctx.ToolsDirs = append(ctx.ToolsDirs, paths.New("downloaded_board_manager_stuff"))
+	ctx.BuiltInToolsDirs = append(ctx.BuiltInToolsDirs, paths.New("downloaded_board_manager_stuff"))
 
 	buildPath := SetupBuildPath(t, ctx)
 	defer buildPath.RemoveAll()
@@ -277,7 +277,7 @@ func TestBuilderSketchNoFunctions(t *testing.T) {
 
 	ctx := prepareBuilderTestContext(t, paths.New("sketch_no_functions", "main.ino"), "RedBearLab:avr:blend")
 	ctx.HardwareDirs = append(ctx.HardwareDirs, paths.New("downloaded_board_manager_stuff"))
-	ctx.ToolsDirs = append(ctx.ToolsDirs, paths.New("downloaded_board_manager_stuff"))
+	ctx.BuiltInToolsDirs = append(ctx.BuiltInToolsDirs, paths.New("downloaded_board_manager_stuff"))
 
 	buildPath := SetupBuildPath(t, ctx)
 	defer buildPath.RemoveAll()
@@ -293,7 +293,7 @@ func TestBuilderSketchWithBackup(t *testing.T) {
 
 	ctx := prepareBuilderTestContext(t, paths.New("sketch_with_backup_files", "sketch.ino"), "arduino:avr:uno")
 	ctx.HardwareDirs = append(ctx.HardwareDirs, paths.New("downloaded_board_manager_stuff"))
-	ctx.ToolsDirs = append(ctx.ToolsDirs, paths.New("downloaded_board_manager_stuff"))
+	ctx.BuiltInToolsDirs = append(ctx.BuiltInToolsDirs, paths.New("downloaded_board_manager_stuff"))
 
 	buildPath := SetupBuildPath(t, ctx)
 	defer buildPath.RemoveAll()

--- a/legacy/builder/test/create_build_options_map_test.go
+++ b/legacy/builder/test/create_build_options_map_test.go
@@ -41,7 +41,7 @@ import (
 func TestCreateBuildOptionsMap(t *testing.T) {
 	ctx := &types.Context{
 		HardwareDirs:       paths.NewPathList("hardware", "hardware2"),
-		ToolsDirs:          paths.NewPathList("tools"),
+		BuiltInToolsDirs:   paths.NewPathList("tools"),
 		OtherLibrariesDirs: paths.NewPathList("libraries"),
 		SketchLocation:     paths.New("sketchLocation"),
 		FQBN:               parseFQBN(t, "my:nice:fqbn"),
@@ -55,15 +55,15 @@ func TestCreateBuildOptionsMap(t *testing.T) {
 	err := create.Run(ctx)
 	NoError(t, err)
 
-	require.Equal(t, "{\n"+
-		"  \"additionalFiles\": \"\",\n"+
-		"  \"builtInLibrariesFolders\": \"\",\n"+
-		"  \"customBuildProperties\": \"\",\n"+
-		"  \"fqbn\": \"my:nice:fqbn\",\n"+
-		"  \"hardwareFolders\": \"hardware,hardware2\",\n"+
-		"  \"otherLibrariesFolders\": \"libraries\",\n"+
-		"  \"runtime.ide.version\": \"ideVersion\",\n"+
-		"  \"sketchLocation\": \"sketchLocation\",\n"+
-		"  \"toolsFolders\": \"tools\"\n"+
-		"}", ctx.BuildOptionsJson)
+	require.Equal(t, `{
+  "additionalFiles": "",
+  "builtInLibrariesFolders": "",
+  "builtInToolsFolders": "tools",
+  "customBuildProperties": "",
+  "fqbn": "my:nice:fqbn",
+  "hardwareFolders": "hardware,hardware2",
+  "otherLibrariesFolders": "libraries",
+  "runtime.ide.version": "ideVersion",
+  "sketchLocation": "sketchLocation"
+}`, ctx.BuildOptionsJson)
 }

--- a/legacy/builder/test/load_vid_pid_specific_properties_test.go
+++ b/legacy/builder/test/load_vid_pid_specific_properties_test.go
@@ -44,7 +44,7 @@ func TestLoadVIDPIDSpecificPropertiesWhenNoVIDPIDAreProvided(t *testing.T) {
 
 	ctx := &types.Context{
 		HardwareDirs:      paths.NewPathList(filepath.Join("..", "hardware"), "hardware", "downloaded_hardware"),
-		ToolsDirs:         paths.NewPathList("downloaded_tools", "./tools_builtin"),
+		BuiltInToolsDirs:  paths.NewPathList("downloaded_tools", "./tools_builtin"),
 		SketchLocation:    paths.New("sketch1", "sketch.ino"),
 		FQBN:              parseFQBN(t, "arduino:avr:micro"),
 		ArduinoAPIVersion: "10600",
@@ -74,7 +74,7 @@ func TestLoadVIDPIDSpecificProperties(t *testing.T) {
 
 	ctx := &types.Context{
 		HardwareDirs:      paths.NewPathList(filepath.Join("..", "hardware"), "hardware", "downloaded_hardware"),
-		ToolsDirs:         paths.NewPathList("downloaded_tools", "./tools_builtin"),
+		BuiltInToolsDirs:  paths.NewPathList("downloaded_tools", "./tools_builtin"),
 		SketchLocation:    paths.New("sketch1", "sketch.ino"),
 		FQBN:              parseFQBN(t, "arduino:avr:micro"),
 		ArduinoAPIVersion: "10600",

--- a/legacy/builder/test/merge_sketch_with_bootloader_test.go
+++ b/legacy/builder/test/merge_sketch_with_bootloader_test.go
@@ -46,7 +46,7 @@ func TestMergeSketchWithBootloader(t *testing.T) {
 
 	ctx := &types.Context{
 		HardwareDirs:         paths.NewPathList(filepath.Join("..", "hardware"), "hardware", "downloaded_hardware"),
-		ToolsDirs:            paths.NewPathList("downloaded_tools"),
+		BuiltInToolsDirs:     paths.NewPathList("downloaded_tools"),
 		BuiltInLibrariesDirs: paths.NewPathList("downloaded_libraries"),
 		OtherLibrariesDirs:   paths.NewPathList("libraries"),
 		SketchLocation:       paths.New("sketch1", "sketch.ino"),
@@ -88,7 +88,7 @@ func TestMergeSketchWithBootloaderSketchInBuildPath(t *testing.T) {
 
 	ctx := &types.Context{
 		HardwareDirs:         paths.NewPathList(filepath.Join("..", "hardware"), "hardware", "downloaded_hardware"),
-		ToolsDirs:            paths.NewPathList("downloaded_tools"),
+		BuiltInToolsDirs:     paths.NewPathList("downloaded_tools"),
 		BuiltInLibrariesDirs: paths.NewPathList("downloaded_libraries"),
 		OtherLibrariesDirs:   paths.NewPathList("libraries"),
 		SketchLocation:       paths.New("sketch1", "sketch.ino"),
@@ -130,7 +130,7 @@ func TestMergeSketchWithBootloaderWhenNoBootloaderAvailable(t *testing.T) {
 
 	ctx := &types.Context{
 		HardwareDirs:         paths.NewPathList(filepath.Join("..", "hardware"), "hardware", "downloaded_hardware"),
-		ToolsDirs:            paths.NewPathList("downloaded_tools"),
+		BuiltInToolsDirs:     paths.NewPathList("downloaded_tools"),
 		BuiltInLibrariesDirs: paths.NewPathList("downloaded_libraries"),
 		OtherLibrariesDirs:   paths.NewPathList("libraries"),
 		SketchLocation:       paths.New("sketch1", "sketch.ino"),
@@ -168,7 +168,7 @@ func TestMergeSketchWithBootloaderPathIsParameterized(t *testing.T) {
 
 	ctx := &types.Context{
 		HardwareDirs:         paths.NewPathList(filepath.Join("..", "hardware"), "hardware", "downloaded_hardware", "user_hardware"),
-		ToolsDirs:            paths.NewPathList("downloaded_tools"),
+		BuiltInToolsDirs:     paths.NewPathList("downloaded_tools"),
 		BuiltInLibrariesDirs: paths.NewPathList("downloaded_libraries"),
 		OtherLibrariesDirs:   paths.NewPathList("libraries"),
 		SketchLocation:       paths.New("sketch1", "sketch.ino"),

--- a/legacy/builder/test/store_build_options_map_test.go
+++ b/legacy/builder/test/store_build_options_map_test.go
@@ -42,7 +42,7 @@ import (
 func TestStoreBuildOptionsMap(t *testing.T) {
 	ctx := &types.Context{
 		HardwareDirs:          paths.NewPathList("hardware"),
-		ToolsDirs:             paths.NewPathList("tools"),
+		BuiltInToolsDirs:      paths.NewPathList("tools"),
 		BuiltInLibrariesDirs:  paths.NewPathList("built-in libraries"),
 		OtherLibrariesDirs:    paths.NewPathList("libraries"),
 		SketchLocation:        paths.New("sketchLocation"),
@@ -73,15 +73,15 @@ func TestStoreBuildOptionsMap(t *testing.T) {
 	bytes, err := buildPath.Join(constants.BUILD_OPTIONS_FILE).ReadFile()
 	NoError(t, err)
 
-	require.Equal(t, "{\n"+
-		"  \"additionalFiles\": \"\",\n"+
-		"  \"builtInLibrariesFolders\": \"built-in libraries\",\n"+
-		"  \"customBuildProperties\": \"custom=prop\",\n"+
-		"  \"fqbn\": \"my:nice:fqbn\",\n"+
-		"  \"hardwareFolders\": \"hardware\",\n"+
-		"  \"otherLibrariesFolders\": \"libraries\",\n"+
-		"  \"runtime.ide.version\": \"ideVersion\",\n"+
-		"  \"sketchLocation\": \"sketchLocation\",\n"+
-		"  \"toolsFolders\": \"tools\"\n"+
-		"}", string(bytes))
+	require.Equal(t, `{
+  "additionalFiles": "",
+  "builtInLibrariesFolders": "built-in libraries",
+  "builtInToolsFolders": "tools",
+  "customBuildProperties": "custom=prop",
+  "fqbn": "my:nice:fqbn",
+  "hardwareFolders": "hardware",
+  "otherLibrariesFolders": "libraries",
+  "runtime.ide.version": "ideVersion",
+  "sketchLocation": "sketchLocation"
+}`, string(bytes))
 }

--- a/legacy/builder/tools_loader.go
+++ b/legacy/builder/tools_loader.go
@@ -30,9 +30,6 @@
 package builder
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/go-paths-helper"
 )
@@ -45,28 +42,9 @@ func (s *ToolsLoader) Run(ctx *types.Context) error {
 		return nil
 	}
 
-	folders := paths.NewPathList()
 	builtinFolders := paths.NewPathList()
-
-	if ctx.BuiltInToolsDirs != nil || len(ctx.BuiltInLibrariesDirs) == 0 {
-		folders = ctx.ToolsDirs
+	if ctx.BuiltInToolsDirs != nil {
 		builtinFolders = ctx.BuiltInToolsDirs
-	} else {
-		// Auto-detect built-in tools folders (for arduino-builder backward compatibility)
-		// this is a deprecated feature and will be removed in the future
-		builtinHardwareFolder, err := ctx.BuiltInLibrariesDirs[0].Join("..").Abs()
-
-		if err != nil {
-			fmt.Println("Error detecting ")
-		}
-
-		for _, folder := range ctx.ToolsDirs {
-			if !strings.Contains(folder.String(), builtinHardwareFolder.String()) { // TODO: make a function to check for subfolders
-				folders = append(folders, folder)
-			} else {
-				builtinFolders = append(builtinFolders, folder)
-			}
-		}
 	}
 
 	pm := ctx.PackageManager

--- a/legacy/builder/types/context.go
+++ b/legacy/builder/types/context.go
@@ -24,7 +24,6 @@ type ProgressStruct struct {
 type Context struct {
 	// Build options
 	HardwareDirs         paths.PathList
-	ToolsDirs            paths.PathList
 	BuiltInToolsDirs     paths.PathList
 	BuiltInLibrariesDirs paths.PathList
 	OtherLibrariesDirs   paths.PathList
@@ -122,7 +121,7 @@ type Context struct {
 func (ctx *Context) ExtractBuildOptions() *properties.Map {
 	opts := properties.NewMap()
 	opts.Set("hardwareFolders", strings.Join(ctx.HardwareDirs.AsStrings(), ","))
-	opts.Set("toolsFolders", strings.Join(ctx.ToolsDirs.AsStrings(), ","))
+	opts.Set("builtInToolsFolders", strings.Join(ctx.BuiltInToolsDirs.AsStrings(), ","))
 	opts.Set("builtInLibrariesFolders", strings.Join(ctx.BuiltInLibrariesDirs.AsStrings(), ","))
 	opts.Set("otherLibrariesFolders", strings.Join(ctx.OtherLibrariesDirs.AsStrings(), ","))
 	opts.SetPath("sketchLocation", ctx.SketchLocation)
@@ -146,7 +145,7 @@ func (ctx *Context) ExtractBuildOptions() *properties.Map {
 
 func (ctx *Context) InjectBuildOptions(opts *properties.Map) {
 	ctx.HardwareDirs = paths.NewPathList(strings.Split(opts.Get("hardwareFolders"), ",")...)
-	ctx.ToolsDirs = paths.NewPathList(strings.Split(opts.Get("toolsFolders"), ",")...)
+	ctx.BuiltInToolsDirs = paths.NewPathList(strings.Split(opts.Get("builtInToolsFolders"), ",")...)
 	ctx.BuiltInLibrariesDirs = paths.NewPathList(strings.Split(opts.Get("builtInLibrariesFolders"), ",")...)
 	ctx.OtherLibrariesDirs = paths.NewPathList(strings.Split(opts.Get("otherLibrariesFolders"), ",")...)
 	ctx.SketchLocation = opts.GetPath("sketchLocation")


### PR DESCRIPTION
The ToolsDirs field has been replaced by BuiltInToolsDirs during the big refactoring in the arduino-builder repo.

The intention was to remove ToolsDirs once done, but for some reasons I forgot to remove it.

This commit completes the transition.