### PR TITLE
Only copy elf file if it exists.

### DIFF
--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -209,10 +209,12 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 
 	// Copy .elf file to sketch directory
 	srcElf := paths.New(outputPath[:len(outputPath)-3] + "elf")
-	dstElf := exportPath.Join(exportFile + ".elf")
-	logrus.WithField("from", srcElf).WithField("to", dstElf).Debug("copying sketch build output")
-	if err = srcElf.CopyTo(dstElf); err != nil {
-		return nil, fmt.Errorf("copying elf file: %s", err)
+	if srcElf.Exist() {
+		dstElf := exportPath.Join(exportFile + ".elf")
+		logrus.WithField("from", srcElf).WithField("to", dstElf).Debug("copying sketch build output")
+		if err = srcElf.CopyTo(dstElf); err != nil {
+			return nil, fmt.Errorf("copying elf file: %s", err)
+		}
 	}
 
 	logrus.Tracef("Compile %s for %s successful", sketch.Name, fqbnIn)


### PR DESCRIPTION
Some boards do not produce elf file intermediate (i.e those that use
build.preferred_export_format=axf or the like).  This changes the
logic so that it's not an error for and elf file to be missing.