### PR TITLE
Use a local Walk function

### DIFF
--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino/globals"
 	"github.com/arduino/arduino-cli/arduino/sketch"
+	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 
 	"github.com/pkg/errors"
@@ -137,7 +138,6 @@ func SketchLoad(sketchPath, buildPath string) (*sketch.Sketch, error) {
 		if err != nil {
 			feedback.Errorf("Error during sketch processing: %v", err)
 			os.Exit(errorcodes.ErrGeneric)
-			return filepath.SkipDir
 		}
 
 		// ignore hidden files and skip hidden directories

--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -135,7 +135,8 @@ func SketchLoad(sketchPath, buildPath string) (*sketch.Sketch, error) {
 	err = simpleLocalWalk(sketchFolder, maxFileSystemDepth, func(path string, info os.FileInfo, err error) error {
 
 		if err != nil {
-			feedback.Printf("\nerror: %+v\n\n", err)
+			feedback.Errorf("Error during sketch processing: %v", err)
+			os.Exit(errorcodes.ErrGeneric)
 			return filepath.SkipDir
 		}
 

--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -60,6 +60,7 @@ func SketchSaveItemCpp(item *sketch.Item, destPath string) error {
 
 // SimpleLocalWalk locally replaces filepath.Walk and/but goes through symlinks
 func SimpleLocalWalk(root string, walkFn func(path string, info os.FileInfo, err error) error) error {
+
 	info, err := os.Stat(root)
 
 	if err != nil {
@@ -115,7 +116,6 @@ func SketchLoad(sketchPath, buildPath string) (*sketch.Sketch, error) {
 	// collect all the sketch files
 	var files []string
 	err = SimpleLocalWalk(sketchFolder, func(path string, info os.FileInfo, err error) error {
-
 		// ignore hidden files and skip hidden directories
 		if strings.HasPrefix(info.Name(), ".") {
 			if info.IsDir() {

--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -62,25 +62,25 @@ func SimpleLocalWalk(root string, walkFn func(path string, info os.FileInfo, err
 	info, err := os.Stat(root)
 
 	if err != nil {
-	    return walkFn(root, nil, err)
+		return walkFn(root, nil, err)
 	}
 
 	err = walkFn(root, info, err)
 	if err == filepath.SkipDir {
-	    return nil
+		return nil
 	}
 
 	if info.IsDir() {
-	    files, err := ioutil.ReadDir(root)
-        if err == nil {
-            for _, file := range files {
-                err = SimpleLocalWalk(root + string(os.PathSeparator) + file.Name(), walkFn)
-                if err == filepath.SkipDir {
-                    return nil
-                }
-            }
-        }
-    }
+		files, err := ioutil.ReadDir(root)
+		if err == nil {
+			for _, file := range files {
+				err = SimpleLocalWalk(root + string(os.PathSeparator) + file.Name(), walkFn)
+				if err == filepath.SkipDir {
+					return nil
+				}
+			}
+		}
+	}
 
 	return nil
 }

--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -74,7 +74,7 @@ func SimpleLocalWalk(root string, walkFn func(path string, info os.FileInfo, err
 		files, err := ioutil.ReadDir(root)
 		if err == nil {
 			for _, file := range files {
-				err = SimpleLocalWalk(root + string(os.PathSeparator) + file.Name(), walkFn)
+				err = SimpleLocalWalk(root+string(os.PathSeparator)+file.Name(), walkFn)
 				if err == filepath.SkipDir {
 					return nil
 				}

--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -23,9 +23,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/arduino/arduino-cli/arduino/globals"
 	"github.com/arduino/arduino-cli/arduino/sketch"
+	"github.com/arduino/arduino-cli/cli/feedback"
 
 	"github.com/pkg/errors"
 )

--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -103,11 +103,13 @@ func SketchLoad(sketchPath, buildPath string) (*sketch.Sketch, error) {
 		sketchFolder = sketchPath
 		mainSketchFile = filepath.Join(sketchPath, stat.Name()+".ino")
 		// in the case a dir was passed, ensure the main file exists and is readable
-		f, err := os.Open(mainSketchFile)
+		info, err := os.Stat(mainSketchFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to find the main sketch file")
 		}
-		f.Close()
+		if info.IsDir() {
+			return nil, errors.Wrap(errors.New(mainSketchFile), "sketch must be a file")
+		}
 	} else {
 		sketchFolder = filepath.Dir(sketchPath)
 		mainSketchFile = sketchPath

--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -60,6 +60,7 @@ func SketchSaveItemCpp(item *sketch.Item, destPath string) error {
 
 // SimpleLocalWalk locally replaces filepath.Walk and/but goes through symlinks
 func SimpleLocalWalk(root string, walkFn func(path string, info os.FileInfo, err error) error) error {
+
 	info, err := os.Stat(root)
 
 	if err != nil {

--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -58,6 +58,33 @@ func SketchSaveItemCpp(item *sketch.Item, destPath string) error {
 	return nil
 }
 
+func SimpleLocalWalk(root string, walkFn func(path string, info os.FileInfo, err error) error) error {
+	info, err := os.Stat(root)
+
+	if err != nil {
+	    return walkFn(root, nil, err)
+	}
+
+	err = walkFn(root, info, err)
+	if err == filepath.SkipDir {
+	    return nil
+	}
+
+	if info.IsDir() {
+	    files, err := ioutil.ReadDir(root)
+        if err == nil {
+            for _, file := range files {
+                err = SimpleLocalWalk(root + string(os.PathSeparator) + file.Name(), walkFn)
+                if err == filepath.SkipDir {
+                    return nil
+                }
+            }
+        }
+    }
+
+	return nil
+}
+
 // SketchLoad collects all the files composing a sketch.
 // The parameter `sketchPath` holds a path pointing to a single sketch file or a sketch folder,
 // the path must be absolute.
@@ -86,7 +113,8 @@ func SketchLoad(sketchPath, buildPath string) (*sketch.Sketch, error) {
 
 	// collect all the sketch files
 	var files []string
-	err = filepath.Walk(sketchFolder, func(path string, info os.FileInfo, err error) error {
+	err = SimpleLocalWalk(sketchFolder, func(path string, info os.FileInfo, err error) error {
+
 		// ignore hidden files and skip hidden directories
 		if strings.HasPrefix(info.Name(), ".") {
 			if info.IsDir() {

--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -103,12 +103,18 @@ func SketchLoad(sketchPath, buildPath string) (*sketch.Sketch, error) {
 		sketchFolder = sketchPath
 		mainSketchFile = filepath.Join(sketchPath, stat.Name()+".ino")
 		// in the case a dir was passed, ensure the main file exists and is readable
-		info, err := os.Stat(mainSketchFile)
+		f, err := os.Open(mainSketchFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to find the main sketch file")
 		}
+		f.Close()
+		// ensure it is not a directory
+		info, err := os.Stat(mainSketchFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to check the main sketch file")
+		}
 		if info.IsDir() {
-			return nil, errors.Wrap(errors.New(mainSketchFile), "sketch must be a file")
+			return nil, errors.Wrap(errors.New(mainSketchFile), "sketch must not be a directory")
 		}
 	} else {
 		sketchFolder = filepath.Dir(sketchPath)

--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -58,6 +58,7 @@ func SketchSaveItemCpp(item *sketch.Item, destPath string) error {
 	return nil
 }
 
+// SimpleLocalWalk locally replaces filepath.Walk and/but goes through symlinks
 func SimpleLocalWalk(root string, walkFn func(path string, info os.FileInfo, err error) error) error {
 	info, err := os.Stat(root)
 

--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -60,7 +60,6 @@ func SketchSaveItemCpp(item *sketch.Item, destPath string) error {
 
 // SimpleLocalWalk locally replaces filepath.Walk and/but goes through symlinks
 func SimpleLocalWalk(root string, walkFn func(path string, info os.FileInfo, err error) error) error {
-
 	info, err := os.Stat(root)
 
 	if err != nil {


### PR DESCRIPTION
Because arduino-cli segfaults when sketchDir is a symbolic link,
a simple walk function is introduced with a twofold effect:
- fix the segfault
- allow to use symlinks

ref: https://www.google.com/search?q=golang+Walk+does+not+follow+symbolic+links


*edit*:
* fixes #424 
* fixes #358 