### PR TITLE
Use patched invoke in e2e requirements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,11 +58,6 @@ jobs:
           architecture: 'x64'
 
       - name: Run integration tests
-        # Since we are investigating issues emerged
-        # with python integration tests on windows
-        # this step is disabled for windows-2019
-        # platform ATM
-        if: matrix.operating-system != 'windows-2019'
         run: |
           pip install -r test/requirements.txt
           task test-integration

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,12 +1,12 @@
 # This file is part of arduino-cli.
-
+#
 # Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
-
+#
 # This software is released under the GNU General Public License version 3,
 # which covers the main part of arduino-cli.
 # The terms of this license can be found at:
 # https://www.gnu.org/licenses/gpl-3.0.en.html
-
+#
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to modify or
 # otherwise use the software for commercial activities involving the Arduino

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,12 +1,12 @@
 # This file is part of arduino-cli.
-#
+
 # Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
-#
+
 # This software is released under the GNU General Public License version 3,
 # which covers the main part of arduino-cli.
 # The terms of this license can be found at:
 # https://www.gnu.org/licenses/gpl-3.0.en.html
-#
+
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to modify or
 # otherwise use the software for commercial activities involving the Arduino
@@ -48,7 +48,7 @@ def working_dir(tmpdir_factory):
 
 
 @pytest.fixture(scope="function")
-def run_command(data_dir, downloads_dir, working_dir):
+def run_command(pytestconfig, data_dir, downloads_dir, working_dir):
     """
     Provide a wrapper around invoke's `run` API so that every test
     will work in the same temporary folder.
@@ -56,7 +56,7 @@ def run_command(data_dir, downloads_dir, working_dir):
     Useful reference:
         http://docs.pyinvoke.org/en/1.2/api/runners.html#invoke.runners.Result
     """
-    cli_path = os.path.join(pytest.config.rootdir, "..", "arduino-cli")
+    cli_path = os.path.join(pytestconfig.rootdir, "..", "arduino-cli")
     env = {
         "ARDUINO_DATA_DIR": data_dir,
         "ARDUINO_DOWNLOADS_DIR": downloads_dir,

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,7 +2,7 @@ astroid==2.2.5
 atomicwrites==1.3.0
 attrs==19.1.0
 importlib-metadata==0.18
-invoke==1.3.0
+git+https://github.com/flazzarini/invoke.git
 isort==4.3.21
 lazy-object-proxy==1.4.1
 mccabe==0.6.1
@@ -13,7 +13,7 @@ pluggy==0.12.0
 py==1.8.0
 pylint==2.3.1
 pyparsing==2.4.0
-pytest==5.0.1
+pytest==5.1.3
 semver==2.8.1
 simplejson==3.16.0
 six==1.12.0

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,6 +2,7 @@ astroid==2.2.5
 atomicwrites==1.3.0
 attrs==19.1.0
 importlib-metadata==0.18
+# temporary, replaces invoke==1.3.0 in favour of https://github.com/pyinvoke/invoke/pull/661
 git+https://github.com/flazzarini/invoke.git
 isort==4.3.21
 lazy-object-proxy==1.4.1

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1,20 +1,21 @@
 # This file is part of arduino-cli.
-
+#
 # Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
-
+#
 # This software is released under the GNU General Public License version 3,
 # which covers the main part of arduino-cli.
 # The terms of this license can be found at:
 # https://www.gnu.org/licenses/gpl-3.0.en.html
-
+#
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to modify or
 # otherwise use the software for commercial activities involving the Arduino
 # software without disclosing the source code of your own applications. To purchase
 # a commercial license, send an email to license@arduino.cc.
-import pytest
 import json
 import os
+
+import pytest
 
 from .common import running_on_ci
 

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1,20 +1,20 @@
 # This file is part of arduino-cli.
-#
+
 # Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
-#
+
 # This software is released under the GNU General Public License version 3,
 # which covers the main part of arduino-cli.
 # The terms of this license can be found at:
 # https://www.gnu.org/licenses/gpl-3.0.en.html
-#
+
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to modify or
 # otherwise use the software for commercial activities involving the Arduino
 # software without disclosing the source code of your own applications. To purchase
 # a commercial license, send an email to license@arduino.cc.
+import pytest
 import json
 import os
-import pytest
 
 from .common import running_on_ci
 
@@ -124,7 +124,7 @@ def test_compile_and_compile_combo(run_command, data_dir):
 
     # Build sketch for each detected board
     for board in detected_boards:
-        log_file_name = "{fqbn}-compile.log".format(fqbn=board.get('fqbn'))
+        log_file_name = "{fqbn}-compile.log".format(fqbn=board.get('fqbn').replace(":", "-"))
         log_file_path = os.path.join(data_dir, log_file_name)
         command_log_flags = "--log-format json --log-file {} --log-level trace".format(log_file_path)
         result = run_command("compile -b {fqbn} --upload -p {address} {sketch_path} {log_flags}".format(


### PR DESCRIPTION
This PR uses a patched version of `invoke` in order to overcome flaky test issue reported in previous PR https://github.com/arduino/arduino-cli/pull/416, and reported also from other users in the `invoke` repo (https://github.com/pyinvoke/invoke/issues/660). 

This PR applies the following changes:
- Adds the patch (https://github.com/pyinvoke/invoke/pull/661) to `test/requirements.txt` 
- Re-enables the windows e2e python test step in the `test` GH Actions workflow
- updates `pytest` to 3.5.1 in `test/requirements.txt` 
