### PR TITLE
Add detected_board fixture

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -12,7 +12,14 @@
 # otherwise use the software for commercial activities involving the Arduino
 # software without disclosing the source code of your own applications. To purchase
 # a commercial license, send an email to license@arduino.cc.
+import collections
 import os
+import pytest
+import invoke
+
+from invoke.context import Context
+
+Board = collections.namedtuple("Board", "address fqbn package architecture id core")
 
 
 def running_on_ci():
@@ -21,3 +28,28 @@ def running_on_ci():
     """
     val = os.getenv("APPVEYOR") or os.getenv("DRONE") or os.getenv("GITHUB_WORKFLOW")
     return val is not None
+
+
+def build_runner(cli_path, env, working_dir):
+    """
+    Provide a wrapper around invoke's `run` API so that every test
+    will work in its own temporary folder.
+
+    Useful reference:
+        http://docs.pyinvoke.org/en/1.2/api/runners.html#invoke.runners.Result
+
+    :param cli_path: the path to the ``arduino-cli`` executable file.
+    :param env: a ``dict`` with the environment variables to use.
+    :param working_dir: the CWD where the command will be executed.
+
+    :returns a runner function with the mechanic to run an ``arduino-cli`` instance
+    with a given environment ``env`` in the directory ```working_dir`.
+    """
+
+    def _run(cmd_string):
+        cli_full_line = "{} {}".format(cli_path, cmd_string)
+        run_context = Context()
+        with run_context.cd(working_dir):
+            return invoke.run(cli_full_line, echo=False, hide=True, warn=True, env=env)
+
+    return _run

--- a/test/common.py
+++ b/test/common.py
@@ -14,8 +14,6 @@
 # a commercial license, send an email to license@arduino.cc.
 import collections
 import os
-import pytest
-import invoke
 
 from invoke.context import Context
 
@@ -50,6 +48,6 @@ def build_runner(cli_path, env, working_dir):
         cli_full_line = "{} {}".format(cli_path, cmd_string)
         run_context = Context()
         with run_context.cd(working_dir):
-            return invoke.run(cli_full_line, echo=False, hide=True, warn=True, env=env)
+            return run_context.run(cli_full_line, echo=False, hide=True, warn=True, env=env)
 
     return _run

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -77,7 +77,10 @@ def _run_session_command(pytestconfig, tmpdir_factory, downloads_dir):
         "ARDUINO_DOWNLOADS_DIR": downloads_dir,
         "ARDUINO_SKETCHBOOK_DIR": data_dir,
     }
-    working_dir = tmpdir_factory.mktemp("SessionTestWork")
+    # it looks like the pyinvoke library has a few problems in dealing with the path
+    # object, so to avoid this issue we can convert them to str.
+    # Take a look at https://github.com/pyinvoke/invoke/issues/454 for more details.
+    working_dir = str(tmpdir_factory.mktemp("SessionTestWork"))
 
     return build_runner(cli_path, env, working_dir)
 


### PR DESCRIPTION
This PR adds a new `detected_boards` fixture with the list of boards attached to the host machine.

I've add specific `_run_session_command` fixture to collect metadata using the same `arduino-cli` executable.

I've started to use the fixture in the `test_compile.py` but I'd love to hear what you think of this approach before go any further in the implementation.