### PR TITLE
Added globals.ParseLibraryReferenceArgs method

### DIFF
--- a/cli/globals/args.go
+++ b/cli/globals/args.go
@@ -72,3 +72,45 @@ func ParseReferenceArg(arg string, parseArch bool) (*ReferenceArg, error) {
 
 	return ret, nil
 }
+
+// LibraryReferenceArg is a command line argument that reference a library.
+type LibraryReferenceArg struct {
+	Name    string
+	Version string
+}
+
+func (r *LibraryReferenceArg) String() string {
+	if r.Version != "" {
+		return r.Name + "@" + r.Version
+	}
+	return r.Name
+}
+
+// ParseLibraryReferenceArg parse a command line argument that reference a
+// library in the form "LibName@Version" or just "LibName".
+func ParseLibraryReferenceArg(arg string) (*LibraryReferenceArg, error) {
+	tokens := strings.SplitN(arg, "@", 2)
+
+	ret := &LibraryReferenceArg{}
+	// TODO: check library Name constraints
+	// TODO: check library Version constraints
+	ret.Name = tokens[0]
+	if len(tokens) > 1 {
+		ret.Version = tokens[1]
+	}
+	return ret, nil
+}
+
+// ParseLibraryReferenceArgs is a convenient wrapper that operates on a slice of strings and
+// calls ParseLibraryReferenceArg for each of them. It returns at the first invalid argument.
+func ParseLibraryReferenceArgs(args []string) ([]*LibraryReferenceArg, error) {
+	ret := []*LibraryReferenceArg{}
+	for _, arg := range args {
+		if reference, err := ParseLibraryReferenceArg(arg); err == nil {
+			ret = append(ret, reference)
+		} else {
+			return nil, err
+		}
+	}
+	return ret, nil
+}

--- a/cli/lib/download.go
+++ b/cli/lib/download.go
@@ -47,7 +47,7 @@ func initDownloadCommand() *cobra.Command {
 
 func runDownloadCommand(cmd *cobra.Command, args []string) {
 	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
-	refs, err := globals.ParseReferenceArgs(args, false)
+	refs, err := globals.ParseLibraryReferenceArgs(args)
 	if err != nil {
 		feedback.Errorf("Invalid argument passed: %v", err)
 		os.Exit(errorcodes.ErrBadArgument)
@@ -56,7 +56,7 @@ func runDownloadCommand(cmd *cobra.Command, args []string) {
 	for _, library := range refs {
 		libraryDownloadReq := &rpc.LibraryDownloadReq{
 			Instance: instance,
-			Name:     library.PackageName,
+			Name:     library.Name,
 			Version:  library.Version,
 		}
 		_, err := lib.LibraryDownload(context.Background(), libraryDownloadReq, output.ProgressBar(),

--- a/cli/lib/install.go
+++ b/cli/lib/install.go
@@ -47,7 +47,7 @@ func initInstallCommand() *cobra.Command {
 
 func runInstallCommand(cmd *cobra.Command, args []string) {
 	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
-	refs, err := globals.ParseReferenceArgs(args, false)
+	refs, err := globals.ParseLibraryReferenceArgs(args)
 	if err != nil {
 		feedback.Errorf("Arguments error: %v", err)
 		os.Exit(errorcodes.ErrBadArgument)
@@ -56,7 +56,7 @@ func runInstallCommand(cmd *cobra.Command, args []string) {
 	for _, library := range refs {
 		libraryInstallReq := &rpc.LibraryInstallReq{
 			Instance: instance,
-			Name:     library.PackageName,
+			Name:     library.Name,
 			Version:  library.Version,
 		}
 		err := lib.LibraryInstall(context.Background(), libraryInstallReq, output.ProgressBar(),

--- a/cli/lib/uninstall.go
+++ b/cli/lib/uninstall.go
@@ -48,7 +48,7 @@ func runUninstallCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino lib uninstall`")
 
 	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
-	refs, err := globals.ParseReferenceArgs(args, false)
+	refs, err := globals.ParseLibraryReferenceArgs(args)
 	if err != nil {
 		feedback.Errorf("Invalid argument passed: %v", err)
 		os.Exit(errorcodes.ErrBadArgument)
@@ -57,7 +57,7 @@ func runUninstallCommand(cmd *cobra.Command, args []string) {
 	for _, library := range refs {
 		err := lib.LibraryUninstall(context.Background(), &rpc.LibraryUninstallReq{
 			Instance: instance,
-			Name:     library.PackageName,
+			Name:     library.Name,
 			Version:  library.Version,
 		}, output.TaskProgress())
 		if err != nil {


### PR DESCRIPTION
Is `MyLib@` or `MyCore:avr@` a "good" parameter?
I'd say that in those cases we should return a "Missing Version" error.