### PR TITLE
[skip changelog] gRPC "client_example" refresh

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -80,7 +80,7 @@ func createCliCommandTree(cmd *cobra.Command) {
 	cmd.AddCommand(version.NewCommand())
 
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Print the logs on the standard output.")
-	cmd.PersistentFlags().StringVar(&globals.LogLevel, "log-level", defaultLogLevel, "Messages with this level and above will be logged (default: warn).")
+	cmd.PersistentFlags().StringVar(&globals.LogLevel, "log-level", defaultLogLevel, "Messages with this level and above will be logged.")
 	cmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Path to the file where logs will be written.")
 	cmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "The output format for the logs, can be [text|json].")
 	cmd.PersistentFlags().StringVar(&globals.OutputFormat, "format", "text", "The output format, can be [text|json].")

--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -41,7 +41,7 @@ const (
 func NewCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:     "daemon",
-		Short:   "Run as a daemon",
+		Short:   fmt.Sprintf("Run as a daemon on port %s", port),
 		Long:    "Running as a daemon the initialization of cores and libraries is done only once.",
 		Example: "  " + os.Args[0] + " daemon",
 		Args:    cobra.NoArgs,

--- a/client_example/go.mod
+++ b/client_example/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/arduino-cli/client_example
 
-go 1.12
+go 1.13
 
 require (
 	github.com/arduino/arduino-cli v0.0.0-20190826141027-35722fda467d

--- a/client_example/main.go
+++ b/client_example/main.go
@@ -167,7 +167,9 @@ func initInstance(client rpc.ArduinoCoreClient) *rpc.Instance {
 	// the data folder.
 	initRespStream, err := client.Init(context.Background(), &rpc.InitReq{
 		Configuration: &rpc.Configuration{
-			DataDir: dataDir,
+			DataDir:       dataDir,
+			SketchbookDir: dataDir,
+			DownloadsDir:  dataDir,
 		},
 	})
 	if err != nil {
@@ -368,11 +370,12 @@ func callBoardsDetails(client rpc.ArduinoCoreClient, instance *rpc.Instance) {
 }
 
 func callBoardAttach(client rpc.ArduinoCoreClient, instance *rpc.Instance) {
+	currDir, _ := os.Getwd()
 	boardattachresp, err := client.BoardAttach(context.Background(),
 		&rpc.BoardAttachReq{
 			Instance:   instance,
 			BoardUri:   "/dev/ttyACM0",
-			SketchPath: filepath.Join(dataDir, "hello.ino"),
+			SketchPath: filepath.Join(currDir, "hello.ino"),
 		})
 
 	if err != nil {
@@ -402,11 +405,12 @@ func callBoardAttach(client rpc.ArduinoCoreClient, instance *rpc.Instance) {
 }
 
 func callCompile(client rpc.ArduinoCoreClient, instance *rpc.Instance) {
+	currDir, _ := os.Getwd()
 	compRespStream, err := client.Compile(context.Background(),
 		&rpc.CompileReq{
 			Instance:   instance,
 			Fqbn:       "arduino:samd:mkr1000",
-			SketchPath: "hello.ino",
+			SketchPath: filepath.Join(currDir, "hello.ino"),
 			Verbose:    true,
 		})
 
@@ -440,11 +444,12 @@ func callCompile(client rpc.ArduinoCoreClient, instance *rpc.Instance) {
 }
 
 func callUpload(client rpc.ArduinoCoreClient, instance *rpc.Instance) {
+	currDir, _ := os.Getwd()
 	uplRespStream, err := client.Upload(context.Background(),
 		&rpc.UploadReq{
 			Instance:   instance,
 			Fqbn:       "arduino:samd:mkr1000",
-			SketchPath: "hello.ino",
+			SketchPath: filepath.Join(currDir, "hello.ino"),
 			Port:       "/dev/ttyACM0",
 			Verbose:    true,
 		})

--- a/client_example/main.go
+++ b/client_example/main.go
@@ -168,8 +168,8 @@ func initInstance(client rpc.ArduinoCoreClient) *rpc.Instance {
 	initRespStream, err := client.Init(context.Background(), &rpc.InitReq{
 		Configuration: &rpc.Configuration{
 			DataDir:       dataDir,
-			SketchbookDir: dataDir,
-			DownloadsDir:  dataDir,
+			SketchbookDir: filepath.Join(dataDir, "sketchbook"),
+			DownloadsDir:  filepath.Join(dataDir, "staging"),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
This PR:
- updates the gRPC `client_example` to align it with the sketch new latest behavior (see #396 ) 
-  applies little cosmetics to `help` printout