### PR TITLE
Fix "lib uninstall" when library name contains spaces

### DIFF
--- a/arduino/libraries/librariesmanager/librariesmanager.go
+++ b/arduino/libraries/librariesmanager/librariesmanager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/libraries"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesindex"
+	"github.com/arduino/arduino-cli/arduino/utils"
 	paths "github.com/arduino/go-paths-helper"
 	"github.com/pmylund/sortutil"
 	"github.com/sirupsen/logrus"
@@ -209,7 +210,8 @@ func (sc *LibrariesManager) LoadLibrariesFromDir(librariesDir *LibrariesDir) err
 // name and version or, if the version is nil, the library installed
 // in the sketchbook.
 func (sc *LibrariesManager) FindByReference(libRef *librariesindex.Reference) *libraries.Library {
-	alternatives, have := sc.Libraries[libRef.Name]
+	saneName := utils.SanitizeName(libRef.Name)
+	alternatives, have := sc.Libraries[saneName]
 	if !have {
 		return nil
 	}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -56,7 +56,7 @@ def run_command(pytestconfig, data_dir, downloads_dir, working_dir):
     Useful reference:
         http://docs.pyinvoke.org/en/1.2/api/runners.html#invoke.runners.Result
     """
-    cli_path = os.path.join(pytestconfig.rootdir, "..", "arduino-cli")
+    cli_path = os.path.join(str(pytestconfig.rootdir), "..", "arduino-cli")
     env = {
         "ARDUINO_DATA_DIR": data_dir,
         "ARDUINO_DOWNLOADS_DIR": downloads_dir,


### PR DESCRIPTION
Now,  the "_" is replaced with a blanket " ", to reslove the
inconsistency problem. However, use the name of the installing
library may be a better solution.

fixes #362 

BTW, when we uninstall libraries, there are no messages to notify the user libraries are successfully uninstalled.
However, when we install libraries message like `Installed LiquidCrystal I2C@1.1.2` is printed to notify  libraries are successfully installed.