### PR TITLE
Do not bail out if invalid PID is detected during board listing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	golang.org/x/text v0.3.0
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190327125643-d831d65fe17d // indirect
 	google.golang.org/grpc v1.21.1
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect


### PR DESCRIPTION
The USB PID, in theory, should be always filled with a value, but for some
reason the serial library is not detecting it correctly.

This should fix a fatal error on MacOSX, for some devices the returned
PID is empty:

  $ lsusb
  2019-10-18 09:47:32.186 system_profiler[34964:3584353] SPUSBDevice: IOCreatePlugInInterfaceForService failed 0xe00002be
  Bus 020 Device 000: ID 05ac:8600 Apple Inc. Apple T1 Controller
  Bus 000 Device 001: ID 1d6b:ISPT Linux Foundation USB 3.0 Bus
  Bus 000 Device 001: ID 1d6b:CIAR Linux Foundation USB 3.1 Bus
  Bus 001 Device 001: ID 1d6b:CIAR Linux Foundation USB 3.1 Bus

This fix should increase robustness until the underlying bug is fixed.