### PR TITLE
[skip changelog] Force windows env to use bash as shell instead of powershell

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,8 @@ jobs:
           go get github.com/golangci/govet
           go get golang.org/x/lint/golint
           go get github.com/golang/protobuf/protoc-gen-go
+        if: matrix.operating-system == 'windows-2019'
+        shell: cmd
 
       - name: Install Taskfile
         uses: Arduino/actions/setup-taskfile@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,11 +28,11 @@ jobs:
           go-version: '1.13'
 
       - name: Install Go deps
-          if: matrix.operating-system != 'windows-2019'
-          run: |
-            go get github.com/golangci/govet
-            go get golang.org/x/lint/golint
-            go get github.com/golang/protobuf/protoc-gen-go
+        if: matrix.operating-system != 'windows-2019'
+        run: |
+          go get github.com/golangci/govet
+          go get golang.org/x/lint/golint
+          go get github.com/golang/protobuf/protoc-gen-go
 
       - name: Install Go deps on windows
         # since 10/23/2019 pwsh is the default shell

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        operating-system: [ubuntu-18.04, windows-2019] #, macOS-10.14]
+        operating-system: [ubuntu-18.04, windows-2019, macOS-10.14]
 
     runs-on: ${{ matrix.operating-system }}
 
@@ -28,12 +28,22 @@ jobs:
           go-version: '1.13'
 
       - name: Install Go deps
+          if: matrix.operating-system != 'windows-2019'
+          run: |
+            go get github.com/golangci/govet
+            go get golang.org/x/lint/golint
+            go get github.com/golang/protobuf/protoc-gen-go
+
+      - name: Install Go deps on windows
+        # since 10/23/2019 pwsh is the default shell
+        # on Windows, but pwsh fails to install protoc-gen-go
+        # so we force cmd as default shell for this task
+        if: matrix.operating-system == 'windows-2019'
+        shell: cmd
         run: |
           go get github.com/golangci/govet
           go get golang.org/x/lint/golint
           go get github.com/golang/protobuf/protoc-gen-go
-        if: matrix.operating-system == 'windows-2019'
-        shell: cmd
 
       - name: Install Taskfile
         uses: Arduino/actions/setup-taskfile@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        operating-system: [ubuntu-18.04, windows-2019, macOS-10.14]
+        operating-system: [windows-2019]
+        # operating-system: [ubuntu-18.04, windows-2019, macOS-10.14]
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,12 +11,10 @@ jobs:
 
     strategy:
       matrix:
-        operating-system: [windows-2019]
-        # operating-system: [ubuntu-18.04, windows-2019, macOS-10.14]
+        operating-system: [ubuntu-18.04, windows-2019, macOS-10.14]
 
     runs-on: ${{ matrix.operating-system }}
-    if: matrix.operating-system == 'windows-2019'
-    shell: cmd
+
     steps:
       - name: Disable EOL conversions
         run: git config --global core.autocrlf false
@@ -34,6 +32,8 @@ jobs:
           go get github.com/golangci/govet
           go get golang.org/x/lint/golint
           go get github.com/golang/protobuf/protoc-gen-go
+        if: matrix.operating-system == 'windows-2019'
+        shell: cmd
 
       - name: Install Taskfile
         uses: Arduino/actions/setup-taskfile@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        operating-system: [ubuntu-18.04, windows-2019, macOS-10.14]
+        operating-system: [ubuntu-18.04, windows-2019] #, macOS-10.14]
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,8 @@ jobs:
         # operating-system: [ubuntu-18.04, windows-2019, macOS-10.14]
 
     runs-on: ${{ matrix.operating-system }}
-
+    if: matrix.operating-system == 'windows-2019'
+    shell: cmd
     steps:
       - name: Disable EOL conversions
         run: git config --global core.autocrlf false
@@ -33,8 +34,6 @@ jobs:
           go get github.com/golangci/govet
           go get golang.org/x/lint/golint
           go get github.com/golang/protobuf/protoc-gen-go
-        if: matrix.operating-system == 'windows-2019'
-        shell: cmd
 
       - name: Install Taskfile
         uses: Arduino/actions/setup-taskfile@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,22 +28,23 @@ jobs:
           go-version: '1.13'
 
       - name: Install Go deps
-        if: matrix.operating-system != 'windows-2019'
+#        if: matrix.operating-system != 'windows-2019'
         run: |
           go get github.com/golangci/govet
           go get golang.org/x/lint/golint
           go get github.com/golang/protobuf/protoc-gen-go
+        shell: bash
 
-      - name: Install Go deps on windows
-        # since 10/23/2019 pwsh is the default shell
-        # on Windows, but pwsh fails to install protoc-gen-go
-        # so we force cmd as default shell for this task
-        if: matrix.operating-system == 'windows-2019'
-        run: |
-          go get github.com/golangci/govet
-          go get golang.org/x/lint/golint
-          go get github.com/golang/protobuf/protoc-gen-go
-        shell: cmd
+#      - name: Install Go deps on windows
+#        # since 10/23/2019 pwsh is the default shell
+#        # on Windows, but pwsh fails to install protoc-gen-go
+#        # so we force cmd as default shell for this task
+#        if: matrix.operating-system == 'windows-2019'
+#        run: |
+#          go get github.com/golangci/govet
+#          go get golang.org/x/lint/golint
+#          go get github.com/golang/protobuf/protoc-gen-go
+#        shell: cmd
 
       - name: Install Taskfile
         uses: Arduino/actions/setup-taskfile@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,11 +39,11 @@ jobs:
         # on Windows, but pwsh fails to install protoc-gen-go
         # so we force cmd as default shell for this task
         if: matrix.operating-system == 'windows-2019'
-        shell: cmd
         run: |
           go get github.com/golangci/govet
           go get golang.org/x/lint/golint
           go get github.com/golang/protobuf/protoc-gen-go
+        shell: cmd
 
       - name: Install Taskfile
         uses: Arduino/actions/setup-taskfile@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,23 +28,14 @@ jobs:
           go-version: '1.13'
 
       - name: Install Go deps
-#        if: matrix.operating-system != 'windows-2019'
+        # Since 10/23/2019 pwsh is the default shell
+        # on Windows, but pwsh fails to install protoc-gen-go so
+        # we force bash as default shell for all OSes in this task
         run: |
           go get github.com/golangci/govet
           go get golang.org/x/lint/golint
           go get github.com/golang/protobuf/protoc-gen-go
         shell: bash
-
-#      - name: Install Go deps on windows
-#        # since 10/23/2019 pwsh is the default shell
-#        # on Windows, but pwsh fails to install protoc-gen-go
-#        # so we force cmd as default shell for this task
-#        if: matrix.operating-system == 'windows-2019'
-#        run: |
-#          go get github.com/golangci/govet
-#          go get golang.org/x/lint/golint
-#          go get github.com/golang/protobuf/protoc-gen-go
-#        shell: cmd
 
       - name: Install Taskfile
         uses: Arduino/actions/setup-taskfile@master


### PR DESCRIPTION
As per [GitHub announcement](https://github.blog/changelog/2019-10-17-github-actions-default-shell-on-windows-runners-is-changing-to-powershell/) the default shell for Windows steps is `pwsh`.

This causes the `Install Go deps` step [fail on windows](https://github.com/arduino/arduino-cli/runs/274628439). 

```
  Install Go deps13s
##[error]Process completed with exit code 1.
Run go get github.com/golangci/govet
  go get github.com/golangci/govet
  go get golang.org/x/lint/golint
  go get github.com/golang/protobuf/protoc-gen-go
  shell: C:\Program Files\PowerShell\6\pwsh.EXE -command ". '{0}'"
  env:
    GOROOT: C:\hostedtoolcache\windows\go\1.13.3\x64
go: finding github.com/golangci/govet latest
go: downloading github.com/golangci/govet v0.0.0-20180818181408-44ddbe260190
go: extracting github.com/golangci/govet v0.0.0-20180818181408-44ddbe260190
go: downloading golang.org/x/tools v0.0.0-20190328211700-ab21143f2384
go: extracting golang.org/x/tools v0.0.0-20190328211700-ab21143f2384
go: finding golang.org/x/tools v0.0.0-20190328211700-ab21143f2384
go: finding golang.org/x/lint latest
go: downloading golang.org/x/lint v0.0.0-20190930215403-16217165b5de
go: extracting golang.org/x/lint v0.0.0-20190930215403-16217165b5de
go: downloading golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3
go: extracting golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3
go: finding github.com/golang/protobuf v1.3.2
##[error]Process completed with exit code 1.
```

Switching to `bash` solves the issue as per [github documentation](https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun)

> The default shell on non-Windows platforms with a fallback to sh. When specifying a bash shell on Windows, the bash shell included with Git for Windows is used.
