### PR TITLE
Fixed upload issue on esp32 (partitions artifacts copy)

### DIFF
--- a/cli/testdata/Blink/Blink.ino
+++ b/cli/testdata/Blink/Blink.ino
@@ -1,0 +1,3 @@
+
+void setup() {}
+void loop() {}

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	golang.org/x/text v0.3.0
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190327125643-d831d65fe17d // indirect
 	google.golang.org/grpc v1.21.1
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c h1:agh2JT96G8egU7FEb13L4dq3fnCN7lxXhJ86t69+W7s=
 github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c/go.mod h1:HK7SpkEax/3P+0w78iRQx1sz1vCDYYw9RXwHjQTB5i8=
-github.com/arduino/go-paths-helper v0.0.0-20190214132331-c3c98d1bf2e1 h1:S0NpDSqjlkNA510vmRCP5Cq9mPgu3rWDSdeN4SI1Mwc=
-github.com/arduino/go-paths-helper v0.0.0-20190214132331-c3c98d1bf2e1/go.mod h1:OGL+FS3aTrS01YsBAJJhkGuxtEGsFRSgZYo8b3vefdc=
 github.com/arduino/go-paths-helper v1.0.1 h1:utYXLM2RfFlc9qp/MJTIYp3t6ux/xM6mWjeEb/WLK4Q=
 github.com/arduino/go-paths-helper v1.0.1/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3v5YYu35Yb+w31Ck=
 github.com/arduino/go-properties-orderedmap v0.0.0-20190828172252-05018b28ff6c h1:4z4PJqNH8WGXtm9ix2muUOAP7gxTGBOdQTuKEDyCnsA=

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -14,6 +14,7 @@ pluggy==0.12.0
 py==1.8.0
 pylint==2.3.1
 pyparsing==2.4.0
+pyserial==3.4
 pytest==5.1.3
 semver==2.8.1
 simplejson==3.16.0


### PR DESCRIPTION
Previously the compile command copied only the following artifacts:

```
sketch.ino.hex (or .bin)
sketch.ino.elf
```

now also the files matching the glob

```
sketch.ino.*.hex
```

will be copied.
This allows for some 3rd party core, like esp32, to copy also extra files like `sketch.ino.partitions.bin`.

Should fix #163