### PR TITLE
[skip changelog] Use github token in Install Taskfile step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Install Taskfile
         uses: Arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check the code is good
         run: task check


### PR DESCRIPTION
Use github token in `Install Taskfile` step after [arduino/actions/setup-taskfile](https://github.com/arduino/actions/pull/7) merged the functionality