### PR TITLE
[skip changelog] Pin python version to 3.7 for integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.x'
+          python-version: '3.7'
           architecture: 'x64'
 
       - name: Run integration tests


### PR DESCRIPTION
As python 3.8 became available, the following [error](https://github.com/arduino/arduino-cli/runs/279178199#step:14:479) appeared in the `test` workflow:

```
pytest test
Traceback (most recent call last):
  File "c:\hostedtoolcache\windows\python\3.8.0\x64\lib\runpy.py", line 192, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\hostedtoolcache\windows\python\3.8.0\x64\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\hostedtoolcache\windows\Python\3.8.0\x64\Scripts\pytest.exe\__main__.py", line 4, in <module>
  File "c:\hostedtoolcache\windows\python\3.8.0\x64\lib\site-packages\pytest.py", line 6, in <module>
    from _pytest.assertion import register_assert_rewrite
  File "c:\hostedtoolcache\windows\python\3.8.0\x64\lib\site-packages\_pytest\assertion\__init__.py", line 6, in <module>
    from _pytest.assertion import rewrite
  File "c:\hostedtoolcache\windows\python\3.8.0\x64\lib\site-packages\_pytest\assertion\rewrite.py", line 24, in <module>
    from _pytest.assertion import util
  File "c:\hostedtoolcache\windows\python\3.8.0\x64\lib\site-packages\_pytest\assertion\util.py", line 5, in <module>
    import _pytest._code
  File "c:\hostedtoolcache\windows\python\3.8.0\x64\lib\site-packages\_pytest\_code\__init__.py", line 2, in <module>
    from .code import Code  # noqa
  File "c:\hostedtoolcache\windows\python\3.8.0\x64\lib\site-packages\_pytest\_code\code.py", line 18, in <module>
    import pluggy
  File "c:\hostedtoolcache\windows\python\3.8.0\x64\lib\site-packages\pluggy\__init__.py", line 16, in <module>
    from .manager import PluginManager, PluginValidationError
  File "c:\hostedtoolcache\windows\python\3.8.0\x64\lib\site-packages\pluggy\manager.py", line 6, in <module>
```

Using a "bleeding edge" python installation in this project is not a strict requirement, so I simply pin the python version.