### PR TITLE
Board identification: always check vid.1/pid.1

### DIFF
--- a/arduino/cores/packagemanager/identify.go
+++ b/arduino/cores/packagemanager/identify.go
@@ -55,7 +55,7 @@ func (pm *PackageManager) IdentifyBoard(idProps *properties.Map) []*cores.Board 
 			if found {
 				foundBoards = append(foundBoards, board)
 			}
-			if !again {
+			if !again && id > 0 { // Always check id 0 and 1 (https://github.com/arduino/arduino-cli/issues/456)
 				break
 			}
 			id++

--- a/arduino/cores/packagemanager/identify.go
+++ b/arduino/cores/packagemanager/identify.go
@@ -30,7 +30,7 @@ func (pm *PackageManager) IdentifyBoard(idProps *properties.Map) []*cores.Board 
 		return []*cores.Board{}
 	}
 
-	checkSuffix := func(props *properties.Map, s string) (checked bool, found bool) {
+	checkSuffix := func(props *properties.Map, s string) (present bool, matched bool) {
 		for k, v1 := range idProps.AsMap() {
 			v2, ok := props.GetOk(k + s)
 			if !ok {
@@ -45,17 +45,17 @@ func (pm *PackageManager) IdentifyBoard(idProps *properties.Map) []*cores.Board 
 
 	foundBoards := []*cores.Board{}
 	for _, board := range pm.InstalledBoards() {
-		if _, found := checkSuffix(board.Properties, ""); found {
+		if _, matched := checkSuffix(board.Properties, ""); matched {
 			foundBoards = append(foundBoards, board)
 			continue
 		}
 		id := 0
 		for {
-			again, found := checkSuffix(board.Properties, fmt.Sprintf(".%d", id))
-			if found {
+			present, matched := checkSuffix(board.Properties, fmt.Sprintf(".%d", id))
+			if matched {
 				foundBoards = append(foundBoards, board)
 			}
-			if !again && id > 0 { // Always check id 0 and 1 (https://github.com/arduino/arduino-cli/issues/456)
+			if !present && id > 0 { // Always check id 0 and 1 (https://github.com/arduino/arduino-cli/issues/456)
 				break
 			}
 			id++

--- a/arduino/cores/packagemanager/package_manager_test.go
+++ b/arduino/cores/packagemanager/package_manager_test.go
@@ -18,6 +18,7 @@
 package packagemanager_test
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 
@@ -294,4 +295,24 @@ func TestFindToolsRequiredForBoard(t *testing.T) {
 		uploadProperties.Merge(requiredTool.RuntimeProperties())
 	}
 	require.Equal(t, bossac18.InstallDir.String(), uploadProperties.Get("runtime.tools.bossac.path"))
+}
+
+func TestIdentifyBoard(t *testing.T) {
+	pm := packagemanager.NewPackageManager(customHardware, customHardware, customHardware, customHardware)
+	pm.LoadHardwareFromDirectory(customHardware)
+
+	identify := func(vid, pid string) []*cores.Board {
+		return pm.IdentifyBoard(properties.NewFromHashmap(map[string]string{
+			"vid": vid, "pid": pid,
+		}))
+	}
+	require.Equal(t, "[arduino:avr:uno]", fmt.Sprintf("%v", identify("0x2341", "0x0001")))
+
+	// Check indexed vid/pid format (vid.0/pid.0)
+	require.Equal(t, "[test:avr:a]", fmt.Sprintf("%v", identify("0x9999", "0x0001")))
+	require.Equal(t, "[test:avr:b]", fmt.Sprintf("%v", identify("0x9999", "0x0002")))
+	require.Equal(t, "[test:avr:c]", fmt.Sprintf("%v", identify("0x9999", "0x0003")))
+	require.Equal(t, "[test:avr:c]", fmt.Sprintf("%v", identify("0x9999", "0x0004")))
+	// https://github.com/arduino/arduino-cli/issues/456
+	require.Equal(t, "[test:avr:d]", fmt.Sprintf("%v", identify("0x9999", "0x0005")))
 }

--- a/arduino/cores/packagemanager/testdata/custom_hardware/test/avr/boards.txt
+++ b/arduino/cores/packagemanager/testdata/custom_hardware/test/avr/boards.txt
@@ -1,0 +1,17 @@
+a.name=Board A
+a.vid=0x9999
+a.pid=0x0001
+
+b.name=Board B
+b.vid.0=0x9999
+b.pid.0=0x0002
+
+c.name=Board C
+c.vid.0=0x9999
+c.pid.0=0x0003
+c.vid.1=0x9999
+c.pid.1=0x0004
+
+d.name=Board D
+d.vid.1=0x9999
+d.pid.1=0x0005


### PR DESCRIPTION
Even if vid.0/pid.0 is missing.

Fix #456

@intrigus