### PR TITLE
Fix handling of referenced cores

### DIFF
--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -177,7 +177,7 @@ func (pm *PackageManager) ResolveFQBN(fqbn *cores.FQBN) (
 	buildPlatformRelease := platformRelease
 	coreParts := strings.Split(buildProperties.Get("build.core"), ":")
 	if len(coreParts) > 1 {
-		referredPackage := coreParts[1]
+		referredPackage := coreParts[0]
 		buildPackage := pm.Packages[referredPackage]
 		if buildPackage == nil {
 			return targetPackage, platformRelease, board, buildProperties, nil,

--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -181,7 +181,7 @@ func (pm *PackageManager) ResolveFQBN(fqbn *cores.FQBN) (
 		buildPackage := pm.Packages[referredPackage]
 		if buildPackage == nil {
 			return targetPackage, platformRelease, board, buildProperties, nil,
-				fmt.Errorf("missing package %s:%s required for build", referredPackage, platform)
+				fmt.Errorf("missing package %s referenced by board %s", referredPackage, fqbn)
 		}
 		buildPlatform := buildPackage.Platforms[fqbn.PlatformArch]
 		buildPlatformRelease = pm.GetInstalledPlatformRelease(buildPlatform)

--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -184,6 +184,10 @@ func (pm *PackageManager) ResolveFQBN(fqbn *cores.FQBN) (
 				fmt.Errorf("missing package %s referenced by board %s", referredPackage, fqbn)
 		}
 		buildPlatform := buildPackage.Platforms[fqbn.PlatformArch]
+		if buildPlatform == nil {
+			return targetPackage, platformRelease, board, buildProperties, nil,
+				fmt.Errorf("missing platform %s:%s referenced by board %s", referredPackage, fqbn.PlatformArch, fqbn)
+		}
 		buildPlatformRelease = pm.GetInstalledPlatformRelease(buildPlatform)
 	}
 

--- a/arduino/cores/packagemanager/testdata/extra_hardware/referenced/avr/boards.txt
+++ b/arduino/cores/packagemanager/testdata/extra_hardware/referenced/avr/boards.txt
@@ -1,0 +1,38 @@
+# Dummy board that is pretty much identical to the Uno, but defined in a
+# different package (to test using a core from a different package where
+# the package name and core name are the same).
+uno.name=Referenced Uno
+
+uno.upload.tool=avrdude
+uno.upload.protocol=arduino
+uno.upload.maximum_size=32256
+uno.upload.maximum_data_size=2048
+uno.upload.speed=115200
+
+uno.bootloader.tool=avrdude
+uno.bootloader.low_fuses=0xFF
+uno.bootloader.high_fuses=0xDE
+uno.bootloader.extended_fuses=0xFD
+uno.bootloader.unlock_bits=0x3F
+uno.bootloader.lock_bits=0x0F
+uno.bootloader.file=optiboot/optiboot_atmega328.hex
+
+uno.build.mcu=atmega328p
+uno.build.f_cpu=16000000L
+uno.build.board=AVR_UNO
+uno.build.core=arduino:arduino
+uno.build.variant=standard
+
+# Dummy board derived from a non-existent package
+dummy_invalid_package.name=Referenced dummy with invalid package
+dummy_invalid_package.build.core=nonexistent:arduino
+
+# Dummy board derived from a non-existent core
+dummy_invalid_core.name=Referenced dummy with invalid core
+dummy_invalid_core.build.core=arduino:nonexistent
+
+# Dummy board derived from a non-existent platform/architecture. The
+# platform is avr, which is implied by the directory this file is in. The
+# adafruit package in this test data only supplies a samd platform.
+dummy_invalid_platform.name=Referenced dummy with invalid platform
+dummy_invalid_platform.build.core=adafruit:arduino

--- a/arduino/cores/packagemanager/testdata/extra_hardware/referenced/samd/boards.txt
+++ b/arduino/cores/packagemanager/testdata/extra_hardware/referenced/samd/boards.txt
@@ -1,0 +1,27 @@
+# Dummy board that is pretty much identical to the feather m0, but
+# defined in a different package (to test using a core from a different
+# package where the package name and core name are different).
+feather_m0.name=Referenced Feather M0
+feather_m0.upload.tool=bossac
+feather_m0.upload.protocol=sam-ba
+feather_m0.upload.maximum_size=262144
+feather_m0.upload.offset=0x2000
+feather_m0.upload.use_1200bps_touch=true
+feather_m0.upload.wait_for_upload_port=true
+feather_m0.upload.native_usb=true
+feather_m0.build.mcu=cortex-m0plus
+feather_m0.build.f_cpu=48000000L
+feather_m0.build.usb_product="Feather M0"
+feather_m0.build.usb_manufacturer="Adafruit"
+feather_m0.build.board=SAMD_ZERO
+feather_m0.build.core=adafruit:arduino
+feather_m0.build.extra_flags=-DARDUINO_SAMD_ZERO -DARM_MATH_CM0PLUS -DADAFRUIT_FEATHER_M0 -D__SAMD21G18A__ {build.usb_flags}
+feather_m0.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
+feather_m0.build.openocdscript=openocd_scripts/feather_m0.cfg
+feather_m0.build.variant=feather_m0
+feather_m0.build.variant_system_lib=
+feather_m0.build.vid=0x239A
+feather_m0.build.pid=0x800B
+feather_m0.bootloader.tool=openocd
+feather_m0.bootloader.file=featherM0/bootloader-feather_m0-v2.0.0-adafruit.5.bin
+


### PR DESCRIPTION
A core is referenced by specifying `build.core=package:core` in board properties. However, the code that handled resolving these, had two problems:
 - It used the second part (`core`) rather than the first part (`package`) to look up the package to reference. The most commonly used core reference is `arduino:arduino` which works because both parts are identical. However, when referencing cores where the core name does not equal the package name (e.g. the Adafruit or STM32 cores), there is no way to actually reference such a core properly.
 - It also failed to handle a missing architecture, resulting in a segfault.

This PR fixes both problems, and additionally adds a testcase for `ResolveFQBN` that exposes these problems (and tests some other cases as well).