### PR TITLE
Added a note to help anyone using an FTDI chip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ $ arduino-cli core update-index
 Updating index: package_index.json downloaded
 ```
 
-Now, just connect the board to your PCs by using the USB cable. In this example we will use the
+Now, just connect the board to your PCs by using the USB cable. (**Note**: Connecting through an FTDI adapter chip will show Unknown for the Board Name because the VID/PID is generic. Uploading should still work as long as you identify the correct FQBN). In this example we will use the
 MKR1000 board:
 
 ```console


### PR DESCRIPTION
I spent most of my weekend trying to figure out why I was always getting an Unknown for the `arduino-cli board list` regardless of what board I was using. I managed to track down [this issue](https://github.com/arduino/arduino-cli/issues/149) that notes the FTDI will have a generic VID/PID so will always be Unknown. I was under the impression the board list needed to be successful in order to upload, but that is not the case. 
This change makes a clarification note and hopefully saves some people some headaches. 