### PR TITLE
[skip changelog] Don't run mocked tests on OSX

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        operating-system: [ubuntu-18.04, windows-2019]
+        operating-system: [ubuntu-18.04, windows-2019, macOS-10.14]
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -13,8 +13,8 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-// These tests are mocked and won't work on OSX, make them run on Linux only
-// +build linux
+// These tests are mocked and won't work on OSX
+// +build !darwin
 
 package cli
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,19 +1,20 @@
-/*
- * This file is part of arduino-cli.
- *
- * Copyright 2018 ARDUINO SA (http://www.arduino.cc/)
- *
- * This software is released under the GNU General Public License version 3,
- * which covers the main part of arduino-cli.
- * The terms of this license can be found at:
- * https://www.gnu.org/licenses/gpl-3.0.en.html
- *
- * You can be released from the requirements of the above licenses by purchasing
- * a commercial license. Buying such a license is mandatory if you want to modify or
- * otherwise use the software for commercial activities involving the Arduino
- * software without disclosing the source code of your own applications. To purchase
- * a commercial license, send an email to license@arduino.cc.
- */
+// This file is part of arduino-cli.
+//
+// Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+// These tests are mocked and won't work on OSX, make them run on Linux only
+// +build linux
 
 package cli
 

--- a/commands/daemon/monitor_test.go
+++ b/commands/daemon/monitor_test.go
@@ -13,8 +13,8 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-// These tests are mocked and won't work on OSX, make them run on Linux only
-// +build linux
+// These tests are mocked and won't work on OSX
+// +build !darwin
 
 package daemon_test
 

--- a/commands/daemon/monitor_test.go
+++ b/commands/daemon/monitor_test.go
@@ -1,3 +1,21 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+// These tests are mocked and won't work on OSX, make them run on Linux only
+// +build linux
+
 package daemon_test
 
 import (
@@ -99,7 +117,7 @@ func mockOpenSerialMonitor(portName string, baudRate int) (*monitors.SerialMonit
 	return mon, nil
 }
 
-func TestFoo(t *testing.T) {
+func TestConnect(t *testing.T) {
 	monkey.Patch(monitors.OpenSerialMonitor, mockOpenSerialMonitor)
 
 	svc := daemon.MonitorService{}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	golang.org/x/text v0.3.0
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190327125643-d831d65fe17d // indirect
 	google.golang.org/grpc v1.21.1
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect


### PR DESCRIPTION
Recent OSX updates make ineffective the mocking strategy from `bou.ke/monkey` on mac platforms, running mocked tests only on other platforms should be ok from the testing perspective and let us keep using the library without refactoring the test cases.