### PR TITLE
[skip ci] fix stalebot

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -26,7 +26,7 @@ jobs:
             const issues = await github.paginate(opts);
 
             // Set this value to whatever makes sense for the repo.
-            let elapsedDays = 15
+            let elapsedDays = 30
 
             let elapsed = elapsedDays * 24 * 60 * 60 * 1000;
             let now = new Date().getTime();
@@ -88,7 +88,7 @@ jobs:
             const issues = await github.paginate(opts);
 
             // Set this value to whatever makes sense for the repo.
-            let elapsedDays = 30;
+            let elapsedDays = 15;
 
             let elapsed = elapsedDays * 24 * 60 * 60 * 1000;
             let now = new Date().getTime();


### PR DESCRIPTION
Invert the time windows, otherwise an issue will be re-marked stale every 15 days, resetting the time window and preventing the closing event (time window is 30 days) to kick in.

With this patch, when it's the case an issue will be closed before it's re-marked stale.

A more comprehensive solution would be filtering out stale issues but that'd require another loop, let's apply this quick fix while we evaluate how useful is the bot.
