### PR TITLE
Fixed nil pointer exception on some rare case with multiple libs selection

### DIFF
--- a/arduino/libraries/librarieslist.go
+++ b/arduino/libraries/librarieslist.go
@@ -61,6 +61,14 @@ func (list *List) SortByArchitecturePriority(arch string) {
 	})
 }
 
+// SortByName sorts the libraries by name
+func (list *List) SortByName() {
+	sort.Slice(*list, func(i, j int) bool {
+		a, b := (*list)[i], (*list)[j]
+		return a.Name < b.Name
+	})
+}
+
 /*
 // HasHigherPriority returns true if library x has higher priority compared to library
 // y for the given header and architecture.

--- a/arduino/libraries/librariesresolver/cpp.go
+++ b/arduino/libraries/librariesresolver/cpp.go
@@ -106,7 +106,7 @@ func (resolver *Cpp) ResolveFor(header, architecture string) *libraries.Library 
 	// If more than one library qualifies use the "closestmatch" algorithm to
 	// find the best matching one (instead of choosing it randomly)
 	if best := findLibraryWithNameBestDistance(header, found); best != nil {
-		logrus.WithField("lib", best.Name).Info("  library with the best mathing name")
+		logrus.WithField("lib", best.Name).Info("  library with the best matching name")
 		return best
 	}
 

--- a/arduino/libraries/librariesresolver/cpp.go
+++ b/arduino/libraries/librariesresolver/cpp.go
@@ -105,11 +105,14 @@ func (resolver *Cpp) ResolveFor(header, architecture string) *libraries.Library 
 
 	// If more than one library qualifies use the "closestmatch" algorithm to
 	// find the best matching one (instead of choosing it randomly)
-	winner := findLibraryWithNameBestDistance(header, found)
-	if winner != nil {
-		logrus.WithField("lib", winner.Name).Info("  library with the best mathing name")
+	if best := findLibraryWithNameBestDistance(header, found); best != nil {
+		logrus.WithField("lib", best.Name).Info("  library with the best mathing name")
+		return best
 	}
-	return winner
+
+	found.SortByName()
+	logrus.WithField("lib", found[0].Name).Info("  first library in alphabetic order")
+	return found[0]
 }
 
 func simplify(name string) string {

--- a/arduino/libraries/librariesresolver/cpp_test.go
+++ b/arduino/libraries/librariesresolver/cpp_test.go
@@ -32,6 +32,18 @@ var l5 = &libraries.Library{Name: "Yet Another Calculus Lib Improved", Location:
 var l6 = &libraries.Library{Name: "Calculus Unified Lib", Location: libraries.Sketchbook}
 var l7 = &libraries.Library{Name: "AnotherLib", Location: libraries.Sketchbook}
 
+func TestClosestMatchWithTotallyDifferentNames(t *testing.T) {
+	libraryList := libraries.List{}
+	libraryList.Add(l5)
+	libraryList.Add(l6)
+	libraryList.Add(l7)
+	resolver := NewCppResolver()
+	resolver.headers["XYZ.h"] = libraryList
+	res := resolver.ResolveFor("XYZ.h", "xyz")
+	require.NotNil(t, res)
+	require.Equal(t, l7, res, "selected library")
+}
+
 func TestCppHeaderPriority(t *testing.T) {
 	r1 := computePriority(l1, "calculus_lib.h", "avr")
 	r2 := computePriority(l2, "calculus_lib.h", "avr")

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	golang.org/x/text v0.3.0
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190327125643-d831d65fe17d // indirect
 	google.golang.org/grpc v1.21.1
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect


### PR DESCRIPTION
The closestmatch algorithm may return 'nil' if none of the candidate libraries has enough matching of the name. In this case just return the first library in alphanumeric ordering.

See arduino/Arduino#9242
