### PR TITLE
Print "multiple libraries found for header.h..." only when it really happens

### DIFF
--- a/legacy/builder/print_used_and_not_used_libraries.go
+++ b/legacy/builder/print_used_and_not_used_libraries.go
@@ -58,6 +58,9 @@ func (s *PrintUsedAndNotUsedLibraries) Run(ctx *types.Context) error {
 	libraryResolutionResults := ctx.LibrariesResolutionResults
 
 	for header, libResResult := range libraryResolutionResults {
+		if len(libResResult.NotUsedLibraries) == 0 {
+			continue
+		}
 		logger.Fprintln(os.Stdout, logLevel, constants.MSG_LIBRARIES_MULTIPLE_LIBS_FOUND_FOR, header)
 		logger.Fprintln(os.Stdout, logLevel, constants.MSG_LIBRARIES_USED, libResResult.Library.InstallDir)
 		for _, notUsedLibrary := range libResResult.NotUsedLibraries {


### PR DESCRIPTION
Previously printed:

```
Multiple libraries were found for "DHT.h"
 Used: /home/megabug/Workspace/sketchbook-cores-beta/libraries/DHT_sensor_library
Multiple libraries were found for "Adafruit_Sensor.h"
 Used: /home/megabug/Workspace/sketchbook-cores-beta/libraries/Adafruit_Unified_Sensor
Using library DHT_sensor_library at version 1.3.8 in folder: /home/megabug/Workspace/sketchbook-cores-beta/libraries/DHT_sensor_library 
Using library Adafruit_Unified_Sensor at version 1.0.3 in folder: /home/megabug/Workspace/sketchbook-cores-beta/libraries/Adafruit_Unified_Sensor 
```

Even if there are no multiple libraries available for the particular header. After this patch we have:

```
Using library DHT_sensor_library at version 1.3.8 in folder: /home/megabug/Workspace/sketchbook-cores-beta/libraries/DHT_sensor_library 
Using library Adafruit_Unified_Sensor at version 1.0.3 in folder: /home/megabug/Workspace/sketchbook-cores-beta/libraries/Adafruit_Unified_Sensor 
```
