### PR TITLE
Avoid panics when compiling for custom boards

### DIFF
--- a/arduino/cores/cores.go
+++ b/arduino/cores/cores.go
@@ -182,10 +182,13 @@ func (platform *Platform) latestReleaseVersion() *semver.Version {
 // GetAllInstalled returns all installed PlatformRelease
 func (platform *Platform) GetAllInstalled() []*PlatformRelease {
 	res := []*PlatformRelease{}
-	for _, release := range platform.Releases {
-		if release.IsInstalled() {
-			res = append(res, release)
+	if platform.Releases != nil {
+		for _, release := range platform.Releases {
+			if release.IsInstalled() {
+				res = append(res, release)
+			}
 		}
+
 	}
 	return res
 }
@@ -225,17 +228,23 @@ func (release *PlatformRelease) RequiresToolRelease(toolRelease *ToolRelease) bo
 // RuntimeProperties returns the runtime properties for this PlatformRelease
 func (release *PlatformRelease) RuntimeProperties() *properties.Map {
 	res := properties.NewMap()
-	res.Set("runtime.platform.path", release.InstallDir.String())
+	if release.InstallDir != nil {
+		res.Set("runtime.platform.path", release.InstallDir.String())
+	}
+
 	return res
 }
 
 // GetLibrariesDir returns the path to the core libraries or nil if not
 // present
 func (release *PlatformRelease) GetLibrariesDir() *paths.Path {
-	libDir := release.InstallDir.Join("libraries")
-	if libDir.IsDir() {
-		return libDir
+	if release.InstallDir != nil {
+		libDir := release.InstallDir.Join("libraries")
+		if libDir.IsDir() {
+			return libDir
+		}
 	}
+
 	return nil
 }
 

--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -191,6 +191,10 @@ func (pm *PackageManager) ResolveFQBN(fqbn *cores.FQBN) (
 				fmt.Errorf("missing platform %s:%s referenced by board %s", referredPackage, fqbn.PlatformArch, fqbn)
 		}
 		buildPlatformRelease = pm.GetInstalledPlatformRelease(buildPlatform)
+		if buildPlatformRelease == nil {
+			return targetPackage, platformRelease, board, buildProperties, nil,
+				fmt.Errorf("missing platform release %s:%s referenced by board %s", referredPackage, fqbn.PlatformArch, fqbn)
+		}
 	}
 
 	// No errors... phew!

--- a/arduino/libraries/librariesmanager/install.go
+++ b/arduino/libraries/librariesmanager/install.go
@@ -77,6 +77,9 @@ func (lm *LibrariesManager) Install(indexLibrary *librariesindex.Release, libPat
 
 // Uninstall removes a Library
 func (lm *LibrariesManager) Uninstall(lib *libraries.Library) error {
+	if lib == nil || lib.InstallDir == nil {
+		return fmt.Errorf("install directory not set")
+	}
 	if err := lib.InstallDir.RemoveAll(); err != nil {
 		return fmt.Errorf("removing lib directory: %s", err)
 	}


### PR DESCRIPTION
Fixes #177 

When working with custom boards some corner cases might arise and provide an inconsistent in-memory representation of the cores. This PR introduces more checks for structs and fields that might be `nil` at some point during compilation.