### PR TITLE
Look for query string into more fields when searching for libs

### DIFF
--- a/commands/lib/search.go
+++ b/commands/lib/search.go
@@ -37,7 +37,10 @@ func LibrarySearch(ctx context.Context, req *rpc.LibrarySearchReq) (*rpc.Library
 	res := []*rpc.SearchedLibrary{}
 
 	for _, lib := range lm.Index.Libraries {
-		if strings.Contains(strings.ToLower(lib.Name), strings.ToLower(req.GetQuery())) {
+		qry := strings.ToLower(req.GetQuery())
+		if strings.Contains(strings.ToLower(lib.Name), qry) ||
+			strings.Contains(strings.ToLower(lib.Latest.Paragraph), qry) ||
+			strings.Contains(strings.ToLower(lib.Latest.Sentence), qry) {
 			releases := map[string]*rpc.LibraryRelease{}
 			for str, rel := range lib.Releases {
 				releases[str] = GetLibraryParameters(rel)

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -106,3 +106,17 @@ def test_search(run_command):
     assert result.ok
     libs_json = json.loads(result.stdout)
     assert 1 == len(libs_json.get("libraries"))
+
+
+def test_search_paragraph(run_command):
+    """
+    Search for a string that's only present in the `paragraph` field
+    within the index file.
+    """
+    assert run_command("lib update-index")
+    result = run_command(
+        'lib search "An efficient and elegant JSON library" --format json'
+    )
+    assert result.ok
+    libs_json = json.loads(result.stdout)
+    assert 1 == len(libs_json.get("libraries"))

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -105,7 +105,7 @@ def test_search(run_command):
     result = run_command("lib search ArduinoJson --format json")
     assert result.ok
     libs_json = json.loads(result.stdout)
-    assert 1 == len(libs_json.get("libraries"))
+    assert len(libs_json.get("libraries")) >= 1
 
 
 def test_search_paragraph(run_command):


### PR DESCRIPTION
fixes #104 

This way the `lib search` behaviour will be the same as the Java IDE.