### PR TITLE
Set the daemon TCP port from config file or command line

### DIFF
--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -34,4 +34,7 @@ func setDefaults(dataDir, sketchBookDir string) {
 	viper.SetDefault("directories.Packages", filepath.Join(dataDir, "packages"))
 	viper.SetDefault("directories.SketchBook", sketchBookDir)
 	viper.SetDefault("directories.Libraries", filepath.Join(sketchBookDir, "libraries"))
+
+	// daemon settings
+	viper.SetDefault("daemon.port", "50051")
 }


### PR DESCRIPTION
Let user configure which TCP port to use for the gRPC daemon:
* from the config file
* from the command line with `--port`
* by setting the env var `ARDUINO_DAEMON_PORT`

Fixes #485 