### PR TITLE
[skip changelog] Sliglthly optimize searchConfigTree

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -124,15 +123,19 @@ func parseFormatString(arg string) (feedback.OutputFormat, bool) {
 func searchConfigTree(cwd string) string {
 	// go back up to root and search for the config file
 	for {
-		if _, err := os.Stat(path.Join(cwd, "arduino-cli.yaml")); os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(cwd, "arduino-cli.yaml")); err == nil {
+			// config file found
+			return cwd
+		} else if os.IsNotExist(err) {
 			// no config file found
-			next := path.Join(cwd, "..")
-			if filepath.Clean(next) == filepath.Clean(cwd) {
+			next := filepath.Dir(cwd)
+			if next == cwd {
 				return ""
 			}
 			cwd = next
 		} else {
-			return cwd
+			// some error we can't handle happened
+			return ""
 		}
 	}
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -513,3 +513,18 @@ func TestSearchConfigTreeInParent(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, searchConfigTree(target), tmp)
 }
+
+var result string
+
+func BenchmarkSearchConfigTree(b *testing.B) {
+	tmp := tmpDirOrDie()
+	defer os.RemoveAll(tmp)
+	target := filepath.Join(tmp, "foo", "bar", "baz")
+	os.MkdirAll(target, os.ModePerm)
+
+	var s string
+	for n := 0; n < b.N; n++ {
+		s = searchConfigTree(target)
+	}
+	result = s
+}


### PR DESCRIPTION
This PR optimize `searchConfigTree` to speed up performance on Windows, where it was particularly slow.