### PR TITLE
Improve error message when port or fqbn flags are not set

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 
 	"bou.ke/monkey"
@@ -168,7 +169,9 @@ func executeWithArgs(args ...string) (int, []byte) {
 		ArduinoCli.ResetFlags()
 		createCliCommandTree(ArduinoCli)
 		ArduinoCli.SetArgs(args)
-		ArduinoCli.Execute()
+		if err := ArduinoCli.Execute(); err != nil {
+			exitCode = errorcodes.ErrGeneric
+		}
 	}()
 
 	return exitCode, output
@@ -309,7 +312,7 @@ func TestCompileCommandsIntegration(t *testing.T) {
 	// Build sketch without FQBN
 	exitCode, d = executeWithArgs("compile", test1)
 	require.NotZero(t, exitCode)
-	require.Contains(t, string(d), "no FQBN provided")
+	require.Contains(t, string(d), "required flag(s) \"fqbn\" not set")
 
 	// Build sketch for arduino:avr:uno
 	exitCode, d = executeWithArgs("compile", "-b", "arduino:avr:uno", test1)

--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -80,6 +80,8 @@ func NewCommand() *cobra.Command {
 	command.Flags().BoolVarP(&verify, "verify", "t", false, "Verify uploaded binary after the upload.")
 	command.Flags().StringVar(&vidPid, "vid-pid", "", "When specified, VID/PID specific build properties are used, if boards supports them.")
 
+	command.MarkFlagRequired("fqbn")
+
 	return command
 }
 

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -56,6 +56,9 @@ func NewCommand() *cobra.Command {
 	uploadCommand.Flags().BoolVarP(&verify, "verify", "t", false, "Verify uploaded binary after the upload.")
 	uploadCommand.Flags().BoolVarP(&verbose, "verbose", "v", false, "Optional, turns on verbose mode.")
 
+	uploadCommand.MarkFlagRequired("fqbn")
+	uploadCommand.MarkFlagRequired("port")
+
 	return uploadCommand
 }
 


### PR DESCRIPTION
This changeset marks the fqbn and port CLI flags as required in the compile and upload commands. The error message is thus changed from the generic:
```
Error during Upload: no upload port provided
```
To the more directly actionable:
```
Error: required flag(s) "fqbn", "port" not set
```
Which is followed by the CLI help text.