### PR TITLE
[skip changelog] Exclude generated code from coverage

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,7 +61,7 @@ tasks:
 vars:
   # all modules of this project except for "legacy/..." module
   DEFAULT_TARGETS:
-    sh: echo `go list ./... | grep -v legacy | tr '\n' ' '`
+    sh: echo `go list ./... | grep -v '/legacy/\|/rpc/' | tr '\n' ' '`
 
   # build vars
   COMMIT:


### PR DESCRIPTION
Do not invoke `go test` on the `rpc` package which contains only generated code.