### PR TITLE
Remove debug prints

### DIFF
--- a/arduino/cores/packageindex/index.go
+++ b/arduino/cores/packageindex/index.go
@@ -206,7 +206,6 @@ func LoadIndex(jsonIndexFile *paths.Path) (*Index, error) {
 	if err != nil {
 		return nil, err
 	}
-	//fmt.Println(string(buff))
 	var index Index
 	err = json.Unmarshal(buff, &index)
 	if err != nil {

--- a/arduino/cores/packageindex/index_test.go
+++ b/arduino/cores/packageindex/index_test.go
@@ -18,7 +18,6 @@
 package packageindex
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/arduino/go-paths-helper"
@@ -35,7 +34,6 @@ func TestIndexParsing(t *testing.T) {
 		if indexFile.Ext() != ".json" {
 			continue
 		}
-		fmt.Println("Loading:", indexFile)
 		_, err := LoadIndex(indexFile)
 		require.NoError(t, err)
 	}

--- a/arduino/cores/packagemanager/package_manager_test.go
+++ b/arduino/cores/packagemanager/package_manager_test.go
@@ -216,7 +216,6 @@ func TestBoardOptionsFunctions(t *testing.T) {
 func TestFindToolsRequiredForBoard(t *testing.T) {
 	os.Setenv("ARDUINO_DATA_DIR", dataDir1.String())
 	configuration.Init("")
-	fmt.Println(viper.AllSettings())
 	pm := packagemanager.NewPackageManager(
 		dataDir1,
 		configuration.PackagesDir(),

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -206,7 +206,6 @@ func detectLatestAVRCore(t *testing.T) string {
 		}
 	}
 	require.NotEmpty(t, latest, "latest avr core version")
-	fmt.Println("Latest AVR core version:", latest)
 	return latest.String()
 }
 

--- a/commands/daemon/daemon.go
+++ b/commands/daemon/daemon.go
@@ -21,7 +21,6 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -116,7 +115,6 @@ func (s *ArduinoCoreServerImpl) Init(req *rpc.InitReq, stream rpc.ArduinoCore_In
 	if err != nil {
 		return err
 	}
-	fmt.Println(resp)
 	return stream.Send(resp)
 }
 

--- a/commands/daemon/settings.go
+++ b/commands/daemon/settings.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	rpc "github.com/arduino/arduino-cli/rpc/settings"
 	"github.com/spf13/viper"
@@ -61,8 +60,6 @@ func (s *SettingsService) Merge(ctx context.Context, req *rpc.RawData) (*rpc.Mer
 func (s *SettingsService) GetValue(ctx context.Context, req *rpc.GetValueRequest) (*rpc.Value, error) {
 	key := req.GetKey()
 	value := &rpc.Value{}
-
-	fmt.Println(viper.AllKeys())
 
 	if !viper.InConfig(key) {
 		return nil, errors.New("key not found in settings")

--- a/commands/daemon/settings_test.go
+++ b/commands/daemon/settings_test.go
@@ -18,7 +18,6 @@ package daemon
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -54,7 +53,6 @@ func TestMerge(t *testing.T) {
 	_, err := svc.Merge(context.Background(), &rpc.RawData{JsonData: bulkSettings})
 	require.Nil(t, err)
 
-	fmt.Println(viper.AllSettings())
 	require.Equal(t, "420", viper.GetString("daemon.port"))
 	require.Equal(t, "bar", viper.GetString("foo"))
 

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -144,7 +144,6 @@ func Init(ctx context.Context, req *rpc.InitReq, downloadCB DownloadProgressCB, 
 	instances[handle] = instance
 
 	if err := instance.checkForBuiltinTools(downloadCB, taskCB, downloaderHeaders); err != nil {
-		fmt.Println(err)
 		return nil, err
 	}
 

--- a/legacy/builder/test/includes_to_include_folders_test.go
+++ b/legacy/builder/test/includes_to_include_folders_test.go
@@ -30,7 +30,6 @@
 package test
 
 import (
-	"fmt"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -331,7 +330,6 @@ func TestIncludesToIncludeFoldersSubfolders(t *testing.T) {
 
 	importedLibraries := ctx.ImportedLibraries
 	sort.Sort(ByLibraryName(importedLibraries))
-	fmt.Println(importedLibraries)
 	require.Equal(t, 3, len(importedLibraries))
 	require.Equal(t, "testlib1", importedLibraries[0].Name)
 	require.Equal(t, "testlib2", importedLibraries[1].Name)

--- a/legacy/builder/tools_loader.go
+++ b/legacy/builder/tools_loader.go
@@ -38,7 +38,6 @@ type ToolsLoader struct{}
 
 func (s *ToolsLoader) Run(ctx *types.Context) error {
 	if ctx.CanUseCachedTools {
-		//fmt.Println("no fs modification, can use cached ctx")
 		return nil
 	}
 


### PR DESCRIPTION
Remove all the `fmt.Println` instances that were meant temporary with debugging purposes.