### PR TITLE
Fix update index on fresh installs

### DIFF
--- a/cli/board/attach.go
+++ b/cli/board/attach.go
@@ -53,7 +53,11 @@ var attachFlags struct {
 }
 
 func runAttachCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstance()
+	instance, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Attach board error: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
 
 	var path *paths.Path
 	if len(args) > 1 {
@@ -62,13 +66,12 @@ func runAttachCommand(cmd *cobra.Command, args []string) {
 		path = initSketchPath(path)
 	}
 
-	_, err := board.Attach(context.Background(), &rpc.BoardAttachReq{
+	if _, err = board.Attach(context.Background(), &rpc.BoardAttachReq{
 		Instance:      instance,
 		BoardUri:      args[0],
 		SketchPath:    path.String(),
 		SearchTimeout: attachFlags.searchTimeout,
-	}, output.TaskProgress())
-	if err != nil {
+	}, output.TaskProgress()); err != nil {
 		feedback.Errorf("Attach board error: %v", err)
 		os.Exit(errorcodes.ErrGeneric)
 	}

--- a/cli/board/details.go
+++ b/cli/board/details.go
@@ -41,8 +41,14 @@ var detailsCommand = &cobra.Command{
 }
 
 func runDetailsCommand(cmd *cobra.Command, args []string) {
+	inst, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Error getting board details: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
 	res, err := board.Details(context.Background(), &rpc.BoardDetailsReq{
-		Instance: instance.CreateInstance(),
+		Instance: inst,
 		Fqbn:     args[0],
 	})
 

--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -61,7 +61,13 @@ func runListCommand(cmd *cobra.Command, args []string) {
 		time.Sleep(timeout)
 	}
 
-	ports, err := board.List(instance.CreateInstance().GetId())
+	inst, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Error detecting boards: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
+	ports, err := board.List(inst.GetId())
 	if err != nil {
 		feedback.Errorf("Error detecting boards: %v", err)
 		os.Exit(errorcodes.ErrNetwork)

--- a/cli/board/listall.go
+++ b/cli/board/listall.go
@@ -46,10 +46,14 @@ var listAllCommand = &cobra.Command{
 
 // runListAllCommand list all installed boards
 func runListAllCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstance()
+	inst, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Error listing boards: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
 
 	list, err := board.ListAll(context.Background(), &rpc.BoardListAllReq{
-		Instance:   instance,
+		Instance:   inst,
 		SearchArgs: args,
 	})
 	if err != nil {

--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -86,7 +86,11 @@ func NewCommand() *cobra.Command {
 }
 
 func run(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstance()
+	inst, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Error during build: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
 
 	var path *paths.Path
 	if len(args) > 0 {
@@ -95,8 +99,8 @@ func run(cmd *cobra.Command, args []string) {
 
 	sketchPath := initSketchPath(path)
 
-	_, err := compile.Compile(context.Background(), &rpc.CompileReq{
-		Instance:        instance,
+	_, err = compile.Compile(context.Background(), &rpc.CompileReq{
+		Instance:        inst,
 		Fqbn:            fqbn,
 		SketchPath:      sketchPath.String(),
 		ShowProperties:  showProperties,
@@ -118,7 +122,7 @@ func run(cmd *cobra.Command, args []string) {
 
 	if uploadAfterCompile {
 		_, err := upload.Upload(context.Background(), &rpc.UploadReq{
-			Instance:   instance,
+			Instance:   inst,
 			Fqbn:       fqbn,
 			SketchPath: sketchPath.String(),
 			Port:       port,

--- a/cli/core/download.go
+++ b/cli/core/download.go
@@ -47,7 +47,12 @@ func initDownloadCommand() *cobra.Command {
 }
 
 func runDownloadCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstance()
+	inst, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Error downloading: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
 	logrus.Info("Executing `arduino core download`")
 
 	platformsRefs, err := globals.ParseReferenceArgs(args, true)
@@ -58,7 +63,7 @@ func runDownloadCommand(cmd *cobra.Command, args []string) {
 
 	for i, platformRef := range platformsRefs {
 		platformDownloadreq := &rpc.PlatformDownloadReq{
-			Instance:        instance,
+			Instance:        inst,
 			PlatformPackage: platformRef.PackageName,
 			Architecture:    platformRef.Architecture,
 			Version:         platformRef.Version,

--- a/cli/core/install.go
+++ b/cli/core/install.go
@@ -48,7 +48,12 @@ func initInstallCommand() *cobra.Command {
 }
 
 func runInstallCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstance()
+	inst, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Error installing: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
 	logrus.Info("Executing `arduino core install`")
 
 	platformsRefs, err := globals.ParseReferenceArgs(args, true)
@@ -59,7 +64,7 @@ func runInstallCommand(cmd *cobra.Command, args []string) {
 
 	for _, platformRef := range platformsRefs {
 		plattformInstallReq := &rpc.PlatformInstallReq{
-			Instance:        instance,
+			Instance:        inst,
 			PlatformPackage: platformRef.PackageName,
 			Architecture:    platformRef.Architecture,
 			Version:         platformRef.Version,

--- a/cli/core/list.go
+++ b/cli/core/list.go
@@ -49,10 +49,15 @@ var listFlags struct {
 }
 
 func runListCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstance()
+	inst, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Error listing platforms: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
 	logrus.Info("Executing `arduino core list`")
 
-	platforms, err := core.GetPlatforms(instance.Id, listFlags.updatableOnly)
+	platforms, err := core.GetPlatforms(inst.Id, listFlags.updatableOnly)
 	if err != nil {
 		feedback.Errorf("Error listing platforms: %v", err)
 		os.Exit(errorcodes.ErrGeneric)

--- a/cli/core/search.go
+++ b/cli/core/search.go
@@ -51,11 +51,16 @@ func initSearchCommand() *cobra.Command {
 }
 
 func runSearchCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstance()
+	inst, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Error saerching for platforms: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
 	logrus.Info("Executing `arduino core search`")
 
 	arguments := strings.ToLower(strings.Join(args, " "))
-	resp, err := core.PlatformSearch(instance.GetId(), arguments, allVersions)
+	resp, err := core.PlatformSearch(inst.GetId(), arguments, allVersions)
 	if err != nil {
 		feedback.Errorf("Error saerching for platforms: %v", err)
 		os.Exit(errorcodes.ErrGeneric)

--- a/cli/core/uninstall.go
+++ b/cli/core/uninstall.go
@@ -44,7 +44,12 @@ func initUninstallCommand() *cobra.Command {
 }
 
 func runUninstallCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstance()
+	inst, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Error uninstalling: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
 	logrus.Info("Executing `arduino core uninstall`")
 
 	platformsRefs, err := globals.ParseReferenceArgs(args, true)
@@ -61,7 +66,7 @@ func runUninstallCommand(cmd *cobra.Command, args []string) {
 	}
 	for _, platformRef := range platformsRefs {
 		_, err := core.PlatformUninstall(context.Background(), &rpc.PlatformUninstallReq{
-			Instance:        instance,
+			Instance:        inst,
 			PlatformPackage: platformRef.PackageName,
 			Architecture:    platformRef.Architecture,
 		}, output.NewTaskProgressCB())

--- a/cli/core/update_index.go
+++ b/cli/core/update_index.go
@@ -44,7 +44,7 @@ func initUpdateIndexCommand() *cobra.Command {
 }
 
 func runUpdateIndexCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
+	instance := instance.CreateInstanceIgnorePlatformIndexErrors()
 	logrus.Info("Executing `arduino core update-index`")
 
 	_, err := commands.UpdateIndex(context.Background(), &rpc.UpdateIndexReq{

--- a/cli/core/upgrade.go
+++ b/cli/core/upgrade.go
@@ -48,12 +48,17 @@ func initUpgradeCommand() *cobra.Command {
 }
 
 func runUpgradeCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstance()
+	inst, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Error upgrading: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
 	logrus.Info("Executing `arduino core upgrade`")
 
 	// if no platform was passed, upgrade allthethings
 	if len(args) == 0 {
-		targets, err := core.GetPlatforms(instance.Id, true)
+		targets, err := core.GetPlatforms(inst.Id, true)
 		if err != nil {
 			feedback.Errorf("Error retrieving core list: %v", err)
 			os.Exit(errorcodes.ErrGeneric)
@@ -85,7 +90,7 @@ func runUpgradeCommand(cmd *cobra.Command, args []string) {
 		}
 
 		r := &rpc.PlatformUpgradeReq{
-			Instance:        instance,
+			Instance:        inst,
 			PlatformPackage: platformRef.PackageName,
 			Architecture:    platformRef.Architecture,
 		}

--- a/cli/instance/instance.go
+++ b/cli/instance/instance.go
@@ -1,3 +1,18 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
 package instance
 
 import (
@@ -14,10 +29,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-// CreateInstaceIgnorePlatformIndexErrors creates and return an instance of the
+// CreateInstanceIgnorePlatformIndexErrors creates and return an instance of the
 // Arduino Core Engine, but won't stop on platforms index loading errors.
-func CreateInstaceIgnorePlatformIndexErrors() *rpc.Instance {
-	return initInstance().GetInstance()
+func CreateInstanceIgnorePlatformIndexErrors() *rpc.Instance {
+	i, _ := getInitResponse()
+	return i.GetInstance()
 }
 
 // CreateInstance creates and return an instance of the Arduino Core engine

--- a/cli/lib/check_deps.go
+++ b/cli/lib/check_deps.go
@@ -53,7 +53,7 @@ func runDepsCommand(cmd *cobra.Command, args []string) {
 		os.Exit(errorcodes.ErrBadArgument)
 	}
 
-	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
+	instance := instance.CreateInstanceIgnorePlatformIndexErrors()
 	deps, err := lib.LibraryResolveDependencies(context.Background(), &rpc.LibraryResolveDependenciesReq{
 		Instance: instance,
 		Name:     libRef.Name,

--- a/cli/lib/download.go
+++ b/cli/lib/download.go
@@ -46,7 +46,7 @@ func initDownloadCommand() *cobra.Command {
 }
 
 func runDownloadCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
+	instance := instance.CreateInstanceIgnorePlatformIndexErrors()
 	refs, err := globals.ParseLibraryReferenceArgs(args)
 	if err != nil {
 		feedback.Errorf("Invalid argument passed: %v", err)

--- a/cli/lib/install.go
+++ b/cli/lib/install.go
@@ -51,7 +51,7 @@ var installFlags struct {
 }
 
 func runInstallCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
+	instance := instance.CreateInstanceIgnorePlatformIndexErrors()
 	libRefs, err := globals.ParseLibraryReferenceArgs(args)
 	if err != nil {
 		feedback.Errorf("Arguments error: %v", err)

--- a/cli/lib/list.go
+++ b/cli/lib/list.go
@@ -51,7 +51,7 @@ var listFlags struct {
 }
 
 func runListCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
+	instance := instance.CreateInstanceIgnorePlatformIndexErrors()
 	logrus.Info("Listing")
 
 	res, err := lib.LibraryList(context.Background(), &rpc.LibraryListReq{

--- a/cli/lib/search.go
+++ b/cli/lib/search.go
@@ -52,7 +52,7 @@ var searchFlags struct {
 }
 
 func runSearchCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
+	instance := instance.CreateInstanceIgnorePlatformIndexErrors()
 	logrus.Info("Executing `arduino lib search`")
 	searchResp, err := lib.LibrarySearch(context.Background(), &rpc.LibrarySearchReq{
 		Instance: instance,

--- a/cli/lib/uninstall.go
+++ b/cli/lib/uninstall.go
@@ -47,7 +47,7 @@ func initUninstallCommand() *cobra.Command {
 func runUninstallCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino lib uninstall`")
 
-	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
+	instance := instance.CreateInstanceIgnorePlatformIndexErrors()
 	refs, err := globals.ParseLibraryReferenceArgs(args)
 	if err != nil {
 		feedback.Errorf("Invalid argument passed: %v", err)

--- a/cli/lib/update_index.go
+++ b/cli/lib/update_index.go
@@ -38,7 +38,7 @@ func initUpdateIndexCommand() *cobra.Command {
 		Example: "  " + os.Args[0] + " lib update-index",
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			instance := instance.CreateInstaceIgnorePlatformIndexErrors()
+			instance := instance.CreateInstanceIgnorePlatformIndexErrors()
 			err := commands.UpdateLibrariesIndex(context.Background(), &rpc.UpdateLibrariesIndexReq{
 				Instance: instance,
 			}, output.ProgressBar())

--- a/cli/lib/upgrade.go
+++ b/cli/lib/upgrade.go
@@ -47,7 +47,7 @@ func initUpgradeCommand() *cobra.Command {
 }
 
 func runUpgradeCommand(cmd *cobra.Command, args []string) {
-	instance := instance.CreateInstaceIgnorePlatformIndexErrors()
+	instance := instance.CreateInstanceIgnorePlatformIndexErrors()
 
 	if len(args) == 0 {
 		err := lib.LibraryUpgradeAll(instance.Id, output.ProgressBar(), output.TaskProgress(), globals.NewHTTPClientHeader())

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -63,7 +63,11 @@ func NewCommand() *cobra.Command {
 }
 
 func run(command *cobra.Command, args []string) {
-	instance := instance.CreateInstance()
+	instance, err := instance.CreateInstance()
+	if err != nil {
+		feedback.Errorf("Error during Upload: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
 
 	var path *paths.Path
 	if len(args) > 0 {
@@ -71,7 +75,7 @@ func run(command *cobra.Command, args []string) {
 	}
 	sketchPath := initSketchPath(path)
 
-	_, err := upload.Upload(context.Background(), &rpc.UploadReq{
+	if _, err := upload.Upload(context.Background(), &rpc.UploadReq{
 		Instance:   instance,
 		Fqbn:       fqbn,
 		SketchPath: sketchPath.String(),
@@ -79,9 +83,7 @@ func run(command *cobra.Command, args []string) {
 		Verbose:    verbose,
 		Verify:     verify,
 		ImportFile: importFile,
-	}, os.Stdout, os.Stderr)
-
-	if err != nil {
+	}, os.Stdout, os.Stderr); err != nil {
 		feedback.Errorf("Error during Upload: %v", err)
 		os.Exit(errorcodes.ErrGeneric)
 	}

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -126,10 +126,6 @@ func (instance *CoreInstance) checkForBuiltinTools(downloadCB DownloadProgressCB
 
 // Init FIXMEDOC
 func Init(ctx context.Context, req *rpc.InitReq, downloadCB DownloadProgressCB, taskCB TaskProgressCB, downloaderHeaders http.Header) (*rpc.InitResp, error) {
-	inConfig := req.GetConfiguration()
-	if inConfig == nil {
-		return nil, fmt.Errorf("invalid request")
-	}
 
 	pm, lm, reqPltIndex, reqLibIndex, err := createInstance(ctx, req.GetLibraryManagerOnly())
 	if err != nil {

--- a/rpc/commands/commands.proto
+++ b/rpc/commands/commands.proto
@@ -93,27 +93,17 @@ service ArduinoCore {
   rpc LibraryList(LibraryListReq) returns (LibraryListResp);
 }
 
-// Configuration contains information to instantiate an Arduino Platform Service
+// DEPRECATED
+// Configuration is deprecated, use the Settings Service instead
 message Configuration {
-  // dataDir represents the current root of the arduino tree (defaulted to
-  // `$HOME/.arduino15` on linux).
   string dataDir = 1;
-
-  // sketchbookDir represents the current root of the sketchbooks tree
-  // (defaulted to `$HOME/Arduino`).
   string sketchbookDir = 2;
-
-  // ArduinoIDEDirectory is the directory of the Arduino IDE if the CLI runs
-  // together with it.
   string downloadsDir = 3;
-
-  // BoardManagerAdditionalUrls contains the additional URL for 3rd party
-  // packages
   repeated string boardManagerAdditionalUrls = 4;
 }
 
 message InitReq {
-  Configuration configuration = 1;
+  Configuration configuration = 1; // DEPRECATED this field will be ignored
   bool library_manager_only = 2;
 }
 


### PR DESCRIPTION
Fixes #529 

On `core update-index`, with this PR the CLI creates all the directories needed to work properly in case of a first usage with a fresh install.

This was a regression shipped in 0.7.0, now the code is more robust and errors bubble up correctly (no more `os.exit` from within lower layers).