### PR TITLE
Fix config init on fresh installs

### DIFF
--- a/cli/config/init.go
+++ b/cli/config/init.go
@@ -49,7 +49,13 @@ var initFlags struct {
 func runInitCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino config init`")
 
-	configFile := filepath.Join(viper.GetString("directories.Data"), "arduino-cli.yaml")
+	dataDir := viper.GetString("directories.Data")
+	if err := os.MkdirAll(dataDir, os.FileMode(0755)); err != nil {
+		feedback.Errorf("Cannot create data directory: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
+	configFile := filepath.Join(dataDir, "arduino-cli.yaml")
 	err := viper.WriteConfigAs(configFile)
 	if err != nil {
 		feedback.Errorf("Cannot create config file: %v", err)


### PR DESCRIPTION
Code in this PR creates the default data dir if it doesn't exist on `config init`.