### PR TITLE
[skip changelog] check if PackagesDir exists when reporting it in HardwareDirectories()

### DIFF
--- a/configuration/directories.go
+++ b/configuration/directories.go
@@ -33,7 +33,10 @@ func HardwareDirectories() paths.PathList {
 	}
 
 	if viper.IsSet("directories.Data") {
-		res.Add(PackagesDir())
+		packagesDir := PackagesDir()
+		if packagesDir.IsDir() {
+			res.Add(packagesDir)
+		}
 	}
 
 	if viper.IsSet("directories.User") {


### PR DESCRIPTION
Fix error on `arduino-cli core update-index` with nonexistent ".arduino15" dir:
"Error initializing package manager: cannot initialize package manager: loading hardware packages: loading hardware from /.../.arduino15/packages: /.../.arduino15/packages is not a directory"
