### PR TITLE
Improve error message on build failure

### DIFF
--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -19,6 +19,7 @@ package compile
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli/feedback"
@@ -88,7 +89,7 @@ func NewCommand() *cobra.Command {
 func run(cmd *cobra.Command, args []string) {
 	inst, err := instance.CreateInstance()
 	if err != nil {
-		feedback.Errorf("Error during build: %v", err)
+		feedback.Errorf("Error creating instance: %v", err)
 		os.Exit(errorcodes.ErrGeneric)
 	}
 
@@ -116,7 +117,11 @@ func run(cmd *cobra.Command, args []string) {
 	}, os.Stdout, os.Stderr, viper.GetString("logging.level") == "debug")
 
 	if err != nil {
-		feedback.Errorf("Error during build: %v", err)
+		errMsg := "Error during build"
+		if err.Error() != "" {
+			errMsg = fmt.Sprintf("%s: %v", errMsg, err)
+		}
+		feedback.Errorf("%s.", errMsg)
 		os.Exit(errorcodes.ErrGeneric)
 	}
 

--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -19,7 +19,6 @@ package compile
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/arduino/arduino-cli/cli/feedback"
@@ -117,11 +116,7 @@ func run(cmd *cobra.Command, args []string) {
 	}, os.Stdout, os.Stderr, viper.GetString("logging.level") == "debug")
 
 	if err != nil {
-		errMsg := "Error during build"
-		if err.Error() != "" {
-			errMsg = fmt.Sprintf("%s: %v", errMsg, err)
-		}
-		feedback.Errorf("%s.", errMsg)
+		feedback.Errorf("Error during build: %v", err)
 		os.Exit(errorcodes.ErrGeneric)
 	}
 

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -163,7 +163,7 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 
 	// if it's a regular build, go on...
 	if err := builder.RunBuilder(builderCtx); err != nil {
-		return nil, fmt.Errorf("build failed: %s", err)
+		return nil, err
 	}
 
 	// FIXME: Make a function to obtain these info...

--- a/legacy/builder/phases/sizer.go
+++ b/legacy/builder/phases/sizer.go
@@ -105,12 +105,12 @@ func checkSize(ctx *types.Context, buildProperties *properties.Map) error {
 
 	if textSize > maxTextSize {
 		logger.Println(constants.LOG_LEVEL_ERROR, constants.MSG_SIZER_TEXT_TOO_BIG)
-		return errors.New("")
+		return errors.New("text section exceeds available space in board")
 	}
 
 	if maxDataSize > 0 && dataSize > maxDataSize {
 		logger.Println(constants.LOG_LEVEL_ERROR, constants.MSG_SIZER_DATA_TOO_BIG)
-		return errors.New("")
+		return errors.New("data section exceeds available space in board")
 	}
 
 	if properties.Get(constants.PROPERTY_WARN_DATA_PERCENT) != "" {


### PR DESCRIPTION
Fixes #527 

At some point, deep into the `legacy` package, some function returns an error with an empty message, causing the command to fail in suspense with `"Error during build: build failed: `.

This is a workaround, the real fix would be going on a quest in search of the command(s) returning the empty error.