### PR TITLE
Allow naming sketches like "RCS" and "CVS"

### DIFF
--- a/arduino/builder/sketch_test.go
+++ b/arduino/builder/sketch_test.go
@@ -105,7 +105,7 @@ func TestLoadSketchFolderBothInoAndPde(t *testing.T) {
 	sketchPath := filepath.Join("testdata", t.Name())
 	_, err := builder.SketchLoad(sketchPath, "")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "more than one main sketch file found")
+	require.Contains(t, err.Error(), "multiple main sketch files found")
 	require.Contains(t, err.Error(), t.Name()+".ino")
 	require.Contains(t, err.Error(), t.Name()+".pde")
 }
@@ -157,7 +157,7 @@ func TestLoadSketchFolderWrongMain(t *testing.T) {
 	sketchPath := filepath.Join("testdata", t.Name())
 	_, err := builder.SketchLoad(sketchPath, "")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "unable to find an sketch file in directory testdata")
+	require.Contains(t, err.Error(), "unable to find a sketch file in directory testdata")
 
 	_, err = builder.SketchLoad("does/not/exist", "")
 	require.Error(t, err)

--- a/legacy/builder/container_setup.go
+++ b/legacy/builder/container_setup.go
@@ -30,6 +30,8 @@
 package builder
 
 import (
+	"fmt"
+
 	bldr "github.com/arduino/arduino-cli/arduino/builder"
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
 	"github.com/arduino/arduino-cli/legacy/builder/i18n"
@@ -74,6 +76,9 @@ func (s *ContainerSetupHardwareToolsLibsSketchAndProps) Run(ctx *types.Context) 
 		sketch, err := bldr.SketchLoad(sketchLocation.String(), ctx.BuildPath.String())
 		if err != nil {
 			return i18n.WrapError(err)
+		}
+		if sketch.MainFile == nil {
+			return fmt.Errorf("main file missing from sketch")
 		}
 		ctx.SketchLocation = paths.New(sketch.MainFile.Path)
 		ctx.Sketch = types.SketchToLegacy(sketch)


### PR DESCRIPTION
Fixes #522 

The filter we use to ignore files contained in version control systems' cache was applied to the sketch folder itself, thus preventing a sketch to be named like `RCS`.

This PR increases resiliency by avoiding panics if a sketch name couldn't be found and applies blacklist filters only to folders contained in the sketch, i.e. excluding the root folder.