### PR TITLE
[skip changelog] Handle non-board serial ports in compile integration tests

### DIFF
--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -173,6 +173,8 @@ def test_compile_and_compile_combo(run_command, data_dir):
     assert isinstance(ports, list)
     for port in ports:
         boards = port.get('boards')
+        if boards is None:
+            continue
         assert isinstance(boards, list)
         for board in boards:
             detected_boards.append(dict(address=port.get('address'), fqbn=board.get('FQBN')))


### PR DESCRIPTION
The alternative is to change the code so that `boards` is always a non-null list.