### PR TITLE
Fix regression on compile and upload with attached sketches

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -312,7 +312,7 @@ func TestCompileCommandsIntegration(t *testing.T) {
 	// Build sketch without FQBN
 	exitCode, d = executeWithArgs("compile", sketchPath)
 	require.NotZero(t, exitCode)
-	require.Contains(t, string(d), "required flag(s) \"fqbn\" not set")
+	require.Contains(t, string(d), "no FQBN provided")
 
 	// Build sketch for arduino:avr:uno
 	exitCode, d = executeWithArgs("compile", "-b", "arduino:avr:uno", sketchPath)

--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -78,8 +78,6 @@ func NewCommand() *cobra.Command {
 	command.Flags().BoolVarP(&verify, "verify", "t", false, "Verify uploaded binary after the upload.")
 	command.Flags().StringVar(&vidPid, "vid-pid", "", "When specified, VID/PID specific build properties are used, if boards supports them.")
 
-	command.MarkFlagRequired("fqbn")
-
 	return command
 }
 

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -54,7 +54,6 @@ func NewCommand() *cobra.Command {
 	uploadCommand.Flags().BoolVarP(&verify, "verify", "t", false, "Verify uploaded binary after the upload.")
 	uploadCommand.Flags().BoolVarP(&verbose, "verbose", "v", false, "Optional, turns on verbose mode.")
 
-	uploadCommand.MarkFlagRequired("fqbn")
 	uploadCommand.MarkFlagRequired("port")
 
 	return uploadCommand


### PR DESCRIPTION
In attempt to improve the error messages we merged #523 but this broke the `compile` and `attach` commands, complaining for missing FQBN even for sketches that have been previously attached.

Side note, since we merged #536, the error messages with this PR will be ok even with #523 partially reverted.


