### PR TITLE
[skip changelog] point the master branch in tests data

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -51,7 +51,7 @@ def test_core_search_no_args(run_command):
     are passed (i.e. all results are shown).
     """
     # update custom index and install test core (installed cores affect `core search`)
-    url = "https://raw.githubusercontent.com/arduino/arduino-cli/massi/506/test/testdata/test_index.json"
+    url = "https://raw.githubusercontent.com/arduino/arduino-cli/master/test/testdata/test_index.json"
     assert run_command("core update-index --additional-urls={}".format(url))
     assert run_command("core install test:x86 --additional-urls={}".format(url))
 

--- a/test/testdata/test_index.json
+++ b/test/testdata/test_index.json
@@ -12,7 +12,7 @@
                     "help": {
                         "online": "https://github.com/Arduino/arduino-cli"
                     },
-                    "url": "https://raw.githubusercontent.com/arduino/arduino-cli/massi/506/test/testdata/core.zip",
+                    "url": "https://raw.githubusercontent.com/arduino/arduino-cli/master/test/testdata/core.zip",
                     "checksum": "SHA-256:1ba93f6aea56842dfef065c0f5eb0a34c1f78b72b3f2426c94e47ba3a359c9ff",
                     "name": "test_core",
                     "version": "1.0.0",
@@ -31,7 +31,7 @@
                     "help": {
                         "online": "https://github.com/Arduino/arduino-cli"
                     },
-                    "url": "https://raw.githubusercontent.com/arduino/arduino-cli/massi/506/test/testdata/core.zip",
+                    "url": "https://raw.githubusercontent.com/arduino/arduino-cli/master/test/testdata/core.zip",
                     "checksum": "SHA-256:1ba93f6aea56842dfef065c0f5eb0a34c1f78b72b3f2426c94e47ba3a359c9ff",
                     "name": "test_core",
                     "version": "2.0.0",


### PR DESCRIPTION
Testdata point to an outdated branch that's been deleted. Use master instead.