### PR TITLE
Fix libraries priority selection (again)

### DIFF
--- a/arduino/libraries/libraries.go
+++ b/arduino/libraries/libraries.go
@@ -83,9 +83,6 @@ func (library *Library) String() string {
 // - the library is architecture independent
 // - the library doesn't specify any `architecture` field in library.properties
 func (library *Library) SupportsAnyArchitectureIn(archs ...string) bool {
-	if len(library.Architectures) == 0 {
-		return true
-	}
 	if library.IsArchitectureIndependent() {
 		return true
 	}
@@ -113,7 +110,7 @@ func (library *Library) IsOptimizedForArchitecture(arch string) bool {
 // compatible with all architectures (the `architecture` field in
 // library.properties contains the `*` item)
 func (library *Library) IsArchitectureIndependent() bool {
-	return library.IsOptimizedForArchitecture("*")
+	return library.IsOptimizedForArchitecture("*") || library.Architectures == nil || len(library.Architectures) == 0
 }
 
 // SourceDir represents a source dir of a library

--- a/arduino/libraries/librariesresolver/cpp.go
+++ b/arduino/libraries/librariesresolver/cpp.go
@@ -155,7 +155,7 @@ func computePriority(lib *libraries.Library, header, arch string) int {
 	case libraries.IDEBuiltIn:
 		priority += 0
 	case libraries.ReferencedPlatformBuiltIn:
-		priority += 1
+		priority++
 	case libraries.PlatformBuiltIn:
 		priority += 2
 	case libraries.User:

--- a/arduino/libraries/librariesresolver/cpp.go
+++ b/arduino/libraries/librariesresolver/cpp.go
@@ -127,33 +127,41 @@ func computePriority(lib *libraries.Library, header, arch string) int {
 	priority := 0
 
 	// Bonus for core-optimized libraries
-	if lib.IsOptimizedForArchitecture(arch) || lib.IsArchitectureIndependent() {
-		priority += 0x0100
+	if lib.IsOptimizedForArchitecture(arch) {
+		// give a slightly better bonus for libraries that have specific optimization
+		// (it is more important than Location but less important than Name)
+		priority += 1010
+	} else if lib.IsArchitectureIndependent() {
+		// standard bonus for architecture independent (vanilla) libraries
+		priority += 1000
+	} else {
+		// the library is not architecture compatible
+		priority += 0
+	}
+
+	if name == header {
+		priority += 500
+	} else if name == header+"-master" {
+		priority += 400
+	} else if strings.HasPrefix(name, header) {
+		priority += 300
+	} else if strings.HasSuffix(name, header) {
+		priority += 200
+	} else if strings.Contains(name, header) {
+		priority += 100
 	}
 
 	switch lib.Location {
 	case libraries.IDEBuiltIn:
-		priority += 0x0000
+		priority += 0
 	case libraries.ReferencedPlatformBuiltIn:
-		priority += 0x0001
+		priority += 1
 	case libraries.PlatformBuiltIn:
-		priority += 0x0002
+		priority += 2
 	case libraries.User:
-		priority += 0x0003
+		priority += 3
 	default:
 		panic(fmt.Sprintf("Invalid library location: %d", lib.Location))
-	}
-
-	if name == header {
-		priority += 0x0050
-	} else if name == header+"-master" {
-		priority += 0x0040
-	} else if strings.HasPrefix(name, header) {
-		priority += 0x0030
-	} else if strings.HasSuffix(name, header) {
-		priority += 0x0020
-	} else if strings.Contains(name, header) {
-		priority += 0x0010
 	}
 	return priority
 }

--- a/arduino/libraries/librariesresolver/cpp_test.go
+++ b/arduino/libraries/librariesresolver/cpp_test.go
@@ -30,10 +30,6 @@ var l5 = &libraries.Library{Name: "Yet Another Calculus Lib Improved", Location:
 var l6 = &libraries.Library{Name: "Calculus Unified Lib", Location: libraries.User}
 var l7 = &libraries.Library{Name: "AnotherLib", Location: libraries.User}
 var bundleServo = &libraries.Library{Name: "Servo", Location: libraries.IDEBuiltIn, Architectures: []string{"avr", "sam", "samd"}}
-var userServo = &libraries.Library{Name: "Servo", Location: libraries.User, Architectures: []string{"avr", "sam", "samd"}}
-var userServoAllArch = &libraries.Library{Name: "Servo", Location: libraries.User, Architectures: []string{"*"}}
-var userServoNonavr = &libraries.Library{Name: "Servo", Location: libraries.User, Architectures: []string{"sam", "samd"}}
-var userAnotherServo = &libraries.Library{Name: "AnotherServo", Location: libraries.User, Architectures: []string{"avr", "sam", "samd", "esp32"}}
 
 func runResolver(include string, arch string, libs ...*libraries.Library) *libraries.Library {
 	libraryList := libraries.List{}
@@ -44,6 +40,23 @@ func runResolver(include string, arch string, libs ...*libraries.Library) *libra
 }
 
 func TestArchitecturePriority(t *testing.T) {
+	userServo := &libraries.Library{
+		Name:          "Servo",
+		Location:      libraries.User,
+		Architectures: []string{"avr", "sam", "samd"}}
+	userServoAllArch := &libraries.Library{
+		Name:          "Servo",
+		Location:      libraries.User,
+		Architectures: []string{"*"}}
+	userServoNonavr := &libraries.Library{
+		Name:          "Servo",
+		Location:      libraries.User,
+		Architectures: []string{"sam", "samd"}}
+	userAnotherServo := &libraries.Library{
+		Name:          "AnotherServo",
+		Location:      libraries.User,
+		Architectures: []string{"avr", "sam", "samd", "esp32"}}
+
 	res := runResolver("Servo.h", "avr", bundleServo, userServo)
 	require.NotNil(t, res)
 	require.Equal(t, userServo, res, "selected library")

--- a/arduino/libraries/librariesresolver/cpp_test.go
+++ b/arduino/libraries/librariesresolver/cpp_test.go
@@ -76,6 +76,17 @@ func TestArchitecturePriority(t *testing.T) {
 	res = runResolver("Servo.h", "esp32", userServoAllArch, userAnotherServo)
 	require.NotNil(t, res)
 	require.Equal(t, userServoAllArch, res, "selected library")
+
+	userSDAllArch := &libraries.Library{
+		Name:          "SD",
+		Location:      libraries.User,
+		Architectures: []string{"*"}}
+	builtinSDesp := &libraries.Library{
+		Name:          "SD",
+		Location:      libraries.PlatformBuiltIn,
+		Architectures: []string{"esp8266"}}
+	res = runResolver("SD.h", "esp8266", userSDAllArch, builtinSDesp)
+	require.Equal(t, builtinSDesp, res, "selected library")
 }
 
 func TestClosestMatchWithTotallyDifferentNames(t *testing.T) {


### PR DESCRIPTION
This PR changes again the lib priority selection to improve backward compatibility. Now the algorithm should be (hopefully) 100% compatible with legacy algorithm used in the `arduino-builder`.

The priority is determined by applying the following rules, one by one in this order, until a rule determine a winner:

1. A library that is architecture compatibile wins against a library that is not architecture compatible
2. A library that has better "name priority" wins (see below for details)
3. A library that is architecture optimized wins against a library that is vanilla
4. A library that has a better "location priority" wins (see below for details)
5. A library that has a name with a better score using "closest-match" algorithm wins
6. A library that has a name that comes first in alphanumeric order wins

Usually the first four rules are enough, the rule 5 is rarely applied and the rule 6 is even more rare. Anyway they are there to not leave the selection process undefined even in those extreme cases.

@per1234 could you check if this solves #572?
I think that this issue alone calls for another release of the Arduino IDE.

---

Details about rules:

A library is considered **compatible** with architecture `X` if the `architecture` field in library.properties:
- contains explicitly the architecure `X`
- contains the catch-all `*`
- is not specified at all.
(see table below for an example)

A library is considered **optimized** for architecture `X` only if the `architecture` field in library.properties contains explicitly the architecure `X`.

`architecture` field in `library.properties` |  Compatible with `avr` | Optimized for `avr`
----------------- | ----------------- | -------------
not specified | YES | NO
`architectures=*` | YES | NO
`architectures=avr` | YES | YES
`architectures=*,avr` | YES | YES
`architectures=*,esp8266` | YES | NO
`architectures=avr,esp8266` | YES | YES
`architectures=samd` | NO | NO

The "name priority" is determined as follows (higher is better):

Priority |  Rule     |       Example for `Servo.h`
---------- | ----------- | --------------
 5   | The name match the include 100% | `Servo`
 4   | The name match the include 100% with a `-master` suffix | `Servo-master`
 3   | The name has a matching prefix | `ServoWhatever`
 2  | The name has a matching suffix  |  `AwesomeServo`
 1  | The name contains the include | `AnAwesomeServoForWhatever`

The "location priority" is determined as follows (higher is better):

Priority |  Rule 
---------- | -------
 4   | The library is in the sketchbook
 3   | The library is bundled in the board platform/core
 2   | The library is bundled in the referenced board platform/core
 1   | The library is bundled in the IDE

