### PR TITLE
Integrate Apple notarization process into Github Actions release pipeline

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -30,6 +30,6 @@ jobs:
           PLUGIN_SOURCE: 'dist/*'
           PLUGIN_TARGET: '/arduino-cli/nightly'
           PLUGIN_STRIP_PREFIX: 'dist/'
-          PLUGIN_BUCKET: 'arduino-downloads-prod-beagle'
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,8 @@ on:
       - '[0-9].[0-9].[0-9]*'
 
 jobs:
-  publish-release:
+
+  create-release-artifacts:
     runs-on: ubuntu-latest
 
     container:
@@ -16,13 +17,120 @@ jobs:
         - $PWD/go:/go
 
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v1
 
-      - name: build
+      - name: Build
+        run: goreleaser
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist
+          path: dist
+
+  notarize-macos:
+    runs-on: macos-latest
+    needs: create-release-artifacts
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+
+      - name: Get the current release tag
+        id: get_tag
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Download Gon
+        run: |
+          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.2/gon_0.2.2_macos.zip
+          unzip gon_0.2.2_macos.zip -d /usr/local/bin
+          rm -f gon_0.2.2_macos.zip
+
+      - name: Notarize binary, re-package it and update checksum
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          TAG: ${{ steps.get_tag.outputs.VERSION }}
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+        # This step performs the following:
+        # 1. Download keychain from GH secrets and decode it from base64
+        # 2. Add the keychain to the system keychains and unlock it
+        # 3. Call Gon to start notarization process (using AC_USERNAME and AC_PASSWORD)
+        # 4. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
+        # 5. Recalculate package checksum and replace it in the goreleaser nnnnnn-checksums.txt file
+        # 6. Remove the keychain from disk
+        run: |
+          echo "${{ secrets.KEYCHAIN }}" | base64 --decode  > ~/Library/Keychains/apple-developer.keychain-db
+          security list-keychains -s ~/Library/Keychains/apple-developer.keychain-db
+          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" ~/Library/Keychains/apple-developer.keychain-db
+          gon gon.config.hcl
+          tar -czvf dist/arduino-cli_${TAG}_macOS_64bit.tar.gz \
+          -C dist/arduino_cli_osx_darwin_amd64/  arduino-cli   \
+          -C ../../ LICENSE.txt
+          CLI_CHECKSUM=$(shasum -a 256 dist/arduino-cli_${TAG}_macOS_64bit.tar.gz | cut -d " " -f 1)
+          perl -pi -w -e "s/.*arduino-cli_${TAG}_macOS_64bit.tar.gz/${CLI_CHECKSUM}  arduino-cli_${TAG}_macOS_64bit.tar.gz/g;" dist/*-checksums.txt
+          rm -f apple-developer.keychain-db
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist
+          path: dist
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: notarize-macos
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Download artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+
+      - name: Read CHANGELOG
+        id: changelog
+        run: |
+          body=$(cat dist/CHANGELOG.md)
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo $body
+          echo "::set-output name=BODY::$body"
+
+      - name: Create Github Release
+        id: create_release
+        uses: actions/create-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{ steps.changelog.outputs.BODY }}
+          draft: false
+          prerelease: false
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/*
+          tag: ${{ github.ref }}
+          file_glob: true
+
+      - name: Downloads upload
+        uses: docker://plugins/s3
+        env:
+          PLUGIN_SOURCE: 'dist/*'
+          PLUGIN_TARGET: '/arduino-cli/__tmp/'
+          PLUGIN_STRIP_PREFIX: 'dist/'
+          PLUGIN_BUCKET: 'arduino-downloads-prod-beagle'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: 'us-east-1'
-        run: goreleaser

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,9 +61,8 @@ jobs:
         # 1. Download keychain from GH secrets and decode it from base64
         # 2. Add the keychain to the system keychains and unlock it
         # 3. Call Gon to start notarization process (using AC_USERNAME and AC_PASSWORD)
-        # 4. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
+        # 4. Repackage the signed binary replaced in place by Gon
         # 5. Recalculate package checksum and replace it in the goreleaser nnnnnn-checksums.txt file
-        # 6. Remove the keychain from disk
         run: |
           echo "${{ secrets.KEYCHAIN }}" | base64 --decode  > ~/Library/Keychains/apple-developer.keychain-db
           security list-keychains -s ~/Library/Keychains/apple-developer.keychain-db
@@ -74,7 +73,6 @@ jobs:
           -C ../../ LICENSE.txt
           CLI_CHECKSUM=$(shasum -a 256 dist/arduino-cli_${TAG}_macOS_64bit.tar.gz | cut -d " " -f 1)
           perl -pi -w -e "s/.*arduino-cli_${TAG}_macOS_64bit.tar.gz/${CLI_CHECKSUM}  arduino-cli_${TAG}_macOS_64bit.tar.gz/g;" dist/*-checksums.txt
-          rm -f apple-developer.keychain-db
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
@@ -117,7 +115,7 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload binaries to release
+      - name: Upload release files on Github
         uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -125,7 +123,7 @@ jobs:
           tag: ${{ github.ref }}
           file_glob: true
 
-      - name: Downloads upload
+      - name: Upload release files on Arduino downloads servers
         uses: docker://plugins/s3
         env:
           PLUGIN_SOURCE: 'dist/*'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,8 +129,8 @@ jobs:
         uses: docker://plugins/s3
         env:
           PLUGIN_SOURCE: 'dist/*'
-          PLUGIN_TARGET: '/arduino-cli/__tmp/'
+          PLUGIN_TARGET: '/arduino-cli/'
           PLUGIN_STRIP_PREFIX: 'dist/'
-          PLUGIN_BUCKET: 'arduino-downloads-prod-beagle'
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,62 +38,62 @@ builds:
     id: arduino_cli_arm
     binary: arduino-cli
     env:
-     - CGO_ENABLED=1
-     - CC=/usr/arm-linux-gnueabi/bin/cc
+      - CGO_ENABLED=1
+      - CC=/usr/arm-linux-gnueabi/bin/cc
     goos:
-     - linux
+      - linux
     goarch:
-     - arm
+      - arm
     goarm:
-     - 6
+      - 6
     ldflags:
-     - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-     - "-extldflags '-static'"
+      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - "-extldflags '-static'"
   -
     # ARMv7
     id: arduino_cli_armv7
     binary: arduino-cli
     env:
-     - CGO_ENABLED=1
-     - CC=/usr/arm-linux-gnueabihf/bin/cc
+      - CGO_ENABLED=1
+      - CC=/usr/arm-linux-gnueabihf/bin/cc
     goos:
-     - linux
+      - linux
     goarch:
-     - arm
+      - arm
     goarm:
-     - 7
+      - 7
     ldflags:
-     - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-     - "-extldflags '-static'"
+      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - "-extldflags '-static'"
   -
     # ARM64
     id: arduino_cli_arm64
     binary: arduino-cli
     env:
-     - CGO_ENABLED=1
-     - CC=/usr/aarch64-linux-gnu/bin/cc
+      - CGO_ENABLED=1
+      - CC=/usr/aarch64-linux-gnu/bin/cc
     goos:
-     - linux
+      - linux
     goarch:
-     - arm64
+      - arm64
     ldflags:
-     - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-     - "-extldflags '-static'"
+      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - "-extldflags '-static'"
   -
     # All the other platforms
     id: arduino_cli
     binary: arduino-cli
     env:
-     - CGO_ENABLED=0
+      - CGO_ENABLED=0
     goos:
-     - linux
-     - windows
+      - linux
+      - windows
     goarch:
-     - amd64
-     - 386
+      - amd64
+      - 386
     ldflags:
-     - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-     - "-extldflags '-static'"
+      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - "-extldflags '-static'"
 
 archives:
   -

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ snapshot:
   name_template: '{{ .Env.PACKAGE_NAME_PREFIX }}-{{ time "20060102" }}'
 
 release:
-  prerelease: auto
+  disable: true
 
 changelog:
   filters:
@@ -34,66 +34,66 @@ builds:
     ldflags:
       - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
   -
-    # ARM
-    id: arduino_cli_arm
-    binary: arduino-cli
-    env:
-      - CGO_ENABLED=1
-      - CC=/usr/arm-linux-gnueabi/bin/cc
-    goos:
-      - linux
-    goarch:
-      - arm
-    goarm:
-      - 6
-    ldflags:
-      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-      - "-extldflags '-static'"
+     # ARM
+     id: arduino_cli_arm
+     binary: arduino-cli
+     env:
+       - CGO_ENABLED=1
+       - CC=/usr/arm-linux-gnueabi/bin/cc
+     goos:
+       - linux
+     goarch:
+       - arm
+     goarm:
+       - 6
+     ldflags:
+       - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+       - "-extldflags '-static'"
   -
-    # ARMv7
-    id: arduino_cli_armv7
-    binary: arduino-cli
-    env:
-      - CGO_ENABLED=1
-      - CC=/usr/arm-linux-gnueabihf/bin/cc
-    goos:
-      - linux
-    goarch:
-      - arm
-    goarm:
-      - 7
-    ldflags:
-      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-      - "-extldflags '-static'"
+     # ARMv7
+     id: arduino_cli_armv7
+     binary: arduino-cli
+     env:
+       - CGO_ENABLED=1
+       - CC=/usr/arm-linux-gnueabihf/bin/cc
+     goos:
+       - linux
+     goarch:
+       - arm
+     goarm:
+       - 7
+     ldflags:
+       - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+       - "-extldflags '-static'"
   -
-    # ARM64
-    id: arduino_cli_arm64
-    binary: arduino-cli
-    env:
-      - CGO_ENABLED=1
-      - CC=/usr/aarch64-linux-gnu/bin/cc
-    goos:
-      - linux
-    goarch:
-      - arm64
-    ldflags:
-      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-      - "-extldflags '-static'"
+     # ARM64
+     id: arduino_cli_arm64
+     binary: arduino-cli
+     env:
+       - CGO_ENABLED=1
+       - CC=/usr/aarch64-linux-gnu/bin/cc
+     goos:
+       - linux
+     goarch:
+       - arm64
+     ldflags:
+       - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+       - "-extldflags '-static'"
   -
-    # All the other platforms
-    id: arduino_cli
-    binary: arduino-cli
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - 386
-    ldflags:
-      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-      - "-extldflags '-static'"
+     # All the other platforms
+     id: arduino_cli
+     binary: arduino-cli
+     env:
+       - CGO_ENABLED=0
+     goos:
+       - linux
+       - windows
+     goarch:
+       - amd64
+       - 386
+     ldflags:
+       - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+       - "-extldflags '-static'"
 
 archives:
   -
@@ -112,11 +112,3 @@ archives:
       windows: Windows
     files:
       - LICENSE.txt
-
-blob:
-  -
-    provider: s3
-    bucket: arduino-downloads-prod-beagle
-    ids:
-      - arduino_cli
-    folder: "{{ .ProjectName }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,66 +34,66 @@ builds:
     ldflags:
       - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
   -
-     # ARM
-     id: arduino_cli_arm
-     binary: arduino-cli
-     env:
-       - CGO_ENABLED=1
-       - CC=/usr/arm-linux-gnueabi/bin/cc
-     goos:
-       - linux
-     goarch:
-       - arm
-     goarm:
-       - 6
-     ldflags:
-       - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-       - "-extldflags '-static'"
+    # ARM
+    id: arduino_cli_arm
+    binary: arduino-cli
+    env:
+     - CGO_ENABLED=1
+     - CC=/usr/arm-linux-gnueabi/bin/cc
+    goos:
+     - linux
+    goarch:
+     - arm
+    goarm:
+     - 6
+    ldflags:
+     - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+     - "-extldflags '-static'"
   -
-     # ARMv7
-     id: arduino_cli_armv7
-     binary: arduino-cli
-     env:
-       - CGO_ENABLED=1
-       - CC=/usr/arm-linux-gnueabihf/bin/cc
-     goos:
-       - linux
-     goarch:
-       - arm
-     goarm:
-       - 7
-     ldflags:
-       - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-       - "-extldflags '-static'"
+    # ARMv7
+    id: arduino_cli_armv7
+    binary: arduino-cli
+    env:
+     - CGO_ENABLED=1
+     - CC=/usr/arm-linux-gnueabihf/bin/cc
+    goos:
+     - linux
+    goarch:
+     - arm
+    goarm:
+     - 7
+    ldflags:
+     - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+     - "-extldflags '-static'"
   -
-     # ARM64
-     id: arduino_cli_arm64
-     binary: arduino-cli
-     env:
-       - CGO_ENABLED=1
-       - CC=/usr/aarch64-linux-gnu/bin/cc
-     goos:
-       - linux
-     goarch:
-       - arm64
-     ldflags:
-       - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-       - "-extldflags '-static'"
+    # ARM64
+    id: arduino_cli_arm64
+    binary: arduino-cli
+    env:
+     - CGO_ENABLED=1
+     - CC=/usr/aarch64-linux-gnu/bin/cc
+    goos:
+     - linux
+    goarch:
+     - arm64
+    ldflags:
+     - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+     - "-extldflags '-static'"
   -
-     # All the other platforms
-     id: arduino_cli
-     binary: arduino-cli
-     env:
-       - CGO_ENABLED=0
-     goos:
-       - linux
-       - windows
-     goarch:
-       - amd64
-       - 386
-     ldflags:
-       - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
-       - "-extldflags '-static'"
+    # All the other platforms
+    id: arduino_cli
+    binary: arduino-cli
+    env:
+     - CGO_ENABLED=0
+    goos:
+     - linux
+     - windows
+    goarch:
+     - amd64
+     - 386
+    ldflags:
+     - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+     - "-extldflags '-static'"
 
 archives:
   -

--- a/gon.config.hcl
+++ b/gon.config.hcl
@@ -1,0 +1,10 @@
+source = ["dist/arduino_cli_osx_darwin_amd64/arduino-cli"]
+bundle_id = "cc.arduino.arduino-cli"
+
+sign {
+  application_identity = "Developer ID Application: ARDUINO SA (7KT7ZWMCJT)"
+}
+
+zip {
+  output_path = "arduino-cli.zip"
+}

--- a/gon.config.hcl
+++ b/gon.config.hcl
@@ -4,7 +4,3 @@ bundle_id = "cc.arduino.arduino-cli"
 sign {
   application_identity = "Developer ID Application: ARDUINO SA (7KT7ZWMCJT)"
 }
-
-zip {
-  output_path = "arduino-cli.zip"
-}


### PR DESCRIPTION
### What:
This PR Integrates the Notarization process in the Arduino CLI Relese pipeline.

### Why:
As per [Apple announcement](https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution):

> Beginning in macOS 10.14.5, software signed with a new Developer ID certificate and all new or updated kernel extensions must be notarized to run. Beginning in macOS 10.15, all software built after June 1, 2019, and distributed with Developer ID must be notarized.

### How:
The PR moves the responsibility of GitHub release creation and Arduino servers upload, from `goreleaser` to GH Actions steps, and adds the notarization step leveraging [Gon](https://github.com/mitchellh/gon) (Thanks to @mitchellh and to @zmoog who discovered the tool :smile: )

The `notarize-macos` job must run on a `macos-latest` VM, in order to allow `gon` to orchestrate all the required notarization tools, this means that container steps cannot be used in the same job.
This is why the release pipeline is split in 3 jobs that share artifacts via the `artifacts` Github Actions feature.

A detailed explanation is required for the `Notarize binary, re-package it and update checksum` step, that configures the MacOs `keychain` with obscure osx commands and calls `gon` doing the following:
1. Download keychain from GH secrets and decode it from base64
2. Add the keychain to the system keychains and unlock it
3. Call Gon to start notarization process (using AC_USERNAME and AC_PASSWORD secrets)
4. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
5. Recalculate package checksum and replace it in the goreleaser `nnnnnn-checksums.txt` file

### Pros:
This way we do not lose:
1. the "build reproducibility", because we still use `goreleaser` plus `multiarch/crossbuild` container to produce the artifacts
1. the automatic changelog generation from `goreleaser`
1. the automatic checksum file generation from `goreleaser`

### Cons:
- We add a bit of complexity to the `release` workflow (that is acceptable in the end, having handy GitHub actions ready to use).
- We lost a portion of my mental health :smile_cat: 