### PR TITLE
Force notarization process to take place configuring Gon zip output

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
         # 1. Download keychain from GH secrets and decode it from base64
         # 2. Add the keychain to the system keychains and unlock it
         # 3. Call Gon to start notarization process (using AC_USERNAME and AC_PASSWORD)
-        # 4. Repackage the signed binary replaced in place by Gon
+        # 4. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         # 5. Recalculate package checksum and replace it in the goreleaser nnnnnn-checksums.txt file
         run: |
           echo "${{ secrets.KEYCHAIN }}" | base64 --decode  > ~/Library/Keychains/apple-developer.keychain-db

--- a/gon.config.hcl
+++ b/gon.config.hcl
@@ -4,3 +4,9 @@ bundle_id = "cc.arduino.arduino-cli"
 sign {
   application_identity = "Developer ID Application: ARDUINO SA (7KT7ZWMCJT)"
 }
+
+# Ask Gon for zip output to force notarization process to take place.
+# The CI will ignore the zip output, using the signed binary only.
+zip {
+  output_path = "arduino-cli.zip"
+}


### PR DESCRIPTION
In order to force the notarization process to take place, we need to ask `gon` to produce a `.zip` file as output.

As explained here https://github.com/arduino/arduino-cli/pull/578 / https://github.com/arduino/arduino-cli/pull/578#discussion_r377794210 the `gon.config.hcl` "zip" section is not mandatory di per se', but not  having an "output" section at all will not start the notarization submission process for the binary.

For our release process the generated `.zip` file has no use, as we repackage the signed binary that `gon` replaces in-place. The `.zip` is functional for the notary service submission only

Thanks to @zmoog for patiently explaining the whole process to me countless times :bowing_man: 