### PR TITLE
Restore permission lost during upload/download

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,9 @@ jobs:
           security list-keychains -s ~/Library/Keychains/apple-developer.keychain-db
           security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" ~/Library/Keychains/apple-developer.keychain-db
           gon gon.config.hcl
+          # GitHub's upload/download-artifact@v1 actions don't preserve file permissions,
+          # so we need to add execution permission back until @v2 actions are released.
+          chmod +x dist/arduino_cli_osx_darwin_amd64/arduino-cli 
           tar -czvf dist/arduino-cli_${TAG}_macOS_64bit.tar.gz \
           -C dist/arduino_cli_osx_darwin_amd64/  arduino-cli   \
           -C ../../ LICENSE.txt


### PR DESCRIPTION
### Motivation

GitHub Actions does not preserve file permission when a file is shared between jobs as an artifact using the [upload-artifact@v1](https://github.com/actions/upload-artifact) and [download-artifact@v1](https://github.com/actions/download-artifact) actions.

I have empirically observed this behavior in a test workflow, and I've found a few [issues](https://github.com/actions/upload-artifact/issues/38) on GitHub.

According to a [comment](https://github.com/actions/upload-artifact/issues/38#issuecomment-562679842) from a user, GitHub will fix this file permission issue in the v2 version of these actions.

### Change description

Execution permission is re-added using `chmod`, until this problem is fixed in the actions.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

User reported bugs:
* Install script doesn't work properly on v0.8.0 #584 

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `master`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.