### PR TITLE
[skip changelog] Run docs build on more path changes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,8 +7,14 @@ on:
       - synchronize
       - closed
     paths:
+      # existing docs
       - 'docs/**'
+      # changes to the cli reference generator
       - 'docsgen/**'
+      # potential changes to commands documentation
+      - 'cli/**'
+      # potential changes to gRPC documentation
+      - 'rpc/**'
 
 jobs:
   build:


### PR DESCRIPTION
Changes to `/cli` and `/rpc` source modules might require a new build of the docs site. We might have false positives but being builds idempotent, let's do it anyways.