### PR TITLE
GH-612: `core search` can exact-match Platform#ID too.

### DIFF
--- a/commands/core/search.go
+++ b/commands/core/search.go
@@ -29,6 +29,10 @@ func match(line, searchArgs string) bool {
 	return strings.Contains(strings.ToLower(line), strings.ToLower(searchArgs))
 }
 
+func exactMatch(line, searchArgs string) bool {
+	return strings.Compare(strings.ToLower(line), strings.ToLower(searchArgs)) == 0
+}
+
 // PlatformSearch FIXMEDOC
 func PlatformSearch(instanceID int32, searchArgs string, allVersions bool) (*rpc.PlatformSearchResp, error) {
 	pm := commands.GetPackageManager(instanceID)
@@ -55,7 +59,7 @@ func PlatformSearch(instanceID int32, searchArgs string, allVersions bool) (*rpc
 				}
 
 				// platform has a valid release, check if it matches the search arguments
-				if match(platform.Name, searchArgs) || match(platform.Architecture, searchArgs) {
+				if match(platform.Name, searchArgs) || match(platform.Architecture, searchArgs) || exactMatch(platform.String(), searchArgs) {
 					if allVersions {
 						res = append(res, platform.GetAllReleases()...)
 					} else {


### PR DESCRIPTION
When matching against a Platform#ID, the match must be a
case-insensitive exact match.

Closes #612.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

```
akos.kitta@Akoss-MacBook-Pro arduino-cli % ./arduino-cli core search                                               
ID                   Version   Name                                             
Arrow:samd           2.1.0     Arrow Boards                                     
Intel:arc32          2.0.4     Intel Curie Boards                               
Intel:i586           1.6.7+1.0 Intel i586 Boards                                
Intel:i686           1.6.7+1.0 Intel i686 Boards                                
Microsoft:win10      1.1.2     Windows 10 Iot Core                              
arduino:avr          1.8.2     Arduino AVR Boards                               
arduino:mbed         1.1.4     Arduino nRF528x Boards (Mbed OS)                 
arduino:megaavr      1.8.5     Arduino megaAVR Boards                           
arduino:nrf52        1.0.2     Arduino nRF52 Boards                             
arduino:sam          1.6.12    Arduino SAM Boards (32-bits ARM Cortex-M3)       
arduino:samd         1.8.5     Arduino SAMD Boards (32-bits ARM Cortex-M0+)     
arduino:samd_beta    1.6.25    Arduino SAMD Beta Boards (32-bits ARM Cortex-M0+)
atmel-avr-xminis:avr 0.6.0     Atmel AVR Xplained-minis                         
emoro:avr            3.2.2     EMORO 2560                                       
industruino:samd     1.0.1     Industruino SAMD Boards (32-bits ARM Cortex-M0+) 
littleBits:avr       1.0.0     littleBits Arduino AVR Modules                   

akos.kitta@Akoss-MacBook-Pro arduino-cli % ./arduino-cli core search "Arduino SAMD Boards (32-bits ARM Cortex-M0+)"
ID           Version Name                                        
arduino:samd 1.8.5   Arduino SAMD Boards (32-bits ARM Cortex-M0+)

akos.kitta@Akoss-MacBook-Pro arduino-cli % ./arduino-cli core search "arduino:samd"                                
ID           Version Name                                        
arduino:samd 1.8.5   Arduino SAMD Boards (32-bits ARM Cortex-M0+)

akos.kitta@Akoss-MacBook-Pro arduino-cli % ./arduino-cli core search "arduino:sa"                                  
No platforms matching your search.
akos.kitta@Akoss-MacBook-Pro arduino-cli % 
```