### PR TITLE
Remove legacy errors handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/fluxio/iohelpers v0.0.0-20160419043813-3a4dd67a94d2 // indirect
 	github.com/fluxio/multierror v0.0.0-20160419044231-9c68d39025e5 // indirect
 	github.com/fsnotify/fsnotify v1.4.7
-	github.com/go-errors/errors v1.0.1
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/golang/protobuf v1.3.3
 	github.com/h2non/filetype v1.0.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.2 // indirect
 	github.com/miekg/dns v1.0.5 // indirect
 	github.com/oleksandr/bonjour v0.0.0-20160508152359-5dcf00d8b228 // indirect
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/pmylund/sortutil v0.0.0-20120526081524-abeda66eb583
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 	github.com/schollz/closestmatch v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmylund/sortutil v0.0.0-20120526081524-abeda66eb583 h1:ogHi8YLNeIxABOaH6UgtbwkODheuAK+ErP8gWXYQVj0=

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/fluxio/multierror v0.0.0-20160419044231-9c68d39025e5/go.mod h1:BEUDl7
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
-github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
@@ -136,8 +134,6 @@ github.com/oleksandr/bonjour v0.0.0-20160508152359-5dcf00d8b228/go.mod h1:MGuVJ1
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/legacy/builder/add_additional_entries_to_context.go
+++ b/legacy/builder/add_additional_entries_to_context.go
@@ -18,8 +18,8 @@ package builder
 import (
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/pkg/errors"
 )
 
 type AddAdditionalEntriesToContext struct{}
@@ -29,19 +29,19 @@ func (*AddAdditionalEntriesToContext) Run(ctx *types.Context) error {
 		buildPath := ctx.BuildPath
 		preprocPath, err := buildPath.Join(constants.FOLDER_PREPROC).Abs()
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		sketchBuildPath, err := buildPath.Join(constants.FOLDER_SKETCH).Abs()
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		librariesBuildPath, err := buildPath.Join("libraries").Abs()
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		coreBuildPath, err := buildPath.Join(constants.FOLDER_CORE).Abs()
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 
 		ctx.PreprocPath = preprocPath
@@ -53,7 +53,7 @@ func (*AddAdditionalEntriesToContext) Run(ctx *types.Context) error {
 	if ctx.BuildCachePath != nil {
 		coreBuildCachePath, err := ctx.BuildCachePath.Join(constants.FOLDER_CORE).Abs()
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 
 		ctx.CoreBuildCachePath = coreBuildCachePath

--- a/legacy/builder/builder.go
+++ b/legacy/builder/builder.go
@@ -25,10 +25,10 @@ import (
 	bldr "github.com/arduino/arduino-cli/arduino/builder"
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/phases"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
+	"github.com/pkg/errors"
 )
 
 var MAIN_FILE_VALID_EXTENSIONS = map[string]bool{".ino": true, ".pde": true}
@@ -194,7 +194,7 @@ func runCommands(ctx *types.Context, commands []types.Command, progressEnabled b
 		builder_utils.PrintProgressIfProgressEnabledAndMachineLogger(ctx)
 		err := command.Run(ctx)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 	return nil

--- a/legacy/builder/container_add_prototypes.go
+++ b/legacy/builder/container_add_prototypes.go
@@ -18,8 +18,8 @@ package builder
 import (
 	bldr "github.com/arduino/arduino-cli/arduino/builder"
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/pkg/errors"
 )
 
 type ContainerAddPrototypes struct{}
@@ -27,14 +27,14 @@ type ContainerAddPrototypes struct{}
 func (s *ContainerAddPrototypes) Run(ctx *types.Context) error {
 	// Generate the full pathname for the preproc output file
 	if err := ctx.PreprocPath.MkdirAll(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	targetFilePath := ctx.PreprocPath.Join(constants.FILE_CTAGS_TARGET_FOR_GCC_MINUS_E)
 
 	// Run preprocessor
 	sourceFile := ctx.SketchBuildPath.Join(ctx.Sketch.MainFile.Name.Base() + ".cpp")
 	if err := GCCPreprocRunner(ctx, sourceFile, targetFilePath, ctx.IncludeFolders); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	commands := []types.Command{
@@ -49,12 +49,12 @@ func (s *ContainerAddPrototypes) Run(ctx *types.Context) error {
 		PrintRingNameIfDebug(ctx, command)
 		err := command.Run(ctx)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 
 	if err := bldr.SketchSaveItemCpp(ctx.Sketch.MainFile.Name.String(), []byte(ctx.Source), ctx.SketchBuildPath.String()); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	return nil

--- a/legacy/builder/container_build_options.go
+++ b/legacy/builder/container_build_options.go
@@ -16,8 +16,8 @@
 package builder
 
 import (
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/pkg/errors"
 )
 
 type ContainerBuildOptions struct{}
@@ -34,7 +34,7 @@ func (s *ContainerBuildOptions) Run(ctx *types.Context) error {
 		PrintRingNameIfDebug(ctx, command)
 		err := command.Run(ctx)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 

--- a/legacy/builder/container_merge_copy_sketch_files.go
+++ b/legacy/builder/container_merge_copy_sketch_files.go
@@ -17,9 +17,8 @@ package builder
 
 import (
 	bldr "github.com/arduino/arduino-cli/arduino/builder"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
-	"github.com/go-errors/errors"
+	"github.com/pkg/errors"
 )
 
 type ContainerMergeCopySketchFiles struct{}
@@ -27,7 +26,7 @@ type ContainerMergeCopySketchFiles struct{}
 func (s *ContainerMergeCopySketchFiles) Run(ctx *types.Context) error {
 	sk := types.SketchFromLegacy(ctx.Sketch)
 	if sk == nil {
-		return i18n.WrapError(errors.New("unable to convert legacy sketch to the new type"))
+		return errors.New("unable to convert legacy sketch to the new type")
 	}
 	offset, source, err := bldr.SketchMergeSources(sk)
 	if err != nil {
@@ -37,11 +36,11 @@ func (s *ContainerMergeCopySketchFiles) Run(ctx *types.Context) error {
 	ctx.Source = source
 
 	if err := bldr.SketchSaveItemCpp(ctx.Sketch.MainFile.Name.String(), []byte(ctx.Source), ctx.SketchBuildPath.String()); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	if err := bldr.SketchCopyAdditionalFiles(sk, ctx.SketchBuildPath.String()); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	return nil

--- a/legacy/builder/container_setup.go
+++ b/legacy/builder/container_setup.go
@@ -20,9 +20,9 @@ import (
 
 	bldr "github.com/arduino/arduino-cli/arduino/builder"
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/go-paths-helper"
+	"github.com/pkg/errors"
 )
 
 type ContainerSetupHardwareToolsLibsSketchAndProps struct{}
@@ -47,7 +47,7 @@ func (s *ContainerSetupHardwareToolsLibsSketchAndProps) Run(ctx *types.Context) 
 		PrintRingNameIfDebug(ctx, command)
 		err := command.Run(ctx)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 
@@ -55,13 +55,13 @@ func (s *ContainerSetupHardwareToolsLibsSketchAndProps) Run(ctx *types.Context) 
 		// get abs path to sketch
 		sketchLocation, err := ctx.SketchLocation.Abs()
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 
 		// load sketch
 		sketch, err := bldr.SketchLoad(sketchLocation.String(), ctx.BuildPath.String())
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		if sketch.MainFile == nil {
 			return fmt.Errorf("main file missing from sketch")
@@ -84,7 +84,7 @@ func (s *ContainerSetupHardwareToolsLibsSketchAndProps) Run(ctx *types.Context) 
 		PrintRingNameIfDebug(ctx, command)
 		err := command.Run(ctx)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 

--- a/legacy/builder/create_build_options_map.go
+++ b/legacy/builder/create_build_options_map.go
@@ -17,8 +17,9 @@ package builder
 
 import (
 	"encoding/json"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
+
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/pkg/errors"
 )
 
 type CreateBuildOptionsMap struct{}
@@ -27,7 +28,7 @@ func (s *CreateBuildOptionsMap) Run(ctx *types.Context) error {
 	buildOptions := ctx.ExtractBuildOptions()
 	bytes, err := json.MarshalIndent(buildOptions, "", "  ")
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	ctx.BuildOptionsJson = string(bytes)
 

--- a/legacy/builder/ctags_runner.go
+++ b/legacy/builder/ctags_runner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
+	"github.com/pkg/errors"
 )
 
 type CTagsRunner struct{}
@@ -42,12 +43,12 @@ func (s *CTagsRunner) Run(ctx *types.Context) error {
 	commandLine := properties.ExpandPropsInString(pattern)
 	command, err := utils.PrepareCommand(commandLine, logger, "")
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	sourceBytes, _, err := utils.ExecCommand(ctx, command, utils.Capture /* stdout */, utils.Ignore /* stderr */)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	ctx.CTagsOutput = string(sourceBytes)

--- a/legacy/builder/ctags_target_file_saver.go
+++ b/legacy/builder/ctags_target_file_saver.go
@@ -16,8 +16,8 @@
 package builder
 
 import (
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/pkg/errors"
 )
 
 type CTagsTargetFileSaver struct {
@@ -30,12 +30,12 @@ func (s *CTagsTargetFileSaver) Run(ctx *types.Context) error {
 
 	preprocPath := ctx.PreprocPath
 	if err := preprocPath.MkdirAll(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	ctagsTargetFilePath := preprocPath.Join(s.TargetFileName)
 	if err := ctagsTargetFilePath.WriteFile([]byte(source)); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	ctx.CTagsTargetFile = ctagsTargetFilePath

--- a/legacy/builder/fail_if_buildpath_equals_sketchpath.go
+++ b/legacy/builder/fail_if_buildpath_equals_sketchpath.go
@@ -19,6 +19,7 @@ import (
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
 	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/pkg/errors"
 )
 
 type FailIfBuildPathEqualsSketchPath struct{}
@@ -30,12 +31,12 @@ func (s *FailIfBuildPathEqualsSketchPath) Run(ctx *types.Context) error {
 
 	buildPath, err := ctx.BuildPath.Abs()
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	sketchPath, err := ctx.SketchLocation.Abs()
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	sketchPath = sketchPath.Parent()
 

--- a/legacy/builder/gcc_preproc_runner.go
+++ b/legacy/builder/gcc_preproc_runner.go
@@ -21,21 +21,21 @@ import (
 
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
 	"github.com/arduino/go-paths-helper"
+	"github.com/pkg/errors"
 )
 
 func GCCPreprocRunner(ctx *types.Context, sourceFilePath *paths.Path, targetFilePath *paths.Path, includes paths.PathList) error {
 	cmd, err := prepareGCCPreprocRecipeProperties(ctx, sourceFilePath, targetFilePath, includes)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	_, _, err = utils.ExecCommand(ctx, cmd /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -44,12 +44,12 @@ func GCCPreprocRunner(ctx *types.Context, sourceFilePath *paths.Path, targetFile
 func GCCPreprocRunnerForDiscoveringIncludes(ctx *types.Context, sourceFilePath *paths.Path, targetFilePath *paths.Path, includes paths.PathList) ([]byte, error) {
 	cmd, err := prepareGCCPreprocRecipeProperties(ctx, sourceFilePath, targetFilePath, includes)
 	if err != nil {
-		return nil, i18n.WrapError(err)
+		return nil, errors.WithStack(err)
 	}
 
 	_, stderr, err := utils.ExecCommand(ctx, cmd /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Capture)
 	if err != nil {
-		return stderr, i18n.WrapError(err)
+		return stderr, errors.WithStack(err)
 	}
 
 	return stderr, nil
@@ -70,7 +70,7 @@ func prepareGCCPreprocRecipeProperties(ctx *types.Context, sourceFilePath *paths
 
 	cmd, err := builder_utils.PrepareCommandForRecipe(ctx, properties, constants.RECIPE_PREPROC_MACROS, true)
 	if err != nil {
-		return nil, i18n.WrapError(err)
+		return nil, errors.WithStack(err)
 	}
 
 	// Remove -MMD argument if present. Leaving it will make gcc try

--- a/legacy/builder/hardware_loader.go
+++ b/legacy/builder/hardware_loader.go
@@ -17,8 +17,8 @@ package builder
 
 import (
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/pkg/errors"
 )
 
 type HardwareLoader struct{}
@@ -27,7 +27,7 @@ func (s *HardwareLoader) Run(ctx *types.Context) error {
 	if ctx.PackageManager == nil {
 		pm := packagemanager.NewPackageManager(nil, nil, nil, nil)
 		if err := pm.LoadHardwareFromDirectories(ctx.HardwareDirs); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		ctx.PackageManager = pm
 	}

--- a/legacy/builder/i18n/errors.go
+++ b/legacy/builder/i18n/errors.go
@@ -1,8 +1,11 @@
 package i18n
 
-import "github.com/arduino/arduino-cli/legacy/builder/constants"
-import "github.com/go-errors/errors"
-import "os"
+import (
+	"os"
+
+	"github.com/arduino/arduino-cli/legacy/builder/constants"
+	"github.com/go-errors/errors"
+)
 
 func ErrorfWithLogger(logger Logger, format string, a ...interface{}) *errors.Error {
 	if logger.Name() == "machine" {
@@ -10,22 +13,4 @@ func ErrorfWithLogger(logger Logger, format string, a ...interface{}) *errors.Er
 		return errors.Errorf("")
 	}
 	return errors.Errorf(Format(format, a...))
-}
-
-func WrapError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return errors.Wrap(err, 0)
-}
-
-func UnwrapError(err error) error {
-	// Perhaps go-errors can do this already in later versions?
-	// See https://github.com/go-errors/errors/issues/14
-	switch e := err.(type) {
-	case *errors.Error:
-		return e.Err
-	default:
-		return err
-	}
 }

--- a/legacy/builder/i18n/errors.go
+++ b/legacy/builder/i18n/errors.go
@@ -4,13 +4,13 @@ import (
 	"os"
 
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/go-errors/errors"
+	"github.com/pkg/errors"
 )
 
-func ErrorfWithLogger(logger Logger, format string, a ...interface{}) *errors.Error {
+func ErrorfWithLogger(logger Logger, format string, a ...interface{}) error {
 	if logger.Name() == "machine" {
 		logger.Fprintln(os.Stderr, constants.LOG_LEVEL_ERROR, format, a...)
-		return errors.Errorf("")
+		return errors.New("")
 	}
-	return errors.Errorf(Format(format, a...))
+	return errors.New(Format(format, a...))
 }

--- a/legacy/builder/libraries_loader.go
+++ b/legacy/builder/libraries_loader.go
@@ -21,8 +21,8 @@ import (
 	"github.com/arduino/arduino-cli/arduino/libraries"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesmanager"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesresolver"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/pkg/errors"
 )
 
 type LibrariesLoader struct{}
@@ -33,7 +33,7 @@ func (s *LibrariesLoader) Run(ctx *types.Context) error {
 
 	builtInLibrariesFolders := ctx.BuiltInLibrariesDirs
 	if err := builtInLibrariesFolders.ToAbs(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	for _, folder := range builtInLibrariesFolders {
 		lm.AddLibrariesDir(folder, libraries.IDEBuiltIn)
@@ -51,14 +51,14 @@ func (s *LibrariesLoader) Run(ctx *types.Context) error {
 
 	librariesFolders := ctx.OtherLibrariesDirs
 	if err := librariesFolders.ToAbs(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	for _, folder := range librariesFolders {
 		lm.AddLibrariesDir(folder, libraries.User)
 	}
 
 	if err := lm.RescanLibraries(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	if debugLevel > 0 {
@@ -66,7 +66,7 @@ func (s *LibrariesLoader) Run(ctx *types.Context) error {
 			for _, libAlt := range lib.Alternatives {
 				warnings, err := libAlt.Lint()
 				if err != nil {
-					return i18n.WrapError(err)
+					return errors.WithStack(err)
 				}
 				for _, warning := range warnings {
 					logger.Fprintln(os.Stdout, "warn", warning)
@@ -77,7 +77,7 @@ func (s *LibrariesLoader) Run(ctx *types.Context) error {
 
 	resolver := librariesresolver.NewCppResolver()
 	if err := resolver.ScanFromLibrariesManager(lm); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	ctx.LibrariesResolver = resolver
 

--- a/legacy/builder/load_previous_build_options.go
+++ b/legacy/builder/load_previous_build_options.go
@@ -17,8 +17,8 @@ package builder
 
 import (
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/pkg/errors"
 )
 
 type LoadPreviousBuildOptionsMap struct{}
@@ -32,7 +32,7 @@ func (s *LoadPreviousBuildOptionsMap) Run(ctx *types.Context) error {
 
 	bytes, err := buildOptionsFile.ReadFile()
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	ctx.BuildOptionsJsonPrevious = string(bytes)

--- a/legacy/builder/load_vid_pid_specific_properties.go
+++ b/legacy/builder/load_vid_pid_specific_properties.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/go-properties-orderedmap"
+	"github.com/pkg/errors"
 )
 
 type LoadVIDPIDSpecificProperties struct{}
@@ -41,7 +41,7 @@ func (s *LoadVIDPIDSpecificProperties) Run(ctx *types.Context) error {
 	buildProperties := ctx.BuildProperties
 	VIDPIDIndex, err := findVIDPIDIndex(buildProperties, vid, pid)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	if VIDPIDIndex < 0 {
 		return nil

--- a/legacy/builder/merge_sketch_with_bootloader.go
+++ b/legacy/builder/merge_sketch_with_bootloader.go
@@ -19,11 +19,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/arduino/go-paths-helper"
-
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/arduino/go-paths-helper"
+	"github.com/pkg/errors"
 )
 
 type MergeSketchWithBootloader struct{}
@@ -115,13 +114,13 @@ func extractActualBootloader(bootloader []string) []string {
 func merge(builtSketchPath, bootloaderPath, mergedSketchPath *paths.Path) error {
 	sketch, err := builtSketchPath.ReadFileAsLines()
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	sketch = sketch[:len(sketch)-2]
 
 	bootloader, err := bootloaderPath.ReadFileAsLines()
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	realBootloader := extractActualBootloader(bootloader)

--- a/legacy/builder/phases/core_builder.go
+++ b/legacy/builder/phases/core_builder.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
+	"github.com/pkg/errors"
 )
 
 type CoreBuilder struct{}
@@ -36,7 +36,7 @@ func (s *CoreBuilder) Run(ctx *types.Context) error {
 	buildProperties := ctx.BuildProperties
 
 	if err := coreBuildPath.MkdirAll(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	if coreBuildCachePath != nil {
@@ -47,13 +47,13 @@ func (s *CoreBuilder) Run(ctx *types.Context) error {
 			coreBuildCachePath = nil
 			ctx.CoreBuildCachePath = nil
 		} else if err := coreBuildCachePath.MkdirAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 
 	archiveFile, objectFiles, err := compileCore(ctx, coreBuildPath, coreBuildCachePath, buildProperties)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	ctx.CoreArchiveFilePath = archiveFile
@@ -82,7 +82,7 @@ func compileCore(ctx *types.Context, buildPath *paths.Path, buildCachePath *path
 	if variantFolder != nil && variantFolder.IsDir() {
 		variantObjectFiles, err = builder_utils.CompileFiles(ctx, variantFolder, true, buildPath, buildProperties, includes)
 		if err != nil {
-			return nil, nil, i18n.WrapError(err)
+			return nil, nil, errors.WithStack(err)
 		}
 	}
 
@@ -107,12 +107,12 @@ func compileCore(ctx *types.Context, buildPath *paths.Path, buildCachePath *path
 
 	coreObjectFiles, err := builder_utils.CompileFiles(ctx, coreFolder, true, buildPath, buildProperties, includes)
 	if err != nil {
-		return nil, nil, i18n.WrapError(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
 	archiveFile, err := builder_utils.ArchiveCompiledFiles(ctx, buildPath, paths.New("core.a"), coreObjectFiles, buildProperties)
 	if err != nil {
-		return nil, nil, i18n.WrapError(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
 	// archive core.a

--- a/legacy/builder/phases/libraries_builder.go
+++ b/legacy/builder/phases/libraries_builder.go
@@ -23,11 +23,11 @@ import (
 	"github.com/arduino/arduino-cli/arduino/libraries"
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
+	"github.com/pkg/errors"
 )
 
 var PRECOMPILED_LIBRARIES_VALID_EXTENSIONS_STATIC = map[string]bool{".a": true}
@@ -44,12 +44,12 @@ func (s *LibrariesBuilder) Run(ctx *types.Context) error {
 	libs := ctx.ImportedLibraries
 
 	if err := librariesBuildPath.MkdirAll(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	objectFiles, err := compileLibraries(ctx, libs, librariesBuildPath, buildProperties, includes)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	ctx.LibrariesObjectFiles = objectFiles
@@ -147,7 +147,7 @@ func compileLibraries(ctx *types.Context, libraries libraries.List, buildPath *p
 	for _, library := range libraries {
 		libraryObjectFiles, err := compileLibrary(ctx, library, buildPath, buildProperties, includes)
 		if err != nil {
-			return nil, i18n.WrapError(err)
+			return nil, errors.WithStack(err)
 		}
 		objectFiles = append(objectFiles, libraryObjectFiles...)
 	}
@@ -163,7 +163,7 @@ func compileLibrary(ctx *types.Context, library *libraries.Library, buildPath *p
 	libraryBuildPath := buildPath.Join(library.Name)
 
 	if err := libraryBuildPath.MkdirAll(); err != nil {
-		return nil, i18n.WrapError(err)
+		return nil, errors.WithStack(err)
 	}
 
 	objectFiles := paths.NewPathList()
@@ -180,7 +180,7 @@ func compileLibrary(ctx *types.Context, library *libraries.Library, buildPath *p
 			// Should we force precompiled libraries to start with "lib" ?
 			err := utils.FindFilesInFolder(&filePaths, precompiledPath.String(), extensions, false)
 			if err != nil {
-				return nil, i18n.WrapError(err)
+				return nil, errors.WithStack(err)
 			}
 			for _, path := range filePaths {
 				if !strings.HasPrefix(filepath.Base(path), "lib") {
@@ -194,12 +194,12 @@ func compileLibrary(ctx *types.Context, library *libraries.Library, buildPath *p
 	if library.Layout == libraries.RecursiveLayout {
 		libObjectFiles, err := builder_utils.CompileFilesRecursive(ctx, library.SourceDir, libraryBuildPath, buildProperties, includes)
 		if err != nil {
-			return nil, i18n.WrapError(err)
+			return nil, errors.WithStack(err)
 		}
 		if library.DotALinkage {
 			archiveFile, err := builder_utils.ArchiveCompiledFiles(ctx, libraryBuildPath, paths.New(library.Name+".a"), libObjectFiles, buildProperties)
 			if err != nil {
-				return nil, i18n.WrapError(err)
+				return nil, errors.WithStack(err)
 			}
 			objectFiles.Add(archiveFile)
 		} else {
@@ -211,7 +211,7 @@ func compileLibrary(ctx *types.Context, library *libraries.Library, buildPath *p
 		}
 		libObjectFiles, err := builder_utils.CompileFiles(ctx, library.SourceDir, false, libraryBuildPath, buildProperties, includes)
 		if err != nil {
-			return nil, i18n.WrapError(err)
+			return nil, errors.WithStack(err)
 		}
 		objectFiles.AddAll(libObjectFiles)
 
@@ -219,7 +219,7 @@ func compileLibrary(ctx *types.Context, library *libraries.Library, buildPath *p
 			utilityBuildPath := libraryBuildPath.Join("utility")
 			utilityObjectFiles, err := builder_utils.CompileFiles(ctx, library.UtilityDir, false, utilityBuildPath, buildProperties, includes)
 			if err != nil {
-				return nil, i18n.WrapError(err)
+				return nil, errors.WithStack(err)
 			}
 			objectFiles.AddAll(utilityObjectFiles)
 		}

--- a/legacy/builder/phases/linker.go
+++ b/legacy/builder/phases/linker.go
@@ -20,11 +20,11 @@ import (
 
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
+	"github.com/pkg/errors"
 )
 
 type Linker struct{}
@@ -43,14 +43,14 @@ func (s *Linker) Run(ctx *types.Context) error {
 	buildPath := ctx.BuildPath
 	coreDotARelPath, err := buildPath.RelTo(coreArchiveFilePath)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	buildProperties := ctx.BuildProperties
 
 	err = link(ctx, objectFiles, coreDotARelPath, coreArchiveFilePath, buildProperties)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	return nil

--- a/legacy/builder/phases/sizer.go
+++ b/legacy/builder/phases/sizer.go
@@ -16,16 +16,15 @@
 package phases
 
 import (
-	"errors"
 	"regexp"
 	"strconv"
 
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
 	"github.com/arduino/go-properties-orderedmap"
+	"github.com/pkg/errors"
 )
 
 type Sizer struct {
@@ -42,7 +41,7 @@ func (s *Sizer) Run(ctx *types.Context) error {
 
 	err := checkSize(ctx, buildProperties)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	return nil

--- a/legacy/builder/phases/sketch_builder.go
+++ b/legacy/builder/phases/sketch_builder.go
@@ -18,9 +18,9 @@ package phases
 import (
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
+	"github.com/pkg/errors"
 )
 
 type SketchBuilder struct{}
@@ -31,12 +31,12 @@ func (s *SketchBuilder) Run(ctx *types.Context) error {
 	includes := utils.Map(ctx.IncludeFolders.AsStrings(), utils.WrapWithHyphenI)
 
 	if err := sketchBuildPath.MkdirAll(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	objectFiles, err := builder_utils.CompileFiles(ctx, sketchBuildPath, false, sketchBuildPath, buildProperties, includes)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	// The "src/" subdirectory of a sketch is compiled recursively
@@ -44,7 +44,7 @@ func (s *SketchBuilder) Run(ctx *types.Context) error {
 	if sketchSrcPath.IsDir() {
 		srcObjectFiles, err := builder_utils.CompileFiles(ctx, sketchSrcPath, true, sketchSrcPath, buildProperties, includes)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		objectFiles.AddAll(srcObjectFiles)
 	}

--- a/legacy/builder/platform_keys_rewrite_loader.go
+++ b/legacy/builder/platform_keys_rewrite_loader.go
@@ -20,12 +20,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/arduino/go-paths-helper"
-
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
+	"github.com/pkg/errors"
 )
 
 type PlatformKeysRewriteLoader struct{}
@@ -35,7 +34,7 @@ func (s *PlatformKeysRewriteLoader) Run(ctx *types.Context) error {
 
 	platformKeysRewriteTxtPath, err := findPlatformKeysRewriteTxt(folders)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	if platformKeysRewriteTxtPath == nil {
 		return nil
@@ -46,7 +45,7 @@ func (s *PlatformKeysRewriteLoader) Run(ctx *types.Context) error {
 
 	txt, err := properties.LoadFromPath(platformKeysRewriteTxtPath)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	keys := txt.Keys()
 	sort.Strings(keys)
@@ -56,7 +55,7 @@ func (s *PlatformKeysRewriteLoader) Run(ctx *types.Context) error {
 		if keyParts[0] == constants.PLATFORM_REWRITE_OLD {
 			index, err := strconv.Atoi(keyParts[1])
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 			rewriteKey := strings.Join(keyParts[2:], ".")
 			oldValue := txt.Get(key)
@@ -78,7 +77,7 @@ func findPlatformKeysRewriteTxt(folders paths.PathList) (*paths.Path, error) {
 		if exist, err := txtPath.ExistCheck(); exist {
 			return txtPath, nil
 		} else if err != nil {
-			return nil, i18n.WrapError(err)
+			return nil, errors.WithStack(err)
 		}
 	}
 

--- a/legacy/builder/preprocess_sketch.go
+++ b/legacy/builder/preprocess_sketch.go
@@ -16,7 +16,6 @@
 package builder
 
 import (
-	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -29,6 +28,7 @@ import (
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
 	properties "github.com/arduino/go-properties-orderedmap"
+	"github.com/pkg/errors"
 )
 
 // ArduinoPreprocessorProperties are the platform properties needed to run arduino-preprocessor
@@ -50,7 +50,7 @@ func (s *PreprocessSketchArduino) Run(ctx *types.Context) error {
 	}
 
 	if err := ctx.PreprocPath.MkdirAll(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	GCCPreprocRunner(ctx, sourceFile, ctx.PreprocPath.Join(constants.FILE_CTAGS_TARGET_FOR_GCC_MINUS_E), ctx.IncludeFolders)
@@ -59,7 +59,7 @@ func (s *PreprocessSketchArduino) Run(ctx *types.Context) error {
 		PrintRingNameIfDebug(ctx, command)
 		err := command.Run(ctx)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 
@@ -108,7 +108,7 @@ func (s *ArduinoPreprocessorRunner) Run(ctx *types.Context) error {
 	commandLine := properties.ExpandPropsInString(pattern)
 	command, err := utils.PrepareCommand(commandLine, logger, "")
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	if runtime.GOOS == "windows" {
@@ -124,7 +124,7 @@ func (s *ArduinoPreprocessorRunner) Run(ctx *types.Context) error {
 
 	buf, err := command.Output()
 	if err != nil {
-		return errors.New(i18n.WrapError(err).Error() + string(err.(*exec.ExitError).Stderr))
+		return errors.New(errors.WithStack(err).Error() + string(err.(*exec.ExitError).Stderr))
 	}
 
 	result := utils.NormalizeUTF8(buf)

--- a/legacy/builder/read_file_and_store_in_context.go
+++ b/legacy/builder/read_file_and_store_in_context.go
@@ -16,9 +16,9 @@
 package builder
 
 import (
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/go-paths-helper"
+	"github.com/pkg/errors"
 )
 
 type ReadFileAndStoreInContext struct {
@@ -29,7 +29,7 @@ type ReadFileAndStoreInContext struct {
 func (s *ReadFileAndStoreInContext) Run(ctx *types.Context) error {
 	bytes, err := s.FileToRead.ReadFile()
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	*s.Target = string(bytes)

--- a/legacy/builder/recipe_runner.go
+++ b/legacy/builder/recipe_runner.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
 	properties "github.com/arduino/go-properties-orderedmap"
+	"github.com/pkg/errors"
 )
 
 type RecipeByPrefixSuffixRunner struct {
@@ -49,7 +49,7 @@ func (s *RecipeByPrefixSuffixRunner) Run(ctx *types.Context) error {
 		}
 		_, _, err := builder_utils.ExecRecipe(ctx, properties, recipe, false /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 

--- a/legacy/builder/set_custom_build_properties.go
+++ b/legacy/builder/set_custom_build_properties.go
@@ -16,9 +16,9 @@
 package builder
 
 import (
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/go-properties-orderedmap"
+	"github.com/pkg/errors"
 )
 
 type SetCustomBuildProperties struct{}
@@ -27,7 +27,7 @@ func (s *SetCustomBuildProperties) Run(ctx *types.Context) error {
 	buildProperties := ctx.BuildProperties
 	customBuildProperties, err := properties.LoadFromSlice(ctx.CustomBuildProperties)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	buildProperties.Merge(customBuildProperties)

--- a/legacy/builder/sketch_loader.go
+++ b/legacy/builder/sketch_loader.go
@@ -19,12 +19,12 @@ import (
 	"sort"
 	"strings"
 
-	paths "github.com/arduino/go-paths-helper"
-
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
 	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
+	"github.com/arduino/go-paths-helper"
+	"github.com/pkg/errors"
 )
 
 type SketchLoader struct{}
@@ -38,11 +38,11 @@ func (s *SketchLoader) Run(ctx *types.Context) error {
 
 	sketchLocation, err := sketchLocation.Abs()
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	mainSketchStat, err := sketchLocation.Stat()
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	if mainSketchStat.IsDir() {
 		sketchLocation = sketchLocation.Join(mainSketchStat.Name() + ".ino")
@@ -52,7 +52,7 @@ func (s *SketchLoader) Run(ctx *types.Context) error {
 
 	allSketchFilePaths, err := collectAllSketchFiles(sketchLocation.Parent())
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	logger := ctx.GetLogger()
@@ -63,7 +63,7 @@ func (s *SketchLoader) Run(ctx *types.Context) error {
 
 	sketch, err := makeSketch(sketchLocation, allSketchFilePaths, ctx.BuildPath, logger)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	ctx.SketchLocation = sketchLocation
@@ -79,10 +79,10 @@ func collectAllSketchFiles(from *paths.Path) (paths.PathList, error) {
 	rootExtensions := func(ext string) bool { return MAIN_FILE_VALID_EXTENSIONS[ext] || ADDITIONAL_FILE_VALID_EXTENSIONS[ext] }
 	err := utils.FindFilesInFolder(&filePaths, from.String(), rootExtensions, true /* recurse */)
 	if err != nil {
-		return nil, i18n.WrapError(err)
+		return nil, errors.WithStack(err)
 	}
 
-	return paths.NewPathList(filePaths...), i18n.WrapError(err)
+	return paths.NewPathList(filePaths...), errors.WithStack(err)
 }
 
 func makeSketch(sketchLocation *paths.Path, allSketchFilePaths paths.PathList, buildLocation *paths.Path, logger i18n.Logger) (*types.Sketch, error) {

--- a/legacy/builder/test/helper.go
+++ b/legacy/builder/test/helper.go
@@ -28,7 +28,6 @@ import (
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
 	paths "github.com/arduino/go-paths-helper"
-	"github.com/go-errors/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,10 +56,7 @@ func Abs(t *testing.T, rel *paths.Path) *paths.Path {
 
 func NoError(t *testing.T, err error, msgAndArgs ...interface{}) {
 	if !assert.NoError(t, err, msgAndArgs...) {
-		switch err.(type) {
-		case *errors.Error:
-			fmt.Println(err.(*errors.Error).ErrorStack())
-		}
+		fmt.Printf("%+v\n", err) // Outputs stack trace in case of wrapped error
 		t.FailNow()
 	}
 }

--- a/legacy/builder/test/helper_tools_downloader.go
+++ b/legacy/builder/test/helper_tools_downloader.go
@@ -30,11 +30,10 @@ import (
 
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
 	"github.com/arduino/arduino-cli/legacy/builder/gohasissues"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
-	"github.com/go-errors/errors"
+	"github.com/pkg/errors"
 )
 
 var hardwareFolder = paths.New("downloaded_hardware")
@@ -236,11 +235,11 @@ func downloadCores(cores []Core, index map[string]interface{}) error {
 	for _, core := range cores {
 		url, err := findCoreUrl(index, core)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		err = downloadAndUnpackCore(core, url, hardwareFolder)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 	return nil
@@ -250,11 +249,11 @@ func downloadBoardManagerCores(cores []Core, index map[string]interface{}) error
 	for _, core := range cores {
 		url, err := findCoreUrl(index, core)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		err = downloadAndUnpackBoardManagerCore(core, url, boardManagerFolder)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 	return nil
@@ -287,11 +286,11 @@ func downloadTools(tools []Tool, index map[string]interface{}) error {
 	for _, tool := range tools {
 		url, err := findToolUrl(index, tool, host)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		err = downloadAndUnpackTool(tool, url, toolsFolder, true)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 
@@ -305,7 +304,7 @@ func downloadToolsMultipleVersions(tools []Tool, index map[string]interface{}) e
 		if !toolAlreadyDownloadedAndUnpacked(toolsFolder, tool) {
 			if toolsFolder.Join(tool.Name).Exist() {
 				if err := toolsFolder.Join(tool.Name).RemoveAll(); err != nil {
-					return i18n.WrapError(err)
+					return errors.WithStack(err)
 				}
 			}
 		}
@@ -314,11 +313,11 @@ func downloadToolsMultipleVersions(tools []Tool, index map[string]interface{}) e
 	for _, tool := range tools {
 		url, err := findToolUrl(index, tool, host)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		err = downloadAndUnpackTool(tool, url, toolsFolder, false)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 
@@ -331,11 +330,11 @@ func downloadBoardsManagerTools(tools []Tool, index map[string]interface{}) erro
 	for _, tool := range tools {
 		url, err := findToolUrl(index, tool, host)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		err = downloadAndUnpackBoardsManagerTool(tool, url, boardManagerFolder)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 
@@ -359,7 +358,7 @@ func allCoresAlreadyDownloadedAndUnpacked(targetPath *paths.Path, cores []Core) 
 	for _, core := range cores {
 		alreadyDownloaded, err := coreAlreadyDownloadedAndUnpacked(targetPath, core)
 		if err != nil {
-			return false, i18n.WrapError(err)
+			return false, errors.WithStack(err)
 		}
 		if !alreadyDownloaded {
 			return false, nil
@@ -376,12 +375,12 @@ func coreAlreadyDownloadedAndUnpacked(targetPath *paths.Path, core Core) (bool, 
 	}
 	platform, err := properties.LoadFromPath(corePath.Join("platform.txt"))
 	if err != nil {
-		return false, i18n.WrapError(err)
+		return false, errors.WithStack(err)
 	}
 
 	if core.Version != platform.Get("version") {
 		err := corePath.RemoveAll()
-		return false, i18n.WrapError(err)
+		return false, errors.WithStack(err)
 	}
 
 	return true, nil
@@ -438,19 +437,19 @@ func libraryAlreadyDownloadedAndUnpacked(targetPath *paths.Path, library Library
 func downloadAndUnpackCore(core Core, url string, targetPath *paths.Path) error {
 	alreadyDownloaded, err := coreAlreadyDownloadedAndUnpacked(targetPath, core)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	if alreadyDownloaded {
 		return nil
 	}
 
 	if err := targetPath.ToAbs(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	unpackFolder, files, err := downloadAndUnpack(url)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	defer unpackFolder.RemoveAll()
 
@@ -459,26 +458,26 @@ func downloadAndUnpackCore(core Core, url string, targetPath *paths.Path) error 
 
 	if corePath.Exist() {
 		if err := corePath.RemoveAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 
 	if len(files) == 1 && files[0].IsDir() {
 		if err := packagerPath.MkdirAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		err = copyRecursive(unpackFolder.Join(files[0].Name()), targetPath.Join(core.Maintainer, core.Arch))
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	} else {
 		if err := targetPath.Join(core.Maintainer, core.Arch).MkdirAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		for _, file := range files {
 			err = copyRecursive(unpackFolder.Join(file.Name()), targetPath.Join(core.Maintainer, core.Arch, file.Name()))
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 		}
 	}
@@ -492,38 +491,38 @@ func downloadAndUnpackBoardManagerCore(core Core, url string, targetPath *paths.
 	}
 
 	if err := targetPath.ToAbs(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	unpackFolder, files, err := downloadAndUnpack(url)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	defer unpackFolder.RemoveAll()
 
 	corePath := targetPath.Join(core.Maintainer, "hardware", core.Arch)
 	if corePath.Exist() {
 		if err := corePath.RemoveAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 
 	if len(files) == 1 && files[0].IsDir() {
 		if err := corePath.MkdirAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		err = copyRecursive(unpackFolder.Join(files[0].Name()), corePath.Join(core.Version))
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	} else {
 		if err := corePath.Join(core.Version).MkdirAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		for _, file := range files {
 			err = copyRecursive(unpackFolder.Join(file.Name()), corePath.Join(core.Version, file.Name()))
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 		}
 	}
@@ -537,31 +536,31 @@ func downloadAndUnpackBoardsManagerTool(tool Tool, url string, targetPath *paths
 	}
 
 	if err := targetPath.ToAbs(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	unpackFolder, files, err := downloadAndUnpack(url)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	defer unpackFolder.RemoveAll()
 
 	if len(files) == 1 && files[0].IsDir() {
 		if err := targetPath.Join(tool.Package, constants.FOLDER_TOOLS, tool.Name).MkdirAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		err = copyRecursive(unpackFolder.Join(files[0].Name()), targetPath.Join(tool.Package, constants.FOLDER_TOOLS, tool.Name, tool.Version))
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	} else {
 		if err := targetPath.Join(tool.Package, constants.FOLDER_TOOLS, tool.Name, tool.Version).MkdirAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		for _, file := range files {
 			err = copyRecursive(unpackFolder.Join(file.Name()), targetPath.Join(tool.Package, constants.FOLDER_TOOLS, tool.Name, tool.Version, file.Name()))
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 		}
 	}
@@ -575,12 +574,12 @@ func downloadAndUnpackTool(tool Tool, url string, targetPath *paths.Path, delete
 	}
 
 	if err := targetPath.ToAbs(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	unpackFolder, files, err := downloadAndUnpack(url)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	defer unpackFolder.RemoveAll()
 
@@ -588,27 +587,27 @@ func downloadAndUnpackTool(tool Tool, url string, targetPath *paths.Path, delete
 	if deleteIfMissing {
 		if toolPath.Exist() {
 			if err := toolPath.MkdirAll(); err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 		}
 	}
 
 	if len(files) == 1 && files[0].IsDir() {
 		if err := toolPath.MkdirAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		err = copyRecursive(unpackFolder.Join(files[0].Name()), toolPath.Join(tool.Version))
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	} else {
 		if err := toolPath.Join(tool.Version).MkdirAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		for _, file := range files {
 			err = copyRecursive(unpackFolder.Join(file.Name()), toolPath.Join(tool.Version, file.Name()))
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 		}
 	}
@@ -621,7 +620,7 @@ func downloadAndUnpack(url string) (*paths.Path, []os.FileInfo, error) {
 
 	unpackFolder, err := paths.MkTempDir("", "arduino-builder-tool")
 	if err != nil {
-		return nil, nil, i18n.WrapError(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
 	urlParts := strings.Split(url, "/")
@@ -630,12 +629,12 @@ func downloadAndUnpack(url string) (*paths.Path, []os.FileInfo, error) {
 
 	res, err := http.Get(url)
 	if err != nil {
-		return nil, nil, i18n.WrapError(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
 	bytes, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return nil, nil, i18n.WrapError(err)
+		return nil, nil, errors.WithStack(err)
 	}
 	res.Body.Close()
 
@@ -645,7 +644,7 @@ func downloadAndUnpack(url string) (*paths.Path, []os.FileInfo, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Println(string(out))
-		return nil, nil, i18n.WrapError(err)
+		return nil, nil, errors.WithStack(err)
 	}
 	if len(out) > 0 {
 		fmt.Println(string(out))
@@ -655,7 +654,7 @@ func downloadAndUnpack(url string) (*paths.Path, []os.FileInfo, error) {
 
 	files, err := gohasissues.ReadDir(unpackFolder.String())
 	if err != nil {
-		return nil, nil, i18n.WrapError(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
 	return unpackFolder, files, nil
@@ -727,11 +726,11 @@ func downloadLibraries(libraries []Library, index map[string]interface{}) error 
 	for _, library := range libraries {
 		url, err := findLibraryUrl(index, library)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		err = downloadAndUnpackLibrary(library, url, librariesFolder)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 
@@ -759,25 +758,25 @@ func downloadAndUnpackLibrary(library Library, url string, targetPath *paths.Pat
 	}
 
 	if err := targetPath.ToAbs(); err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	unpackFolder, files, err := downloadAndUnpack(url)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	defer unpackFolder.RemoveAll()
 
 	libPath := targetPath.Join(strings.Replace(library.Name, " ", "_", -1))
 	if libPath.Exist() {
 		if err := libPath.RemoveAll(); err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 	}
 
 	err = copyRecursive(unpackFolder.Join(files[0].Name()), libPath)
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -791,42 +790,42 @@ func copyRecursive(from, to *paths.Path) error {
 
 		rel, err := filepath.Rel(from.String(), currentPath)
 		if err != nil {
-			return i18n.WrapError(err)
+			return errors.WithStack(err)
 		}
 		targetPath := filepath.Join(to.String(), rel)
 		if info.IsDir() {
 			err := os.MkdirAll(targetPath, info.Mode())
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 		} else if info.Mode().IsRegular() {
 			fromFile, err := os.Open(currentPath)
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 			defer fromFile.Close()
 			targetFile, err := os.Create(targetPath)
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 			defer targetFile.Close()
 			_, err = io.Copy(targetFile, fromFile)
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 			err = os.Chmod(targetPath, info.Mode())
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 		} else if info.Mode()&os.ModeSymlink == os.ModeSymlink {
 			linkedFile, err := os.Readlink(currentPath)
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 			fromFile := filepath.Join(filepath.Dir(targetPath), linkedFile)
 			err = os.Symlink(fromFile, targetPath)
 			if err != nil {
-				return i18n.WrapError(err)
+				return errors.WithStack(err)
 			}
 		} else {
 			return errors.Errorf("unable to copy file " + currentPath)
@@ -835,5 +834,5 @@ func copyRecursive(from, to *paths.Path) error {
 		return nil
 	}
 	err := gohasissues.Walk(from.String(), copyFunc)
-	return i18n.WrapError(err)
+	return errors.WithStack(err)
 }

--- a/legacy/builder/unused_compiled_libraries_remover.go
+++ b/legacy/builder/unused_compiled_libraries_remover.go
@@ -17,9 +17,9 @@ package builder
 
 import (
 	"github.com/arduino/arduino-cli/arduino/libraries"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
+	"github.com/pkg/errors"
 )
 
 type UnusedCompiledLibrariesRemover struct{}
@@ -35,13 +35,13 @@ func (s *UnusedCompiledLibrariesRemover) Run(ctx *types.Context) error {
 
 	files, err := librariesBuildPath.ReadDir()
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	for _, file := range files {
 		if file.IsDir() {
 			if !utils.SliceContains(libraryNames, file.Base()) {
 				if err := file.RemoveAll(); err != nil {
-					return i18n.WrapError(err)
+					return errors.WithStack(err)
 				}
 			}
 		}

--- a/legacy/builder/utils/utils.go
+++ b/legacy/builder/utils/utils.go
@@ -35,6 +35,7 @@ import (
 	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	paths "github.com/arduino/go-paths-helper"
+	"github.com/pkg/errors"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
 )
@@ -100,7 +101,7 @@ type filterFiles func([]os.FileInfo) []os.FileInfo
 func ReadDirFiltered(folder string, fn filterFiles) ([]os.FileInfo, error) {
 	files, err := gohasissues.ReadDir(folder)
 	if err != nil {
-		return nil, i18n.WrapError(err)
+		return nil, errors.WithStack(err)
 	}
 	return fn(files), nil
 }
@@ -209,7 +210,7 @@ type argFilterFunc func(int, string, []string) bool
 func PrepareCommandFilteredArgs(pattern string, filter argFilterFunc, logger i18n.Logger, relativePath string) (*exec.Cmd, error) {
 	parts, err := ParseCommandLine(pattern, logger)
 	if err != nil {
-		return nil, i18n.WrapError(err)
+		return nil, errors.WithStack(err)
 	}
 	command := parts[0]
 	parts = parts[1:]
@@ -301,7 +302,7 @@ func ExecCommand(ctx *types.Context, command *exec.Cmd, stdout int, stderr int) 
 
 	err := command.Start()
 	if err != nil {
-		return nil, nil, i18n.WrapError(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
 	err = command.Wait()
@@ -314,7 +315,7 @@ func ExecCommand(ctx *types.Context, command *exec.Cmd, stdout int, stderr int) 
 		errbytes = buf.Bytes()
 	}
 
-	return outbytes, errbytes, i18n.WrapError(err)
+	return outbytes, errbytes, errors.WithStack(err)
 }
 
 func AbsolutizePaths(files []string) ([]string, error) {
@@ -324,7 +325,7 @@ func AbsolutizePaths(files []string) ([]string, error) {
 		}
 		absFile, err := filepath.Abs(file)
 		if err != nil {
-			return nil, i18n.WrapError(err)
+			return nil, errors.WithStack(err)
 		}
 		files[idx] = absFile
 	}

--- a/legacy/builder/wipeout_build_path_if_build_options_changed.go
+++ b/legacy/builder/wipeout_build_path_if_build_options_changed.go
@@ -22,9 +22,9 @@ import (
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
 	"github.com/arduino/arduino-cli/legacy/builder/constants"
 	"github.com/arduino/arduino-cli/legacy/builder/gohasissues"
-	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	properties "github.com/arduino/go-properties-orderedmap"
+	"github.com/pkg/errors"
 )
 
 type WipeoutBuildPathIfBuildOptionsChanged struct{}
@@ -71,7 +71,7 @@ func (s *WipeoutBuildPathIfBuildOptionsChanged) Run(ctx *types.Context) error {
 	buildPath := ctx.BuildPath
 	files, err := gohasissues.ReadDir(buildPath.String())
 	if err != nil {
-		return i18n.WrapError(err)
+		return errors.WithStack(err)
 	}
 	for _, file := range files {
 		buildPath.Join(file.Name()).RemoveAll()


### PR DESCRIPTION
* updated `github.com/pkg/errors` dependency to 0.9.1
* removed legacy `gtihub.com/go-errors/errors` package usage from everywhere
* removed dependency on `gtihub.com/go-errors/errors`
