### PR TITLE
update compile --build-path to support both relative and absolute flags

### DIFF
--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -123,7 +123,12 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 	builderCtx.OtherLibrariesDirs.Add(configuration.LibrariesDir())
 
 	if req.GetBuildPath() != "" {
-		builderCtx.BuildPath = paths.New(req.GetBuildPath())
+		if req.GetBuildPath() != "/" {
+			builderCtx.BuildPath = paths.New(req.GetSketchPath() + strings.TrimPrefix(req.GetBuildPath(), "."))
+		} else {
+			builderCtx.BuildPath = paths.New(req.GetBuildPath())
+		}
+
 		err = builderCtx.BuildPath.MkdirAll()
 		if err != nil {
 			return nil, fmt.Errorf("cannot create build directory: %s", err)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -84,6 +84,42 @@ def test_compile_with_simple_sketch(run_command, data_dir, working_dir):
     assert result.ok
     assert os.path.exists(target)
 
+def test_build_path_flag(run_command, data_dir, working_dir):
+    # Init the environment explicitly
+    result = run_command("core update-index")
+    assert result.ok
+
+    # Download latest AVR
+    result = run_command("core install arduino:avr")
+    assert result.ok
+
+    # Create a test sketch
+    sketch_path = os.path.join(data_dir, "test_output_flag_default_path")
+    fqbn = "arduino:avr:uno"
+    result = run_command("sketch new {}".format(sketch_path))
+    assert result.ok
+
+    build_file_path = os.path.join(data_dir, "test_output_flag_default_path","build","test_output_flag_default_path.ino.hex")
+
+    # Test the --build-path flag for a relative build path
+    result = run_command(
+        "compile -b {fqbn} {sketch_path} --build-path ./build".format(
+            fqbn=fqbn, sketch_path=sketch_path
+        )
+    )
+    assert result.ok
+    assert os.path.exists(build_file_path)
+
+    abs_build_path = os.path.join(sketch_path, "/build")
+
+    # Test the --build-path flag for a absolute build path
+    result = run_command(
+        "compile -b {fqbn} {sketch_path} --build-path {abs_build_path}".format(
+            fqbn=fqbn, sketch_path=sketch_path, abs_build_path=abs_build_path
+        )
+    )
+    assert result.ok
+    assert os.path.exists(build_file_path)
 
 @pytest.mark.skipif(
     running_on_ci() and platform.system() == "Windows",


### PR DESCRIPTION
Small change in compile.go to allow people to use either relative or absolute paths
A person would use relative paths assuming he wants it in the same directory as that of the sketch, allowing us to use the sketch path.

Can fix #630 