### PR TITLE
Add macro during lib discovery phase

### DIFF
--- a/legacy/builder/gcc_preproc_runner.go
+++ b/legacy/builder/gcc_preproc_runner.go
@@ -77,6 +77,8 @@ func prepareGCCPreprocRecipeProperties(ctx *types.Context, sourceFilePath *paths
 	// to create a /dev/null.d dependency file, which won't work.
 	cmd.Args = utils.Filter(cmd.Args, func(a string) bool { return a != "-MMD" })
 
+	cmd.Args = append(cmd.Args, "-DARDUINO_LIB_DISCOVERY_PHASE")
+
 	return cmd, nil
 }
 


### PR DESCRIPTION
This information can be used by the core to turn off certain heavyweight headers (that don't need to be discovered anyway)