### PR TITLE
Bump required go version to 1.14

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2-beta
         with:
-          go-version: '1.13'
+          go-version: '1.14'
 
       - name: Install Go dependencies
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13'
+          go-version: '1.14'
 
       - name: Install Go deps
         # Since 10/23/2019 pwsh is the default shell

--- a/Dockerfiles/builder/Dockerfile
+++ b/Dockerfiles/builder/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH $PATH:/usr/local/go/bin
 # Install tooling
 ENV GORELEASER_VER 0.113.0
 ENV GORELEASER_SHA 2379beebb6369b75ccead7f7a43269de700b51821feae3857701d106ed72bd63
-ENV GOVER 1.13
+ENV GOVER 1.14
 RUN set -ex \
     && curl -o goreleaser.tar.gz -LO https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VER}/goreleaser_Linux_x86_64.tar.gz \
     && echo "$GORELEASER_SHA goreleaser.tar.gz" | sha256sum -c - || exit 1 \

--- a/arduino/cores/packageindex/testdata/package_Zoubworld_index.json
+++ b/arduino/cores/packageindex/testdata/package_Zoubworld_index.json
@@ -182,28 +182,28 @@
               "url": "http://zoubworld.hd.free.fr/~zoubworld_Arduino/files/Release/JLink_MacOSX_V630c.pkg",
               "archiveFileName": "JLink_MacOSX_V630c.pkg",
               "checksum": "SHA-256:",
-              "size": ""
+              "size": "0"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "http://zoubworld.hd.free.fr/~zoubworld_Arduino/files/Release/JLink_Linux_V630c_x86_64.tgz",
               "archiveFileName": "JLink_Linux_V630c_x86_64.tgz",
               "checksum": "SHA-256:",
-              "size": ""
+              "size": "0"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "http://zoubworld.hd.free.fr/~zoubworld_Arduino/files/Release/JLink_Linux_V630c_i386.tgz",
               "archiveFileName": "JLink_Linux_V630c_i386.tgz",
               "checksum": "SHA-256:",
-              "size": ""
+              "size": "0"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "http://zoubworld.hd.free.fr/~zoubworld_Arduino/files/Release/JLink_Linux_V630c_arm.tgz",
               "archiveFileName": "JLink_Linux_V630c_arm.tgz",
               "checksum": "SHA-256:",
-              "size": ""
+              "size": "0"
             },
             {
               "host": "all",

--- a/arduino/cores/packageindex/testdata/package_infineon_index.json
+++ b/arduino/cores/packageindex/testdata/package_infineon_index.json
@@ -371,7 +371,7 @@
                "url":"https://github.com/Infineon/XMC-for-Arduino/releases/download/V1.1.2/XMC_IFX_1.1.2.zip",
                "archiveFileName":"XMC_IFX_1.1.2.zip",
                "checksum":"SHA-256:c9247f7a02b03cb3b69e8b2f120f5e9d92f529954c2d71a0a13774a61ba8f025",
-               "size":"1480694  ",
+               "size":"1480694",
                "help":{
                   "online":"https://github.com/Infineon/XMC-for-Arduino"
                },

--- a/client_example/go.mod
+++ b/client_example/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/arduino-cli/client_example
 
-go 1.13
+go 1.14
 
 replace github.com/arduino/arduino-cli => ../
 

--- a/docsgen/go.mod
+++ b/docsgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/arduino-cli/docsgen
 
-go 1.13
+go 1.14
 
 require (
 	github.com/arduino/arduino-cli v0.0.0-20200228161349-4b874a02b096

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/arduino-cli
 
-go 1.13
+go 1.14
 
 require (
 	bou.ke/monkey v1.0.1


### PR DESCRIPTION
Fixed faulty json because of new behaviour of encoding/json:

> encoding/json
> Number no longer accepts invalid numbers, to follow the documented behavior more closely.

Signed-off-by: Matteo Suppo <matteo.suppo@gmail.com>