### PR TITLE
Typo fix in short description of installCommand

### DIFF
--- a/cli/lib/install.go
+++ b/cli/lib/install.go
@@ -32,7 +32,7 @@ import (
 func initInstallCommand() *cobra.Command {
 	installCommand := &cobra.Command{
 		Use:   "install LIBRARY[@VERSION_NUMBER](S)",
-		Short: "Installs one of more specified libraries into the system.",
+		Short: "Installs one or more specified libraries into the system.",
 		Long:  "Installs one or more specified libraries into the system.",
 		Example: "" +
 			"  " + os.Args[0] + " lib install AudioZero       # for the latest version.\n" +


### PR DESCRIPTION
Changed the short description from "Installs one of more [...]" to "Installs one or more [...]", thus matching the long one.

**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.


* **What is the current behavior?**
<!-- You can also link to an open issue here -->
"Installs one of more specified libraries into the system."


* **What is the new behavior?**
<!-- if this is a feature change -->
"Installs one or more specified libraries into the system."



* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
It shouldn't, as the only change is to a command description string.



* **Other information**:
<!-- Any additional information that could help the review process -->
It's just a typo fix, "one of more" was written instead of "one or more" on the short description, but it was correct in the long one, so now both are correct.


---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
