### PR TITLE
[skip changelog] Github Actions bugfixes

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,7 +13,7 @@ jobs:
       image: arduino/arduino-cli:builder-1
       volumes:
         # cache go dependencies across pipeline's steps
-        - $PWD/go:/go
+        - ${{ github.workspace }}/go:/go
 
     steps:
       - name: checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       image: arduino/arduino-cli:builder-1
       volumes:
         # cache go dependencies across pipeline's steps
-        - $PWD/go:/go
+        - ${{ github.workspace }}/go:/go
 
     steps:
       - name: Checkout
@@ -70,7 +70,7 @@ jobs:
           gon gon.config.hcl
           # GitHub's upload/download-artifact@v1 actions don't preserve file permissions,
           # so we need to add execution permission back until @v2 actions are released.
-          chmod +x dist/arduino_cli_osx_darwin_amd64/arduino-cli 
+          chmod +x dist/arduino_cli_osx_darwin_amd64/arduino-cli
           tar -czvf dist/arduino-cli_${TAG}_macOS_64bit.tar.gz \
           -C dist/arduino_cli_osx_darwin_amd64/  arduino-cli   \
           -C ../../ LICENSE.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,6 +102,15 @@ jobs:
           echo $body
           echo "::set-output name=BODY::$body"
 
+      - name: Identify Prerelease
+        # This is a workaround while waiting for create-release action
+        # to implement auto pre-release based on tag
+        id: prerelease
+        run: |
+          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.0.0.zip
+          unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
+          if [[ $(/tmp/semver get prerel ${GITHUB_REF/refs\/tags\//}) ]]; then echo "::set-output name=IS_PRE::true"; fi
+
       - name: Create Github Release
         id: create_release
         uses: actions/create-release@master
@@ -112,7 +121,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: ${{ steps.changelog.outputs.BODY }}
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
 
       - name: Upload release files on Github
         uses: svenstaro/upload-release-action@v1-release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,10 +42,6 @@ jobs:
         with:
           name: dist
 
-      - name: Get the current release tag
-        id: get_tag
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
       - name: Download Gon
         run: |
           wget -q https://github.com/mitchellh/gon/releases/download/v0.2.2/gon_0.2.2_macos.zip
@@ -54,7 +50,6 @@ jobs:
 
       - name: Notarize binary, re-package it and update checksum
         env:
-          TAG: ${{ steps.get_tag.outputs.VERSION }}
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
         # This step performs the following:
@@ -71,6 +66,7 @@ jobs:
           # GitHub's upload/download-artifact@v1 actions don't preserve file permissions,
           # so we need to add execution permission back until @v2 actions are released.
           chmod +x dist/arduino_cli_osx_darwin_amd64/arduino-cli
+          TAG=${GITHUB_REF/refs\/tags\//}
           tar -czvf dist/arduino-cli_${TAG}_macOS_64bit.tar.gz \
           -C dist/arduino_cli_osx_darwin_amd64/  arduino-cli   \
           -C ../../ LICENSE.txt


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)

* **What kind of change does this PR introduce?**

   - **Bugfix**: Replace $PWD with github actions workspace variable to solve invalid chars issue in container volume binding (https://github.com/arduino/arduino-cli/runs/569994650?check_suite_focus=true#step:3:65)
   - **Bugfix**: Add semver tool to enable pre-release flag in release creation. We lost this bit of functionality (https://github.com/actions/create-release/issues/9) when we moved the github release creation from goreleaser to github actions
   - **Refactoring**: Removed `get_tag` step in release workflow, adding the tag parse directly in `Notarize binary` step


* **What is the current behavior?**
Nightly and Release workflow fail


* **What is the new behavior?**
Release workflow now supports pre-releases automatically again



* **Does this PR introduce a breaking change?**
No


* **Other information**:
<!-- Any additional information that could help the review process -->


---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
