### PR TITLE
update search paragraph command to match ArduinoJSON latest release

### DIFF
--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -152,7 +152,7 @@ def test_search_paragraph(run_command):
     """
     assert run_command("lib update-index")
     result = run_command(
-        'lib search "An efficient and elegant JSON library" --format json'
+        'lib search "A simple and efficient JSON library" --format json'
     )
     assert result.ok
     libs_json = json.loads(result.stdout)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)



* **What kind of change does this PR introduce?**
Bug Fix -
The `test_search_paragraph` searches for an outdated string as the new version of ArduinoJSON is released [6.15.1](https://github.com/bblanchon/ArduinoJson/releases/tag/v6.15.1)
This changes the sentence making the existing test fail.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
`test_search_paragraph` under `test_lib.py` fails as it returns an empty json

* **What is the new behavior?**
<!-- if this is a feature change -->
The tests now pass as the search term has been updated

---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
