### PR TITLE
Fix serial port URI parsing in board attach command

### DIFF
--- a/commands/board/attach.go
+++ b/commands/board/attach.go
@@ -112,7 +112,10 @@ func Attach(ctx context.Context, req *rpc.BoardAttachReq, taskCB commands.TaskPr
 // for the matching.
 func findSerialConnectedBoard(pm *packagemanager.PackageManager, monitor *discovery.Monitor, deviceURI *url.URL) *cores.Board {
 	found := false
-	location := deviceURI.Path
+	// to support both cases:
+	// serial:///dev/ttyACM2 parsing gives: deviceURI.Host = ""      and deviceURI.Path = /dev/ttyACM2
+	// serial://COM3 parsing gives:         deviceURI.Host = "COM3"  and deviceURI.Path = ""
+	location := deviceURI.Host + deviceURI.Path
 	var serialDevice discovery.SerialDevice
 	for _, device := range monitor.Serial() {
 		if device.Port == location {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fixes bug on windows related to `board attach` command


* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The message
```
Attach board error: no supported board found at serial://COM7

```
is returned even if a board is attached to COM7 port

```
C:\Users\umber\Downloads\empty>..\arduino-cli.exe board list
Port Type              Board Name            FQBN                     Core         
COM3 Serial Port       Unknown
COM4 Serial Port       Unknown
COM7 Serial Port (USB) Arduino MKR WiFi 1010 arduino:samd:mkrwifi1010 arduino:samd
```

* **What is the new behavior?**
<!-- if this is a feature change -->



* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->



* **Other information**:
<!-- Any additional information that could help the review process -->
There is already an integration test that uses board attach command

---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
