### PR TITLE
[skip changelog] Gather downloads stats from GitHub releases

### DIFF
--- a/.github/workflows/github-stats.yaml
+++ b/.github/workflows/github-stats.yaml
@@ -1,9 +1,6 @@
 name: download-stats
 
 on:
-  push:
-    branches:
-      - massi/stats
   schedule:
     # run every 5 minutes
     - cron:  '*/5 * * * *'

--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -1,0 +1,67 @@
+name: download-stats
+
+on:
+  push:
+    branches:
+      - massi/stats
+  schedule:
+    # run every 5 minutes
+    - cron:  '*/5 * * * *'
+
+jobs:
+  push-stats:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch downloads count
+        uses: actions/github-script@0.2.0
+        with:
+          github-token: ${{github.token}}
+          script: |
+            let metrics = []
+
+            // Get a list of releases
+            const opts = github.repos.listReleases.endpoint.merge({
+              ...context.repo
+            })
+            const releases = await github.paginate(opts)
+
+            // Get download stats for every release
+            for (const rel of releases) {
+              // Names for assets are like `arduino-cli_0.4.0_Linux_32bit.tar.gz`,
+              // we'll use this later to split the asset file name more easily
+              const baseName = `arduino-cli_${rel.name}_`
+
+              // Get a list of assets for this release
+              const opts = github.repos.listAssetsForRelease.endpoint.merge({
+                ...context.repo,
+                release_id: rel.id
+              })
+              const assets = await github.paginate(opts)
+
+              for (const asset of assets) {
+                // Ignore checksums file
+                if (asset.name.endsWith(".txt")) {
+                  continue
+                }
+
+                // Strip the base and remove file extension to get `Linux_32bit`
+                systemArch = asset.name.replace(baseName, "").split(".")[0].split("_")
+
+                // Add a metric object to the list of gathered metrics
+                metrics.push({
+                  "type": "gauge",
+                  "name": "arduino.downloads.total",
+                  "value": asset.download_count,
+                  "host": "${{ github.repository }}",
+                  "tags": [
+                    `os:${systemArch[0]}`,
+                    `arch:${systemArch[1]}`,
+                    "cdn:github.com",
+                    "project:arduino-cli"
+                  ]
+                })
+              }
+            }
+
+            console.log(`::set-output name=metrics::${metrics}`)

--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Send metrics
         uses: masci/datadog@v1
         with:
-          api-key: ${{ secrets.DD_API_KEY }}
+          api-key: ${{ secrets._DD_API_KEY }}
           # Metrics input expects YAML but JSON will work just right.
           metrics: ${{steps.fetch.outputs.result}}
 

--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
       - name: Fetch downloads count
+        id: fetch
         uses: actions/github-script@0.2.0
         with:
           github-token: ${{github.token}}
@@ -40,8 +41,8 @@ jobs:
               const assets = await github.paginate(opts)
 
               for (const asset of assets) {
-                // Ignore checksums file
-                if (asset.name.endsWith(".txt")) {
+                // Ignore files that are not arduino-cli packages
+                if (!asset.name.startsWith(baseName)) {
                   continue
                 }
 
@@ -55,6 +56,7 @@ jobs:
                   "value": asset.download_count,
                   "host": "${{ github.repository }}",
                   "tags": [
+                    `version:${rel.name}`,
                     `os:${systemArch[0]}`,
                     `arch:${systemArch[1]}`,
                     "cdn:github.com",
@@ -64,4 +66,10 @@ jobs:
               }
             }
 
-            console.log(`::set-output name=metrics::${metrics}`)
+            return metrics
+
+      - name: Send metrics
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.DD_API_KEY }}
+          metrics: ${{steps.fetch.outputs.result}}

--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -75,7 +75,7 @@ jobs:
         uses: masci/datadog@v1
         with:
           api-key: ${{ secrets.DD_API_KEY }}
-          // metrics input expects YAML but JSON will do the job
+          # Metrics input expects YAML but JSON will work just right.
           metrics: ${{steps.fetch.outputs.result}}
 
       - name: Report failure

--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -66,10 +66,28 @@ jobs:
               }
             }
 
+            // The action will put whatever we return from this function in
+            // `outputs.result`, JSON encoded. So we just return the array
+            // of objects and GitHub will do the rest.
             return metrics
 
       - name: Send metrics
         uses: masci/datadog@v1
         with:
           api-key: ${{ secrets.DD_API_KEY }}
+          // metrics input expects YAML but JSON will do the job
           metrics: ${{steps.fetch.outputs.result}}
+
+      - name: Report failure
+        if: failure()
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.DD_API_KEY }}
+          events: |
+            - title: "Arduino CLI stats failing"
+              text: "Stats collection failed"
+              alert_type: "error"
+              host: ${{ github.repository }}
+              tags:
+                - "project:arduino-cli"
+                - "cdn:github.com"

--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Send metrics
         uses: masci/datadog@v1
         with:
-          api-key: ${{ secrets._DD_API_KEY }}
+          api-key: ${{ secrets.DD_API_KEY }}
           # Metrics input expects YAML but JSON will work just right.
           metrics: ${{steps.fetch.outputs.result}}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
No changes to the Arduino CLI


* **Other information**:
<!-- Any additional information that could help the review process -->
This PR introduces a cron action that will gather download statistics from GitHub releases and push results to Datadog.

---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
