### PR TITLE
[skip changelog] Collect download stats less often

### DIFF
--- a/.github/workflows/github-stats.yaml
+++ b/.github/workflows/github-stats.yaml
@@ -1,9 +1,9 @@
-name: download-stats
+name: github-stats
 
 on:
   schedule:
-    # run every 5 minutes
-    - cron:  '*/5 * * * *'
+    # run every 30 minutes
+    - cron:  '*/30 * * * *'
 
 jobs:
   push-stats:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [ ] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
No CLI changes

* **Other information**:
<!-- Any additional information that could help the review process -->
No need to collect stats every five minutes. Also changed workflow name so it's easier to understand which had issues between github/arduino in case of failure

---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
