### PR TITLE
[skip changelog] Replace obsolete BoardDetailsResp.GetRequiredTools() call in gRPC client example

### DIFF
--- a/client_example/main.go
+++ b/client_example/main.go
@@ -445,7 +445,7 @@ func callBoardsDetails(client rpc.ArduinoCoreClient, instance *rpc.Instance) {
 	}
 
 	log.Printf("Board details for %s", details.GetName())
-	log.Printf("Required tools: %s", details.GetRequiredTools())
+	log.Printf("Required tools: %s", details.GetToolsDependencies())
 	log.Printf("Config options: %s", details.GetConfigOptions())
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Replace BoardDetailsResp.GetRequiredTools() call in gRPC client example with the new equivalent method `GetToolsDependencies()`.

* **What is the current behavior?**
`GetRequiredTools()` was removed in https://github.com/arduino/arduino-cli/pull/674 so the client example now fails:
```
# command-line-arguments
.\main.go:448:42: details.GetRequiredTools undefined (type *commands.BoardDetailsResp has no field or method GetRequiredTools)
```

* **What is the new behavior?**
<!-- if this is a feature change -->
client example works.

* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No