### PR TITLE
Fix sketch metadata loader

### DIFF
--- a/arduino/sketches/sketches.go
+++ b/arduino/sketches/sketches.go
@@ -43,6 +43,9 @@ type BoardMetadata struct {
 
 // NewSketchFromPath loads a sketch from the specified path
 func NewSketchFromPath(path *paths.Path) (*Sketch, error) {
+	if !path.IsDir() {
+		path = path.Parent()
+	}
 	sketch := &Sketch{
 		FullPath: path,
 		Name:     path.Base(),

--- a/arduino/sketches/sketches_test.go
+++ b/arduino/sketches/sketches_test.go
@@ -16,6 +16,7 @@
 package sketches
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/arduino/go-paths-helper"
@@ -30,13 +31,15 @@ func TestSketchLoadingFromFolderOrMainFile(t *testing.T) {
 		sk, err := NewSketchFromPath(skFolder)
 		require.NoError(t, err)
 		require.Equal(t, sk.Name, "Sketch1")
-		require.True(t, sk.FullPath.EqualsTo(skFolder))
+		fmt.Println(sk.FullPath.String(), "==", skFolder.String())
+		require.True(t, sk.FullPath.EquivalentTo(skFolder))
 	}
 
 	{
 		sk, err := NewSketchFromPath(skMainIno)
 		require.NoError(t, err)
 		require.Equal(t, sk.Name, "Sketch1")
-		require.True(t, sk.FullPath.EqualsTo(skFolder))
+		fmt.Println(sk.FullPath.String(), "==", skFolder.String())
+		require.True(t, sk.FullPath.EquivalentTo(skFolder))
 	}
 }

--- a/arduino/sketches/sketches_test.go
+++ b/arduino/sketches/sketches_test.go
@@ -1,0 +1,42 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package sketches
+
+import (
+	"testing"
+
+	"github.com/arduino/go-paths-helper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSketchLoadingFromFolderOrMainFile(t *testing.T) {
+	skFolder := paths.New("testdata/Sketch1")
+	skMainIno := skFolder.Join("Sketch1.ino")
+
+	{
+		sk, err := NewSketchFromPath(skFolder)
+		require.NoError(t, err)
+		require.Equal(t, sk.Name, "Sketch1")
+		require.True(t, sk.FullPath.EqualsTo(skFolder))
+	}
+
+	{
+		sk, err := NewSketchFromPath(skMainIno)
+		require.NoError(t, err)
+		require.Equal(t, sk.Name, "Sketch1")
+		require.True(t, sk.FullPath.EqualsTo(skFolder))
+	}
+}

--- a/arduino/sketches/testdata/Sketch1/Sketch1.ino
+++ b/arduino/sketches/testdata/Sketch1/Sketch1.ino
@@ -1,0 +1,3 @@
+
+void setup() {}
+void loop() {}

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -211,11 +211,7 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 		var exportPath *paths.Path
 		var exportFile string
 		if req.GetExportFile() == "" {
-			if sketch.FullPath.IsDir() {
-				exportPath = sketch.FullPath
-			} else {
-				exportPath = sketch.FullPath.Parent()
-			}
+			exportPath = sketch.FullPath
 			exportFile = sketch.Name + "." + fqbnSuffix // "sketch.arduino.avr.uno"
 		} else {
 			exportPath = paths.New(req.GetExportFile()).Parent()


### PR DESCRIPTION
- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [X] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


This PR makes `sketches.NewSketchFromPath` tolerant to different input paths:
1. `sketch := sketches.NewSketchFromPath(paths.New("path/to/sketch"))`
2. `sketch := sketches.NewSketchFromPath(paths.New("path/to/sketch/sketch.ino"))`

Previously the function would return different `Sketch` struct with different `Name` fields:
1. `sketch.Name == "sketch"`
2. `sketch.Name == "sketch.ino"`

now it will return the same `Name` consistently in both cases:
1. `sketch.Name == "sketch"`
2. `sketch.Name == "sketch"`

This PR solves the different treatment of sketch path argument between `compile`, `upload` and `debug`. In particular, using the combined `compile + upload` with a sketch path containing `.ino` previously produced a sucessful compile followed by an upload error (because upload will not find the output file due to the extra `.ino`. This behaviour is now fixed.
