### PR TITLE
Fixed race condition in legacy i18n.LoggerToCustomStreams

### DIFF
--- a/legacy/builder/i18n/i18n.go
+++ b/legacy/builder/i18n/i18n.go
@@ -40,9 +40,12 @@ type Logger interface {
 type LoggerToCustomStreams struct {
 	Stdout io.Writer
 	Stderr io.Writer
+	mux    sync.Mutex
 }
 
 func (s LoggerToCustomStreams) Fprintln(w io.Writer, level string, format string, a ...interface{}) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
 	target := s.Stdout
 	if w == os.Stderr {
 		target = s.Stderr
@@ -51,6 +54,8 @@ func (s LoggerToCustomStreams) Fprintln(w io.Writer, level string, format string
 }
 
 func (s LoggerToCustomStreams) UnformattedFprintln(w io.Writer, str string) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
 	target := s.Stdout
 	if w == os.Stderr {
 		target = s.Stderr
@@ -59,6 +64,8 @@ func (s LoggerToCustomStreams) UnformattedFprintln(w io.Writer, str string) {
 }
 
 func (s LoggerToCustomStreams) UnformattedWrite(w io.Writer, data []byte) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
 	target := s.Stdout
 	if w == os.Stderr {
 		target = s.Stderr


### PR DESCRIPTION
This PR serializes access to underlying streams.

Should solve:
```
WARNING: DATA RACE
Write at 0x00c04c8c5a88 by goroutine 61:
   bytes.(*Buffer).grow()
       /usr/local/go/src/bytes/buffer.go:147 +0x27f
   bytes.(*Buffer).Write()
       /usr/local/go/src/bytes/buffer.go:172 +0x154
   fmt.Fprintln()
       /usr/local/go/src/fmt/print.go:265 +0xb2
   github.com/arduino/arduino-cli/legacy/builder/i18n.LoggerToCustomStreams.Fprintln()
       /go/pkg/mod/github.com/arduino/arduino-cli@v0.0.0-20200324101224-985b2c99c8a4/legacy/builder/i18n/i18n.go:50 +0x125

Previous read at 0x00c04c8c5a88 by goroutine 9:
   bytes.(*Buffer).grow()
       /usr/local/go/src/bytes/buffer.go:143 +0x19d
   bytes.(*Buffer).Write()
       /usr/local/go/src/bytes/buffer.go:172 +0x154
   fmt.Fprintln()
       /usr/local/go/src/fmt/print.go:265 +0xb2
   github.com/arduino/arduino-cli/legacy/builder/i18n.LoggerToCustomStreams.Fprintln()
       /go/pkg/mod/github.com/arduino/arduino-cli@v0.0.0-20200324101224-985b2c99c8a4/legacy/builder/i18n/i18n.go:50 +0x125
   github.com/arduino/arduino-cli/legacy/builder/i18n.(*LoggerToCustomStreams).Fprintln()
```

/cc @matteosuppo 