### PR TITLE
[skip changelog] Clarify installation instructions for Windows

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,12 +27,20 @@ If you want to target a different directory, for example `~/local/bin`, set the
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=~/local/bin sh
 ```
 
-### Download the latest packages
+If you would like to use the `arduino-cli` command from any location, install
+Arduino CLI to a directory already in your `PATH` or add the Arduino CLI
+installation path to your `PATH` environment variable.
 
-You can download the latest version of the pre-built binaries for the supported
-platforms from the [release page](https://github.com/arduino/arduino-cli/releases)
-or following the links in the following table. Once downloaded, extract the
-binary `arduino-cli` into a directory that is in your `PATH`.
+### Download
+
+Pre-built binaries for all the supported platforms are available for download
+from the links below.
+
+If you would like to use the `arduino-cli` command from any location, extract
+the downloaded file to a directory already in your `PATH` or add the Arduino CLI
+installation path to your `PATH` environment variable.
+
+#### Latest packages
 
 Platform  |                    |                    |
 --------- | ------------------ | ------------------ |
@@ -54,7 +62,11 @@ Mac OSX   |                    | [Mac OSX]          |
   won’t be further updated. That URL will provide the version
   `0.3.7-alpha.preview`, regardless of further releases.
 
-### Download a nightly build
+#### Previous versions
+
+These are available from the [releases page](https://github.com/arduino/arduino-cli/releases)
+
+#### Nightly builds
 
 These builds are generated everyday at 01:00 GMT from the `master` branch and
 should be considered unstable. In order to get the latest nightly build
@@ -82,9 +94,6 @@ Mac OSX   |                            | [Mac OSX]                  |
 
 Checksums for the nightly builds are available at
 `https://downloads.arduino.cc/arduino-cli/nightly/nightly-<DATE>-checksums.txt`
-
-Once downloaded, extract the executable `arduino-cli` into a directory
-which is in your ``PATH``.
 
 ### Build from source
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,16 +10,18 @@ brew install arduino-cli
 
 ### Use the install script
 
-The easiest way to get the latest version of the Arduino CLI on any
-supported platform is using the `install.sh` script:
+The script requires `sh`. This is always available on Linux and macOS. `sh` is
+not available by default on Windows. The script may be run on Windows by
+installing [Git for Windows], then running it from Git Bash.
+
+This script will install the latest version of Arduino CLI to `$PWD/bin`:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
 ```
 
-The script will install `arduino-cli` at `$PWD/bin` but if you want to target a
-different directory, for example `~/local/bin`, set the `BINDIR` environment
-variable like this:
+If you want to target a different directory, for example `~/local/bin`, set the
+`BINDIR` environment variable like this:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=~/local/bin sh
@@ -100,3 +102,5 @@ docker run -v $PWD:/arduino-cli -w /arduino-cli -e PACKAGE_NAME_PREFIX='snapshot
 
 Once the build is over, you will find a `./dist/` folder containing the packages
 built out of the current source tree.
+
+[Git for Windows]: https://gitforwindows.org/


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Improve the installation instructions for Windows users.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The installation instructions are not very friendly to Windows users.

* **What is the new behavior?**
<!-- if this is a feature change -->
The installation process for Windows is documented a little bit better.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.


* **Other information**:
<!-- Any additional information that could help the review process -->
Resolves (partially?) https://github.com/arduino/arduino-cli/issues/705