### PR TITLE
add #line tags to AdditionalFiles when copying to build directory, to…

### DIFF
--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -281,6 +281,9 @@ func writeIfDifferent(sourcePath, destPath string) error {
 		return errors.Wrap(err, "unable to read contents of the source item")
 	}
 
+	// tag each addtional file with the filename of the source it was copied from
+	newbytes = []byte("#line 1 " + QuoteCppString(sourcePath) + "\n" + string(newbytes))
+
 	// check whether the destination file exists
 	_, err = os.Stat(destPath)
 	if os.IsNotExist(err) {


### PR DESCRIPTION
… improve error messages

**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
Feature. Usable file:line locations in compiler error messages for Additional files


* **What is the current behavior?**
Additional files show error message location in build directory, which is not useful

* **What is the new behavior?**
Compiler Error messages in additional files now reference the original file. Same behaviour as for main and extra sketch files


* **Does this PR introduce a breaking change?**
No

* **Other information**:
It's a trivial one liner. Please change it there is a better way. 

---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
