### PR TITLE
[skip changelog] use absolute URL in docs version selector

### DIFF
--- a/docs/js/version-select.js
+++ b/docs/js/version-select.js
@@ -35,7 +35,7 @@ window.addEventListener("DOMContentLoaded", function () {
       return { text: i.title, value: i.version };
     }), realVersion);
     select.addEventListener("change", function (event) {
-      window.location.href = REL_BASE_URL + "/../" + this.value;
+      window.location.href = ABS_BASE_URL + "/../" + this.value;
     });
 
     var container = document.createElement("div");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [ ] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix in docs website


* **What is the current behavior?**
<!-- You can also link to an open issue here -->
When users select the docs version from the recently added selector control, the relative URL is used and browser is pointed to `https://arduino.github.io/<version>` instead of `https://arduino.github.io/arduino-cli/<version>/` resulting in a 404


* **What is the new behavior?**
<!-- if this is a feature change -->
Use the absolute url `https://arduino.github.io/arduino-cli/` as a prefix for the destination URL



* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No changes to the CLI


---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
