### PR TITLE
[skip changelog] Use local path for github.com/arduino/arduino-cli module dependency of docsgen

### DIFF
--- a/docsgen/go.mod
+++ b/docsgen/go.mod
@@ -2,7 +2,9 @@ module github.com/arduino/arduino-cli/docsgen
 
 go 1.14
 
+replace github.com/arduino/arduino-cli => ../
+
 require (
-	github.com/arduino/arduino-cli v0.0.0-20200228161349-4b874a02b096
+	github.com/arduino/arduino-cli v0.0.0
 	github.com/spf13/cobra v0.0.6
 )


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Cause the command line interface documentation generation system to use  the `github.com/arduino/arduino-cli` module from the local path.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
As reported in https://github.com/arduino/arduino-cli/issues/714, previously, the generated documentation for the command line interface did not reflect recent development work. This is caused by [`docsgen`](https://github.com/arduino/arduino-cli/tree/master/docsgen) using a pinned version of the `github.com/arduino/arduino-cli` module, which resulted in the the documentation only applying to the interface of the pinned version of Arduino CLI.

* **What is the new behavior?**
<!-- if this is a feature change -->
The generated command line interface documentation will always match the code at its state when the documentation was generated.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.


* **Other information**:
<!-- Any additional information that could help the review process -->
Fixes https://github.com/arduino/arduino-cli/issues/714

Generated docs: https://per1234.github.io/arduino-cli/4.2/commands/arduino-cli/