### PR TITLE
Reduce codecov threshold to 30%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,7 +7,7 @@ coverage:
   status:
     project:
       default:
-        target: 35%
+        target: 30%
         threshold: null
     patch: off
     changes: off


### PR DESCRIPTION
We are currently hitting ~31.8% of test coverage, keeping the threshold to 35% will mark all the commits as failing, for example int [the latest merge](https://github.com/arduino/arduino-cli/commit/f5b41257d7e0ba721562fabf57ad91163eeea9d6):

![image](https://user-images.githubusercontent.com/423515/83015562-e2a3ba80-a020-11ea-8cf3-6f1c26b8b035.png)

but this is the same for all the recent merge commits.
