### PR TITLE
lib install command will exit with non-zero status code if library dependency could not be resolved

### DIFF
--- a/cli/lib/install.go
+++ b/cli/lib/install.go
@@ -72,6 +72,7 @@ func runInstallCommand(cmd *cobra.Command, args []string) {
 			})
 			if err != nil {
 				feedback.Errorf("Error resolving dependencies for %s: %s", libRef, err)
+				os.Exit(errorcodes.ErrGeneric)
 			}
 			for _, dep := range depsResp.GetDependencies() {
 				feedback.Printf("%s depends on %s@%s", libRef, dep.GetName(), dep.GetVersionRequired())


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
Bug fix. Return non-zero exit code if library install fails due to dependency resolution.
Fixes #712 


* **What is the current behavior?**
Failure to resolve library dependency is logged, but does not exit with non-zero status code to indicate the error.


* **What is the new behavior?**
If it is not possible to resolve the dependency of a library, the error is logged and the process exits with an error code.



* **Does this PR introduce a breaking change?**
The lib install command will now exit with a non-zero code if a library dependency cannot be resolved. 

* **Other information**:


---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
