### PR TITLE
Pin mike at version 0.5.1

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,5 @@
 mkdocs<1.2
 mkdocs-material<5
-mike
+mike==0.5.1
 gitpython
 click<7.2


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [ ] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
It pins `mike` version at 0.5.1 in the requirements file

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
`mike` version is not pinned and it gets the latest at each docs build. We're having a problem with latest version 0.5.2 as seen here https://github.com/arduino/arduino-cli/runs/716092672#step:11:103

* **What is the new behavior?**
<!-- if this is a feature change -->
While we investigate why 0.5.2 fails, pin 0.5.1 that was proven to work


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No CLI changes



---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
