### PR TITLE
[skip changelog] Make library location priority documentation more relevant to Arduino CLI

### DIFF
--- a/docs/sketch-build-process.md
+++ b/docs/sketch-build-process.md
@@ -73,10 +73,11 @@ The folder name contains the include | `AnAwesomeServoForWhatever`
 
 The "location priority" is determined as follows (in order of highest to lowest priority):
 
-1. The library is in the sketchbook (`{sketchbook path}/libraries`)
+1. The library is in the `libraries` subfolder of the IDE's sketchbook or Arduino CLI's user directory
 1. The library is bundled with the board platform/core ([`{runtime.platform.path}/libraries`](platform-specification.md#global-predefined-properties))
 1. The library is bundled with the [referenced](platform-specification.md#referencing-another-core-variant-or-tool) board platform/core
 1. The library is bundled with the Arduino IDE ([`{runtime.ide.path}/libraries`](platform-specification.md#global-predefined-properties))
+    - This location is only used by Arduino CLI when it's located in the Arduino IDE installation folder
 
 ## Compilation
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Make the [library dependency resolution location priority section of the sketch build process documentation](https://arduino.github.io/arduino-cli/latest/sketch-build-process/#location-priority) more relevant to Arduino CLI.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
This section of the documentation was written with a focus on the Arduino IDE, and thus was not very friendly to Arduino CLI users.


* **What is the new behavior?**
<!-- if this is a feature change -->
The documentation is more relevant to the Arduino CLI.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.


* **Other information**:
Fixes https://github.com/arduino/arduino-cli/issues/713

@itsayellow I welcome your feedback on this change.