### PR TITLE
[skip changelog] Update latest tag at mike deploy

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,7 +40,7 @@ tasks:
       - docs:gen:commands
       - docs:gen:protobuf
     cmds:
-      - mike deploy -p -r {{.DOCS_REMOTE}} {{.DOCS_VERSION}} {{.DOCS_ALIAS}}
+      - mike deploy -u -p -r {{.DOCS_REMOTE}} {{.DOCS_VERSION}} {{.DOCS_ALIAS}}
 
   docs:serve:
     desc: Run documentation website locally


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [ ] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Pass an extra option, `-u` when invoking `mike deploy`.


* **What is the current behavior?**
<!-- You can also link to an open issue here -->
We use an alias called `latest` to point to the most recent of the docs. Problem is when we do `mike deploy`, it produces an error as `latest` is already taken.


* **What is the new behavior?**
<!-- if this is a feature change -->
By passing `mike deploy -u` we can "move" the alias as we produce newer versions.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No changes to the CLI


* **Other information**:
<!-- Any additional information that could help the review process -->
Tested locally

---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
