### PR TITLE
Fixed codecov.yml file

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,6 +8,5 @@ coverage:
     project:
       default:
         target: 30%
-        threshold: null
     patch: off
     changes: off


### PR DESCRIPTION
For some reasons the changes in #727 have been ignored. Reading the codecov docs one possibility is that the file format is wrong, so I validated it with the webservice provided by codecov.

Before the patch:
```
$ curl --data-binary @.codecov.yml https://codecov.io/validate
Path: coverage->status->project->default->threshold
<shared.validation.helpers.PercentSchemaField object at 0x7f172d3e5a10>.validate(None) raised TypeError('expected string or bytes-like object')
```
After the patch:
```
$ curl --data-binary @.codecov.yml https://codecov.io/validate
Valid!

{
  "comment": false,
  "coverage": {
    "status": {
      "patch": false,
      "changes": false,
      "project": {
        "default": {
          "target": 30.0
        }
      }
    }
  }
}
```

Let's see if after this change the new configuration will get through...
