### PR TITLE
I18n fetch language codes from transifex

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -124,7 +124,7 @@ tasks:
   i18n:pull:
     desc: Pull i18n files from transifex
     cmds:
-      - go run ./i18n/cmd/main.go transifex pull -l {{.I18N_LANGS}} ./i18n/data
+      - go run ./i18n/cmd/main.go transifex pull ./i18n/data
       - task: i18n:generate
 
   i18n:push:
@@ -169,4 +169,3 @@ vars:
   DOCS_VERSION: dev
   DOCS_ALIAS: ""
   DOCS_REMOTE: "origin"
-  I18N_LANGS: "pt_BR"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -190,6 +190,43 @@ a list of items you can check before submitting a PR:
   failures that seem
   not related to the change you are making.
 
+## Internationalization (i18n)
+
+In order to support i18n in the cli, any messages that are intended to be translated 
+should be wrapped in a call to `i18n.Tr`. This call allows us to build a catalog of 
+translatable strings, replacing the reference string at runtime with the localized value.
+
+Adding or modifying these messages requires an i18n update, as this process creates the
+reference catalog that are shared with translators. For that reason, the `task check`
+command will fail if the catalog was not updated to sync with changes to the source code.
+
+To update the catalog, execute the following command and commit the changes.
+
+```shell
+task i18n:update
+```
+
+To verify that the catalog is up-to-date, you may execute the command:
+
+```shell
+task i18n:check
+```
+
+Example usage:
+
+```golang
+package main
+
+import (
+  "fmt"
+  "github.com/arduino/arduino-cli/i18n"
+)
+
+func main() {
+  fmt.Println(i18n.Tr("Hello World!"))
+}
+```
+
 ## Additional settings
 
 If you need to push a commit that's only shipping documentation changes or

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -42,12 +42,3 @@ task i18n:push
 ```sh
 task i18n:pull
 ```
-
-## Adding a new language
-
-To add a new supported language add the locale string to the project's Taskfile.yml (comma separated list)
-
-e.g
-```
-I18N_LANGS: "pt_BR,es,jp"
-```


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
Fetches available translation languages directly from transifex, removes the language configuration list. Adds documentation.

* **What is the current behavior?**
Supported i18n languages need to be listed as configuration values.

* **What is the new behavior?**
Supported i18n languages will be fetched from translation resources at transifex

* **Does this PR introduce a breaking change?**

* **Other information**:

---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
