### PR TITLE
Excluding some modules from code coverage analisys

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,9 @@
 comment: off
 
-# ignore:
-#   - legacy/**/*
+ignore:
+  - rpc/**
+  - i18n/cmd/**
+  - i18n/rice-box.go
 
 coverage:
   status:


### PR DESCRIPTION
This commits excludes:

- generated files
- i18n tooling for generating translations files that are not used in the final build of the cli.