### PR TITLE
[skip changelog] Fix installation script's latest tag determination code

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,9 +84,9 @@ checkLatestVersion() {
 	local regex="[0-9][A-Za-z0-9\.-]*"
 	local latest_url="https://github.com/arduino/arduino-cli/releases/latest"
 	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-		tag=$(curl -SsL $latest_url | grep -o "Release $regex · arduino/arduino-cli" | grep -o "$regex")
+		tag=$(curl -SsL $latest_url | grep -o "<title>Release $regex · arduino/arduino-cli" | grep -o "$regex")
 	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-		tag=$(wget -q -O - $latest_url | grep -o "Release $regex · arduino/arduino-cli" | grep -o "$regex")
+		tag=$(wget -q -O - $latest_url | grep -o "<title>Release $regex · arduino/arduino-cli" | grep -o "$regex")
 	fi
 	if [ "x$tag" = "x" ]; then
 		echo "Cannot determine latest tag."


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Expand the grep pattern used by the installation script to scrape the latest tag from the GitHub release page to something that should only ever occur once on an HTML page.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
GitHub changed the HTML of the release page, which resulted in grep finding multiple instances of the pattern, causing the installation script to fail when no version parameter was provided:
```
$ curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
Installing in /home/per/temporary/bin
ARCH=64bit
OS=Linux
Using curl as download tool
TAG=0.11.0
0.11.0
0.11.0
CLI_DIST=arduino-cli_0.11.0
0.11.0
0.11.0_Linux_64bit.tar.gz
Downloading https://downloads.arduino.cc/arduino-cli/arduino-cli_0.11.0
0.11.0
0.11.0_Linux_64bit.tar.gz
Failed to install arduino-cli
```

* **What is the new behavior?**
<!-- if this is a feature change -->
The installation script works correctly when no version parameter is provided.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
