### PR TITLE
GH-680: Reduced the log level in package manager

### DIFF
--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -338,20 +338,20 @@ func (pm *PackageManager) GetInstalledPlatformRelease(platform *cores.Platform) 
 		return nil
 	}
 
-	log := func(msg string, pl *cores.PlatformRelease) {
+	debug := func(msg string, pl *cores.PlatformRelease) {
 		pm.Log.WithField("bundle", pl.IsIDEBundled).
 			WithField("version", pl.Version).
 			WithField("managed", pm.IsManagedPlatformRelease(pl)).
-			Infof("%s: %s", msg, pl)
+			Debugf("%s: %s", msg, pl)
 	}
 
 	best := releases[0]
 	bestIsManaged := pm.IsManagedPlatformRelease(best)
-	log("current best", best)
+	debug("current best", best)
 
 	for _, candidate := range releases[1:] {
 		candidateIsManaged := pm.IsManagedPlatformRelease(candidate)
-		log("candidate", candidate)
+		debug("candidate", candidate)
 		// TODO: Disentangle this algorithm and make it more straightforward
 		if bestIsManaged == candidateIsManaged {
 			if best.IsIDEBundled == candidate.IsIDEBundled {
@@ -367,7 +367,7 @@ func (pm *PackageManager) GetInstalledPlatformRelease(platform *cores.Platform) 
 			best = candidate
 			bestIsManaged = true
 		}
-		log("current best", best)
+		debug("current best", best)
 	}
 	return best
 }


### PR DESCRIPTION
From now on, we log with the `debug` level instead of `info`. Without this change, the daemon log was full of this information when customing the CLI features via gRPC.

Closes #680

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

----

**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Reduces the log-level of the package-manager from `info` to `debug`

* **What is the current behavior?**
<!-- You can also link to an open issue here -->

Now, when I consume the CLI in the Pro IDE, I do not see the daemon log full of:
```
[INFO] current best: arduino:avr@1.8.2 [bundle: false, managed: true, version: 1.8.2]
[INFO] current best: arduino:avr@1.8.2 [bundle: false, managed: true, version: 1.8.2]
[INFO] current best: arduino:avr@1.8.2 [bundle: false, managed: true, version: 1.8.2]
[INFO] current best: arduino:avr@1.8.2 [bundle: false, managed: true, version: 1.8.2]
```

I have verified it with a  local CLI build against the `0.11.0` tag.

* **What is the new behavior?**
<!-- if this is a feature change -->

n/a

* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->

No. I hope no clients are parsing the stdout of the daemon.

* **Other information**:
<!-- Any additional information that could help the review process -->

The fix is not urgent for the Pro IDE. We have to do filtering on our side too anyways; the CLI version is pinned to `0.11.0` so we cannot use this fix.

---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
