### PR TITLE
[skip changelog][skip ci] Correct lib name specification re: leading/trailing space

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -29,7 +29,7 @@ This file allows the *Library Manager* to search and install a library and its d
 
 The library.properties file is a key=value properties list. Every field in this file is UTF-8 encoded. Unless noted otherwise below, **all fields are required**. The available fields are:
 
-* **name** - the name of the library. Library names must contain only basic letters (`A`-`Z` or `a`-`z`) and numbers (`0`-`9`), spaces (` `), underscores (`_`), dots (`.`) and dashes (`-`). It cannot start or end with a space, and also it cannot start with a number. Note that libraries with a `name` value starting with `Arduino` will no longer be allowed [addition to the Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ) as these names are now reserved for official Arduino libraries.
+* **name** - the name of the library. Library names must contain only basic letters (`A`-`Z` or `a`-`z`) and numbers (`0`-`9`), spaces (` `), underscores (`_`), dots (`.`) and dashes (`-`). They cannot start with a number. Note that libraries with a `name` value starting with `Arduino` will no longer be allowed [addition to the Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ) as these names are now reserved for official Arduino libraries.
 * **version** - version of the library. Version should be [semver](http://semver.org/) compliant. 1.2.0 is correct; 1.2 is accepted; r5, 003, 1.1c are invalid
 * **author** - name/nickname of the authors and their email addresses (not mandatory) separated by comma ","
 * **maintainer** - name and email of the maintainer


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Remove incorrect prohibition on leading or trailing spaces in the library.properties `name` field.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The library specification includes an unnecessary prohibition against leading or trailing spaces in the library.properties `name` field.

Leading and trailing space is correctly trimmed on all fields of library.properties, including `name`.

The unnecessary extra verbosity in the name specification may cause people to miss the other important restrictions.

* **What is the new behavior?**
<!-- if this is a feature change -->
The `name` specification only contains the true requirements.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.