### PR TITLE
[skip changelog][skip ci] Replace duplicate content with link to config docs

### DIFF
--- a/docs/integration-options.md
+++ b/docs/integration-options.md
@@ -38,10 +38,7 @@ package index that can be used to work with experimental versions of cores:
 
 ![configuration methods screenshot][]
 
-One note about the example above: passing a value through a command line flag
-always takes precedence over reading an environment variable, which in turn
-always takes precedence over reading the same value from the configuration file
-(if you have one). For more information, see the [configuration documentation].
+See the [configuration documentation] for details about Arduino CLI's configuration system.
 
 Consistent with the previous paragraph, when it comes to providing output the
 Arduino CLI aims to be user friendly but also slightly verbose, something that


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Replace content duplicating low level details from the configuration documentation with a link to that content.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
Low level details about the configuration system are present in a general overview of the three methods for using Arduino CLI

* **What is the new behavior?**
<!-- if this is a feature change -->
A link is provided for people interested in the details of the configuration system to get more information.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.