### PR TITLE
[skip changelog] Correct documentation re: arduino-cli config init behavior

### DIFF
--- a/cli/config/init.go
+++ b/cli/config/init.go
@@ -33,10 +33,10 @@ const defaultFileName = "arduino-cli.yaml"
 func initInitCommand() *cobra.Command {
 	initCommand := &cobra.Command{
 		Use:   "init",
-		Short: "Initializes a new configuration file into the default location.",
-		Long:  "Initializes a new configuration file into the default location ($EXE_DIR/cli-config.yml).",
+		Short: "Writes current configuration to a configuration file.",
+		Long:  "Creates or updates the configuration file in the data directory or custom directory with the current configuration settings.",
 		Example: "" +
-			"  # Creates a default configuration file into the default location.\n" +
+			"  # Writes current configuration to the configuration file in the data directory.\n" +
 			"  " + os.Args[0] + " config init",
 		Args: cobra.NoArgs,
 		Run:  runInitCommand,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation correction.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
Documentation of `arduino-cli config init` doesn't accurately or fully match its behavior (which can be somewhat unintuitive under certain conditions):

- Configuration filename is now arduino-cli.yaml, not "cli-config.yml"
- Default configuration file location is no longer correctly described as "$EXE_DIR". It is now directories.data.
- Location of the written configuration file location may be customized via --dest-dir.
- Current configuration is written, not the default configuration.
- If configuration file already exists, it is updated with the current configuration.

* **What is the new behavior?**
<!-- if this is a feature change -->
Documentation of `arduino-cli config init` matches its behavior.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.