### PR TITLE
[skip changelog][skip ci] Document location priority of custom libraries paths

### DIFF
--- a/docs/sketch-build-process.md
+++ b/docs/sketch-build-process.md
@@ -73,6 +73,7 @@ The folder name contains the include | `AnAwesomeServoForWhatever`
 
 The "location priority" is determined as follows (in order of highest to lowest priority):
 
+1. The library is in a custom libraries path specified via the [`--libraries` option](../commands/arduino-cli_compile/#options) of `arduino-cli compile` (in decreasing order of priority when multiple custom paths are defined)
 1. The library is in the `libraries` subfolder of the IDE's sketchbook or Arduino CLI's user directory
 1. The library is bundled with the board platform/core ([`{runtime.platform.path}/libraries`](platform-specification.md#global-predefined-properties))
 1. The library is bundled with the [referenced](platform-specification.md#referencing-another-core-variant-or-tool) board platform/core


### PR DESCRIPTION
Custom libraries paths may be specified via arduino-cli compile --libraries.

**Please check if the PR fulfills these requirements**
- [s] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [s] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [s] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
Custom libraries paths may be specified via `arduino-cli compile --libraries`. Priority of all other libraries paths are documented in the sketch build process documentation, but not custom libraries paths.

* **What is the new behavior?**
<!-- if this is a feature change -->
Priority of custom libraries paths is documented.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.