### PR TITLE
[skip changelog][skip ci] Fix contributing guidelines link on tests readme

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -34,4 +34,4 @@ To run very specific test functions:
 pytest test_lib.py::test_list
 ```
 
-[0]: ../CONTRIBUTING.md
+[0]: ../docs/CONTRIBUTING.md


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
Contributing guidelines link on tests readme is broken.

* **What is the new behavior?**
<!-- if this is a feature change -->
Contributing guidelines link on tests readme is not broken.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No


* **Other information**:
<!-- Any additional information that could help the review process -->
Linked to the Markdown file rather than the documentation site page so the link will always point to the matching docs.