### PR TITLE
[skip changelog] Remove duplicate content re: keywords.txt from platform specification

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -595,4 +595,4 @@ Introduced in Arduino IDE 1.6.6. This file can be used to override properties de
 
 ## keywords.txt
 
-As of Arduino IDE 1.6.6, per-platform keywords can be defined by adding a keywords.txt file to the platform's architecture folder. These keywords are only highlighted in the Arduino IDE when one of the boards of that platform are selected. This file follows the [same format](library-specification.md#keywords) as the keywords.txt used in libraries. Each keyword must be separated from the keyword identifier by a tab.
+As of Arduino IDE 1.6.6, per-platform keywords can be defined by adding a keywords.txt file to the platform's architecture folder. These keywords are only highlighted in the Arduino IDE when one of the boards of that platform are selected. This file follows the [same format](library-specification.md#keywords) as the keywords.txt used in libraries.


### PR DESCRIPTION
The documentation for the keywords.txt formatting should be maintained in one location.

**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
keywords.txt formatting documentation content is duplicated in the platform specification.

* **What is the new behavior?**
<!-- if this is a feature change -->
keywords.txt formatting documentation content is maintained in a [single location](https://arduino.github.io/arduino-cli/latest/library-specification/#keywordstxt-format).


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.