### PR TITLE
[skip changelog] Mention Boards Manager installation option in platform specification intro

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -1,6 +1,6 @@
 This specification is a 3rd party hardware format to be used in Arduino development software starting from the Arduino IDE 1.5.x series.<br>
-This specification allows a 3rd party vendor/maintainer to add support for new boards to the Arduino development software by providing a file to unzip into the *hardware* folder of Arduino's sketchbook folder.<br>
-It is also possible to add new 3rd party boards by providing just one configuration file.
+Platforms add support for new boards to the Arduino development software. They are installable either via [Boards Manager](package_index_json-specification.md) or manual installation to the *hardware* folder of Arduino's sketchbook folder.<br>
+A platform may consist of as little as a single configuration file.
 
 ## Hardware Folders structure
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentaiton update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
Manual platform installation alone was specifically described in the platform specification introduction, which might cause new platform authors to think the specification is only for manually installed platforms. Boards Manager was only mentioned in passing, deep within the document.

* **What is the new behavior?**
<!-- if this is a feature change -->
Boards Manager installation is also mentioned, with a link to the package_index.json specification.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.