### PR TITLE
[skip changelog] Clarify use of platform.txt's name property in Arduino development software

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -79,7 +79,7 @@ The following meta-data must be defined:
     name=Arduino AVR Boards
     version=1.5.3
 
-The **name** will be shown in the Arduino IDE's Board menu or the Name field of [`arduino-cli core`](https://arduino.github.io/arduino-cli/commands/arduino-cli_core/)'s output.<br>
+The **name** will be shown as the Arduino IDE's Board menu section title or the Name field of [`arduino-cli core list`](../commands/arduino-cli_core_list)'s output for the platform.<br>
 The **version** is currently unused, it is reserved for future use (probably together with the Boards Manager to handle dependencies on cores).
 
 ### Build process


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The description of the use of platform.txt's name property in the Arduino IDE was vague and potentially confusing.


* **What is the new behavior?**
<!-- if this is a feature change -->
Use of platform.txt's name property by Arduino development software is more clear.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.