### PR TITLE
[skip changelog] Document Arduino IDE's default to Upload Using Programmer feature

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -469,6 +469,10 @@ To let the Arduino development software perform these steps, two board parameter
 
 Note that the IDE implementation of this 1200 bps touch has some peculiarities, and the newer `arduino-cli` implementation also seems different (does not wait for the port after the reset, which is probably only needed in the IDE to prevent opening the wrong port on the serial monitor, and does not have a shorter timeout when the port never disappears).
 
+#### Upload Using Programmer by default
+
+If the **upload.protocol** property is not defined for a board, the Arduino IDE's "Upload" process will use the same behavior as ["Upload Using Programmer"](#upload-using-an-external-programmer). This is convenient for boards which only support uploading via programmer.
+
 ### Serial port
 
 The port selected via the IDE or [`arduino-cli upload`](https://arduino.github.io/arduino-cli/commands/arduino-cli_upload/)'s `--port` option is available as a configuration property **{serial.port}**.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The Arduino IDE has a useful feature where a board can be configured to use the "Upload Using Programmer" behavior when the user does an Upload, but this isn't documented.

* **What is the new behavior?**
<!-- if this is a feature change -->
The feature is documented.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.