### PR TITLE
[skip changelog] Fix issues with command reference section of the documentation's navigation pane

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
     - board details: commands/arduino-cli_board_details.md
     - board list: commands/arduino-cli_board_list.md
     - board listall: commands/arduino-cli_board_listall.md
+    - burn-bootloader: commands/arduino-cli_burn-bootloader.md
     - cache: commands/arduino-cli_cache.md
     - cache clean: commands/arduino-cli_cache_clean.md
     - compile: commands/arduino-cli_compile.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,7 +60,7 @@ nav:
   - CONTRIBUTING.md
   - FAQ.md
   - Command reference:
-    - commands/arduino-cli.md
+    - arduino-cli: commands/arduino-cli.md
     - board: commands/arduino-cli_board.md
     - board attach: commands/arduino-cli_board_attach.md
     - board details: commands/arduino-cli_board_details.md


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation fix.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
- Incorrect name for the `arduino-cli` command is shown in the command reference section of the documentation's navigation pane.
- `arduino-cli burn-bootloader` is missing from the command reference section of the documentation's navigation pane.

* **What is the new behavior?**
<!-- if this is a feature change -->
Command reference section of the documentation's navigation pane correctly shows all commands.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.