### PR TITLE
[skip changelog] Document boards.txt hide property

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -369,6 +369,14 @@ In any case, the contents of the selected variant folder path is added to the in
 
 The parameter **build.variant.path** is automatically generated.
 
+### Hiding boards
+
+Adding a **hide** property to a board definition causes it to not be shown in the Arduino IDE's **Tools > Board** menu.
+
+    uno.hide=
+
+The value of the property is ignored; it's the presence or absence of the property that controls the board's visibility.
+
 ## Tools
 
 The Arduino development software uses external command line tools to upload the compiled sketch to the board or to burn bootloaders using external programmers. For example, *avrdude* is used for AVR based boards and *bossac* for SAM based boards, but there is no limit, any command line executable can be used. The command line parameters are specified using **recipes** in the same way used for platform build process.


### PR DESCRIPTION
The Arduino IDE has a useful, previously undocumented, feature that allows hiding boards from the Tools > Board menu.

**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The Arduino IDE has a useful feature that allows control over the visibility of boards in the **Tools > Board** menu via a property in boards.txt, but this feature is undocumented.

* **What is the new behavior?**
<!-- if this is a feature change -->
The hide property of boards.txt is documented.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.