### PR TITLE
[skip changelog] Remove unnecessary "TODO" note from platform specification

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -551,8 +551,6 @@ Note that when the user selects an option value, all the "sub properties" of tha
 
 There is no limit to the number of custom menus that can be defined.
 
-**TODO: add an example with more than one submenu**
-
 ## Referencing another core, variant or tool
 
 Inside the boards.txt we can define a board that uses a core provided by another vendor/maintainer using the syntax **VENDOR_ID:CORE_ID**. For example, if we want to define a board that uses the "arduino" core from the "arduino" vendor we should write:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The platform specification contains a "TODO" note about adding an example of using multiple custom board options. This note clutters the documentation.

* **What is the new behavior?**
<!-- if this is a feature change -->
Although it would be easy enough to add the suggested example of multiple custom board menus, I don't see that this is really necessary to document the feature. My opinion is that the existing documentation already does a great job of explaining this feature and I haven't seen evidence to the contrary while providing support to 3rd party platform authors. For that reason, I chose to simply remove the "TODO" note from the platform specification.

* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.


* **Other information**:
<!-- Any additional information that could help the review process -->
If you prefer that I follow the advice of the note and replace it with an example of multiple custom board options instead of only removing the note, I'm happy to do so.