### PR TITLE
[skip changelog] Notarize nightly macOS build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,7 +6,8 @@ on:
     - cron:  '0 1 * * *'
 
 jobs:
-  publish-nightly:
+
+  create-nightly-artifacts:
     runs-on: ubuntu-latest
 
     container:
@@ -23,6 +24,72 @@ jobs:
         env:
           PACKAGE_NAME_PREFIX: ${{ github.workflow }}
         run: goreleaser --snapshot
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist
+          path: dist
+
+  notarize-macos:
+    runs-on: macos-latest
+    needs: create-nightly-artifacts
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+
+      - name: Download Gon
+        run: |
+          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.2/gon_0.2.2_macos.zip
+          unzip gon_0.2.2_macos.zip -d /usr/local/bin
+          rm -f gon_0.2.2_macos.zip
+
+      - name: Notarize binary, re-package it and update checksum
+        env:
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+        # This step performs the following:
+        # 1. Download keychain from GH secrets and decode it from base64
+        # 2. Add the keychain to the system keychains and unlock it
+        # 3. Call Gon to start notarization process (using AC_USERNAME and AC_PASSWORD)
+        # 4. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
+        # 5. Recalculate package checksum and replace it in the goreleaser nnnnnn-checksums.txt file
+        run: |
+          echo "${{ secrets.KEYCHAIN }}" | base64 --decode  > ~/Library/Keychains/apple-developer.keychain-db
+          security list-keychains -s ~/Library/Keychains/apple-developer.keychain-db
+          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" ~/Library/Keychains/apple-developer.keychain-db
+          gon gon.config.hcl
+          # GitHub's upload/download-artifact@v1 actions don't preserve file permissions,
+          # so we need to add execution permission back until @v2 actions are released.
+          chmod +x dist/arduino_cli_osx_darwin_amd64/arduino-cli
+          PACKAGE_FILENAME="$(basename dist/arduino-cli_${{ github.workflow }}-*_macOS_64bit.tar.gz)"
+          tar -czvf dist/$PACKAGE_FILENAME \
+          -C dist/arduino_cli_osx_darwin_amd64/  arduino-cli   \
+          -C ../../ LICENSE.txt
+          CLI_CHECKSUM=$(shasum -a 256 dist/$PACKAGE_FILENAME | cut -d " " -f 1)
+          perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CLI_CHECKSUM}  ${PACKAGE_FILENAME}/g;" dist/*-checksums.txt
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist
+          path: dist
+
+  publish-nightly:
+    runs-on: ubuntu-latest
+    needs: notarize-macos
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
 
       - name: upload
         uses: docker://plugins/s3


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature?

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
macOS nightly builds are not notarized.

* **What is the new behavior?**
<!-- if this is a feature change -->
macOS nightly builds are notarized.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.


* **Other information**:
<!-- Any additional information that could help the review process -->
Nightly build from testing: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly_test-20200708_macOS_64bit.tar.gz