### PR TITLE
[skip-changelog] Add ci step to automatically update arduino-cli homebrew formula

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,3 +140,9 @@ jobs:
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Update Homebrew formula
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.ARDUINOBOT_GITHUB_TOKEN }}
+          formula: arduino-cli


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
update CI

* **What is the current behavior?**
<!-- You can also link to an open issue here -->


* **What is the new behavior?**
<!-- if this is a feature change -->
Add a new CI step to automatically update tag & revision of [arduino-cli](https://github.com/Homebrew/homebrew-core/blob/master/Formula/arduino-cli.rb) homebrew formula when a new version of the CLI is released. It should automatically open a PR to the homebrew repo.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no


* **Other information**:
<!-- Any additional information that could help the review process -->
@rsora remember to add the secret in the settings!

---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
