### PR TITLE
[skip changelog] Make Homebrew formula update only run on stable releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,6 +142,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Update Homebrew formula
+        if: steps.prerelease.outputs.IS_PRE != 'true'
         uses: dawidd6/action-homebrew-bump-formula@v3
         with:
           token: ${{ secrets.ARDUINOBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
The formula should not be updated on pre-releases.

**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The "release" GitHub Actions workflow will update the Homebrew formula on every tag, including release candidates.

* **What is the new behavior?**
<!-- if this is a feature change -->
The "release" GitHub Actions workflow will update the Homebrew formula only on production release tags.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.