### PR TITLE
[skip changelog] Replace gender-specific grammar in package_index.json specification

### DIFF
--- a/docs/package_index_json-specification.md
+++ b/docs/package_index_json-specification.md
@@ -4,7 +4,7 @@ Boards Manager functionality is provided by [Arduino CLI](getting-started.md#add
 
 ## Naming of the JSON index file
 
-Many different index files coming from different vendors may be in use, so each vendor should name his own index file in a way that won't conflict with others. The file must be named as follows:
+Many different index files coming from different vendors may be in use, so each vendor should name their own index file in a way that won't conflict with others. The file must be named as follows:
 
 `package_YOURNAME_PACKAGENAME_index.json`
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
package_index.json specification contains gender-specific grammar.

* **What is the new behavior?**
<!-- if this is a feature change -->
package_index.json specification uses singular "their" in place of gender-specific grammar.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.


* **Other information**:
<!-- Any additional information that could help the review process -->
This violates traditional rules of grammar. I don't think that's a problem, but there is the altenative of rewording the sentence to dodge the issue entirely:
>Many different index files coming from different vendors may be in use, so vendors should name their own index files in a way that won't conflict with others.

However, I feel this makes the meaning of the sentence slightly less clear.