### PR TITLE
[skip changelog] Document the boards.txt vid and pid properties

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -443,6 +443,22 @@ linked with the sketch.
 
 The parameter **build.variant.path** is automatically generated.
 
+### Board VID/PID
+
+USB vendor IDs (VID) and product IDs (PID) identify USB devices to the computer. If the board uses a unique VID/PID
+pair, it may be defined in boards.txt:
+
+    uno.vid.0=0x2341
+    uno.pid.0=0x0043
+    uno.vid.1=0x2341
+    uno.pid.1=0x0001
+
+The **vid** and **pid** properties end with an arbitrary number, which allows multiple VID/PID pairs to be defined for a
+board. The snippet above is defining the 2341:0043 and 2341:0001 pairs used by Uno boards.
+
+The Arduino development software uses the **vid** and **pid** properties to automatically identify the boards connected
+to the computer. This convenience feature isn't available for boards that don't present a unique VID/PID pair.
+
 ### Hiding boards
 
 Adding a **hide** property to a board definition causes it to not be shown in the Arduino IDE's **Tools > Board** menu.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The boards.txt `vid` and `pid` properties are not documented. These properties are becoming increasingly important as the modern Arduino development software takes advantage of them for features based on automatic board detection (e.g., Arduino Web Editor's automatic board selection, `arduino-cli board attach <port>`)

* **What is the new behavior?**
<!-- if this is a feature change -->
The `vid` and `pid` properties of boards.txt are documented in the platform specification.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.