### PR TITLE
[skip changelog] Use consistent indentation style in example snippets of package_index.json specification

### DIFF
--- a/docs/package_index_json-specification.md
+++ b/docs/package_index_json-specification.md
@@ -26,8 +26,8 @@ The root of the JSON index is an array of `packages`:
 ```json
 {
   "packages": [
-      PACKAGE_XXXX
-   ]
+    PACKAGE_XXXX
+  ]
 }
 ```
 
@@ -41,19 +41,19 @@ The root of the JSON index is an array of `packages`:
   "email": "packages@arduino.cc",
 
   "platforms": [
-      PLATFORM_AVR,
-      PLATFORM_ARM,
-      PLATFORM_XXXXX,
-      PLATFORM_YYYYY,
+    PLATFORM_AVR,
+    PLATFORM_ARM,
+    PLATFORM_XXXXX,
+    PLATFORM_YYYYY,
   ],
 
   "tools": [
-      TOOLS_COMPILER_AVR,
-      TOOLS_UPLOADER_AVR,
-      TOOLS_COMPILER_ARM,
-      TOOLS_XXXXXXX,
-      TOOLS_YYYYYYY,
-   ],
+    TOOLS_COMPILER_AVR,
+    TOOLS_UPLOADER_AVR,
+    TOOLS_COMPILER_ARM,
+    TOOLS_XXXXXXX,
+    TOOLS_YYYYYYY,
+  ],
 }
 ```
 

--- a/docs/package_index_json-specification.md
+++ b/docs/package_index_json-specification.md
@@ -34,27 +34,27 @@ The root of the JSON index is an array of `packages`:
 3rd party vendors should use a single `PACKAGE_XXXX` that is a dictionary map with the vendor's metadata, a list of `PLATFORMS` and a list of `TOOLS`. For example:
 
 ```json
-{
-  "name": "arduino",
-  "maintainer": "Arduino LLC",
-  "websiteURL": "http://www.arduino.cc/",
-  "email": "packages@arduino.cc",
+    {
+      "name": "arduino",
+      "maintainer": "Arduino LLC",
+      "websiteURL": "http://www.arduino.cc/",
+      "email": "packages@arduino.cc",
 
-  "platforms": [
-    PLATFORM_AVR,
-    PLATFORM_ARM,
-    PLATFORM_XXXXX,
-    PLATFORM_YYYYY,
-  ],
+      "platforms": [
+        PLATFORM_AVR,
+        PLATFORM_ARM,
+        PLATFORM_XXXXX,
+        PLATFORM_YYYYY,
+      ],
 
-  "tools": [
-    TOOLS_COMPILER_AVR,
-    TOOLS_UPLOADER_AVR,
-    TOOLS_COMPILER_ARM,
-    TOOLS_XXXXXXX,
-    TOOLS_YYYYYYY,
-  ],
-}
+      "tools": [
+        TOOLS_COMPILER_AVR,
+        TOOLS_UPLOADER_AVR,
+        TOOLS_COMPILER_ARM,
+        TOOLS_XXXXXXX,
+        TOOLS_YYYYYYY,
+      ],
+    }
 ```
 
 The metadata fields are:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
Some of the indentation of the example snippets in the package_index.json specification is inconsistent.

* **What is the new behavior?**
<!-- if this is a feature change -->
All indentation of example snippets in the package_index.json specification is consistent.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.