### PR TITLE
[skip changelog] Always mention "user directory" along with "sketchbook" in documentation

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -185,7 +185,7 @@ A hypothetical library named "Servo" that adheres to the specification follows:
 
 ## Working with multiple architectures
 
-Libraries placed in the user’s sketchbook folder (in the libraries/ subfolder) will be made available for all boards, which may include multiple different processor architectures. To provide architecture-specific code or optimizations, library authors can use the `ARDUINO_ARCH_XXX` preprocessor macro (`#define`), where XXX is the name of the architecture (as determined by the name of the folder containing it), e.g. `ARDUINO_ARCH_AVR` will be defined when compiling for AVR-based boards. For example,
+Libraries placed in the `libraries` subfolder of the sketchbook folder (AKA "user directory") will be made available for all boards, which may include multiple different processor architectures. To provide architecture-specific code or optimizations, library authors can use the `ARDUINO_ARCH_XXX` preprocessor macro (`#define`), where XXX is the name of the architecture (as determined by the name of the folder containing it), e.g. `ARDUINO_ARCH_AVR` will be defined when compiling for AVR-based boards. For example,
 
     #if defined(ARDUINO_ARCH_AVR)
       // AVR-specific code

--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -1,5 +1,5 @@
 This is the Arduino platform specification, for use with Arduino development software starting from the Arduino IDE 1.5.x series.<br>
-Platforms add support for new boards to the Arduino development software. They are installable either via [Boards Manager](package_index_json-specification.md) or manual installation to the *hardware* folder of Arduino's sketchbook folder.<br>
+Platforms add support for new boards to the Arduino development software. They are installable either via [Boards Manager](package_index_json-specification.md) or manual installation to the *hardware* folder of Arduino's sketchbook folder (AKA "user directory").<br>
 A platform may consist of as little as a single configuration file.
 
 ## Hardware Folders structure


### PR DESCRIPTION
Arduino IDE and Arduino Web Editor use the term "sketchbook", while Arduino CLI and Arduino Pro IDE use the term "user directory". In order for the documentation to be friendly to all users of Arduino's development software, both terms must be used in the documentation.

**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
In a couple places, the documentation uses only the term "sketchbook". Arduino IDE and Arduino Web Editor use the term "sketchbook", while Arduino CLI and Arduino Pro IDE use the term "user directory". In order for the documentation to be friendly to all users of Arduino's development software, both terms must be used.

* **What is the new behavior?**
<!-- if this is a feature change -->
"User directory" is always mentioned in conjunction with the use of the term "sketchbook" in the documentation.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No