### PR TITLE
[skip changelog] Document that use of auto-set build.board property results in warning

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -363,8 +363,8 @@ The **uno.name** property contains the human-friendly name of the board. This is
 the "Board Name" field of Arduino CLI's text output, or the "name" key of Arduino CLI's JSON output.
 
 The **uno.build.board** property is used to set a compile-time variable **ARDUINO\_{build.board}** to allow use of
-conditional code between `#ifdef`s. A **build.board** value is automatically generated if not defined. In this case the
-variable defined at compile time will be `ARDUINO_AVR_UNO`.
+conditional code between `#ifdef`s. If not defined, a **build.board** value is automatically generated and the Arduino
+development software outputs a warning. In this case the variable defined at compile time will be `ARDUINO_AVR_UNO`.
 
 The other properties will override the corresponding global properties when the user selects the board. These properties
 will be globally available, in other configuration files too, without the board ID prefix:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
Documentation of the auto-set property makes it sound like a convenience feature, with the `build.board` property only needed if you prefer a custom value for some reason. However, the resulting warning (`Warning: Board foo:bar:baz doesn't define a 'build.board' preference. Auto-set to: BAR_BAZ`) can cause confusion and act as a "red herring" for users of board definitions that don't define a `build.board` property.

* **What is the new behavior?**
<!-- if this is a feature change -->
The platform specification mentions that not defining a `build.board` property results in a warning.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No