### PR TITLE
[skip changelog] Remove inaccurate "3rd party" descriptions from documentation

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -1,4 +1,4 @@
-This is the specification for the 3rd party library format to be used with Arduino IDE 1.5.x onwards.
+This is the specification for the Arduino library format, to be used with Arduino IDE 1.5.x onwards.
 
 * rev.1 has been implemented starting with Arduino IDE version 1.5.3 (now superseded by rev.2)
 * rev.2 will be implemented starting from version Arduino IDE 1.5.6

--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -1,4 +1,4 @@
-This specification is a 3rd party hardware format to be used in Arduino development software starting from the Arduino IDE 1.5.x series.<br>
+This is the Arduino platform specification, for use with Arduino development software starting from the Arduino IDE 1.5.x series.<br>
 Platforms add support for new boards to the Arduino development software. They are installable either via [Boards Manager](package_index_json-specification.md) or manual installation to the *hardware* folder of Arduino's sketchbook folder.<br>
 A platform may consist of as little as a single configuration file.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The library and platform specifications are described as "3rd party", yet they apply to all libraries and platforms, including official ones.

* **What is the new behavior?**
<!-- if this is a feature change -->
The library and platform specifications aren't described as being for "3rd party".


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No