### PR TITLE
[skip changelog] Improve install script's check for conflicting installation in $PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -196,7 +196,7 @@ testVersion() {
 		CLI_REALPATH="$(cd -- "$(dirname -- "$CLI")" && pwd -P)"
 		LBINDIR_REALPATH="$(cd -- "$LBINDIR" && pwd -P)"
 		if [ "$CLI_REALPATH" != "$LBINDIR_REALPATH" ]; then
-			fail "An existing $PROJECT_NAME was found at $CLI. Please prepend "$LBINDIR" to your "'$PATH'" or remove the existing one."
+			echo "An existing $PROJECT_NAME was found at $CLI. Please prepend "$LBINDIR" to your "'$PATH'" or remove the existing one."
 		fi
 	fi
 

--- a/install.sh
+++ b/install.sh
@@ -191,8 +191,13 @@ testVersion() {
 	CLI="$(which $PROJECT_NAME)"
 	if [ "$?" = "1" ]; then
 		echo "$PROJECT_NAME not found. You might want to add "$LBINDIR" to your "'$PATH'
-	elif [ $CLI != "$LBINDIR/$PROJECT_NAME" ]; then
-		fail "An existing $PROJECT_NAME was found at $CLI. Please prepend "$LBINDIR" to your "'$PATH'" or remove the existing one."
+	else
+		# Convert to resolved, absolute paths before comparison
+		CLI_REALPATH="$(cd -- "$(dirname -- "$CLI")" && pwd -P)"
+		LBINDIR_REALPATH="$(cd -- "$LBINDIR" && pwd -P)"
+		if [ "$CLI_REALPATH" != "$LBINDIR_REALPATH" ]; then
+			fail "An existing $PROJECT_NAME was found at $CLI. Please prepend "$LBINDIR" to your "'$PATH'" or remove the existing one."
+		fi
 	fi
 
 	set -e


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

---
* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

---
* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The installation script's check for a conflicting prior installation in `$PATH` was prone to false positives. For example, any of these examples result in a spurious "An existing arduino-cli was found at..." error:

- Paths differ by a redundant slash in `$PATH`:
    ```sh
    $ export PATH="$PATH:$PWD/bin/"
    $ curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
    ..
    An existing arduino-cli was found at /home/foo/bin//arduino-cli. Please prepend /home/foo/bin to your $PATH or remove the existing one.
    Failed to install arduino-cli
    ```
- Paths differ by a redundant slash on custom installation path:
    ```sh
    $ export PATH="$PATH:$PWD/custom-path"
    $ curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR="$PWD/custom-path/" sh
    ...
    An existing arduino-cli was found at /home/foo/custom-path/arduino-cli. Please prepend /home/foo/custom-path/ to your $PATH or remove the existing one.
    Failed to install arduino-cli
    ```
- Use of relative paths:
    ```sh
    $ export PATH="$PATH:$PWD/relative-path"
    $ curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR="./relative-path" sh
    ...
    An existing arduino-cli was found at /home/foo/relative-path/arduino-cli. Please prepend ./relative-path to your $PATH or remove the existing one.
    Failed to install arduino-cli
    ```
- Symlink:
  ```sh
  $ export PATH="$PATH:/home/foo/symlink-path"
  $ ln -s "$PWD/bin" "/home/foo/symlink-path"
  $ curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
  ...
  An existing arduino-cli was found at /home/foo/symlink-path/arduino-cli. Please prepend /home/foo/bin to your $PATH or remove the existing one.
  Failed to install arduino-cli
  ```

When the check for conflicting installation in `$PATH` has a positive, a "Failed to install arduino-cli" error message is displayed, even though the installation was successful.

When the check for conflicting installation in `$PATH` has a positive, the script has exit status 1, even though this positive does not really represent an error.

---
* **What is the new behavior?**
<!-- if this is a feature change -->
The check for conflicting installation in `$PATH` is made more robust by comparing the resolved, absolute paths.

When the check for conflicting installation in `$PATH` has a positive, no confusing "Failed to install arduino-cli" error message is displayed.

When the check for conflicting installation in `$PATH` has a positive, it prints a helpful warning, but the script's exit status is 0.

---
* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
The script no longer returns exit status 1 when a conflicting installation in `$PATH` is detected. This is a breaking change for anyone relying on the previous behavior. However, I think this is unlikely.

---
* **Other information**:
<!-- Any additional information that could help the review process -->
If you want to test the modified script using the recommended installation method, the command is:
```
curl -fsSL https://raw.githubusercontent.com/per1234/arduino-cli/fix-install-script/install.sh | sh
```

---
My initial instinct for improving the comparison was to use the `-ef` [file test operator](https://www.tldp.org/LDP/abs/html/fto.html), but that is bash-specific while the install script specifies sh.

---
It didn't end up being relevant to this work, but I'll add the information here for future reference since I had trouble finding it: The original base for the install script is here: https://github.com/Masterminds/glide.sh/blob/master/get, not in the repository mentioned by the comment in the script.