### PR TITLE
[skip changelog] Use correct configuration for MkDocs pymdownx.magiclink extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,8 +42,8 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.magiclink:
       repo_url_shorthand: true
-      user: squidfunk
-      repo: mkdocs-material
+      user: arduino
+      repo: arduino-cli
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.superfences


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.


* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The [`pymdownx.magiclink`](https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/) Python-Markdown extension adds support for GitHub-style auto-linked issue/PR/commit/user references in the documentation. In order for the issue/PR/commit references to work correctly in the case where no repository is specified, the extension must be configured with the owner and repository name of the repository that is using it. As a result of not having been updated after it was copied, the extension was previously configured for the `squidfunk/mkdocs-material` repository, which would result in any references that didn't specify a repository to be relative to that repository, rather than `arduino/arduino-cli`.

For example, with the previous configuration, this Markdown:
```markdown
See issue #42 for details.
```
would result in a link to `https://github.com/squidfunk/mkdocs-material/issues/42` rather than the intended https://github.com/arduino/arduino-cli/issues/42.

similarly, this Markdown:
```markdown
The feature was added in e7638c7390fda8bb852688b21014ea392727ea67
```
would result in a link to `https://github.com/squidfunk/mkdocs-material/commit/e7638c7390fda8bb852688b21014ea392727ea67` rather than the intended https://github.com/arduino/arduino-cli/commit/e7638c7390fda8bb852688b21014ea392727ea67.

* **What is the new behavior?**
<!-- if this is a feature change -->
The `pymdownx.magiclink` extension is correctly configured for use in this repository.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.