### PR TITLE
[skip changelog] Disable date stamp in command line reference documentation

### DIFF
--- a/docsgen/main.go
+++ b/docsgen/main.go
@@ -29,6 +29,7 @@ func main() {
 	}
 
 	cli := cli.NewCommand()
+	cli.DisableAutoGenTag = true  // Disable addition of auto-generated date stamp
 	err := doc.GenMarkdownTree(cli, os.Args[1])
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature?

* **What is the current behavior?**
<!-- You can also link to an open issue here -->


* **What is the new behavior?**
<!-- if this is a feature change -->
By default, Cobra automatically adds a date stamp to the generated command line reference content. Having a date stamp is not necessarily a bad thing, though it's doubtful that it is useful enough to justify its presence. However, the formatting of this date stamp causes it to be shown as an item in the table of contents of each command reference page, inappropriately located under the "SEE ALSO" heading. This clutters up the documentation without providing any benefits at all.

---
![Clipboard01](https://user-images.githubusercontent.com/8572152/87251584-93271b80-c421-11ea-83a0-db7538e2890b.png)
---


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
Cobra has provided an option to disable the automatic insertion of the date stamp:  https://github.com/spf13/cobra/blob/master/doc/README.md#disableautogentag
This pull request uses that option to remove the date stamp from the command reference documentation.


* **Other information**:
<!-- Any additional information that could help the review process -->
You can see a demonstration of the generated docs after this change here:
https://per1234.github.io/arduino-cli/42.0/commands/arduino-cli/