### PR TITLE
[skip changelog] Mention ArduinoCore-API in the "Cores" section of the platform specification

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -407,6 +407,17 @@ or if the RTOS core is needed, to:
 In any case the contents of the selected core folder are compiled and the core folder path is added to the include files
 search path.
 
+#### ArduinoCore-API
+
+Although much of the implementation of a core is architecture-specific, the standardized core API and the hardware
+independent components should be the same for every Arduino platform. In order to free platform authors from the burden
+of individually maintaining duplicates of this common code, Arduino has published it in a dedicated repository from
+which it may easily be shared by all platforms. In addition to significantly reducing the effort required to write and
+maintain a core, ArduinoCore-API assists core authors in providing the unprecedented level of portability between
+platforms that is a hallmark of the Arduino project.
+
+See the [arduino/ArduinoCore-API repository](https://github.com/arduino/ArduinoCore-API) for more information.
+
 ### Core Variants
 
 Sometimes a board needs some tweaking on default core configuration (different pin mapping is a typical example). A core


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
[ArduinoCore-API](https://github.com/arduino/ArduinoCore-API) is an important resource for core authors, but they may not be aware of its existence. Aspiring platform authors are very likely to read the Arduino platform specification, but it contains no mention of ArduinoCore-API.

* **What is the new behavior?**
<!-- if this is a feature change -->
The existence and purpose of ArduinoCore-API is mentioned in the "Cores" section of the Arduino platform specification.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.