### PR TITLE
[skip changelog] Document library.properties precompiled field's "full" option

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -82,10 +82,20 @@ otherwise below, **all fields are required**. The available fields are:
 - **includes** - **(available from Arduino IDE 1.6.10)** (optional) a comma separated list of files to be added to the
   sketch as `#include <...>` lines. This property is used with the "Include library" command in the Arduino IDE. If the
   `includes` property is missing, all the header files (.h) on the root source folder are included.
-- **precompiled** - **(available from Arduino IDE 1.8.6/arduino-builder 1.4.0)** (optional) set to `true` to allow the
-  use of .a (archive) and .so (shared object) files. The .a/.so file must be located at `src/{build.mcu}` where
-  `{build.mcu}` is the architecture name of the target the file was compiled for. Ex: `cortex-m3` for the Arduino DUE.
-  The static library should be linked as an ldflag.
+- **precompiled** - **(available from Arduino IDE 1.8.6/arduino-builder 1.4.0)** (optional) enables support for .a
+  (archive) and .so (shared object) files. The .a/.so file must be located at `src/{build.mcu}` where `{build.mcu}` is
+  the architecture name of the target the file was compiled for. Ex: `cortex-m3` for the Arduino DUE. The static library
+  should be linked as an ldflag. The **precompiled** field has two supported values, which control how any source files
+  in the library are handled:
+  - true - Source files are always compiled. This is useful for "mixed" libraries, such as those that contain both open
+    source code and the precompiled binary of a closed source component. Support for "mixed" libraries was inadvertently
+    lost in Arduino IDE 1.8.12/arduino-builder 1.5.2/Arduino CLI 0.8.0, and returned in Arduino IDE
+    1.8.13/arduino-builder 1.5.3/Arduino CLI 0.11.0.
+  - full - **(available from Arduino IDE 1.8.13/arduino-builder 1.5.3/Arduino CLI 0.11.0)** If the library provides a
+    precompiled library for the board being compiled for, the source files will not be compiled. If no precompiled
+    library was provided for the selected board, source files are compiled as a fallback. This is useful for
+    precompiling the library to reduce compilation time for specific target hardware, but also providing support for
+    arbitrary boards by compiling the library on demand.
 - **ldflags** - **(available from Arduino IDE 1.8.6/arduino-builder 1.4.0)** (optional) the linker flags to be added.
   Ex: `ldflags=-lm`
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
Previously, the `precompiled` field of library.properties only supported one value: `true`. As it became apparent that there were two distinct use cases for this feature (https://github.com/arduino/arduino-builder/issues/353), it was necessary to add a new `full` option so that both use cases could be fully supported (https://github.com/arduino/arduino-cli/pull/611). However, the `full` option is not documented.

* **What is the new behavior?**
<!-- if this is a feature change -->
The `precompiled` field of library.properties' `full` value is documented in the appropriate section of the Arduino library specification.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.


* **Other information**:
<!-- Any additional information that could help the review process -->
The undocumented nature of this option was noted in https://github.com/arduino/arduino-cli/issues/754