### PR TITLE
Fix ARDUINO_LIB_DISCOVERY_PHASE automatic flag incompatiblity

### DIFF
--- a/legacy/builder/gcc_preproc_runner.go
+++ b/legacy/builder/gcc_preproc_runner.go
@@ -77,8 +77,6 @@ func prepareGCCPreprocRecipeProperties(ctx *types.Context, sourceFilePath *paths
 	// to create a /dev/null.d dependency file, which won't work.
 	cmd.Args = utils.Filter(cmd.Args, func(a string) bool { return a != "-MMD" })
 
-	cmd.Args = append(cmd.Args, "-DARDUINO_LIB_DISCOVERY_PHASE")
-
 	return cmd, nil
 }
 

--- a/legacy/builder/gcc_preproc_runner.go
+++ b/legacy/builder/gcc_preproc_runner.go
@@ -57,6 +57,7 @@ func GCCPreprocRunnerForDiscoveringIncludes(ctx *types.Context, sourceFilePath *
 
 func prepareGCCPreprocRecipeProperties(ctx *types.Context, sourceFilePath *paths.Path, targetFilePath *paths.Path, includes paths.PathList) (*exec.Cmd, error) {
 	properties := ctx.BuildProperties.Clone()
+	properties.Set("build.library_discovery_phase", "1")
 	properties.SetPath(constants.BUILD_PROPERTIES_SOURCE_FILE, sourceFilePath)
 	properties.SetPath(constants.BUILD_PROPERTIES_PREPROCESSED_FILE_PATH, targetFilePath)
 

--- a/legacy/builder/setup_build_properties.go
+++ b/legacy/builder/setup_build_properties.go
@@ -67,6 +67,7 @@ func (s *SetupBuildProperties) Run(ctx *types.Context) error {
 	buildProperties.Set("build.fqbn", ctx.FQBN.String())
 	buildProperties.Set("ide_version", ctx.ArduinoAPIVersion)
 	buildProperties.Set("runtime.os", properties.GetOSSuffix())
+	buildProperties.Set("build.library_discovery_phase", "0")
 
 	if ctx.OptimizeForDebug {
 		if buildProperties.ContainsKey("compiler.optimization_flags.debug") {


### PR DESCRIPTION
Previously we added `-DARDUINO_LIB_DISCOVERY_PHASE` to the gcc command line during the library discovery phase: unfortunately this has an incompatiblity with compilers using non-standard `-d` flag instead of `-D` as reported here: https://github.com/arduino/arduino-cli/pull/633#issuecomment-659529026

To fix this behaviour this PR adds a new build variable `{build.library_discovery_phase}` that is set to `1` during library discovery or to `0` during normal build.

The platforms that wants to use it may add in their `platform.txt` something like:

```
# to keep backward compatibility...
build.library_discovery_phase=0

# define -D flag for gcc
build.library_discovery_phase_flag=-DARDUINO_LIBRARY_DISCOVERY_PHASE={build.library_discovery_phase}
```

and use `{build.library_discovery_phase_flag}` inside the `gcc` command line.

This way the gcc command line is not altered and all the other platforms not interested in this change will remain unaffected.

/cc @fpistm @facchinm 