### PR TITLE
[skip changelog] Document compiler.libraries.ldflags property in platform specification

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -189,16 +189,23 @@ The recipe can be built concatenating the following automatically generated prop
 - `{archive_file_path}`: fully qualified archive file (ex. "/path/to/core.a"). This property was added in Arduino IDE
   1.6.6/arduino builder 1.0.0-beta12 as a replacement for `{build.path}/{archive_file}`.
 - `{archive_file}`: the name of the core archive file (ex. "core.a")
+- `{compiler.libraries.ldflags}`: the linking flags for precompiled libraries, which consist of automatically generated
+  `-L` flags for the library path and `-l` flags for library files, as well as any custom flags provided via the
+  `ldflags` field of library.properties. In order to support precompiled libraries, platform.txt must contain a
+  definition of `compiler.libraries.ldflags`, to which any automatically generated flags will be appended. Support for
+  precompiled libraries was added in Arduino IDE 1.8.6/arduino-builder 1.4.0.
 
 For example the following is used for AVR:
 
     compiler.c.elf.flags=-Os -Wl,--gc-sections
     compiler.c.elf.cmd=avr-gcc
 
+    compiler.libraries.ldflags=
+
     [......]
 
     ## Combine gc-sections, archives, and objects
-    recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} -o "{build.path}/{build.project_name}.elf" {object_files} "{archive_file_path}" "-L{build.path}" -lm
+    recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} -o "{build.path}/{build.project_name}.elf" {object_files} {compiler.libraries.ldflags} "{archive_file_path}" "-L{build.path}" -lm
 
 #### Recipes for extraction of executable files and other binary data
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
The Arduino platform specification provides no documentation for the precompiled libraries system.

* **What is the new behavior?**
<!-- if this is a feature change -->
Documentation on what is required for platforms to support precompiled libraries is provided by the platform specification.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.


* **Other information**:
<!-- Any additional information that could help the review process -->
I'm unsure on what the best approach is for documenting which recipes can use `{compiler.libraries.ldflags}` (and properties in general).  This property is only used by official platforms in `recipe.c.combine.pattern`, so I documented it in that section, but that gives the impression that it's only accessible in that recipe, which is not true. I don't know whether there is an application for it elsewhere, but anything is possible in the world of 3rd party platforms