### PR TITLE
[skip changelog] Document serial.port.file property

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -484,7 +484,9 @@ If the **upload.protocol** property is not defined for a board, the Arduino IDE'
 
 ### Serial port
 
-The port selected via the IDE or [`arduino-cli upload`](../commands/arduino-cli_upload)'s `--port` option is available as a configuration property **{serial.port}**.
+The full path (e.g., `/dev/ttyACM0`) of the port selected via the IDE or [`arduino-cli upload`](../commands/arduino-cli_upload)'s `--port` option is available as a configuration property **{serial.port}**.
+
+The file component of the port's path (e.g., `ttyACM0`) is available as the configuration property **{serial.port.file}**.
 
 ### Upload using an external programmer
 


### PR DESCRIPTION
Previously, only the serial.port property was documented. However, serial.port.file is in widespread use (e.g., Arduino SAMD Boards).

**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
Despite being in widespread use, the `{serial.port.file}` property is not mentioned in the Arduino platform specification.

* **What is the new behavior?**
<!-- if this is a feature change -->
The `{serial.port.file}` property is documented in the Arduino platform specification.


* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.