### PR TITLE
[skip changelog] Add link to library dependency resolution process docs from library specification

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -13,7 +13,8 @@ Arduino development software supports multiple microcontroller architectures (e.
 
 ## See also
 
-The Arduino library style guide is here : http://arduino.cc/en/Reference/APIStyleGuide
+* [Arduino library style guide](http://arduino.cc/en/Reference/APIStyleGuide)
+* [Library dependency resolution process documentation](../sketch-build-process/#dependency-resolution)
 
 ## 1.5 library format (rev. 2.2)
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.

* **What is the current behavior?**
<!-- You can also link to an open issue here -->
Many of the things documented in the library specification are used as determining factors in library dependency resolution. An understanding of how the components of a library influence dependency resolution priorities can be very helpful to a library developer. However, they might not think to look for valuable information about libraries in the "Sketch build process" documentation.

The "See also" section of the Arduino library specification consists of only a single link.

* **What is the new behavior?**
<!-- if this is a feature change -->
A link to the relevant section of the sketch build process documentation is provided by the Arduino library specification.

The "See also" section of the Arduino library specification is filled out a bit more.

* **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.


* **Other information**:
<!-- Any additional information that could help the review process -->
The link text "Library dependency resolution process documentation" is a bit long winded. If anyone has a suggestion for something shorter that still gets the point across, I'm glad to hear it.