### PR TITLE
Add Sentence field to lib list output

### DIFF
--- a/cli/lib/list.go
+++ b/cli/lib/list.go
@@ -90,7 +90,10 @@ func (ir installedResult) String() string {
 	}
 
 	t := table.New()
-	t.SetHeader("Name", "Installed", "Available", "Location", "Sentence")
+	t.SetHeader("Name", "Installed", "Available", "Location", "Description")
+	t.SetColumnWidthMode(1, table.Average)
+	t.SetColumnWidthMode(2, table.Average)
+	t.SetColumnWidthMode(4, table.Average)
 
 	lastName := ""
 	for _, libMeta := range ir.installedLibs {
@@ -115,7 +118,10 @@ func (ir installedResult) String() string {
 			sentence := lib.Sentence
 			if sentence == "" {
 				sentence = "-"
+			} else if len(sentence) > 40 {
+				sentence = sentence[:39] + "…"
 			}
+
 			t.AddRow(name, lib.Version, available, location, sentence)
 		}
 	}

--- a/cli/lib/list.go
+++ b/cli/lib/list.go
@@ -119,7 +119,7 @@ func (ir installedResult) String() string {
 			if sentence == "" {
 				sentence = "-"
 			} else if len(sentence) > 40 {
-				sentence = sentence[:39] + "…"
+				sentence = sentence[:37] + "..."
 			}
 
 			t.AddRow(name, lib.Version, available, location, sentence)

--- a/cli/lib/list.go
+++ b/cli/lib/list.go
@@ -90,7 +90,7 @@ func (ir installedResult) String() string {
 	}
 
 	t := table.New()
-	t.SetHeader("Name", "Installed", "Available", "Location")
+	t.SetHeader("Name", "Installed", "Available", "Location", "Sentence")
 
 	lastName := ""
 	for _, libMeta := range ir.installedLibs {
@@ -109,11 +109,14 @@ func (ir installedResult) String() string {
 
 		if libMeta.GetRelease() != nil {
 			available := libMeta.GetRelease().GetVersion()
-			if available != "" {
-				t.AddRow(name, lib.Version, available, location)
-			} else {
-				t.AddRow(name, lib.Version, "-", location)
+			if available == "" {
+				available = "-"
 			}
+			sentence := lib.Sentence
+			if sentence == "" {
+				sentence = "-"
+			}
+			t.AddRow(name, lib.Version, available, location, sentence)
 		}
 	}
 

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -46,7 +46,7 @@ def test_list(run_command):
     assert "" != toks[1]
     assert "" != toks[2]
     # Verifies library sentence
-    assert "An efficient and elegant JSON library for Arduino." == toks[4]
+    assert "An efficient and elegant JSON library f…" == toks[4]
 
     # Look at the JSON output
     result = run_command("lib list --format json")

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -46,7 +46,7 @@ def test_list(run_command):
     assert "" != toks[1]
     assert "" != toks[2]
     # Verifies library sentence
-    assert "An efficient and elegant JSON library f…" == toks[4]
+    assert "An efficient and elegant JSON library..." == toks[4]
 
     # Look at the JSON output
     result = run_command("lib list --format json")

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -39,10 +39,14 @@ def test_list(run_command):
     assert "" == result.stderr
     lines = result.stdout.strip().splitlines()
     assert 2 == len(lines)
-    toks = [t.strip() for t in lines[1].split()]
+    toks = [t.strip() for t in lines[1].split(maxsplit=4)]
+    # Verifies the expected number of field
+    assert 5 == len(toks)
     # be sure line contain the current version AND the available version
     assert "" != toks[1]
     assert "" != toks[2]
+    # Verifies library sentence
+    assert "An efficient and elegant JSON library for Arduino." == toks[4]
 
     # Look at the JSON output
     result = run_command("lib list --format json")


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Installed libraries' sentences are now shown in `arduino-cli lib list` output.

Now:
```shell
$ ./arduino-cli lib list
Name         Installed Available Location Sentence                                                                      
ArduinoJson  6.11.0    6.15.2    user     An efficient and elegant JSON library for Arduino.                            
AudioZero    1.1.1     -         user     Allows playing audio files from an SD card. For Arduino Zero and MKR1000 only.
Sodaq_HTS221 1.0.0     -         user     An Arduino library for the HTS221 sensor.                                     
```

Before:
```shell
$ ./arduino-cli lib list
Name         Installed Available Location
ArduinoJson  6.11.0    6.15.2    user
AudioZero    1.1.1     -         user
Sodaq_HTS221 1.0.0     -         user
```


---
See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
