### PR TITLE
[skip changelog] Fix test workflow not running when editing docs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - "docs/**"
-      - ".github/workflows/docs.yaml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - ".github/workflows/docs.yaml"
 
 jobs:
   test-matrix:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

So I've investigated the issue about the CI skip and the required Checks to merge PRs, I've made some tests in a separate repo.
In the `test.yaml` I've added the following config:

```    paths-ignore:
      - "docs/**"
      - ".github/workflows/docs.yaml"```

Both when pushing on `master` and PRs creation if only `docs.yaml` or anything inside the `docs` folder is modified the Workflow is not run at all.

We discovered that this is an issue because the repo is configured to require the 3 checks generated by the `test-matrix` job to merge a PR.

So I tried to skip conditionally the whole job `test-matrix`, problem is that the required checks are not on `test-matrix` but on `test-matrix (ubuntu-latest)`, `test-matrix (windows-latest)` and `test-matrix (macOS-latest)`; so GH still expects those checks.

Easy you might say, set `test-matrix` as required so we can skip the whole job. Nope, can't do because if the matrix is actually run the `test-matrix` check is never run.

So the only solution that I've come up is to skip every single step in `test-matrix` job, so that it's as if the whole test matrix is run, this way GH is happy because checks are passing.

This is the repo I've used for testing: https://github.com/silvanocerza/nodenode

We discussed several solutions but decided to keep it simple and avoid workarounds that might be hard to understand in the future, therefore we remove the `paths-ignore` for the test workflow and run the whole test matrix in any case.

---

See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
