### PR TITLE
[skip changelog] Add workflow to mirror issue on Jira to ease grooming

### DIFF
--- a/.github/workflows/jira-issue.yaml
+++ b/.github/workflows/jira-issue.yaml
@@ -1,0 +1,48 @@
+name: "Mirror new issue to Jira for grooming"
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  create-issue:
+    runs-on: ubuntu-latest
+
+  env:
+    JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+  steps:
+    - name: Installs Jira CLI
+      uses: atlassian/gajira-cli@master
+      with:
+        version: 1.0.23
+
+    - name: Create issue
+      run: |
+        jira create \
+        --noedit \
+        -e ${{ secrets.JIRA_BASE_URL }} \
+        -u ${{ secrets.JIRA_USER_EMAIL }} \
+        -p ${{ secrets.JIRA_PROJECT_CODE }} \
+        -i Task \
+        -o summary="${{ github.event.issues.issue.title }}" \
+        -o description="${{ github.event.issues.issue.body }}\n${{ github.event.issues.issue.html_url }}" \
+        >> output
+
+    - name: Set label on Jira issue
+      run: |
+        jira label add
+        $(cat output | awk '{split($0,a," "); print a[2]}')
+        grooming arduino-cli
+
+    - name: Set label on Github issue
+      uses: actions/github-script@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['tracked']
+          })


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
Whenever a new issue is created in this repository this new workflow is triggered, it creates a new issue on Jira with the same content as the GH one and add labels to both. This is done to ease grooming of new issues.

- **What is the current behavior?**
Newly created issues on Github are processed manully.

* **What is the new behavior?**
Newly created issues on Github are mirrored on Jira to ease grooming.

- **Does this PR introduce a breaking change?**
No.

* **Other information**:
None.
---

See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
