### PR TITLE
[skip changelog] Fix broken links in "How to contribute" documentation

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -347,6 +347,8 @@ If your PR doesn't need to be included in the changelog, please start the PR tit
 [10]: https://github.com/jimporter/mike
 [11]: https://github.com/arduino/arduino-cli/blob/master/.github/workflows/docs.yaml
 [12]: https://github.com/arduino/arduino-cli/blob/master/docs/build.py
+[poetry-website]: https://python-poetry.org/
+[poetry-docs]: https://python-poetry.org/docs/
 [prettier-website]: https://prettier.io/
 [prettier-vscode-extension]: https://github.com/prettier/prettier-vscode
 [npm-install-docs]: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm


### PR DESCRIPTION
The references for the Poetry website links were missing their URL definitions.

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation fix.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The references for the Poetry links CONTRIBUTING.md are missing URL definitions.
* **What is the new behavior?**
<!-- if this is a feature change -->
All links in CONTRIBUTING.md are working.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.