### PR TITLE
[skip changelog] Document build.library_discovery_phase property in platform specification

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -91,6 +91,12 @@ The following automatically generated properties can be used globally in all con
   `VENDOR:ARCHITECTURE:BOARD_ID[:MENU_ID=OPTION_ID[,MENU2_ID=OPTION_ID ...]]`
 - `{build.source.path}`: Path to the sketch being compiled. If the sketch is in an unsaved state, it will the path of
   its temporary folder.
+- `{build.library_discovery_phase}`: set to 1 during library discovery and to 0 during normal build. A macro defined
+  with this property can be used to disable the inclusion of heavyweight headers during discovery to reduce compilation
+  time. This property was added in Arduino IDE 1.8.14/Arduino Builder 1.6.0/Arduino CLI 0.12.0. Note: with the same
+  intent, `-DARDUINO_LIB_DISCOVERY_PHASE` was added to `recipe.preproc.macros` during library discovery in Arduino
+  Builder 1.5.3/Arduino CLI 0.10.0. That flag was replaced by the more flexible `{build.library_discovery_phase}`
+  property.
 - `{extra.time.utc}`: Unix time (seconds since 1970-01-01T00:00:00Z) according to the machine the build is running on
 - `{extra.time.local}`: Unix time with local timezone and DST offset
 - `{extra.time.zone}`: local timezone offset without the DST component


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The `build.library_discovery_phase` property is undocumented.
* **What is the new behavior?**
<!-- if this is a feature change -->
The `build.library_discovery_phase` property is documented in the Arduino platform specification.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.
* **Other information**:
<!-- Any additional information that could help the review process -->
Introduction of `ARDUINO_LIB_DISCOVERY_PHASE` macro: https://github.com/arduino/arduino-cli/pull/633
Introduction of `build.library_discovery_phase` property: https://github.com/arduino/arduino-cli/pull/838

Note: I am guessing that the next release versions will be:
- Arduino CLI: 0.12.0
- Arduino Builder: 1.6.0
- Arduino IDE; 1.8.14

If things go differently, the version numbers specified in this documentation will need to be corrected.