### PR TITLE
[skip changelog] Document automatic generation of recipe.preproc.macros

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -293,6 +293,8 @@ which will usually result in a permission error. Since platforms typically inclu
 includes `-MMD`, the `-MMD` option is automatically filtered out of the `recipe.preproc.macros` recipe to prevent this
 error.
 
+If **recipe.preproc.macros** is not defined, it is automatically generated from **recipe.cpp.o.pattern**.
+
 Note that older Arduino IDE versions used the **recipe.preproc.includes** recipe to determine includes, which is
 undocumented here. Since Arduino IDE 1.6.7 (arduino-builder 1.2.0) this was changed and **recipe.preproc.includes** is
 no longer used.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Despite being in widespread use, the builder's behavior of generating a default `recipe.preproc.macros` when the platform author doesn't define one is undocumented.
* **What is the new behavior?**
<!-- if this is a feature change -->
The builder's behavior of generating a default `recipe.preproc.macros` when not defined is documented in the Arduino platform specification.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
Reference: https://github.com/arduino/arduino-cli/blob/3775f51183dd8b40afa9f9b1b4bebcc1db7709cb/legacy/builder/gcc_preproc_runner.go#L67-L70
---

See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
