### PR TITLE
[skip changelog] Add previously undocumented global predefined properties to platform specification

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -84,6 +84,10 @@ The following automatically generated properties can be used globally in all con
   meaningless version number.
 - `{ide_version}`: Compatibility alias for `{runtime.ide.version}`
 - `{runtime.os}`: the running OS ("linux", "windows", "macosx")
+- `{build.fqbn}`: the FQBN (fully qualified board name) of the board being compiled for. The FQBN follows the format:
+  `VENDOR:ARCHITECTURE:BOARD_ID[:MENU_ID=OPTION_ID[,MENU2_ID=OPTION_ID ...]]`
+- `{build.source.path}`: Path to the sketch being compiled. If the sketch is in an unsaved state, it will the path of
+  its temporary folder.
 - `{extra.time.utc}`: Unix time (seconds since 1970-01-01T00:00:00Z) according to the machine the build is running on
 - `{extra.time.local}`: Unix time with local timezone and DST offset
 - `{extra.time.zone}`: local timezone offset without the DST component

--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -84,6 +84,10 @@ The following automatically generated properties can be used globally in all con
   meaningless version number.
 - `{ide_version}`: Compatibility alias for `{runtime.ide.version}`
 - `{runtime.os}`: the running OS ("linux", "windows", "macosx")
+- `{extra.time.utc}`: Unix time (seconds since 1970-01-01T00:00:00Z) according to the machine the build is running on
+- `{extra.time.local}`: Unix time with local timezone and DST offset
+- `{extra.time.zone}`: local timezone offset without the DST component
+- `{extra.time.dst}`: local daylight savings time offset
 
 Compatibility note: Versions before Arduino IDE 1.6.0 only used one digit per version number component in
 `{runtime.ide.version}` (so 1.5.9 was `159`, not `10509`).

--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -84,6 +84,9 @@ The following automatically generated properties can be used globally in all con
   meaningless version number.
 - `{ide_version}`: Compatibility alias for `{runtime.ide.version}`
 - `{runtime.os}`: the running OS ("linux", "windows", "macosx")
+- `{software}`: set to "ARDUINO"
+- `{name}`: platform vendor name
+- `{_id}`: [board ID](#boardstxt) of the board being compiled for
 - `{build.fqbn}`: the FQBN (fully qualified board name) of the board being compiled for. The FQBN follows the format:
   `VENDOR:ARCHITECTURE:BOARD_ID[:MENU_ID=OPTION_ID[,MENU2_ID=OPTION_ID ...]]`
 - `{build.source.path}`: Path to the sketch being compiled. If the sketch is in an unsaved state, it will the path of


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Some global predefined properties are undocumented:
- `{software}`
- `{name}`
- `{_id}`
- `{build.fqbn}`
- `{build.source.path}`
- `{extra.time.utc}`
- `{extra.time.local}`
- `{extra.time.zone}`
- `{extra.time.dst}`
* **What is the new behavior?**
<!-- if this is a feature change -->
The Arduino platform specification documents all global predefined properties.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No