### PR TITLE
[skip changelog] Add headings to delineate the platform referencing documentation

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -731,6 +731,12 @@ There is no limit to the number of custom menus that can be defined.
 
 ## Referencing another core, variant or tool
 
+The Arduino platform referencing system allows using components of other platforms in cases where it would otherwise be
+necessary to duplicate those components. This feature allows us to reduce the minimum set of files needed to define a
+new "hardware" to just the boards.txt file.
+
+### Core reference
+
 Inside the boards.txt we can define a board that uses a core provided by another vendor/maintainer using the syntax
 **VENDOR_ID:CORE_ID**. For example, if we want to define a board that uses the "arduino" core from the "arduino" vendor
 we should write:
@@ -750,19 +756,26 @@ The libraries from the referenced platform are used, thus there is no need to pr
 provided the list of available libraries are the sum of the 2 libraries where the referencing platform has priority over
 the referenced platform.
 
-In the same way we can use variants and tools defined on another platform:
+### Variant reference
+
+In the same way we can use a variant defined on another platform using the syntax **VENDOR_ID:VARIANT_ID**:
 
     [....]
     myboard.build.variant=arduino:standard
-    myboard.upload.tool=arduino:avrdude
-    myboard.bootloader.tool=arduino:avrdude
     [....]
-
-Using this syntax allows us to reduce the minimum set of files needed to define a new "hardware" to just the boards.txt
-file.
 
 Note that referencing a variant in another platform does _not_ inherit any properties from that platform's platform.txt
 (like referencing a core does).
+
+### Tool references
+
+Tool recipes defined in the platform.txt of other platforms can also be referenced using the syntax
+**VENDOR_ID:TOOL_ID**:
+
+    [....]
+    myboard.upload.tool=arduino:avrdude
+    myboard.bootloader.tool=arduino:avrdude
+    [....]
 
 ### Platform Terminology
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The platform referencing documentation content in the Arduino platform specification falls into four categories:

- general
- core
- variant
- tool

but it's not obvious where the content for each category began and ended.
* **What is the new behavior?**
<!-- if this is a feature change -->
The referencing documentation content is clearly separated into its areas of applicability.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.