### PR TITLE
[skip changelog] Pin platform versions used in integration tests

### DIFF
--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -26,8 +26,8 @@ def test_compile_without_fqbn(run_command):
     result = run_command("core update-index")
     assert result.ok
 
-    # Download latest AVR
-    result = run_command("core install arduino:avr")
+    # Install Arduino AVR Boards
+    result = run_command("core install arduino:avr@1.8.3")
     assert result.ok
 
     # Build sketch without FQBN
@@ -92,8 +92,8 @@ def test_output_flag_default_path(run_command, data_dir, working_dir):
     result = run_command("core update-index")
     assert result.ok
 
-    # Download latest AVR
-    result = run_command("core install arduino:avr")
+    # Install Arduino AVR Boards
+    result = run_command("core install arduino:avr@1.8.3")
     assert result.ok
 
     # Create a test sketch
@@ -114,8 +114,8 @@ def test_compile_with_sketch_with_symlink_selfloop(run_command, data_dir):
     result = run_command("core update-index")
     assert result.ok
 
-    # Download latest AVR
-    result = run_command("core install arduino:avr")
+    # Install Arduino AVR Boards
+    result = run_command("core install arduino:avr@1.8.3")
     assert result.ok
 
     sketch_name = "CompileIntegrationTestSymlinkSelfLoop"
@@ -168,8 +168,8 @@ def test_compile_and_upload_combo(run_command, data_dir, detected_boards):
     assert result.ok
 
     # Install required core(s)
-    result = run_command("core install arduino:avr")
-    result = run_command("core install arduino:samd")
+    result = run_command("core install arduino:avr@1.8.3")
+    result = run_command("core install arduino:samd@1.8.7")
     assert result.ok
 
     # Create a test sketch
@@ -228,8 +228,8 @@ def test_compile_blacklisted_sketchname(run_command, data_dir):
     result = run_command("core update-index")
     assert result.ok
 
-    # Download latest AVR
-    result = run_command("core install arduino:avr")
+    # Install Arduino AVR Boards
+    result = run_command("core install arduino:avr@1.8.3")
     assert result.ok
 
     sketch_name = "RCS"
@@ -251,11 +251,13 @@ def test_compile_without_precompiled_libraries(run_command, data_dir):
     url = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json"
     result = run_command("core update-index --additional-urls={}".format(url))
     assert result.ok
-    result = run_command("core install arduino:mbed --additional-urls={}".format(url))
+    # arduino:mbed 1.1.5 is incompatible with the Arduino_TensorFlowLite library
+    # see: https://github.com/arduino/ArduinoCore-nRF528x-mbedos/issues/93
+    result = run_command("core install arduino:mbed@1.1.4 --additional-urls={}".format(url))
     assert result.ok
-    result = run_command("core install arduino:samd --additional-urls={}".format(url))
+    result = run_command("core install arduino:samd@1.8.7 --additional-urls={}".format(url))
     assert result.ok
-    result = run_command("core install adafruit:samd --additional-urls={}".format(url))
+    result = run_command("core install adafruit:samd@1.6.0 --additional-urls={}".format(url))
     assert result.ok
 
     # Install pre-release version of Arduino_TensorFlowLite (will be officially released

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -107,7 +107,7 @@ def test_core_install_esp32(run_command, data_dir):
     url = "https://dl.espressif.com/dl/package_esp32_index.json"
     assert run_command("core update-index --additional-urls={}".format(url))
     # install 3rd-party core
-    assert run_command("core install esp32:esp32 --additional-urls={}".format(url))
+    assert run_command("core install esp32:esp32@1.0.4 --additional-urls={}".format(url))
     # create a sketch and compile to double check the core was successfully installed
     sketch_path = os.path.join(data_dir, "test_core_install_esp32")
     assert run_command("sketch new {}".format(sketch_path))


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The `test_compile_without_precompiled_libraries` integration test fails due to a release of the arduino:mbed platform that introduces an incompatibility with the Arduino_LSM9DS1 library used by that test. This failure has nothing to do with any change to Arduino CLI and doesn't indicate any problem with Arduino CLI, so it's not helpful.
* **What is the new behavior?**
<!-- if this is a feature change -->
Where appropriate, platforms used by tests are pinned. This fixes the spurious test failure.

In some integration tests, using the latest version of a platform is appropriate and useful. In those cases, the platform was not pinned.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.
* **Other information**:
<!-- Any additional information that could help the review process -->
References:
- https://github.com/arduino/arduino-cli/pull/877/checks?check_run_id=918309587#step:16:33
- https://github.com/arduino/ArduinoCore-nRF528x-mbedos/issues/93