### PR TITLE
[skip changelog] Format generated documentation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,7 @@ tasks:
       # we invoke `arduino-cli` like this instead of `./arduino-cli` to remove
       # the `./` chars from the examples
       - PATH=. arduino-cli ../docs/commands
+      - task: docs:format
 
   docs:gen:protobuf:
     desc: Generate markdown contents for protobuffers
@@ -19,6 +20,7 @@ tasks:
       - '{{ default "protoc" .PROTOC_BINARY }} --doc_out=./docs/rpc --doc_opt=markdown,monitor.md --proto_path=rpc ./rpc/monitor/*.proto'
       - '{{ default "protoc" .PROTOC_BINARY }} --doc_out=./docs/rpc --doc_opt=markdown,settings.md --proto_path=rpc ./rpc/settings/*.proto'
       - '{{ default "protoc" .PROTOC_BINARY }} --doc_out=./docs/rpc --doc_opt=markdown,debug.md --proto_path=rpc ./rpc/debug/*.proto'
+      - task: docs:format
 
   docs:gen:
     desc: Generate documentation files


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.
- **What is the current behavior?**
We now use Prettier to enforce a formatting standard on the Arduino CLI documentation. The generated documentation is not compliant with this standard, which causes some problems:

- Incorrect list formatting of gRPC reference's table of contents. Prettier uses a two space indent. Because the stock Python-Markdown renderer requires a four space indent for nested lists, it was necessary to start using the [`mdx_truly_sane_lists` extension](https://github.com/radude/mdx_truly_sane_lists) to support the Prettier indent size. The use of the extension caused the four space indent used in the generated gRPC interface documentation's nested lists to no longer be rendered.
  - Example from before mdx_truly_sane_lists: https://arduino.github.io/arduino-cli/latest/rpc/commands/
  - Example from after: https://arduino.github.io/arduino-cli/dev/rpc/commands/
- `task docs:check` fails when run after generating docs. 

<!-- You can also link to an open issue here -->
* **What is the new behavior?**
gRPC table of contents in the docs website is correctly rendered.

It's possible that inconsistent formatting could cause similar issues. By making the formatting of all the documentation consistent, we can be sure that a specific renderer will handle all the docs correctly.

Although the `task docs:check` failure could also have been fixed by excluding the generated documentation paths, the list formatting issue needed to be fixed anyway, and this PR happens to fix the check failure issue as well.

<!-- if this is a feature change -->

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No

* **Other information**:
<!-- Any additional information that could help the review process -->
Demonstration of deployment of docs after applying this change: https://per1234.github.io/arduino-cli/0.42/rpc/commands/