### PR TITLE
Change update --outdated flag to --show-outdated

### DIFF
--- a/cli/update/update.go
+++ b/cli/update/update.go
@@ -42,7 +42,7 @@ func NewCommand() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Run:     runUpdateCommand,
 	}
-	updateCommand.Flags().BoolVar(&updateFlags.showOutdated, "outdated", false, "Show outdated cores and libraries after index update")
+	updateCommand.Flags().BoolVar(&updateFlags.showOutdated, "show-outdated", false, "Show outdated cores and libraries after index update")
 	return updateCommand
 }
 

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -38,7 +38,7 @@ def test_update_showing_outdated(run_command):
     assert run_command("lib install ArduinoJson")
 
     # Verifies outdated cores and libraries are printed after updating indexes
-    result = run_command("update --outdated")
+    result = run_command("update --show-outdated")
     assert result.ok
     lines = [l.strip() for l in result.stdout.splitlines()]
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
Small feature change.

- **What is the current behavior?**
To show outdated cores and libraries after running `update` you must use the flag `--outdated`.

* **What is the new behavior?**
To show outdated cores and libraries after running `update` you must use the flag `--show-outdated`.

- **Does this PR introduce a breaking change?**
Not really.

---

See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
