### PR TITLE
[skip changelog] Remove unnecessary token input from Codecov upload steps of test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,43 +77,28 @@ jobs:
         run: task test-integration
 
       - name: Send unit tests coverage to Codecov
-        # Since secrets aren't available on forks, we only
-        # upload coverage on `push`. This might change if
-        # Codecov whitelists GitHub, lifting the need
-        # for a token.
         if: >
           matrix.operating-system == 'ubuntu-latest' &&
           github.event_name == 'push'
         uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage_unit.txt
           flags: unit
 
       - name: Send legacy tests coverage to Codecov
-        # Since secrets aren't available on forks, we only
-        # upload coverage on `push`. This might change if
-        # Codecov whitelists GitHub, lifting the need
-        # for a token.
         if: >
           matrix.operating-system == 'ubuntu-latest' &&
           github.event_name == 'push'
         uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage_legacy.txt
           flags: unit
 
       - name: Send integration tests coverage to Codecov
-        # Since secrets aren't available on forks, we only
-        # upload coverage on `push`. This might change if
-        # Codecov whitelists GitHub, lifting the need
-        # for a token.
         if: >
           matrix.operating-system == 'ubuntu-latest' &&
           github.event_name == 'push'
         uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage_integ.txt
           flags: integ

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
         if: >
           matrix.operating-system == 'ubuntu-latest' &&
           github.event_name == 'push'
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage_unit.txt
@@ -98,7 +98,7 @@ jobs:
         if: >
           matrix.operating-system == 'ubuntu-latest' &&
           github.event_name == 'push'
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage_legacy.txt
@@ -112,7 +112,7 @@ jobs:
         if: >
           matrix.operating-system == 'ubuntu-latest' &&
           github.event_name == 'push'
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage_integ.txt


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
An outdated version of the `codecov/codecov-action` GitHub Actions action is pinned in the `test` workflow. This outdated version imposes a requirement for an upload token. This token is defined by a repository secret, which causes two issues:
- The `test` workflow fails when run in forks of the repository because they are missing this secret. This spurious failure will cause confusion to contributors who are checking to be sure their contribution will pass CI.
- We are prevented from configuring the workflow to trigger on `pull_request` events because GitHub Actions disables secrets when a workflow is triggered by an event from a fork.

Modern versions of the `codecov/codecov-action` action do not require the token when used in public repositories.
* **What is the new behavior?**
<!-- if this is a feature change -->
The `v1` ref of the  `codecov/codecov-action` GitHub Actions action is specified by the `test` workflow. In addition to making the token unnecessary, this will also cause the workflow to automatically use the latest 1.x.x version of the action, so we will continue to benefit from the ongoing development work up to the point where any breaking changes cause them to do a major version bump.

The  `codecov/codecov-action` action's `token` input is not used in the `test` workflow, eliminating the workflow's dependence on repository secrets.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.