### PR TITLE
[skip changelog] Run CI workflows that are useful to contributors on pushes to any branch

### DIFF
--- a/.github/workflows/link-validation.yaml
+++ b/.github/workflows/link-validation.yaml
@@ -2,8 +2,6 @@ name: Verifies documentation links
 
 on:
   push:
-    branches:
-      - master
   pull_request:
   schedule:
     - cron: "0 3 * * 1" # Every Monday at 03:00

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,18 +1,6 @@
-name: docs
+name: publish-docs
 
 on:
-  pull_request:
-    paths:
-      # existing docs
-      - "docs/**"
-      # changes to the cli reference generator
-      - "docsgen/**"
-      # potential changes to commands documentation
-      - "cli/**"
-      # potential changes to gRPC documentation
-      - "rpc/**"
-      # changes to the workflow itself
-      - ".github/workflows/docs.yaml"
   push:
     branches:
       - master
@@ -24,10 +12,10 @@ on:
       - "docsgen/**"
       - "cli/**"
       - "rpc/**"
-      - ".github/workflows/docs.yaml"
+      - ".github/workflows/publish-docs.yaml"
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
 
     steps:
@@ -73,17 +61,10 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -r ./requirements_docs.txt
 
-      - name: Build docs website
-        # This runs on every PR to ensure the docs build is sane, these docs
-        # won't be published
-        if: github.event_name == 'pull_request'
-        run: task docs:build
-
       - name: Publish docs
         # Determine docs version for the commit pushed and publish accordingly using Mike.
         # Publishing implies creating a git commit on the gh-pages branch, we let
         # ArduinoBot own these commits.
-        if: github.event_name == 'push'
         run: |
           git config --global user.email "bot@arduino.cc"
           git config --global user.name "ArduinoBot"

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -2,8 +2,6 @@ name: "Lints Python code"
 
 on:
   push:
-    branches:
-      - master
     paths:
       - "**.py"
       - ".flake8"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,8 +2,6 @@ name: test
 
 on:
   push:
-    branches:
-      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/validate-docs.yaml
+++ b/.github/workflows/validate-docs.yaml
@@ -1,0 +1,74 @@
+name: validate-docs
+
+on:
+  pull_request:
+    paths:
+      # existing docs
+      - "docs/**"
+      # changes to the cli reference generator
+      - "docsgen/**"
+      # potential changes to commands documentation
+      - "cli/**"
+      # potential changes to gRPC documentation
+      - "rpc/**"
+      # changes to the workflow itself
+      - ".github/workflows/validate-docs.yaml"
+  push:
+    # At this day, GitHub doesn't support YAML anchors, d'oh!
+    paths:
+      - "docs/**"
+      - "docsgen/**"
+      - "cli/**"
+      - "rpc/**"
+      - ".github/workflows/validate-docs.yaml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Taskfile
+        uses: Arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v2-beta
+        with:
+          go-version: "1.14"
+
+      - name: Install Go dependencies
+        run: |
+          go version
+          go get -u github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
+
+      - name: Install protoc compiler
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.6"
+          architecture: "x64"
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r ./requirements_docs.txt
+
+      - name: Build docs website
+        # Ensure the docs build is sane, these docs won't be published
+        run: task docs:build


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Contributors should run CI in their feature branch to make sure it's passing before submitting a PR. However, the CI workflows are configured to run only on pushes to the `master` branch, meaning that contributors need to modify the workflows just to get them to run on a feature branch. It's very unlikely that a contributor would do that, so they are more likely to just submit the PR, then if CI on the PR fails push fixup commits until CI is passing.
* **What is the new behavior?**
<!-- if this is a feature change -->
Workflows that are useful to contributors are configured to be triggered by pushes to any branch.

The `docs` workflow had two distinct uses:
- Check that changes to docs don't break the static website build system
- Publish the docs to the website

Only the first use is of interest to contributors, so it was easiest to split that workflow into two, and only configure the validation workflow to run on pushes to any branch.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
The current `test` workflow fails when run in a fork, which will be more likely to occur after the change made in this PR. That issue is fixed by https://github.com/arduino/arduino-cli/pull/886