### PR TITLE
[skip changelog] Disable scheduled workflows that would always fail from running in forks

### DIFF
--- a/.github/workflows/arduino-stats.yaml
+++ b/.github/workflows/arduino-stats.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   push-stats:
+    # This workflow is only of value to the arduino/arduino-cli repository and
+    # would always fail in forks
+    if: github.repository == 'arduino/arduino-cli'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/github-stats.yaml
+++ b/.github/workflows/github-stats.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   push-stats:
+    # This workflow is only of value to the arduino/arduino-cli repository and
+    # would always fail in forks
+    if: github.repository == 'arduino/arduino-cli'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/i18n-nightly-push.yaml
+++ b/.github/workflows/i18n-nightly-push.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   push-to-transifex:
+    # This workflow is only of value to the arduino/arduino-cli repository and
+    # would always fail in forks
+    if: github.repository == 'arduino/arduino-cli'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/i18n-weekly-pull.yaml
+++ b/.github/workflows/i18n-weekly-pull.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   pull-from-transifex:
+    # This workflow is only of value to the arduino/arduino-cli repository and
+    # would always fail in forks
+    if: github.repository == 'arduino/arduino-cli'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/link-validation.yaml
+++ b/.github/workflows/link-validation.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   verify-links:
+    # Don't trigger on schedule event when in a fork
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'arduino/arduino-cli')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   create-nightly-artifacts:
+    # This workflow is only of value to the arduino/arduino-cli repository and
+    # would always fail in forks
+    if: github.repository == 'arduino/arduino-cli'
     runs-on: ubuntu-latest
 
     container:


### PR DESCRIPTION
These workflows use resources that are only available when run in the arduino/arduino-cli repository, so would always fail when they run in a repository. They are of no value to fork repositories. They are triggered by the schedule event, so they cause regular annoying and confusing workflow failure notifications for every fork owner.

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
It's extremely annoying to have a fork of this workflow with GitHub Actions workflows enabled because there are multiple workflows that are triggered by `schedule` events which rely on secrets that are only defined when run in the upstream repository. This causes the fork owner to get lots of notifications of failed workflow runs.
* **What is the new behavior?**
<!-- if this is a feature change -->
Scheduled workflows of no value to contributors are configured to only run when in the `arduino/arduino-cli` repository.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.