### PR TITLE
Use v1 ref of arduino/setup-protoc action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -50,7 +50,7 @@ jobs:
           go get -u github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
 
       - name: Install protoc compiler
-        uses: arduino/setup-protoc@v1.1.0
+        uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/link-validation.yaml
+++ b/.github/workflows/link-validation.yaml
@@ -31,7 +31,7 @@ jobs:
         run: go get -u github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
 
       - name: Install protoc compiler
-        uses: arduino/setup-protoc@v1.1.0
+        uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
         run: task check
 
       - name: Install protoc compiler
-        uses: arduino/setup-protoc@v1.1.0
+        uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
CI workflows use the `v1.0.0` ref of the [`arduino/setup-protoc` action](https://github.com/arduino/setup-protoc). This presents two issues:
- Because that version of the action is missing metadata for its `repo-token` input, an  `Unexpected input(s) 'repo-token', valid inputs are ['version']` warning is displayed in every workflow run summary, which could result in confusion for contributors.
- Pinning to a specific version results in either not benefiting from ongoing development, or the need to update the workflows on every release.

* **What is the new behavior?**
<!-- if this is a feature change -->
The `v1` ref of the action is specified, which has two benefits:
- The "unexpected input" warning is no longer displayed in the workflow run summaries.
- The workflow will automatically use any minor or patch releases of the action, but will require manual updating in the event that breaking changes result in a major version release.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.