### PR TITLE
[skip changelog] Update broken or outdated references to docs workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ tools needed to use any Arduino compatible board and platforms.
 
 [![tests-badge]](https://github.com/Arduino/arduino-cli/actions?workflow=test)
 [![nightly-badge]](https://github.com/Arduino/arduino-cli/actions?workflow=nightly)
-[![docs-badge]](https://github.com/Arduino/arduino-cli/actions?workflow=docs)
+[![docs-badge]](https://github.com/Arduino/arduino-cli/actions?workflow=publish-docs)
 [![codecov-badge]](https://codecov.io/gh/arduino/arduino-cli)
 
 > **Note:** this software is currently under active development: anything can change at any time, API and UI must be
@@ -42,7 +42,7 @@ e-mail contact: security@arduino.cc
 
 [tests-badge]: https://github.com/Arduino/arduino-cli/workflows/test/badge.svg
 [nightly-badge]: https://github.com/Arduino/arduino-cli/workflows/nightly/badge.svg
-[docs-badge]: https://github.com/Arduino/arduino-cli/workflows/docs/badge.svg
+[docs-badge]: https://github.com/Arduino/arduino-cli/workflows/publish-docs/badge.svg
 [codecov-badge]: https://codecov.io/gh/arduino/arduino-cli/branch/master/graph/badge.svg
 [install]: https://arduino.github.io/arduino-cli/installation
 [user documentation]: https://arduino.github.io/arduino-cli/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -281,7 +281,7 @@ case of failures we might ask you to update the PR with correct formatting.
 ### Docs automation
 
 In order to avoid unwanted changes to the public website hosting the Arduino CLI documentation, only Mike is allowed to
-push changes to the `gh-pages` branch, and this only happens from within the CI, in a workflow named [docs][11].
+push changes to the `gh-pages` branch, and this only happens from within the CI, in a workflow named [publish-docs][11].
 
 The CI is responsible for guessing which version of the Arduino CLI we're building docs for, so that generated contents
 will be stored in the appropriate section of the documentation website. Because this guessing might be fairly complex,
@@ -344,7 +344,7 @@ If your PR doesn't need to be included in the changelog, please start the PR tit
 [7]: https://pages.github.com/
 [9]: https://www.mkdocs.org/
 [10]: https://github.com/jimporter/mike
-[11]: https://github.com/arduino/arduino-cli/blob/master/.github/workflows/docs.yaml
+[11]: https://github.com/arduino/arduino-cli/blob/master/.github/workflows/publish-docs.yaml
 [12]: https://github.com/arduino/arduino-cli/blob/master/docs/build.py
 [prettier-website]: https://prettier.io/
 [prettier-vscode-extension]: https://github.com/prettier/prettier-vscode


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The docs workflow was split into two workflows: publish-docs and validate-docs, but the references to the original workflow were not updated. This resulted in two problems:
- The "docs" badge in the readme won't reflect the true state of the documentation publishing system
- Broken link in CONTRIBUTING.md


* **What is the new behavior?**
<!-- if this is a feature change -->
All references to the `docs` workflow have been updated to point to the `publish-docs` workflow.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
