### PR TITLE
Git-ignore the `arduino-cli.exe` on Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /debug
-/arduino-cli
+/arduino-cli*
 /main
 /.vscode/
 /cmd/formatter/debug.test


### PR DESCRIPTION
When I build the CLI on Windows, I do not want to see the executable as
an outgoing Git change. Same as on POSIX.

Running `git check-ignore -v arduino-cli` on macOS shows which line is used to ignore the executable:
```
.gitignore:2:/arduino-cli	arduino-cli
```

This PR adjusts the `.gitignore` file, to improve the contributing experience for Windows devs.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Feature.

- **What is the current behavior?**
<!-- You can also link to an open issue here -->

When I run `go build` on Windows, I have a git outgoing change.

* **What is the new behavior?**
<!-- if this is a feature change -->

After building the CLI from the sources, and running `git status -s` it returns with nothing. Previously, it was:
```
git status -s
?? arduino-cli.exe
```

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->

No.

* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)