### PR TITLE
[skip changelog] fix docs links pointing to an older version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,8 @@
 
 - [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
       before creating one)
-- [ ] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
+- [ ] The PR follows
+      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 
@@ -23,4 +24,4 @@
 
 ---
 
-See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
+See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ e-mail contact: security@arduino.cc
 [nightly-badge]: https://github.com/Arduino/arduino-cli/workflows/nightly/badge.svg
 [docs-badge]: https://github.com/Arduino/arduino-cli/workflows/publish-docs/badge.svg
 [codecov-badge]: https://codecov.io/gh/arduino/arduino-cli/branch/master/graph/badge.svg
-[install]: https://arduino.github.io/arduino-cli/installation
-[user documentation]: https://arduino.github.io/arduino-cli/
-[getting started]: https://arduino.github.io/arduino-cli/getting-started/
-[commands reference]: https://arduino.github.io/arduino-cli/commands/arduino-cli
-[faq]: https://arduino.github.io/arduino-cli/FAQ/
-[how to contribute]: https://arduino.github.io/arduino-cli/CONTRIBUTING/
+[install]: https://arduino.github.io/arduino-cli/latest/installation
+[user documentation]: https://arduino.github.io/arduino-cli/latest/
+[getting started]: https://arduino.github.io/arduino-cli/latest/getting-started/
+[commands reference]: https://arduino.github.io/arduino-cli/latest/commands/arduino-cli
+[faq]: https://arduino.github.io/arduino-cli/latest/FAQ/
+[how to contribute]: https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/
 [contributors]: https://github.com/arduino/arduino-cli/graphs/contributors
 [security policy]: https://github.com/arduino/arduino-cli/security/policy


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Readme and template for PR have links pointing to an older version of the documentation
* **What is the new behavior?**
<!-- if this is a feature change -->

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->

* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/CONTRIBUTING/)
