### PR TITLE
Fix tools tty detection (fix avrdude running in safe mode)

### DIFF
--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -377,8 +377,6 @@ func runTool(recipeID string, props *properties.Map, outStream, errStream io.Wri
 		return fmt.Errorf("cannot execute upload tool: %s", err)
 	}
 
-	executils.AttachStdoutListener(cmd, executils.PrintToStdout)
-	executils.AttachStderrListener(cmd, executils.PrintToStderr)
 	cmd.Stdout = outStream
 	cmd.Stderr = errStream
 

--- a/executils/executils.go
+++ b/executils/executils.go
@@ -81,5 +81,12 @@ func Command(args []string) (*exec.Cmd, error) {
 	}
 	cmd := exec.Command(args[0], args[1:]...)
 	TellCommandNotToSpawnShell(cmd)
+
+	// This is required because some tools detects if the program is running
+	// from terminal by looking at the stdin/out bindings.
+	// https://github.com/arduino/arduino-cli/issues/844
+	cmd.Stdout = NullWriter
+	cmd.Stderr = NullWriter
+	cmd.Stdin = NullReader
 	return cmd, nil
 }

--- a/executils/executils.go
+++ b/executils/executils.go
@@ -85,8 +85,6 @@ func Command(args []string) (*exec.Cmd, error) {
 	// This is required because some tools detects if the program is running
 	// from terminal by looking at the stdin/out bindings.
 	// https://github.com/arduino/arduino-cli/issues/844
-	cmd.Stdout = NullWriter
-	cmd.Stderr = NullWriter
 	cmd.Stdin = NullReader
 	return cmd, nil
 }

--- a/executils/null.go
+++ b/executils/null.go
@@ -1,0 +1,36 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package executils
+
+import "io"
+
+// NullReader is an io.Reader that will always return EOF
+var NullReader = &nullReader{}
+
+type nullReader struct{}
+
+func (r *nullReader) Read(buff []byte) (int, error) {
+	return 0, io.EOF
+}
+
+// NullWriter is an io.Writer that discards any output
+var NullWriter = &nullWriter{}
+
+type nullWriter struct{}
+
+func (r *nullWriter) Write(buff []byte) (int, error) {
+	return len(buff), nil
+}


### PR DESCRIPTION
Some tools detects if the program is running from terminal by looking at the stdin/out bindings.
Previously stdin wasn't bound to any custom stream, this fact lead `avrdude` to think it was run from terminal (instead of a script) and start it in "safe-mode". This turn out to be a problem in some cases, see #844 

From the avrdude source code:

```
  if (isatty(STDIN_FILENO) == 0)
      safemode  = 0;       /* Turn off safemode if this isn't a terminal */
```

So we need to ensure that `isatty(STDIN_FILENO)` returns `0` when we run tools.
I've tried to run the following test program:

```c
#include <stdio.h>
#include <unistd.h>
#include <io.h>

int main(void) {
    printf("%d\n", isatty(STDIN_FILENO));
    return 0;
}
```

compiled with:

```
x86_64-pc-cygwin-gcc test.c -o test-cygwin
```

and 

```
i686-w64-mingw32-gcc test.c -o test-mingw32
```

using the following launcher in go:

```go
func main() {
	cmd, err := executils.Command([]string{"test-cygwin.exe"})
	if err != nil {
		log.Fatalf("cannot execute upload tool: %s", err)
	}

	var o, e bytes.Buffer
	outStream := bufio.NewWriter(&o)
	errStream := bufio.NewWriter(&e)
	inStream := bufio.NewReader(&o)
	cmd.Stdout = outStream
	cmd.Stderr = errStream
	cmd.Stdin = inStream      // <---
	if err := cmd.Start(); err != nil {
		log.Fatalf("cannot execute upload tool: %s", err)
	}

	err = cmd.Wait()
	fmt.Println(o.String())
	if err != nil {
		log.Fatalf("uploading error: %s", err)
	}
}
```

I tried with and without the `cmd.Stdin = inStream`:
- the `cygwin` build is unaffected it always returns `0`
- the `mingw32` build instead returns `64` without the stdin redirect and `0` with the stdin redirect.

This makes me think that `avrdude` has been built with `mingw32` and this PR should fix the issue, but a direct test is required.

Fix: #844
