### PR TITLE
[skip changelog] Prevent Prettier from wrapping nightly download link definitions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,10 +84,12 @@ to get the latest nightly build available for the supported platform, use the fo
 
 [nightly linux 64 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_64bit.tar.gz
 [nightly linux 32 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_32bit.tar.gz
-[nightly linux arm 64 bit]:
-  https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_ARM64.tar.gz
-[nightly linux arm 32 bit]:
-  https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_ARMv7.tar.gz
+
+<!-- prettier-ignore -->
+[nightly linux arm 64 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_ARM64.tar.gz
+
+<!-- prettier-ignore -->
+[nightly linux arm 32 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_ARMv7.tar.gz
 [nightly windows 64 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Windows_64bit.zip
 [nightly windows 32 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Windows_32bit.zip
 [nightly mac osx]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_macOS_64bit.tar.gz


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Prettier is configured to wrap lines in Markdown files at 120 characters. The reference definitions for the [nightly ARM download links](https://arduino.github.io/arduino-cli/dev/installation/#nightly-builds) happen to be longer than 120 characters, and so get wrapped.

With the modern Markdown specification, this is permitted:
https://spec.commonmark.org/0.29/#link-reference-definitions

> A link reference definition consists of a link label, indented up to three spaces, followed by a colon (:), optional whitespace (including up to one line ending), a link destination

but apparently the Python-Markdown renderer used by MkDocs does not support this, so these links are broken.

* **What is the new behavior?**
<!-- if this is a feature change -->
The links are fixed by remove the line breaks added by Prettier and add markup to instruct Prettier to ignore these lines so the auto formatter won't reintroduce the issue:
https://prettier.io/docs/en/ignore.html#markdown

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.