### PR TITLE
Fix board list failing because stdin is already set

### DIFF
--- a/commands/bundled_tools_serial_discovery.go
+++ b/commands/bundled_tools_serial_discovery.go
@@ -138,6 +138,7 @@ func ListBoards(pm *packagemanager.PackageManager) ([]*BoardPort, error) {
 	}
 
 	// attach in/out pipes to the process
+	cmd.Stdin = nil
 	in, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, fmt.Errorf("creating stdin pipe for discovery: %s", err)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
Fixes `board list` always failing.

- **What is the current behavior?**
`board list` fails.

* **What is the new behavior?**
`board list` doesn't fail.

- **Does this PR introduce a breaking change?**
Nope.

* **Other information**:
No other info.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
