### PR TITLE
Package index is now downloaded automatically when is required

### DIFF
--- a/test/test_board.py
+++ b/test/test_board.py
@@ -449,5 +449,5 @@ def test_board_details_no_flags(run_command):
     assert result.ok
     result = run_command("board details")
     assert not result.ok
-    assert "Error getting board details: parsing fqbn: invalid fqbn:"
+    assert "Error getting board details: parsing fqbn: invalid fqbn:" in result.stderr
     assert result.stdout == ""

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -99,6 +99,14 @@ def test_core_updateindex_invalid_url(run_command):
     assert result.failed
 
 
+def test_core_install_without_updateindex(run_command):
+    # Missing "core update-index"
+    # Download samd core pinned to 1.8.6
+    result = run_command("core install arduino:samd@1.8.6")
+    assert result.ok
+    assert "Updating index: package_index.json downloaded" in result.stdout
+
+
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="core fails with fatal error: bits/c++config.h: No such file or directory",
 )


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
update

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
When users run a command requiring `package_index.json` to be already there (for example `core install arduino:samd@1.8.6`) the CLI was giving this error: `Error installing: There were errors loading platform indexes`
https://github.com/arduino/arduino-cli/issues/792

* **What is the new behavior?**
<!-- if this is a feature change -->
Now it should download automatically the `package_index.json` when it's not already in place and it is required by the command the user is running.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no, the user can still use `core update-index`

* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
