### PR TITLE
Allow post_install for untrusted platforms

### DIFF
--- a/commands/core/install.go
+++ b/commands/core/install.go
@@ -140,7 +140,7 @@ func installPlatform(pm *packagemanager.PackageManager,
 	}
 
 	// Perform post install
-	if !skipPostInstall && platformRelease.IsTrusted {
+	if !skipPostInstall {
 		log.Info("Running post_install script")
 		taskCB(&rpc.TaskProgress{Message: "Configuring platform (post_install run)"})
 		if err := pm.RunPostInstallScript(platformRelease); err != nil {


### PR DESCRIPTION
Follows https://github.com/arduino/arduino-cli/pull/893#issuecomment-673556652

> Does it really add anything to add an isTrusted flag here? AFAICS, an "untrusted" platform can still provide custom compiler binaries and compiler commands in platform.txt, so this trusted flag would only prevent running untrusted code at platform install time, as soon as you actually use the platform to compile a sketch, untrusted code will be ran in any case?

/cc @luigigubello @rsora 