### PR TITLE
If installer can't run post_install do not give up

### DIFF
--- a/commands/core/install.go
+++ b/commands/core/install.go
@@ -146,7 +146,7 @@ func installPlatform(pm *packagemanager.PackageManager,
 		if err := pm.RunPostInstallScript(platformRelease); err != nil {
 			return errors.Errorf("running post install: %s", err)
 		}
-	} else if skipPostInstall {
+	} else {
 		log.Info("Skipping platform configuration (post_install run).")
 		taskCB(&rpc.TaskProgress{Message: "Skipping platform configuration"})
 	}

--- a/commands/core/install.go
+++ b/commands/core/install.go
@@ -144,7 +144,7 @@ func installPlatform(pm *packagemanager.PackageManager,
 		log.Info("Running post_install script")
 		taskCB(&rpc.TaskProgress{Message: "Configuring platform"})
 		if err := pm.RunPostInstallScript(platformRelease); err != nil {
-			return errors.Errorf("running post install: %s", err)
+			taskCB(&rpc.TaskProgress{Message: fmt.Sprintf("WARNING: cannot run post install: %s", err)})
 		}
 	} else {
 		log.Info("Skipping platform configuration (post_install run).")

--- a/commands/core/install.go
+++ b/commands/core/install.go
@@ -142,13 +142,13 @@ func installPlatform(pm *packagemanager.PackageManager,
 	// Perform post install
 	if !skipPostInstall {
 		log.Info("Running post_install script")
-		taskCB(&rpc.TaskProgress{Message: "Configuring platform (post_install run)"})
+		taskCB(&rpc.TaskProgress{Message: "Configuring platform"})
 		if err := pm.RunPostInstallScript(platformRelease); err != nil {
 			return errors.Errorf("running post install: %s", err)
 		}
 	} else if skipPostInstall {
 		log.Info("Skipping platform configuration (post_install run).")
-		taskCB(&rpc.TaskProgress{Message: "Skipping platform configuration (post_install run)"})
+		taskCB(&rpc.TaskProgress{Message: "Skipping platform configuration"})
 	}
 
 	log.Info("Platform installed")


### PR DESCRIPTION
This PR:

* change the post_install error into a warning from
```
Error during install: running post install: fork/exec /home/alien/.arduino15/packages/sensebox/hardware/samd/1.1.2/post_install.sh: permission denied
```
to
```
WARNING: cannot run post install: fork/exec /home/alien/.arduino15/packages/sensebox/hardware/samd/1.1.2/post_install.sh: permission denied
```

* make some small tweaks to other messages.