### PR TITLE
[skip changelog] Fix contributing instructions re: skipping changelog

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -332,7 +332,8 @@ If you need to push a commit that's only shipping documentation changes or examp
 test suite, please start the commit message with the string **[skip ci]** to skip the build and give that slot to
 someone else who does need it.
 
-If your PR doesn't need to be included in the changelog, please start the PR title with the string **[skip changelog]**
+If your PR doesn't need to be included in the changelog, please start the commit message and PR title with the string
+**[skip changelog]**
 
 [0]: https://cla-assistant.io/arduino/arduino-cli
 [1]: https://golang.org/doc/install


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The arduino/arduino-cli repository's automatic changelog generation system adds a changelog item for every commit, except those that start with "[skip changelog]". This is useful for keeping the changelog to only mentioning the changes that are significant to the user.

All pull requests are merged using GitHub's "Squash & Merge" feature.

The behavior of "Squash & Merge":

- If the PR only contains a single commit, the pre-filled squash commit message is taken from the commit, not the PR.
- If the PR contains multiple commits, the prefilled squash commit title is the PR title.

This means that a PR will end up in the changelog against the wishes of the contributor when all of the following occur:

- The PR author followed the instructions and only added "[skip changelog]" to the PR title.
- The PR only contains a single commit.
- The maintainer who merges the PR uses the pre-filled commit message provided by GitHub.

The first two conditions are common. There is evidence that the third will also be common.
* **What is the new behavior?**
<!-- if this is a feature change -->
To make the instructions as easy as possible to follow, the contributor is now instructed to add "[skip changelog]" to both the commit message and PR title, even though it is really only necessary to add it to one or the other, depending on the conditions.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No