### PR TITLE
[skip changelog] Specify list format for --additional-urls option

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -106,7 +106,7 @@ func createCliCommandTree(cmd *cobra.Command) {
 	viper.BindPFlag("logging.format", cmd.PersistentFlags().Lookup("log-format"))
 	cmd.PersistentFlags().StringVar(&outputFormat, "format", "text", "The output format, can be {text|json}.")
 	cmd.PersistentFlags().StringVar(&configFile, "config-file", "", "The custom config file (if not specified the default will be used).")
-	cmd.PersistentFlags().StringSlice("additional-urls", []string{}, "Additional URLs for the board manager.")
+	cmd.PersistentFlags().StringSlice("additional-urls", []string{}, "Comma-separated list of additional URLs for the board manager.")
 	viper.BindPFlag("board_manager.additional_urls", cmd.PersistentFlags().Lookup("additional-urls"))
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
In order to specify multiple Boards Manager URLs via a single `--additional-urls` option, they must be in a comma-separated list. However, this is not at all clear from the current documentation:
>--additional-urls strings   Additional URLs for the board manager.

* **What is the new behavior?**
<!-- if this is a feature change -->
The format of of the list of URLs passed via the `--additional-urls` option is documented.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No