### PR TITLE
[skip changelog] Clarify in documentation that the upload command will not compile beforehand

### DIFF
--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -45,7 +45,7 @@ func NewCommand() *cobra.Command {
 	uploadCommand := &cobra.Command{
 		Use:     "upload",
 		Short:   "Upload Arduino sketches.",
-		Long:    "Upload Arduino sketches.",
+		Long:    "Upload Arduino sketches. This does NOT compile the sketch prior to upload.",
 		Example: "  " + os.Args[0] + " upload /home/user/Arduino/MySketch",
 		Args:    cobra.MaximumNArgs(1),
 		Run:     run,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The upload command documentation does not specify that the sketch isn't compiled prior to upload. I thought this would be a helpful clarification since that's the behavior in the Arduino IDE.

* **What is the new behavior?**
<!-- if this is a feature change -->
The upload command documentation clarifies that the upload command does not compile the specified sketch.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No, doc changes.

