### PR TITLE
[skip changelog]Use standardized term for Boards Manager in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![cli-logo](./docs/img/CLI_Logo_small.png)
 
-Arduino CLI is an all-in-one solution that provides builder, boards/library manager, uploader, discovery and many other
+Arduino CLI is an all-in-one solution that provides builder, Boards/Library Manager, uploader, discovery and many other
 tools needed to use any Arduino compatible board and platforms.
 
 [![tests-badge]](https://github.com/Arduino/arduino-cli/actions?workflow=test)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -106,7 +106,7 @@ func createCliCommandTree(cmd *cobra.Command) {
 	viper.BindPFlag("logging.format", cmd.PersistentFlags().Lookup("log-format"))
 	cmd.PersistentFlags().StringVar(&outputFormat, "format", "text", "The output format, can be {text|json}.")
 	cmd.PersistentFlags().StringVar(&configFile, "config-file", "", "The custom config file (if not specified the default will be used).")
-	cmd.PersistentFlags().StringSlice("additional-urls", []string{}, "Comma-separated list of additional URLs for the board manager.")
+	cmd.PersistentFlags().StringSlice("additional-urls", []string{}, "Comma-separated list of additional URLs for the Boards Manager.")
 	viper.BindPFlag("board_manager.additional_urls", cmd.PersistentFlags().Lookup("additional-urls"))
 }
 

--- a/cli/core/search.go
+++ b/cli/core/search.go
@@ -37,8 +37,8 @@ var (
 func initSearchCommand() *cobra.Command {
 	searchCommand := &cobra.Command{
 		Use:     "search <keywords...>",
-		Short:   "Search for a core in the package index.",
-		Long:    "Search for a core in the package index using the specified keywords.",
+		Short:   "Search for a core in Boards Manager.",
+		Long:    "Search for a core in Boards Manager using the specified keywords.",
 		Example: "  " + os.Args[0] + " core search MKRZero -a -v",
 		Args:    cobra.ArbitraryArgs,
 		Run:     runSearchCommand,

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -26,7 +26,7 @@ func setDefaults(dataDir, userDir string) {
 	viper.SetDefault("logging.level", "info")
 	viper.SetDefault("logging.format", "text")
 
-	// board manager
+	// Boards Manager
 	viper.SetDefault("board_manager.additional_urls", []string{})
 
 	// arduino directories

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,12 +1,12 @@
 ## Configuration keys
 
 - `board_manager`
-  - `additional_urls` - the URLs to any additional Board Manager package index files needed for your boards platforms.
+  - `additional_urls` - the URLs to any additional Boards Manager package index files needed for your boards platforms.
 - `daemon` - options related to running Arduino CLI as a [gRPC] server.
   - `port` - TCP port used for gRPC client connections.
 - `directories` - directories used by Arduino CLI.
-  - `data` - directory used to store Board/Library Manager index files and Board Manager platform installations.
-  - `downloads` - directory used to stage downloaded archives during Board/Library Manager installations.
+  - `data` - directory used to store Boards/Library Manager index files and Boards Manager platform installations.
+  - `downloads` - directory used to stage downloaded archives during Boards/Library Manager installations.
   - `user` - the equivalent of the Arduino IDE's ["sketchbook" directory][sketchbook directory]. Library Manager
     installations are made to the `libraries` subdirectory of the user directory.
 - `logging` - configuration options for Arduino CLI's logs.
@@ -39,7 +39,7 @@ Arduino CLI's command line flags are documented in the command line help and the
 
 #### Example
 
-Setting an additional Board Manager URL using the [`--additional-urls`][arduino-cli global flags] command line flag:
+Setting an additional Boards Manager URL using the [`--additional-urls`][arduino-cli global flags] command line flag:
 
 ```shell
 $ arduino-cli core update-index --additional-urls https://downloads.arduino.cc/packages/package_staging_index.json
@@ -56,7 +56,7 @@ can use the [`set` command][set command].
 
 #### Example
 
-Setting an additional Board Manager URL using the `ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS` environment variable:
+Setting an additional Boards Manager URL using the `ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS` environment variable:
 
 ```sh
 $ export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS=https://downloads.arduino.cc/packages/package_staging_index.json
@@ -109,7 +109,7 @@ arduino-cli config dump --verbose
 
 #### Example
 
-Setting an additional Board Manager URL using a YAML format configuration file:
+Setting an additional Boards Manager URL using a YAML format configuration file:
 
 ```yaml
 board_manager:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,7 +20,7 @@ Available Commands:
     download     Downloads one or more cores and corresponding tool dependencies.
     install      Installs one or more cores and corresponding tool dependencies.
     list         Shows the list of installed platforms.
-    search       Search for a core in the package index.
+    search       Search for a core in Boards Manager.
     uninstall    Uninstalls one or more cores and corresponding tool dependencies if no more used.
     update-index Updates the index of cores.
     upgrade      Upgrades one or all installed platforms to the latest version.
@@ -29,7 +29,7 @@ Flags:
     -h, --help   help for core
 
 Global Flags:
-        --additional-urls strings   Additional URLs for the board manager.
+        --additional-urls strings   Additional URLs for Boards Manager.
         --config-file string        The custom config file (if not specified the default will be used).
         --format string             The output format, can be [text|json]. (default "text")
         --log-file string           Path to the file where logs will be written.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-Arduino CLI is an all-in-one solution that provides builder, boards/library manager, uploader, discovery and many other
+Arduino CLI is an all-in-one solution that provides builder, Boards/Library Manager, uploader, discovery and many other
 tools needed to use any Arduino compatible board and platforms.
 
 ## Installation


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The term "Boards Manager" has been well established in the Arduino development tools and documentation. Perhaps influenced by the mismatch with the singular term used for its companion "Library Manager", Arduino CLI's documentation has diverged from this standard by sometimes (but not always) referring to it as "Board Manager".
* **What is the new behavior?**
<!-- if this is a feature change -->
Boards Manager is always referred to by the standardized term in the documentation.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
Note that "Boards Manager" and "Library Manager" are proper nouns, and so should always be capitalized.
