### PR TITLE
[skip changelog] Completely document resources not inherited from referenced platform

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -927,8 +927,8 @@ In the same way we can use a variant defined on another platform using the synta
     myboard.build.variant=arduino:standard
     [....]
 
-Note that referencing a variant in another platform does _not_ inherit any properties from that platform's platform.txt
-(like referencing a core does).
+Note that, unlike core references, other resources (platform.txt, bundled libraries, programmers) are _not_ inherited
+from the referenced platform.
 
 ### Tool references
 
@@ -939,6 +939,9 @@ Tool recipes defined in the platform.txt of other platforms can also be referenc
     myboard.upload.tool=arduino:avrdude
     myboard.bootloader.tool=arduino:avrdude
     [....]
+
+Note that, unlike core references, referencing a tool recipe does _not_ result in any other resources being inherited
+from the referenced platform.
 
 ### Platform Terminology
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The inherited resources resulting from a core reference are clearly documented. However, the variant reference mentioned the non-inheritance of platform.txt properties alone. For me, this left it unclear whether the lack of mention of the other resources implied that variant and tool references resulted in their inheritance, and that it was only considered necessary to document it once in the platform reference documentation.
* **What is the new behavior?**
<!-- if this is a feature change -->
One option for resolving this would be to remove the statement that caused the confusion. However, since this is a complex subject, I thought it better to just explicitly document the non-inheritance of the resources in both the variant and tools reference sections of the documentation to make it completely clear.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No