### PR TITLE
Generate compile_commands.json compilation database

### DIFF
--- a/arduino/builder/compilation_database.go
+++ b/arduino/builder/compilation_database.go
@@ -1,0 +1,73 @@
+package builder
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/arduino/go-paths-helper"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+type compilationCommand struct {
+	Directory string   `json:"directory"`
+	Arguments []string `json:"arguments"`
+	File      string   `json:"file"`
+}
+
+type CompilationDatabase struct {
+	contents []compilationCommand
+	filename *paths.Path
+}
+
+func NewCompilationDatabase(filename *paths.Path) *CompilationDatabase {
+	return &CompilationDatabase{
+		filename: filename,
+	}
+}
+
+func (db *CompilationDatabase) UpdateFile(complete bool) {
+	// TODO: Read any existing file and use its contents for any
+	// kept files, or any files not in db.contents if !complete.
+	fmt.Printf("Writing compilation database to \"%s\"...\n", db.filename.String())
+
+	contents := db.contents
+	jsonContents, err := json.MarshalIndent(contents, "", " ")
+	if err != nil {
+		fmt.Printf("Error serializing compilation database: %s", err)
+		return
+	}
+	err = ioutil.WriteFile(db.filename.String(), jsonContents, 0644)
+	if err != nil {
+		fmt.Printf("Error writing compilation database: %s", err)
+	}
+}
+
+func (db *CompilationDatabase) dirForCommand(command *exec.Cmd) string {
+	// This mimics what Cmd.Run also does: Use Dir if specified,
+	// current directory otherwise
+	if command.Dir != "" {
+		return command.Dir
+	} else {
+		dir, err := os.Getwd()
+		if err != nil {
+			fmt.Printf("Error getting current directory for compilation database: %s", err)
+			return ""
+		}
+		return dir
+	}
+}
+
+func (db *CompilationDatabase) ReplaceEntry(filename *paths.Path, command *exec.Cmd) {
+	entry := compilationCommand{
+		Directory: db.dirForCommand(command),
+		Arguments: command.Args,
+		File:      filename.String(),
+	}
+
+	db.contents = append(db.contents, entry)
+}
+
+func (db *CompilationDatabase) KeepEntry(filename *paths.Path) {
+	// TODO
+}

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	clibuilder "github.com/arduino/arduino-cli/arduino/builder"
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/arduino/sketches"
@@ -119,6 +120,12 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 	builderCtx.PackageManager = pm
 	builderCtx.FQBN = fqbn
 	builderCtx.SketchLocation = sketch.FullPath
+	// TODO: Make optional using commandline option?
+	if !req.GetDryRun() {
+		builderCtx.CompilationDatabase = clibuilder.NewCompilationDatabase(
+			sketch.FullPath.Join("compile_commands.json"),
+		)
+	}
 
 	// FIXME: This will be redundant when arduino-builder will be part of the cli
 	builderCtx.HardwareDirs = configuration.HardwareDirectories()

--- a/legacy/builder/builder.go
+++ b/legacy/builder/builder.go
@@ -101,6 +101,11 @@ func (s *Builder) Run(ctx *types.Context) error {
 
 	mainErr := runCommands(ctx, commands)
 
+	// TODO: Make proper step?
+	if ctx.CompilationDatabase != nil {
+		ctx.CompilationDatabase.UpdateFile(mainErr != nil)
+	}
+
 	commands = []types.Command{
 		&PrintUsedAndNotUsedLibraries{SketchError: mainErr != nil},
 

--- a/legacy/builder/builder_utils/utils.go
+++ b/legacy/builder/builder_utils/utils.go
@@ -249,7 +249,7 @@ func compileFileWithRecipe(ctx *types.Context, sourcePath *paths.Path, source *p
 		return nil, errors.WithStack(err)
 	}
 	if !objIsUpToDate {
-		_, _, err = ExecRecipe(ctx, properties, recipe, false /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show)
+		_, _, _, err = ExecRecipe(ctx, properties, recipe, false /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -480,7 +480,7 @@ func ArchiveCompiledFiles(ctx *types.Context, buildPath *paths.Path, archiveFile
 		properties.SetPath(constants.BUILD_PROPERTIES_ARCHIVE_FILE_PATH, archiveFilePath)
 		properties.SetPath(constants.BUILD_PROPERTIES_OBJECT_FILE, objectFile)
 
-		if _, _, err := ExecRecipe(ctx, properties, constants.RECIPE_AR_PATTERN, false /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show); err != nil {
+		if _, _, _, err := ExecRecipe(ctx, properties, constants.RECIPE_AR_PATTERN, false /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show); err != nil {
 			return nil, errors.WithStack(err)
 		}
 	}
@@ -488,14 +488,15 @@ func ArchiveCompiledFiles(ctx *types.Context, buildPath *paths.Path, archiveFile
 	return archiveFilePath, nil
 }
 
-func ExecRecipe(ctx *types.Context, buildProperties *properties.Map, recipe string, removeUnsetProperties bool, stdout int, stderr int) ([]byte, []byte, error) {
+func ExecRecipe(ctx *types.Context, buildProperties *properties.Map, recipe string, removeUnsetProperties bool, stdout int, stderr int) (*exec.Cmd, []byte, []byte, error) {
 	// See util.ExecCommand for stdout/stderr arguments
 	command, err := PrepareCommandForRecipe(ctx, buildProperties, recipe, removeUnsetProperties)
 	if err != nil {
-		return nil, nil, errors.WithStack(err)
+		return nil, nil, nil, errors.WithStack(err)
 	}
 
-	return utils.ExecCommand(ctx, command, stdout, stderr)
+	outbytes, errbytes, err := utils.ExecCommand(ctx, command, stdout, stderr)
+	return command, outbytes, errbytes, err
 }
 
 const COMMANDLINE_LIMIT = 30000

--- a/legacy/builder/builder_utils/utils.go
+++ b/legacy/builder/builder_utils/utils.go
@@ -249,11 +249,17 @@ func compileFileWithRecipe(ctx *types.Context, sourcePath *paths.Path, source *p
 		return nil, errors.WithStack(err)
 	}
 	if !objIsUpToDate {
-		_, _, _, err = ExecRecipe(ctx, properties, recipe, false /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show)
+		command, _, _, err := ExecRecipe(ctx, properties, recipe, false /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show)
+		if ctx.CompilationDatabase != nil {
+			ctx.CompilationDatabase.ReplaceEntry(source, command)
+		}
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 	} else if ctx.Verbose {
+		if ctx.CompilationDatabase != nil {
+			ctx.CompilationDatabase.KeepEntry(source)
+		}
 		logger.Println(constants.LOG_LEVEL_INFO, constants.MSG_USING_PREVIOUS_COMPILED_FILE, objectFile)
 	}
 

--- a/legacy/builder/phases/linker.go
+++ b/legacy/builder/phases/linker.go
@@ -67,7 +67,7 @@ func link(ctx *types.Context, objectFiles paths.PathList, coreDotARelPath *paths
 	properties.Set(constants.BUILD_PROPERTIES_ARCHIVE_FILE_PATH, coreArchiveFilePath.String())
 	properties.Set(constants.BUILD_PROPERTIES_OBJECT_FILES, objectFileList)
 
-	_, _, err := builder_utils.ExecRecipe(ctx, properties, constants.RECIPE_C_COMBINE_PATTERN, false /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show)
+	_, _, _, err := builder_utils.ExecRecipe(ctx, properties, constants.RECIPE_C_COMBINE_PATTERN, false /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show)
 	return err
 }
 

--- a/legacy/builder/phases/sizer.go
+++ b/legacy/builder/phases/sizer.go
@@ -112,7 +112,7 @@ func checkSize(ctx *types.Context, buildProperties *properties.Map) error {
 }
 
 func execSizeRecipe(ctx *types.Context, properties *properties.Map) (textSize int, dataSize int, eepromSize int, resErr error) {
-	out, _, err := builder_utils.ExecRecipe(ctx, properties, constants.RECIPE_SIZE_PATTERN, false /* stdout */, utils.Capture /* stderr */, utils.Show)
+	_, out, _, err := builder_utils.ExecRecipe(ctx, properties, constants.RECIPE_SIZE_PATTERN, false /* stdout */, utils.Capture /* stderr */, utils.Show)
 	if err != nil {
 		resErr = errors.New("Error while determining sketch size: " + err.Error())
 		return

--- a/legacy/builder/recipe_runner.go
+++ b/legacy/builder/recipe_runner.go
@@ -47,7 +47,7 @@ func (s *RecipeByPrefixSuffixRunner) Run(ctx *types.Context) error {
 		if ctx.DebugLevel >= 10 {
 			logger.Fprintln(os.Stdout, constants.LOG_LEVEL_DEBUG, constants.MSG_RUNNING_RECIPE, recipe)
 		}
-		_, _, err := builder_utils.ExecRecipe(ctx, properties, recipe, false /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show)
+		_, _, _, err := builder_utils.ExecRecipe(ctx, properties, recipe, false /* stdout */, utils.ShowIfVerbose /* stderr */, utils.Show)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/legacy/builder/types/context.go
+++ b/legacy/builder/types/context.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/arduino/arduino-cli/arduino/builder"
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/arduino/libraries"
@@ -158,6 +159,9 @@ type Context struct {
 	// Out and Err stream to redirect all Exec commands
 	ExecStdout io.Writer
 	ExecStderr io.Writer
+
+	// Compilation Database to build/update
+	CompilationDatabase *builder.CompilationDatabase
 }
 
 func (ctx *Context) ExtractBuildOptions() *properties.Map {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
New feature: Allow generating `compile_commands.json` file as a side effect of compilation, for consumption by editors and other tooling, as requested in #849.

* **What is the new behavior?**
All compile commands (not linking and other steps) ran are output to a compilation database, a file called `compile_commands.json` (see https://clang.llvm.org/docs/JSONCompilationDatabase.html for the format). This file can be used by editors (often using `clang` or `clangd`) to provide code completion, navigation and diagnostics.

* **Other information**:
This is just a rough draft, that still needs more work, some decisions and some feedback. I wanted to quickly throw something together, which ended up a bit more work than I thought. The basics work, though this is probably more of a proof of concept that might need to be significantly restructured. Open points are:
 - How to log:  introduced a `CompilationDatabase` class outside of the `legacy/builder` directory (seemed good to not add more legacy), but now I'm unsure how to approach logging. It seems that the cli and builder code have distinct logging facilities, neither of which seems easily accessible. For now I just added "fmt.Print". Suggestions are welcome.
 - Where to write the file: I now write a `compile_commands.json` to the sketch directory, since that's where editors would look for it. I later realized that it would probably be good to *also* write a version to the temp build directory (note: I mean the `/tmp/arduino-sketch-XYZ` directory, not the `build` subdirectory of the sketch dir where the compilation result is exported), for any tooling that wants to inspect the copied and preprocessed sketch files.
 - Updating sketch paths: Currently, the paths are written as they passed to the compiler, so pointing at the copy of the sketch in the temp build dir. This is probably good for the `compile_commands.json` to be written to the temp build dir, but the sketch dir version should really point to the original sketch files. This means that the `file` element in the json should be updated, but maybe also any compiler arguments that resolve to sketch files should have their paths updated. This should probably be applied generically (i.e. search replacing back to the original sketch dir) to all arguments, since we can't be sure what a `platform.txt` does exactly. Alternatively, updating just the `file` field might be sufficient and can be done by passing the original filename around (does require significant refactoring, I think).
 - Handling .ino files: Currently, only one entry is generated for .cpp file resulting from the combined and preprocessed .ino file(s). This is again fine for the temp build version, but for the sketch dir version, I think this should have a separate entry for each .ino file, with an `-include=Arduino.h` flag added (as suggested in https://github.com/arduino/arduino-cli/issues/849#issuecomment-690635998). This is imperfect, but probably as close as we can get.
 - Making this optional: I believe that writing a `compile_commands.json` to the temp build dir can always be done, but writing to the sketch directory should almost certainly be opt-in (through commandline or config), to prevent user surprise and because the IDE and arduino-cli seem to try hard to prevent touching the sketch dir now. For arduino-cli, it might make sense to always generate the file in the `build` subdirectory, along with the compiled program, and provide an option to also, or instead of, generate in the sketch directory itself (where it will be mostly automatically picked up by editors or `clangd`). For the IDE, some extra care should probably be taken to not generate this file in the sketch directory for unmodified examples, even if the user enabled it in the config.
 - Partial compilation: Currently, the file is written from scratch at the end of every compilation. So if compilation fails, or files are not changed and thus not recompiled, files will be missing from the `compile_commands.json` file. Ideally, any existing file should be read and merged, taking care to remove any extra entries (e.g. for deleted files), but only when compilation was successful (or at least complete). Alternatively, a complete list of files to be compiled could also be used maybe (even when compilation is aborted halfway).