### PR TITLE
Match port properties (e.g. USB vid/pid) case insensitively against board.txt values (in e.g. board list)

### DIFF
--- a/arduino/cores/packagemanager/identify.go
+++ b/arduino/cores/packagemanager/identify.go
@@ -17,6 +17,7 @@ package packagemanager
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/arduino/arduino-cli/arduino/cores"
 	properties "github.com/arduino/go-properties-orderedmap"
@@ -34,7 +35,7 @@ func (pm *PackageManager) IdentifyBoard(idProps *properties.Map) []*cores.Board 
 			if !ok {
 				return false, false
 			}
-			if v1 != v2 {
+			if !strings.EqualFold(v1, v2) {
 				return true, false
 			}
 		}

--- a/arduino/cores/packagemanager/package_manager_test.go
+++ b/arduino/cores/packagemanager/package_manager_test.go
@@ -316,4 +316,7 @@ func TestIdentifyBoard(t *testing.T) {
 	require.Equal(t, "[test:avr:c]", fmt.Sprintf("%v", identify("0x9999", "0x0004")))
 	// https://github.com/arduino/arduino-cli/issues/456
 	require.Equal(t, "[test:avr:d]", fmt.Sprintf("%v", identify("0x9999", "0x0005")))
+	// Check mixed case
+	require.Equal(t, "[test:avr:e]", fmt.Sprintf("%v", identify("0xAB00", "0xcd00")))
+	require.Equal(t, "[test:avr:e]", fmt.Sprintf("%v", identify("0xab00", "0xCD00")))
 }

--- a/arduino/cores/packagemanager/testdata/custom_hardware/test/avr/boards.txt
+++ b/arduino/cores/packagemanager/testdata/custom_hardware/test/avr/boards.txt
@@ -15,3 +15,7 @@ c.pid.1=0x0004
 d.name=Board D
 d.vid.1=0x9999
 d.pid.1=0x0005
+
+e.name=Board E
+e.vid.1=0xAB00
+e.pid.1=0xcd00


### PR DESCRIPTION
This allows both uppercase and lowercase properties (e.g. vid and pid)
from boards.txt and matches what the Java IDE does:

    https://github.com/arduino/Arduino/blob/5e30bec23/arduino-core/src/cc/arduino/packages/BoardPort.java#L185

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs do not seem needed

* **What kind of change does this PR introduce?**
Bugfix

- **What is the current behavior?**
USB ids or other identifying properties from a (serial) port are matched case sensitively, so if boards.txt specifies uppercase usb ids, `board list` does not match the port with the corresponding board.

* **What is the new behavior?**
Properties are matched case insensitively, just like the Java IDE does: https://github.com/arduino/Arduino/blob/5e30bec23/arduino-core/src/cc/arduino/packages/BoardPort.java#L185

- **Does this PR introduce a breaking change?**
No.