### PR TITLE
Change behaviour of --config-file flag with config commands

### DIFF
--- a/cli/config/dump.go
+++ b/cli/config/dump.go
@@ -18,7 +18,6 @@ package config
 import (
 	"os"
 
-	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -60,21 +59,5 @@ func (dr dumpResult) String() string {
 
 func runDumpCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino config dump`")
-
-	configFlag := cmd.InheritedFlags().Lookup("config-file")
-	configFile := ""
-	if configFlag != nil {
-		configFile = configFlag.Value.String()
-	}
-
-	if configFile != "" {
-		viper.SetConfigFile(configFile)
-		err := viper.MergeInConfig()
-		if err != nil {
-			feedback.Errorf("Error reading config file: %s", configFile)
-			os.Exit(errorcodes.ErrBadArgument)
-		}
-	}
-
 	feedback.PrintResult(dumpResult{viper.AllSettings()})
 }

--- a/cli/config/dump.go
+++ b/cli/config/dump.go
@@ -18,6 +18,7 @@ package config
 import (
 	"os"
 
+	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -59,5 +60,21 @@ func (dr dumpResult) String() string {
 
 func runDumpCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino config dump`")
+
+	configFlag := cmd.InheritedFlags().Lookup("config-file")
+	configFile := ""
+	if configFlag != nil {
+		configFile = configFlag.Value.String()
+	}
+
+	if configFile != "" {
+		viper.SetConfigFile(configFile)
+		err := viper.MergeInConfig()
+		if err != nil {
+			feedback.Errorf("Error reading config file: %s", configFile)
+			os.Exit(errorcodes.ErrBadArgument)
+		}
+	}
+
 	feedback.PrintResult(dumpResult{viper.AllSettings()})
 }

--- a/cli/config/init.go
+++ b/cli/config/init.go
@@ -26,8 +26,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-var destDir string
-var overwrite bool
+var (
+	destDir   string
+	destFile  string
+	overwrite bool
+)
 
 const defaultFileName = "arduino-cli.yaml"
 
@@ -38,25 +41,21 @@ func initInitCommand() *cobra.Command {
 		Long:  "Creates or updates the configuration file in the data directory or custom directory with the current configuration settings.",
 		Example: "" +
 			"  # Writes current configuration to the configuration file in the data directory.\n" +
-			"  " + os.Args[0] + " config init",
+			"  " + os.Args[0] + " config init" +
+			"  " + os.Args[0] + " config init --dest-dir /home/user/MyDirectory" +
+			"  " + os.Args[0] + " config init --dest-file /home/user/MyDirectory/my_settings.yaml",
 		Args: cobra.NoArgs,
 		Run:  runInitCommand,
 	}
 	initCommand.Flags().StringVar(&destDir, "dest-dir", "", "Sets where to save the configuration file.")
+	initCommand.Flags().StringVar(&destFile, "dest-file", "", "Sets where to save the configuration file.")
 	initCommand.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite existing config file.")
 	return initCommand
 }
 
 func runInitCommand(cmd *cobra.Command, args []string) {
-	configFlag := cmd.InheritedFlags().Lookup("config-file")
-	configFilePath := ""
-
-	if configFlag != nil {
-		configFilePath = configFlag.Value.String()
-	}
-
-	if configFilePath != "" && destDir != "" {
-		feedback.Errorf("Can't use both --config-file and --dest-dir flags at the same time.")
+	if destFile != "" && destDir != "" {
+		feedback.Errorf("Can't use both --dest-file and --dest-dir flags at the same time.")
 		os.Exit(errorcodes.ErrGeneric)
 	}
 
@@ -65,8 +64,8 @@ func runInitCommand(cmd *cobra.Command, args []string) {
 	var err error
 
 	switch {
-	case configFilePath != "":
-		configFileAbsPath, err = paths.New(configFilePath).Abs()
+	case destFile != "":
+		configFileAbsPath, err = paths.New(destFile).Abs()
 		if err != nil {
 			feedback.Errorf("Cannot find absolute path: %v", err)
 			os.Exit(errorcodes.ErrGeneric)

--- a/commands/daemon/settings_test.go
+++ b/commands/daemon/settings_test.go
@@ -18,6 +18,7 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -30,12 +31,12 @@ import (
 var svc = SettingsService{}
 
 func init() {
-	configuration.Init("testdata")
+	configuration.Init(filepath.Join("testdata", "arduino-cli.yaml"))
 }
 
 func reset() {
 	viper.Reset()
-	configuration.Init("testdata")
+	configuration.Init(filepath.Join("testdata", "arduino-cli.yaml"))
 }
 
 func TestGetAll(t *testing.T) {

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -198,15 +198,10 @@ func FindConfigFile() string {
 	}
 
 	if configFile != "" {
-		if fi, err := os.Stat(configFile); err == nil {
-			if fi.IsDir() {
-				return configFile
-			}
-			return filepath.Dir(configFile)
-		}
+		return filepath.Dir(configFile)
 	}
 
-	return searchCwdForConfig()
+	return ""
 }
 
 func searchConfigTree(cwd string) string {
@@ -229,14 +224,4 @@ func searchConfigTree(cwd string) string {
 		}
 	}
 
-}
-
-func searchCwdForConfig() string {
-	cwd, err := os.Getwd()
-
-	if err != nil {
-		return ""
-	}
-
-	return searchConfigTree(cwd)
 }

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	configuration.Init(configuration.FindConfigFile())
+	configuration.Init(configuration.FindConfigFile(os.Args))
 	i18n.Init()
 	arduinoCmd := cli.NewCommand()
 	if err := arduinoCmd.Execute(); err != nil {

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -62,15 +62,15 @@ def test_init_dest_flag_with_overwrite_flag(run_command, working_dir):
 
 
 def test_init_dest_and_config_file_flags(run_command, working_dir):
-    result = run_command('config init --config-file "some_other_path" --dest-dir "some_path"')
+    result = run_command('config init --dest-file "some_other_path" --dest-dir "some_path"')
     assert result.failed
-    assert "Can't use both --config-file and --dest-dir flags at the same time." in result.stderr
+    assert "Can't use both --dest-file and --dest-dir flags at the same time." in result.stderr
 
 
 def test_init_config_file_flag_absolute_path(run_command, working_dir):
     config_file = Path(working_dir) / "config" / "test" / "config.yaml"
     assert not config_file.exists()
-    result = run_command(f'config init --config-file "{config_file}"')
+    result = run_command(f'config init --dest-file "{config_file}"')
     assert result.ok
     assert str(config_file) in result.stdout
     assert config_file.exists()
@@ -79,7 +79,7 @@ def test_init_config_file_flag_absolute_path(run_command, working_dir):
 def test_init_config_file_flag_relative_path(run_command, working_dir):
     config_file = Path(working_dir) / "config.yaml"
     assert not config_file.exists()
-    result = run_command('config init --config-file "config.yaml"')
+    result = run_command('config init --dest-file "config.yaml"')
     assert result.ok
     assert str(config_file) in result.stdout
     assert config_file.exists()
@@ -89,15 +89,15 @@ def test_init_config_file_flag_with_overwrite_flag(run_command, working_dir):
     config_file = Path(working_dir) / "config" / "test" / "config.yaml"
     assert not config_file.exists()
 
-    result = run_command(f'config init --config-file "{config_file}"')
+    result = run_command(f'config init --dest-file "{config_file}"')
     assert result.ok
     assert config_file.exists()
 
-    result = run_command(f'config init --config-file "{config_file}"')
+    result = run_command(f'config init --dest-file "{config_file}"')
     assert result.failed
     assert "Config file already exists, use --overwrite to discard the existing one." in result.stderr
 
-    result = run_command(f'config init --config-file "{config_file}" --overwrite')
+    result = run_command(f'config init --dest-file "{config_file}" --overwrite')
     assert result.ok
     assert str(config_file) in result.stdout
 
@@ -106,7 +106,7 @@ def test_dump(run_command, working_dir):
     # Create a config file first
     config_file = Path(working_dir) / "config" / "test" / "config.yaml"
     assert not config_file.exists()
-    result = run_command(f'config init --config-file "{config_file}"')
+    result = run_command(f'config init --dest-file "{config_file}"')
     assert result.ok
     assert config_file.exists()
 
@@ -120,7 +120,7 @@ def test_dump_with_config_file_flag(run_command, working_dir):
     # Create a config file first
     config_file = Path(working_dir) / "config" / "test" / "config.yaml"
     assert not config_file.exists()
-    result = run_command(f'config init --config-file "{config_file}" --additional-urls=https://example.com')
+    result = run_command(f'config init --dest-file "{config_file}" --additional-urls=https://example.com')
     assert result.ok
     assert config_file.exists()
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -13,6 +13,7 @@
 # software without disclosing the source code of your own applications. To purchase
 # a commercial license, send an email to license@arduino.cc.
 from pathlib import Path
+import json
 
 
 def test_init(run_command, data_dir, working_dir):
@@ -21,8 +22,116 @@ def test_init(run_command, data_dir, working_dir):
     assert data_dir in result.stdout
 
 
-def test_init_dest(run_command, working_dir):
-    dest = str(Path(working_dir) / "config" / "test")
+def test_init_dest_absolute_path(run_command, working_dir):
+    dest = Path(working_dir) / "config" / "test"
+    expected_config_file = dest / "arduino-cli.yaml"
+    assert not expected_config_file.exists()
     result = run_command(f'config init --dest-dir "{dest}"')
     assert result.ok
-    assert dest in result.stdout
+    assert str(expected_config_file) in result.stdout
+    assert expected_config_file.exists()
+
+
+def test_init_dest_relative_path(run_command, working_dir):
+    dest = Path(working_dir) / "config" / "test"
+    expected_config_file = dest / "arduino-cli.yaml"
+    assert not expected_config_file.exists()
+    result = run_command('config init --dest-dir "config/test"')
+    assert result.ok
+    assert str(expected_config_file) in result.stdout
+    assert expected_config_file.exists()
+
+
+def test_init_dest_flag_with_overwrite_flag(run_command, working_dir):
+    dest = Path(working_dir) / "config" / "test"
+
+    expected_config_file = dest / "arduino-cli.yaml"
+    assert not expected_config_file.exists()
+
+    result = run_command(f'config init --dest-dir "{dest}"')
+    assert result.ok
+    assert expected_config_file.exists()
+
+    result = run_command(f'config init --dest-dir "{dest}"')
+    assert result.failed
+    assert "Config file already exists, use --overwrite to discard the existing one." in result.stderr
+
+    result = run_command(f'config init --dest-dir "{dest}" --overwrite')
+    assert result.ok
+    assert str(expected_config_file) in result.stdout
+
+
+def test_init_dest_and_config_file_flags(run_command, working_dir):
+    result = run_command('config init --config-file "some_other_path" --dest-dir "some_path"')
+    assert result.failed
+    assert "Can't use both --config-file and --dest-dir flags at the same time." in result.stderr
+
+
+def test_init_config_file_flag_absolute_path(run_command, working_dir):
+    config_file = Path(working_dir) / "config" / "test" / "config.yaml"
+    assert not config_file.exists()
+    result = run_command(f'config init --config-file "{config_file}"')
+    assert result.ok
+    assert str(config_file) in result.stdout
+    assert config_file.exists()
+
+
+def test_init_config_file_flag_relative_path(run_command, working_dir):
+    config_file = Path(working_dir) / "config.yaml"
+    assert not config_file.exists()
+    result = run_command('config init --config-file "config.yaml"')
+    assert result.ok
+    assert str(config_file) in result.stdout
+    assert config_file.exists()
+
+
+def test_init_config_file_flag_with_overwrite_flag(run_command, working_dir):
+    config_file = Path(working_dir) / "config" / "test" / "config.yaml"
+    assert not config_file.exists()
+
+    result = run_command(f'config init --config-file "{config_file}"')
+    assert result.ok
+    assert config_file.exists()
+
+    result = run_command(f'config init --config-file "{config_file}"')
+    assert result.failed
+    assert "Config file already exists, use --overwrite to discard the existing one." in result.stderr
+
+    result = run_command(f'config init --config-file "{config_file}" --overwrite')
+    assert result.ok
+    assert str(config_file) in result.stdout
+
+
+def test_dump(run_command, working_dir):
+    # Create a config file first
+    config_file = Path(working_dir) / "config" / "test" / "config.yaml"
+    assert not config_file.exists()
+    result = run_command(f'config init --config-file "{config_file}"')
+    assert result.ok
+    assert config_file.exists()
+
+    result = run_command("config dump --format json")
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert [] == settings_json["board_manager"]["additional_urls"]
+
+
+def test_dump_with_config_file_flag(run_command, working_dir):
+    # Create a config file first
+    config_file = Path(working_dir) / "config" / "test" / "config.yaml"
+    assert not config_file.exists()
+    result = run_command(f'config init --config-file "{config_file}" --additional-urls=https://example.com')
+    assert result.ok
+    assert config_file.exists()
+
+    result = run_command(f'config dump --config-file "{config_file}" --format json')
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert ["https://example.com"] == settings_json["board_manager"]["additional_urls"]
+
+    result = run_command(
+        f'config dump --config-file "{config_file}" --additional-urls=https://another-url.com --format json'
+    )
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert ["https://another-url.com"] == settings_json["board_manager"]["additional_urls"]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**

Changes the behaviour of `config init` and `config dump` when using the `--config-file` flag.

- **What is the current behavior?**

`config init --dest-file <some_path_file>` doesn't initialize a new config file using the specified path and always overrides existing file in default config path.

Calling `config init --dest-file <path> --dest-dir <path>` creates a new config file in path specified by `--dest-dir`.

Calling `config dump --config-file <some_path_file>` always prints the default configurations.

* **What is the new behavior?**

Calling `config init --dest-file <some_path_file>` initializes a new config file using the specified path, if the file exists and the `--overwrite` flag is not set an error is returned, otherwise a new file is created.

Calling `config init --dest-file <path> --dest-dir <path>` now returns an error.

Calling `config dump --config-file <some_path_file>` prints the configuration file specified.

Calling `config dump --config-file <some_path_file> --additional-urls=<urls>` prints the configuration file specified but `additional_urls` are overridden by the ones specified with the flag.

- **Does this PR introduce a breaking change?**

I don't think so. :thinking: 

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
