### PR TITLE
[skip changelog] Document ability to override properties of referenced tools

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -940,6 +940,9 @@ Tool recipes defined in the platform.txt of other platforms can also be referenc
     myboard.bootloader.tool=arduino:avrdude
     [....]
 
+When using Arduino CLI or Arduino Pro IDE (but not Arduino IDE), properties used in the referenced tool recipe may be
+overridden in the referencing platform's platform.txt.
+
 Note that, unlike core references, referencing a tool recipe does _not_ result in any other resources being inherited
 from the referenced platform.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Arduino CLI (and thus Arduino Pro IDE as well) provides the very interesting capability to modify referenced tool recipes via overrides in the referencing platform's platform.txt but this is undocumented.

The equivalent capabilty is mentioned in the core reference documentation, so the lack of mention of it in the tools referencing section could be seen as implying that it's not supported.

Overrides don't apply to referenced variants, so this is not a universal capability that can be documented in the general purpose referencing documentation.

* **What is the new behavior?**
<!-- if this is a feature change -->
The ability to override properties used in referenced tool recipes from the platform.txt of the referencing platform is documented in the platform specification.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
Arduino IDE does not currently provide this capability.
