### PR TITLE
[skip changelog] Change CI Go version from 1.15 to 1.14

### DIFF
--- a/.github/workflows/i18n-nightly-push.yaml
+++ b/.github/workflows/i18n-nightly-push.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.14"
 
       - name: Install Taskfile
         uses: Arduino/actions/setup-taskfile@master

--- a/.github/workflows/i18n-weekly-pull.yaml
+++ b/.github/workflows/i18n-weekly-pull.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.14"
 
       - name: Install Go deps
         run: |

--- a/.github/workflows/link-validation.yaml
+++ b/.github/workflows/link-validation.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.14"
 
       - name: Installs Go dependencies
         shell: bash

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.14"
 
       - name: Install Go dependencies
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.14"
 
       - name: Install Go deps
         # Since 10/23/2019 pwsh is the default shell

--- a/.github/workflows/validate-docs.yaml
+++ b/.github/workflows/validate-docs.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.14"
 
       - name: Install Go dependencies
         run: |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,7 +29,7 @@ submitting a PR:
 
 To build the Arduino CLI from sources you need the following tools to be available in your local environment:
 
-- [Go][1] version 1.15 or later
+- [Go][1] version 1.14 or later
 - [Taskfile][2] to help you run the most common tasks from the command line
 
 If you want to run integration tests you will also need:
@@ -195,7 +195,7 @@ If you want to check out how the documentation would look after some local chang
 happens in the CI, generating the full documentation website from your personal computer. To run the docs toolchain
 locally, you need to have a few dependencies and tools installed:
 
-- [Go][1] version 1.12 or later
+- [Go][1] version 1.14 or later
 - [Taskfile][2] to help you run the most common tasks from the command line
 - A working [Python][3] environment, see [this paragraph](#integration-tests) if you need to setup one
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

This changes the version of Go used in the CI from 1.15 to 1.14. 
The cross compilation container we use to compile the project doesn't support Go 1.15 in OS X for now, thus the revert to an older version.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
