### PR TITLE
[skip changelog] Add nightly builds link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ contribute your changes to the project.
 
 :sparkles: Thanks to all our [contributors]! :sparkles:
 
+### Beta testing
+
+[Nightly builds] are available for beta testing.
+
 ## Security
 
 If you think you found a vulnerability or other security-related bug in the Arduino CLI, please read our [security
@@ -51,4 +55,5 @@ e-mail contact: security@arduino.cc
 [faq]: https://arduino.github.io/arduino-cli/latest/FAQ/
 [how to contribute]: https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/
 [contributors]: https://github.com/arduino/arduino-cli/graphs/contributors
+[nightly builds]: https://arduino.github.io/arduino-cli/latest/installation/#nightly-builds
 [security policy]: https://github.com/arduino/arduino-cli/security/policy


### PR DESCRIPTION
This makes it easier for contributors to participate by beta testing Arduino CLI.

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
It may not be obvious how to find the nightly builds of Arduino CLI.
* **What is the new behavior?**
<!-- if this is a feature change -->
It is easy to find nightly builds and participation in the project by beta testing is encouraged.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No