### PR TITLE
[skip changelog] Document library location priorities in Arduino Web Editor

### DIFF
--- a/docs/sketch-build-process.md
+++ b/docs/sketch-build-process.md
@@ -114,6 +114,27 @@ The "location priority" is determined as follows (in order of highest to lowest 
    ([`{runtime.ide.path}/libraries`](platform-specification.md#global-predefined-properties))
    - This location is only used by Arduino CLI when it's located in the Arduino IDE installation folder
 
+#### Location priorities in Arduino Web Editor
+
+The location priorities system works in the same manner in [Arduino Web Editor](https://create.arduino.cc/editor), but
+its cloud-based nature may make the locations of libraries less obvious.
+
+1. **Custom**: the imported libraries, shown under the **Libraries > Custom** tab.
+   - These libraries are under `/tmp/\<some number>/custom`
+1. **Pinned**: libraries that were [associated with the sketch](sketch-specification.md#metadata) by choosing a specific
+   version from the library's "Include" dropdown menu.
+   - These libraries are under `/tmp/\<some number>/pinned`
+   - Note: clicking the "Include" button does not result in the library being pinned to the sketch.
+1. **[Platform bundled](platform-specification.md#platform-bundled-libraries)**: these are listed under the
+   **Libraries > Default** tab, but with "for \<architecture name\>" appended to the library name (e.g., "SPI for AVR").
+   - These libraries are under `/home/builder/.arduino15/packages`
+   1. [Board platform](platform-specification.md#platform-terminology) bundled
+   1. [Core platform](platform-specification.md#platform-terminology) bundled
+1. **Built-in**:
+   - The non-platform bundled libraries listed under the **Libraries > Default** tab.
+   - Libraries listed under **Libraries > Library Manager**.
+   - These libraries are under `/home/builder/opt/libraries/latest`
+
 ## Compilation
 
 Sketches are compiled by avr-gcc and avr-g++ according to the variables in the boards.txt file of the selected board's


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Although Arduino Web Editor uses the same build system as the other Arduino development software, the cloud-based nature can make it more difficult to determine library locations.

Although very convenient, Arduino Web Editor having every one of the thousands of Library Manager libraries pre-installed does result in a higher incidence of header filename collisions. This means it is especially important for Arduino Web Editor users to understand library location priorities. However, the sketch build process documentation's ["Location priority" section](https://arduino.github.io/arduino-cli/dev/sketch-build-process/#location-priority) doesn't provide any Arduino Web Editor-specific information.
* **What is the new behavior?**
<!-- if this is a feature change -->
Library location priorities in Arduino Web Editor are fully documented.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No

* **Other information**:
<!-- Any additional information that could help the review process -->
The `-libraries` options passed to `arduino-builder` by Arduino Web Editor are in this order:
```
-libraries /tmp/803503227/custom -libraries /tmp/803503227/pinned
```
This order causes the "custom" libraries to have a higher location priority than the "pinned" libraries.