### PR TITLE
Programmers can't be listed anymore using burn-bootloader programmer …

### DIFF
--- a/cli/burnbootloader/burnbootloader.go
+++ b/cli/burnbootloader/burnbootloader.go
@@ -55,7 +55,7 @@ func NewCommand() *cobra.Command {
 	burnBootloaderCommand.Flags().StringVarP(&port, "port", "p", "", "Upload port, e.g.: COM10 or /dev/ttyACM0")
 	burnBootloaderCommand.Flags().BoolVarP(&verify, "verify", "t", false, "Verify uploaded binary after the upload.")
 	burnBootloaderCommand.Flags().BoolVarP(&verbose, "verbose", "v", false, "Turns on verbose mode.")
-	burnBootloaderCommand.Flags().StringVarP(&programmer, "programmer", "P", "", "Use the specified programmer to upload or 'list' to list supported programmers.")
+	burnBootloaderCommand.Flags().StringVarP(&programmer, "programmer", "P", "", "Use the specified programmer to upload.")
 
 	return burnBootloaderCommand
 }
@@ -65,21 +65,6 @@ func run(command *cobra.Command, args []string) {
 	if err != nil {
 		feedback.Errorf("Error during Upload: %v", err)
 		os.Exit(errorcodes.ErrGeneric)
-	}
-
-	if programmer == "list" {
-		resp, err := upload.ListProgrammersAvailableForUpload(context.Background(), &rpc.ListProgrammersAvailableForUploadReq{
-			Instance: instance,
-			Fqbn:     fqbn,
-		})
-		if err != nil {
-			feedback.Errorf("Error listing programmers: %v", err)
-			os.Exit(errorcodes.ErrGeneric)
-		}
-		feedback.PrintResult(&programmersList{
-			Programmers: resp.GetProgrammers(),
-		})
-		os.Exit(0)
 	}
 
 	if _, err := upload.BurnBootloader(context.Background(), &rpc.BurnBootloaderReq{

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -58,7 +58,7 @@ func NewCommand() *cobra.Command {
 	uploadCommand.Flags().StringVarP(&importFile, "input-file", "i", "", "Binary file to upload.")
 	uploadCommand.Flags().BoolVarP(&verify, "verify", "t", false, "Verify uploaded binary after the upload.")
 	uploadCommand.Flags().BoolVarP(&verbose, "verbose", "v", false, "Optional, turns on verbose mode.")
-	uploadCommand.Flags().StringVarP(&programmer, "programmer", "P", "", "Optional, use the specified programmer to upload or 'list' to list supported programmers.")
+	uploadCommand.Flags().StringVarP(&programmer, "programmer", "P", "", "Optional, use the specified programmer to upload.")
 
 	return uploadCommand
 }


### PR DESCRIPTION
…flag

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
Removes a hackish way to list programmers and updates `upload` command documentation.

- **What is the current behavior?**
Calling the `burn-bootloader` command with the `-P list` flag returns a list of programmers.

* **What is the new behavior?**
Calling the `burn-bootloader` command with the `-P list` flag doesn't work anymore, the right way to do it is calling `board details <fqbn> --list-programmers`.

- **Does this PR introduce a breaking change?**
Yes.

* **Other information**:
None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
