### PR TITLE
Do not overwrite full headers list with declared 'includes' in library.properties

### DIFF
--- a/arduino/libraries/libraries.go
+++ b/arduino/libraries/libraries.go
@@ -73,6 +73,7 @@ type Library struct {
 	License                string
 	Properties             *properties.Map
 	Examples               paths.PathList
+	declaredHeaders        []string
 	sourceHeaders          []string
 }
 
@@ -157,7 +158,15 @@ func (library *Library) LocationPriorityFor(platformRelease, refPlatformRelease 
 	return 0
 }
 
-// SourceHeaders returns the C++ headers in the library.
+// DeclaredHeaders returns the C++ headers that the library declares in library.properties
+func (library *Library) DeclaredHeaders() []string {
+	if library.declaredHeaders == nil {
+		library.declaredHeaders = []string{}
+	}
+	return library.declaredHeaders
+}
+
+// SourceHeaders returns all the C++ headers in the library even if not declared in library.properties
 func (library *Library) SourceHeaders() ([]string, error) {
 	if library.sourceHeaders == nil {
 		cppHeaders, err := library.SourceDir.ReadDir()

--- a/arduino/libraries/loader.go
+++ b/arduino/libraries/loader.go
@@ -101,7 +101,7 @@ func makeNewLibrary(libraryDir *paths.Path, location LibraryLocation) (*Library,
 	}
 
 	if includes := libProperties.Get("includes"); includes != "" {
-		library.sourceHeaders = commaSeparatedToList(includes)
+		library.declaredHeaders = commaSeparatedToList(includes)
 	}
 
 	if err := addExamples(library); err != nil {

--- a/commands/lib/list.go
+++ b/commands/lib/list.go
@@ -146,11 +146,6 @@ func GetOutputLibrary(lib *libraries.Library) (*rpc.Library, error) {
 		cntplat = lib.ContainerPlatform.String()
 	}
 
-	libHeaders, err := lib.SourceHeaders()
-	if err != nil {
-		return nil, errors.Errorf("getting library headers: %s", err)
-	}
-
 	return &rpc.Library{
 		Name:              lib.Name,
 		Author:            lib.Author,
@@ -175,7 +170,7 @@ func GetOutputLibrary(lib *libraries.Library) (*rpc.Library, error) {
 		Version:           lib.Version.String(),
 		License:           lib.License,
 		Examples:          lib.Examples.AsStrings(),
-		ProvidesIncludes:  libHeaders,
+		ProvidesIncludes:  lib.DeclaredHeaders(),
 	}, nil
 }
 

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -56,21 +56,18 @@ def test_list(run_command):
     assert 1 == len(data)
     # be sure data contains the available version
     assert "" != data[0]["release"]["version"]
-    # be sure data contains the correct provides_includes field
-    assert "ArduinoJson.h" == data[0]["library"]["provides_includes"][0]
-    assert "ArduinoJson.hpp" == data[0]["library"]["provides_includes"][1]
 
     # Install something we can list without provides_includes field given in library.properties
-    result = run_command("lib install Braccio@2.0.4")
+    result = run_command("lib install Arduino_APDS9960@1.0.3")
     assert result.ok
     # Look at the JSON output
-    result = run_command("lib list Braccio --format json")
+    result = run_command("lib list Arduino_APDS9960 --format json")
     assert result.ok
     assert "" == result.stderr
     data = json.loads(result.stdout)
     assert 1 == len(data)
     # be sure data contains the correct provides_includes field
-    assert "Braccio.h" == data[0]["library"]["provides_includes"][0]
+    assert "Arduino_APDS9960.h" == data[0]["library"]["provides_includes"][0]
 
 
 def test_install(run_command):


### PR DESCRIPTION
Otherwise, automatic library discovery would be affected.

Fix #960
