### PR TITLE
Fix core search command not searching through package terms

### DIFF
--- a/commands/core/search.go
+++ b/commands/core/search.go
@@ -59,7 +59,9 @@ func PlatformSearch(instanceID int32, searchArgs string, allVersions bool) (*rpc
 				}
 
 				// platform has a valid release, check if it matches the search arguments
-				if match(platform.Name, searchArgs) || match(platform.Architecture, searchArgs) || exactMatch(platform.String(), searchArgs) {
+				if match(platform.Name, searchArgs) || match(platform.Architecture, searchArgs) ||
+					exactMatch(platform.String(), searchArgs) || match(targetPackage.Name, searchArgs) ||
+					match(targetPackage.Maintainer, searchArgs) || match(targetPackage.WebsiteURL, searchArgs) {
 					if allVersions {
 						res = append(res, platform.GetAllReleases()...)
 					} else {

--- a/commands/core/testdata/package_index.json
+++ b/commands/core/testdata/package_index.json
@@ -1,0 +1,135 @@
+{
+  "packages": [
+    {
+      "name": "arduino",
+      "maintainer": "Arduino",
+      "websiteURL": "https://www.arduino.cc/",
+      "email": "packages@arduino.cc",
+      "help": {
+        "online": "http://www.arduino.cc/en/Reference/HomePage"
+      },
+      "platforms": [
+        {
+          "name": "Arduino AVR Boards",
+          "architecture": "avr",
+          "version": "1.8.3",
+          "category": "Arduino",
+          "help": {
+            "online": "http://www.arduino.cc/en/Reference/HomePage"
+          },
+          "url": "http://downloads.arduino.cc/cores/avr-1.8.3.tar.bz2",
+          "archiveFileName": "avr-1.8.3.tar.bz2",
+          "checksum": "SHA-256:de8a9b982477762d3d3e52fc2b682cdd8ff194dc3f1d46f4debdea6a01b33c14",
+          "size": "4941548",
+          "boards": [
+            { "name": "Arduino Yún" },
+            { "name": "Arduino Uno" },
+            { "name": "Arduino Uno WiFi" },
+            { "name": "Arduino Diecimila" },
+            { "name": "Arduino Nano" },
+            { "name": "Arduino Mega" },
+            { "name": "Arduino MegaADK" },
+            { "name": "Arduino Leonardo" },
+            { "name": "Arduino Leonardo Ethernet" },
+            { "name": "Arduino Micro" },
+            { "name": "Arduino Esplora" },
+            { "name": "Arduino Mini" },
+            { "name": "Arduino Ethernet" },
+            { "name": "Arduino Fio" },
+            { "name": "Arduino BT" },
+            { "name": "Arduino LilyPadUSB" },
+            { "name": "Arduino Lilypad" },
+            { "name": "Arduino Pro" },
+            { "name": "Arduino ATMegaNG" },
+            { "name": "Arduino Robot Control" },
+            { "name": "Arduino Robot Motor" },
+            { "name": "Arduino Gemma" },
+            { "name": "Adafruit Circuit Playground" },
+            { "name": "Arduino Yún Mini" },
+            { "name": "Arduino Industrial 101" },
+            { "name": "Linino One" }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "7.3.0-atmel3.6.1-arduino7"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            },
+            {
+              "packager": "arduino",
+              "name": "arduinoOTA",
+              "version": "1.3.0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Retrokits-RK002",
+      "maintainer": "Retrokits (www.retrokits.com)",
+      "websiteURL": "https://www.retrokits.com",
+      "email": "info@retrokits.com",
+      "help": { "online": "https://www.retrokits.com/rk002/arduino" },
+      "platforms": [
+        {
+          "name": "RK002",
+          "architecture": "arm",
+          "version": "1.0.5",
+          "category": "Contributed",
+          "help": {
+            "online": "https://www.retrokits.com/rk002/arduino"
+          },
+          "url": "https://www.retrokits.com/rk002/arduino/retrokits-rk002-1.0.5.tar.bz2",
+          "archiveFileName": "retrokits-rk002-1.0.5.tar.bz2",
+          "checksum": "SHA-256:9a012867baf4bb26f656f84502e0acce6a653c3452cca4505ebac77256802fb6",
+          "size": "290784",
+          "boards": [{ "name": "RK002" }],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "version": "4.8.3-2014q1",
+              "name": "arm-none-eabi-gcc"
+            }
+          ]
+        }
+      ],
+      "tools": []
+    },
+    {
+      "name": "Retrokits-RK002",
+      "maintainer": "Retrokits (www.retrokits.com)",
+      "websiteURL": "https://www.retrokits.com",
+      "email": "info@retrokits.com",
+      "help": { "online": "https://www.retrokits.com/rk002/arduino" },
+      "platforms": [
+        {
+          "name": "RK002",
+          "architecture": "arm",
+          "version": "1.0.6",
+          "category": "Contributed",
+          "help": {
+            "online": "https://www.retrokits.com/rk002/arduino"
+          },
+          "url": "https://www.retrokits.com/rk002/arduino/retrokits-rk002-1.0.6.tar.bz2",
+          "archiveFileName": "retrokits-rk002-1.0.6.tar.bz2",
+          "checksum": "SHA-256:8a3b63efcf4dfaed047a37844861387e542d8519485b5305d5979630cb3feb20",
+          "size": "291631",
+          "boards": [{ "name": "RK002" }],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "version": "4.8.3-2014q1",
+              "name": "arm-none-eabi-gcc"
+            }
+          ]
+        }
+      ],
+      "tools": []
+    }
+  ]
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -45,6 +45,37 @@ def test_core_search(run_command, httpserver):
     data = json.loads(result.stdout)
     assert 2 == len(data)
 
+    # Search all Retrokit platforms
+    result = run_command(f"core search retrokit --all --additional-urls={url}")
+    assert result.ok
+    assert 3 == len(result.stdout.strip().splitlines())
+    lines = [l.split(maxsplit=2) for l in result.stdout.strip().splitlines()]
+    assert ["Retrokits-RK002:arm", "1.0.5", "RK002"] in lines
+    assert ["Retrokits-RK002:arm", "1.0.6", "RK002"] in lines
+
+    # Search using Retrokit Package Maintainer
+    result = run_command(f"core search Retrokits-RK002 --all --additional-urls={url}")
+    assert result.ok
+    assert 3 == len(result.stdout.strip().splitlines())
+    lines = [l.split(maxsplit=2) for l in result.stdout.strip().splitlines()]
+    assert ["Retrokits-RK002:arm", "1.0.5", "RK002"] in lines
+    assert ["Retrokits-RK002:arm", "1.0.6", "RK002"] in lines
+
+    # Search using the Retrokit Platform name
+    result = run_command(f"core search rk002 --all --additional-urls={url}")
+    assert result.ok
+    assert 3 == len(result.stdout.strip().splitlines())
+    lines = [l.split(maxsplit=2) for l in result.stdout.strip().splitlines()]
+    assert ["Retrokits-RK002:arm", "1.0.5", "RK002"] in lines
+    assert ["Retrokits-RK002:arm", "1.0.6", "RK002"] in lines
+
+    # Search using a board name
+    result = run_command(f"core search myboard --all --additional-urls={url}")
+    assert result.ok
+    assert 2 == len(result.stdout.strip().splitlines())
+    lines = [l.split(maxsplit=2) for l in result.stdout.strip().splitlines()]
+    assert ["Package:x86", "1.2.3", "Platform"] in lines
+
 
 def test_core_search_no_args(run_command, httpserver):
     """

--- a/test/testdata/test_index.json
+++ b/test/testdata/test_index.json
@@ -111,6 +111,99 @@
                     ]
                 }
             ]
+        },
+        {
+            "name": "Retrokits-RK002",
+            "maintainer": "Retrokits (www.retrokits.com)",
+            "websiteURL": "https://www.retrokits.com",
+            "email": "info@retrokits.com",
+            "help": { "online": "https://www.retrokits.com/rk002/arduino" },
+            "platforms": [
+              {
+                "name": "RK002",
+                "architecture": "arm",
+                "version": "1.0.5",
+                "category": "Contributed",
+                "help": {
+                  "online": "https://www.retrokits.com/rk002/arduino"
+                },
+                "url": "https://www.retrokits.com/rk002/arduino/retrokits-rk002-1.0.5.tar.bz2",
+                "archiveFileName": "retrokits-rk002-1.0.5.tar.bz2",
+                "checksum": "SHA-256:9a012867baf4bb26f656f84502e0acce6a653c3452cca4505ebac77256802fb6",
+                "size": "290784",
+                "boards": [{ "name": "RK002" }],
+                "toolsDependencies": [
+                  {
+                    "packager": "arduino",
+                    "version": "4.8.3-2014q1",
+                    "name": "arm-none-eabi-gcc"
+                  }
+                ]
+              }
+            ],
+            "tools": []
+          },
+          {
+            "name": "Retrokits-RK002",
+            "maintainer": "Retrokits (www.retrokits.com)",
+            "websiteURL": "https://www.retrokits.com",
+            "email": "info@retrokits.com",
+            "help": { "online": "https://www.retrokits.com/rk002/arduino" },
+            "platforms": [
+              {
+                "name": "RK002",
+                "architecture": "arm",
+                "version": "1.0.6",
+                "category": "Contributed",
+                "help": {
+                  "online": "https://www.retrokits.com/rk002/arduino"
+                },
+                "url": "https://www.retrokits.com/rk002/arduino/retrokits-rk002-1.0.6.tar.bz2",
+                "archiveFileName": "retrokits-rk002-1.0.6.tar.bz2",
+                "checksum": "SHA-256:8a3b63efcf4dfaed047a37844861387e542d8519485b5305d5979630cb3feb20",
+                "size": "291631",
+                "boards": [{ "name": "RK002" }],
+                "toolsDependencies": [
+                  {
+                    "packager": "arduino",
+                    "version": "4.8.3-2014q1",
+                    "name": "arm-none-eabi-gcc"
+                  }
+                ]
+              }
+            ],
+            "tools": []
+          },
+          {
+            "name": "Package",
+            "tools": [],
+            "email": "test@example.com",
+            "maintainer": "Arduino",
+            "help": {
+                "online": "https://github.com/Arduino/arduino-cli"
+            },
+            "websiteURL": "https://github.com/Arduino/arduino-cli",
+            "platforms": [
+                {
+                    "category": "Test",
+                    "help": {
+                        "online": "https://github.com/Arduino/arduino-cli"
+                    },
+                    "url": "https://raw.githubusercontent.com/arduino/arduino-cli/master/test/testdata/core.zip",
+                    "checksum": "SHA-256:6a338cf4d6d501176a2d352c87a8d72ac7488b8c5b82cdf2a4e2cef630391092",
+                    "name": "Platform",
+                    "version": "1.2.3",
+                    "architecture": "x86",
+                    "archiveFileName": "core.zip",
+                    "size": "486",
+                    "toolsDependencies": [],
+                    "boards": [
+                        {
+                            "name": "MyBoard"
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**

Fixes `core search` command.

- **What is the current behavior?**

`core search` command doesn't search in a Platform's Package name, maintaner or website fields.
`arduino-cli core search retro --additional-urls https://www.retrokits.com/rk002/arduino/package_retrokits_index.json` doesn't find any core.

`arduino-cli core search rk --additional-urls https://www.retrokits.com/rk002/arduino/package_retrokits_index.json` finds the expected Retrokit core.

* **What is the new behavior?**

`core search` command now searches in a Platform's Package name, maintaner or website fields.
Now both `arduino-cli core search retro --additional-urls https://www.retrokits.com/rk002/arduino/package_retrokits_index.json` and `arduino-cli core search rk --additional-urls https://www.retrokits.com/rk002/arduino/package_retrokits_index.json` find the expected Retrokit core.

- **Does this PR introduce a breaking change?**

No.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
