### PR TITLE
Temporary fix for incorrect merge sketch+bootloader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cmaglie/pb v1.0.27
 	github.com/codeclysm/cc v1.2.2 // indirect
 	github.com/codeclysm/extract/v3 v3.0.2
+	github.com/facchinm/gohex v0.0.0-20201008150446-be2a6be25790
 	github.com/fatih/color v1.7.0
 	github.com/fluxio/iohelpers v0.0.0-20160419043813-3a4dd67a94d2 // indirect
 	github.com/fluxio/multierror v0.0.0-20160419044231-9c68d39025e5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,10 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/facchinm/gohex v0.0.0-20200531163658-baab2527a9a2 h1:wxlJYuJ7fk9Hb1i3ITRCi96oyRKenYffFdIA+V3A22c=
+github.com/facchinm/gohex v0.0.0-20200531163658-baab2527a9a2/go.mod h1:sErAiirjQXs3P13DBW7oPmJ6Q0WsFjYXVAhz7Xt59UQ=
+github.com/facchinm/gohex v0.0.0-20201008150446-be2a6be25790 h1:GTx/F+6TdhQAMtaDrpGDgnAzxYJhTVuTdSKpMsUbMNA=
+github.com/facchinm/gohex v0.0.0-20201008150446-be2a6be25790/go.mod h1:sErAiirjQXs3P13DBW7oPmJ6Q0WsFjYXVAhz7Xt59UQ=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fluxio/iohelpers v0.0.0-20160419043813-3a4dd67a94d2 h1:C6sOwknxwWfLBEQ91zhmptlfxf7pVEs5s6wOnDxNpS4=

--- a/legacy/builder/merge_sketch_with_bootloader.go
+++ b/legacy/builder/merge_sketch_with_bootloader.go
@@ -24,7 +24,7 @@ import (
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
 	"github.com/arduino/go-paths-helper"
-	"github.com/marcinbor85/gohex"
+	"github.com/facchinm/gohex"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This patch includes https://github.com/facchinm/gohex/commit/be2a6be257904703762abd66e6ce630074e3ca01 , which allows supporting .hex sections bigger than 64KB. 

Should fix https://github.com/arduino/ArduinoCore-avr/issues/366 and https://github.com/arduino/arduino-cli/issues/1009

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
See linked issues

* **What is the new behavior?**
<!-- if this is a feature change -->
The produced `with_bootloader.hex` and `with_bootloader.bin` can be flashed and are functional

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->

* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
