### PR TITLE
Fix platform tool dependency determination

### DIFF
--- a/arduino/cores/cores.go
+++ b/arduino/cores/cores.go
@@ -218,7 +218,7 @@ func (release *PlatformRelease) RequiresToolRelease(toolRelease *ToolRelease) bo
 	for _, toolDep := range release.Dependencies {
 		if toolDep.ToolName == toolRelease.Tool.Name &&
 			toolDep.ToolPackager == toolRelease.Tool.Package.Name &&
-			toolDep.ToolVersion == toolRelease.Version {
+			toolDep.ToolVersion.Equal(toolRelease.Version) {
 			return true
 		}
 	}

--- a/arduino/cores/cores_test.go
+++ b/arduino/cores/cores_test.go
@@ -1,0 +1,57 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package cores
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	semver "go.bug.st/relaxed-semver"
+)
+
+func TestRequiresToolRelease(t *testing.T) {
+	toolDependencyName := "avr-gcc"
+	toolDependencyVersion := "7.3.0-atmel3.6.1-arduino7"
+	toolDependencyPackager := "arduino"
+
+	release := PlatformRelease{
+		Dependencies: ToolDependencies{
+			{
+				ToolName:     toolDependencyName,
+				ToolVersion:  semver.ParseRelaxed(toolDependencyVersion),
+				ToolPackager: toolDependencyPackager,
+			},
+		},
+	}
+
+	toolRelease := &ToolRelease{
+		Version: semver.ParseRelaxed(toolDependencyVersion + "not"),
+		Tool: &Tool{
+			Name: toolDependencyName + "not",
+			Package: &Package{
+				Name: toolDependencyPackager + "not",
+			},
+		},
+	}
+
+	require.False(t, release.RequiresToolRelease(toolRelease))
+	toolRelease.Tool.Name = toolDependencyName
+	require.False(t, release.RequiresToolRelease(toolRelease))
+	toolRelease.Tool.Package.Name = toolDependencyPackager
+	require.False(t, release.RequiresToolRelease(toolRelease))
+	toolRelease.Version = semver.ParseRelaxed(toolDependencyVersion)
+	require.True(t, release.RequiresToolRelease(toolRelease))
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -205,6 +205,27 @@ def test_core_uninstall(run_command):
     assert not _in(result.stdout, "arduino:avr")
 
 
+def test_core_uninstall_tool_dependency_removal(run_command, data_dir):
+    # These platforms both have a dependency on the arduino:avr-gcc@7.3.0-atmel3.6.1-arduino5 tool
+    # arduino:avr@1.8.2 has a dependency on arduino:avrdude@6.3.0-arduino17
+    assert run_command("core install arduino:avr@1.8.2")
+    # arduino:megaavr@1.8.4 has a dependency on arduino:avrdude@6.3.0-arduino16
+    assert run_command("core install arduino:megaavr@1.8.4")
+    assert run_command("core uninstall arduino:avr")
+
+    arduino_tools_path = Path(data_dir, "packages", "arduino", "tools")
+
+    avr_gcc_binaries_path = arduino_tools_path.joinpath("avr-gcc", "7.3.0-atmel3.6.1-arduino5", "bin")
+    # The tool arduino:avr-gcc@7.3.0-atmel3.6.1-arduino5 that is a dep of another installed platform should remain
+    assert avr_gcc_binaries_path.joinpath("avr-gcc").exists() or avr_gcc_binaries_path.joinpath("avr-gcc.exe").exists()
+
+    avrdude_binaries_path = arduino_tools_path.joinpath("avrdude", "6.3.0-arduino17", "bin")
+    # The tool arduino:avrdude@6.3.0-arduino17 that is only a dep of arduino:avr should have been removed
+    assert (
+        avrdude_binaries_path.joinpath("avrdude").exists() or avrdude_binaries_path.joinpath("avrdude.exe").exists()
+    ) is False
+
+
 def test_core_zipslip(run_command):
     url = "https://raw.githubusercontent.com/arduino/arduino-cli/master/test/testdata/test_index.json"
     assert run_command("core update-index --additional-urls={}".format(url))


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The platform tool dependency check was giving false negatives due to comparing pointers instead of version values.

This caused tools to be removed during platform uninstallation even when another installed platform had a dependency on
that tool.
* **What is the new behavior?**
<!-- if this is a feature change -->
The `semver` package's `Equal` method is used for the comparison, resulting in accurate tool dependency determination.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
Steps to reproduce the bug fixed by this PR:
```
arduino-cli core install arduino-beta:mbed
arduino-cli core install arduino:samd
arduino-cli core uninstall arduino:samd
arduino-cli sketch new /tmp/Foo
arduino-cli compile -b arduino-beta-development:mbed:envie_m7 /tmp/Foo
```
`arduino-cli core uninstall arduino:samd` removes `arduino:arm-none-eabi-gcc@7-2017q4`, even though it's a dependency of the installed `arduino-beta:mbed` platform, causing the compilation for any board of that platform to fail.
