### PR TITLE
Fix default config file not found

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -43,14 +43,6 @@ func Init(configPath string) {
 		viper.SetConfigName("arduino-cli")
 	}
 
-	// Get default data path if none was provided
-	if configPath == "" {
-		configPath = getDefaultArduinoDataDir()
-	}
-
-	// Add paths where to search for a config file
-	viper.AddConfigPath(filepath.Dir(configPath))
-
 	// Bind env vars
 	viper.SetEnvPrefix("ARDUINO")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
@@ -60,6 +52,18 @@ func Init(configPath string) {
 	viper.BindEnv("directories.User", "ARDUINO_SKETCHBOOK_DIR")
 	viper.BindEnv("directories.Downloads", "ARDUINO_DOWNLOADS_DIR")
 	viper.BindEnv("directories.Data", "ARDUINO_DATA_DIR")
+
+	if configPath == "" {
+		// Get default data path if none was provided
+		if configPath = viper.GetString("directories.Data"); configPath != "" {
+			viper.AddConfigPath(configPath)
+		} else {
+			configPath = getDefaultArduinoDataDir()
+			viper.AddConfigPath(configPath)
+		}
+	} else {
+		viper.AddConfigPath(filepath.Dir(configPath))
+	}
 
 	// Early access directories.Data and directories.User in case
 	// those were set through env vars or cli flags

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -102,7 +102,7 @@ def test_init_config_file_flag_with_overwrite_flag(run_command, working_dir):
     assert str(config_file) in result.stdout
 
 
-def test_dump(run_command, working_dir):
+def test_dump(run_command, data_dir, working_dir):
     # Create a config file first
     config_file = Path(working_dir) / "config" / "test" / "config.yaml"
     assert not config_file.exists()
@@ -110,10 +110,21 @@ def test_dump(run_command, working_dir):
     assert result.ok
     assert config_file.exists()
 
-    result = run_command("config dump --format json")
+    result = run_command(f'config dump --config-file "{config_file}" --format json')
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert [] == settings_json["board_manager"]["additional_urls"]
+
+    result = run_command('config init --additional-urls "https://example.com"')
+    assert result.ok
+    config_file = Path(data_dir) / "arduino-cli.yaml"
+    assert str(config_file) in result.stdout
+    assert config_file.exists()
+
+    result = run_command("config dump --format json")
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert ["https://example.com"] == settings_json["board_manager"]["additional_urls"]
 
 
 def test_dump_with_config_file_flag(run_command, working_dir):


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
Fixes default config file never found.

- **What is the current behavior?**
Default config file is never found by the CLI.

* **What is the new behavior?**
Default config file is now found correctly.

- **Does this PR introduce a breaking change?**
No.

* **Other information**:
Fixes  #1018 

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
