### PR TITLE
[skip changelog] Resolve impossible to satisfy Flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,8 @@
 
 [flake8]
 max-line-length = 120
-ignore = E741
+ignore =
+    E741,
+    # W503 and W504 are mutually exclusive, so one or the other must be ignored.
+    # PEP 8 recommends line break before, so we keep W504.
+    W503


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Flake8/pycodestyle has a pair of mutually exclusive checks:

- [`W503`](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=W503%20(*)%09line%20break%20before): line break before binary operator
- [`W504`](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=W504%20(*)%09line%20break%20after): line break after binary operator

Having both these checks enabled results in a failed check when there is a line break at a binary operator, which can't be
resolved by moving the operator.

```python
if (
    some_long_condition
    and some_other_long_condition
):
```
fails the `W503` check.

```python
if (
    some_long_condition and
    some_other_long_condition
):
```
fails the `W504` check.
* **What is the new behavior?**
<!-- if this is a feature change -->
[PEP 8 recommends line break before the binary operator](https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator), so the logical choice of which of the two checks to keep is `W504`.

Flake8 is now configured to ignore `W503` and it is possible to format the Python code in a way that will pass the check.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No