### PR TITLE
[skip changelog] Document available memory build properties

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -270,6 +270,19 @@ For AVR we have:
     recipe.size.regex=^(?:\.text|\.data|\.bootloader)\s+([0-9]+).*
     recipe.size.regex.data=^(?:\.data|\.bss|\.noinit)\s+([0-9]+).*
 
+Two properties can be used to define the total available memory:
+
+- `{upload.maximum_size}`: available program storage space
+- `{upload.maximum_data_size}`: available dynamic memory for global variables
+
+If the binary sketch size exceeds the value of these properties, the compilation process fails.
+
+This information is displayed in the console output after compiling a sketch, along with the relative memory usage
+value:
+
+    Sketch uses 924 bytes (2%) of program storage space. Maximum is 32256 bytes.
+    Global variables use 9 bytes (0%) of dynamic memory, leaving 2039 bytes for local variables. Maximum is 2048 bytes.
+
 #### Recipes to export compiled binary
 
 When you do a **Sketch > Export compiled Binary** in the Arduino IDE, the compiled binary is copied from the build


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
`upload.maximum_data_size` and `upload.maximum_size` are properties used by the build system to fail
compilation when memory usage exceeds a threshold and to calculate the relative memory usage for display in the console.

These important properties, used in most boards platforms are undocumented.
* **What is the new behavior?**
<!-- if this is a feature change -->
`upload.maximum_data_size` and `upload.maximum_size` are documented.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No