### PR TITLE
[skip changelog] Link to Sketch build process docs from Platform specification

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -124,9 +124,9 @@ unused, it is reserved for future use (probably together with the Boards Manager
 
 ### Build process
 
-The platform.txt file is used to configure the build process. This is done through a list of **recipes**. Each recipe is
-a command line expression that explains how to call the compiler (or other tools) for every build step and which
-parameter should be passed.
+The platform.txt file is used to configure the [build process](sketch-build-process.md). This is done through a list of
+**recipes**. Each recipe is a command line expression that explains how to call the compiler (or other tools) for every
+build step and which parameter should be passed.
 
 The Arduino development software, before starting the build, determines the list of files to compile. The list is
 composed of:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The "Build process" section of the Arduino platform specification contains a short summary of the Arduino sketch build
process. The "Sketch build process" page of the documentation provides much more detailed information, which wouldn't be
appropriate in the platform specification, but could well be of interest to a platform developer.
* **What is the new behavior?**
<!-- if this is a feature change -->
Adding a link to the "Sketch build process" documentation from that section of the Platform specification makes all
relevant information easily accessible to the reader.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No