### PR TITLE
Refactored config to not use viper singleton instance

### DIFF
--- a/arduino/cores/packagemanager/loader.go
+++ b/arduino/cores/packagemanager/loader.go
@@ -30,12 +30,12 @@ import (
 
 // LoadHardware read all plaforms from the configured paths
 func (pm *PackageManager) LoadHardware() error {
-	dirs := configuration.HardwareDirectories()
+	dirs := configuration.HardwareDirectories(configuration.Settings)
 	if err := pm.LoadHardwareFromDirectories(dirs); err != nil {
 		return err
 	}
 
-	dirs = configuration.BundleToolsDirectories()
+	dirs = configuration.BundleToolsDirectories(configuration.Settings)
 	return pm.LoadToolsFromBundleDirectories(dirs)
 }
 

--- a/arduino/cores/packagemanager/package_manager_test.go
+++ b/arduino/cores/packagemanager/package_manager_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/arduino/arduino-cli/configuration"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	semver "go.bug.st/relaxed-semver"
 )
@@ -213,11 +212,11 @@ func TestBoardOptionsFunctions(t *testing.T) {
 
 func TestFindToolsRequiredForBoard(t *testing.T) {
 	os.Setenv("ARDUINO_DATA_DIR", dataDir1.String())
-	configuration.Init("")
+	configuration.Settings = configuration.Init("")
 	pm := packagemanager.NewPackageManager(
 		dataDir1,
-		configuration.PackagesDir(),
-		paths.New(viper.GetString("directories.Downloads")),
+		configuration.PackagesDir(configuration.Settings),
+		paths.New(configuration.Settings.GetString("directories.Downloads")),
 		dataDir1,
 	)
 

--- a/cli/cache/clean.go
+++ b/cli/cache/clean.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
+	"github.com/arduino/arduino-cli/configuration"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func initCleanCommand() *cobra.Command {
@@ -40,7 +40,7 @@ func initCleanCommand() *cobra.Command {
 func runCleanCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino cache clean`")
 
-	cachePath := viper.GetString("directories.Downloads")
+	cachePath := configuration.Settings.GetString("directories.Downloads")
 	err := os.RemoveAll(cachePath)
 	if err != nil {
 		feedback.Errorf("Error cleaning caches: %v", err)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -42,13 +42,13 @@ import (
 	"github.com/arduino/arduino-cli/cli/upgrade"
 	"github.com/arduino/arduino-cli/cli/upload"
 	"github.com/arduino/arduino-cli/cli/version"
+	"github.com/arduino/arduino-cli/configuration"
 	"github.com/arduino/arduino-cli/i18n"
 	"github.com/arduino/arduino-cli/inventory"
 	"github.com/mattn/go-colorable"
 	"github.com/rifflock/lfshook"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -99,15 +99,15 @@ func createCliCommandTree(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Print the logs on the standard output.")
 	cmd.PersistentFlags().String("log-level", "", "Messages with this level and above will be logged. Valid levels are: trace, debug, info, warn, error, fatal, panic")
-	viper.BindPFlag("logging.level", cmd.PersistentFlags().Lookup("log-level"))
+	configuration.Settings.BindPFlag("logging.level", cmd.PersistentFlags().Lookup("log-level"))
 	cmd.PersistentFlags().String("log-file", "", "Path to the file where logs will be written.")
-	viper.BindPFlag("logging.file", cmd.PersistentFlags().Lookup("log-file"))
+	configuration.Settings.BindPFlag("logging.file", cmd.PersistentFlags().Lookup("log-file"))
 	cmd.PersistentFlags().String("log-format", "", "The output format for the logs, can be {text|json}.")
-	viper.BindPFlag("logging.format", cmd.PersistentFlags().Lookup("log-format"))
+	configuration.Settings.BindPFlag("logging.format", cmd.PersistentFlags().Lookup("log-format"))
 	cmd.PersistentFlags().StringVar(&outputFormat, "format", "text", "The output format, can be {text|json}.")
 	cmd.PersistentFlags().StringVar(&configFile, "config-file", "", "The custom config file (if not specified the default will be used).")
 	cmd.PersistentFlags().StringSlice("additional-urls", []string{}, "Comma-separated list of additional URLs for the Boards Manager.")
-	viper.BindPFlag("board_manager.additional_urls", cmd.PersistentFlags().Lookup("additional-urls"))
+	configuration.Settings.BindPFlag("board_manager.additional_urls", cmd.PersistentFlags().Lookup("additional-urls"))
 }
 
 // convert the string passed to the `--log-level` option to the corresponding
@@ -136,10 +136,10 @@ func parseFormatString(arg string) (feedback.OutputFormat, bool) {
 }
 
 func preRun(cmd *cobra.Command, args []string) {
-	configFile := viper.ConfigFileUsed()
+	configFile := configuration.Settings.ConfigFileUsed()
 
 	// initialize inventory
-	inventory.Init(viper.GetString("directories.Data"))
+	inventory.Init(configuration.Settings.GetString("directories.Data"))
 
 	//
 	// Prepare logging
@@ -157,13 +157,13 @@ func preRun(cmd *cobra.Command, args []string) {
 	}
 
 	// set the Logger format
-	logFormat := strings.ToLower(viper.GetString("logging.format"))
+	logFormat := strings.ToLower(configuration.Settings.GetString("logging.format"))
 	if logFormat == "json" {
 		logrus.SetFormatter(&logrus.JSONFormatter{})
 	}
 
 	// should we log to file?
-	logFile := viper.GetString("logging.file")
+	logFile := configuration.Settings.GetString("logging.file")
 	if logFile != "" {
 		file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 		if err != nil {
@@ -180,8 +180,8 @@ func preRun(cmd *cobra.Command, args []string) {
 	}
 
 	// configure logging filter
-	if lvl, found := toLogLevel(viper.GetString("logging.level")); !found {
-		feedback.Errorf("Invalid option for --log-level: %s", viper.GetString("logging.level"))
+	if lvl, found := toLogLevel(configuration.Settings.GetString("logging.level")); !found {
+		feedback.Errorf("Invalid option for --log-level: %s", configuration.Settings.GetString("logging.level"))
 		os.Exit(errorcodes.ErrBadArgument)
 	} else {
 		logrus.SetLevel(lvl)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -99,15 +99,12 @@ func createCliCommandTree(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Print the logs on the standard output.")
 	cmd.PersistentFlags().String("log-level", "", "Messages with this level and above will be logged. Valid levels are: trace, debug, info, warn, error, fatal, panic")
-	configuration.Settings.BindPFlag("logging.level", cmd.PersistentFlags().Lookup("log-level"))
 	cmd.PersistentFlags().String("log-file", "", "Path to the file where logs will be written.")
-	configuration.Settings.BindPFlag("logging.file", cmd.PersistentFlags().Lookup("log-file"))
 	cmd.PersistentFlags().String("log-format", "", "The output format for the logs, can be {text|json}.")
-	configuration.Settings.BindPFlag("logging.format", cmd.PersistentFlags().Lookup("log-format"))
 	cmd.PersistentFlags().StringVar(&outputFormat, "format", "text", "The output format, can be {text|json}.")
 	cmd.PersistentFlags().StringVar(&configFile, "config-file", "", "The custom config file (if not specified the default will be used).")
 	cmd.PersistentFlags().StringSlice("additional-urls", []string{}, "Comma-separated list of additional URLs for the Boards Manager.")
-	configuration.Settings.BindPFlag("board_manager.additional_urls", cmd.PersistentFlags().Lookup("additional-urls"))
+	configuration.BindFlags(cmd, configuration.Settings)
 }
 
 // convert the string passed to the `--log-level` option to the corresponding

--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/arduino/arduino-cli/cli/feedback"
+	"github.com/arduino/arduino-cli/configuration"
 
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/instance"
@@ -29,7 +30,6 @@ import (
 	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -124,7 +124,7 @@ func run(cmd *cobra.Command, args []string) {
 		Libraries:        libraries,
 		OptimizeForDebug: optimizeForDebug,
 		Clean:            clean,
-	}, os.Stdout, os.Stderr, viper.GetString("logging.level") == "debug")
+	}, os.Stdout, os.Stderr, configuration.Settings.GetString("logging.level") == "debug")
 
 	if err != nil {
 		feedback.Errorf("Error during build: %v", err)

--- a/cli/config/dump.go
+++ b/cli/config/dump.go
@@ -19,9 +19,9 @@ import (
 	"os"
 
 	"github.com/arduino/arduino-cli/cli/feedback"
+	"github.com/arduino/arduino-cli/configuration"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )
 
@@ -59,5 +59,5 @@ func (dr dumpResult) String() string {
 
 func runDumpCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino config dump`")
-	feedback.PrintResult(dumpResult{viper.AllSettings()})
+	feedback.PrintResult(dumpResult{configuration.Settings.AllSettings()})
 }

--- a/cli/config/init.go
+++ b/cli/config/init.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
+	"github.com/arduino/arduino-cli/configuration"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var destDir string
@@ -47,7 +47,7 @@ func initInitCommand() *cobra.Command {
 
 func runInitCommand(cmd *cobra.Command, args []string) {
 	if destDir == "" {
-		destDir = viper.GetString("directories.Data")
+		destDir = configuration.Settings.GetString("directories.Data")
 	}
 
 	absPath, err := filepath.Abs(destDir)
@@ -64,7 +64,7 @@ func runInitCommand(cmd *cobra.Command, args []string) {
 		os.Exit(errorcodes.ErrGeneric)
 	}
 
-	if err := viper.WriteConfigAs(configFileAbsPath); err != nil {
+	if err := configuration.Settings.WriteConfigAs(configFileAbsPath); err != nil {
 		feedback.Errorf("Cannot create config file: %v", err)
 		os.Exit(errorcodes.ErrGeneric)
 	}

--- a/cli/config/init.go
+++ b/cli/config/init.go
@@ -17,16 +17,21 @@ package config
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/arduino/arduino-cli/configuration"
+	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-var destDir string
+var (
+	destDir   string
+	destFile  string
+	overwrite bool
+)
 
 const defaultFileName = "arduino-cli.yaml"
 
@@ -37,39 +42,71 @@ func initInitCommand() *cobra.Command {
 		Long:  "Creates or updates the configuration file in the data directory or custom directory with the current configuration settings.",
 		Example: "" +
 			"  # Writes current configuration to the configuration file in the data directory.\n" +
-			"  " + os.Args[0] + " config init",
+			"  " + os.Args[0] + " config init" +
+			"  " + os.Args[0] + " config init --dest-dir /home/user/MyDirectory" +
+			"  " + os.Args[0] + " config init --dest-file /home/user/MyDirectory/my_settings.yaml",
 		Args: cobra.NoArgs,
 		Run:  runInitCommand,
 	}
 	initCommand.Flags().StringVar(&destDir, "dest-dir", "", "Sets where to save the configuration file.")
+	initCommand.Flags().StringVar(&destFile, "dest-file", "", "Sets where to save the configuration file.")
+	initCommand.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite existing config file.")
 	return initCommand
 }
 
 func runInitCommand(cmd *cobra.Command, args []string) {
-	if destDir == "" {
-		destDir = configuration.Settings.GetString("directories.Data")
-	}
-
-	absPath, err := filepath.Abs(destDir)
-	if err != nil {
-		feedback.Errorf("Cannot find absolute path: %v", err)
+	if destFile != "" && destDir != "" {
+		feedback.Errorf("Can't use both --dest-file and --dest-dir flags at the same time.")
 		os.Exit(errorcodes.ErrGeneric)
 	}
-	configFileAbsPath := filepath.Join(absPath, defaultFileName)
+
+	var configFileAbsPath *paths.Path
+	var absPath *paths.Path
+	var err error
+
+	switch {
+	case destFile != "":
+		configFileAbsPath, err = paths.New(destFile).Abs()
+		if err != nil {
+			feedback.Errorf("Cannot find absolute path: %v", err)
+			os.Exit(errorcodes.ErrGeneric)
+		}
+
+		absPath = configFileAbsPath.Parent()
+	case destDir == "":
+		destDir = configuration.Settings.GetString("directories.Data")
+		fallthrough
+	default:
+		absPath, err = paths.New(destDir).Abs()
+		if err != nil {
+			feedback.Errorf("Cannot find absolute path: %v", err)
+			os.Exit(errorcodes.ErrGeneric)
+		}
+		configFileAbsPath = absPath.Join(defaultFileName)
+	}
+
+	if !overwrite && configFileAbsPath.Exist() {
+		feedback.Error("Config file already exists, use --overwrite to discard the existing one.")
+		os.Exit(errorcodes.ErrGeneric)
+	}
 
 	logrus.Infof("Writing config file to: %s", absPath)
 
-	if err := os.MkdirAll(absPath, os.FileMode(0755)); err != nil {
+	if err := absPath.MkdirAll(); err != nil {
 		feedback.Errorf("Cannot create config file directory: %v", err)
 		os.Exit(errorcodes.ErrGeneric)
 	}
 
-	if err := configuration.Settings.WriteConfigAs(configFileAbsPath); err != nil {
+	newSettings := viper.New()
+	configuration.SetDefaults(newSettings)
+	configuration.BindFlags(cmd, newSettings)
+
+	if err := newSettings.WriteConfigAs(configFileAbsPath.String()); err != nil {
 		feedback.Errorf("Cannot create config file: %v", err)
 		os.Exit(errorcodes.ErrGeneric)
 	}
 
-	msg := "Config file written to: " + configFileAbsPath
+	msg := "Config file written to: " + configFileAbsPath.String()
 	logrus.Info(msg)
 	feedback.Print(msg)
 }

--- a/commands/board/list_test.go
+++ b/commands/board/list_test.go
@@ -22,9 +22,18 @@ import (
 	"testing"
 
 	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/configuration"
 	"github.com/arduino/go-properties-orderedmap"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	configuration.Settings = configuration.Init("")
+}
+
+func reset() {
+	configuration.Settings = configuration.Init("")
+}
 
 func TestGetByVidPid(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/commands/board/list_test.go
+++ b/commands/board/list_test.go
@@ -31,10 +31,6 @@ func init() {
 	configuration.Settings = configuration.Init("")
 }
 
-func reset() {
-	configuration.Settings = configuration.Init("")
-}
-
 func TestGetByVidPid(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -39,7 +39,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/segmentio/stats/v4"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // Compile FIXMEDOC
@@ -122,11 +121,11 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 	builderCtx.SketchLocation = sketch.FullPath
 
 	// FIXME: This will be redundant when arduino-builder will be part of the cli
-	builderCtx.HardwareDirs = configuration.HardwareDirectories()
-	builderCtx.BuiltInToolsDirs = configuration.BundleToolsDirectories()
+	builderCtx.HardwareDirs = configuration.HardwareDirectories(configuration.Settings)
+	builderCtx.BuiltInToolsDirs = configuration.BundleToolsDirectories(configuration.Settings)
 
 	builderCtx.OtherLibrariesDirs = paths.NewPathList(req.GetLibraries()...)
-	builderCtx.OtherLibrariesDirs.Add(configuration.LibrariesDir())
+	builderCtx.OtherLibrariesDirs.Add(configuration.LibrariesDir(configuration.Settings))
 
 	if req.GetBuildPath() != "" {
 		builderCtx.BuildPath = paths.New(req.GetBuildPath())
@@ -168,7 +167,7 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 	builderCtx.ArduinoAPIVersion = "10607"
 
 	// Check if Arduino IDE is installed and get it's libraries location.
-	dataDir := paths.New(viper.GetString("directories.Data"))
+	dataDir := paths.New(configuration.Settings.GetString("directories.Data"))
 	preferencesTxt := dataDir.Join("preferences.txt")
 	ideProperties, err := properties.LoadFromPath(preferencesTxt)
 	if err == nil {

--- a/commands/core/search_test.go
+++ b/commands/core/search_test.go
@@ -46,7 +46,7 @@ func TestPlatformSearch(t *testing.T) {
 	err := paths.New("testdata").Join("package_index.json").CopyTo(dataDir.Join("package_index.json"))
 	require.Nil(t, err)
 
-	configuration.Init(paths.TempDir().Join("test", "arduino-cli.yaml").String())
+	configuration.Settings = configuration.Init(paths.TempDir().Join("test", "arduino-cli.yaml").String())
 
 	inst, err := instance.CreateInstance()
 	require.Nil(t, err)

--- a/commands/daemon/settings.go
+++ b/commands/daemon/settings.go
@@ -20,8 +20,8 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/arduino/arduino-cli/configuration"
 	rpc "github.com/arduino/arduino-cli/rpc/settings"
-	"github.com/spf13/viper"
 )
 
 // SettingsService implements the `Settings` service
@@ -30,7 +30,7 @@ type SettingsService struct{}
 // GetAll returns a message with a string field containing all the settings
 // currently in use, marshalled in JSON format.
 func (s *SettingsService) GetAll(ctx context.Context, req *rpc.GetAllRequest) (*rpc.RawData, error) {
-	b, err := json.Marshal(viper.AllSettings())
+	b, err := json.Marshal(configuration.Settings.AllSettings())
 	if err == nil {
 		return &rpc.RawData{
 			JsonData: string(b),
@@ -47,7 +47,7 @@ func (s *SettingsService) Merge(ctx context.Context, req *rpc.RawData) (*rpc.Mer
 		return nil, err
 	}
 
-	if err := viper.MergeConfigMap(toMerge); err != nil {
+	if err := configuration.Settings.MergeConfigMap(toMerge); err != nil {
 		return nil, err
 	}
 
@@ -61,11 +61,11 @@ func (s *SettingsService) GetValue(ctx context.Context, req *rpc.GetValueRequest
 	key := req.GetKey()
 	value := &rpc.Value{}
 
-	if !viper.InConfig(key) {
+	if !configuration.Settings.InConfig(key) {
 		return nil, errors.New("key not found in settings")
 	}
 
-	b, err := json.Marshal(viper.Get(key))
+	b, err := json.Marshal(configuration.Settings.Get(key))
 	if err == nil {
 		value.Key = key
 		value.JsonData = string(b)
@@ -81,7 +81,7 @@ func (s *SettingsService) SetValue(ctx context.Context, val *rpc.Value) (*rpc.Se
 
 	err := json.Unmarshal([]byte(val.GetJsonData()), &value)
 	if err == nil {
-		viper.Set(key, value)
+		configuration.Settings.Set(key, value)
 	}
 
 	return &rpc.SetValueResponse{}, err

--- a/commands/daemon/settings_test.go
+++ b/commands/daemon/settings_test.go
@@ -18,9 +18,8 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"testing"
-
-	"github.com/spf13/viper"
 
 	"github.com/arduino/arduino-cli/configuration"
 	rpc "github.com/arduino/arduino-cli/rpc/settings"
@@ -30,19 +29,18 @@ import (
 var svc = SettingsService{}
 
 func init() {
-	configuration.Init("testdata")
+	configuration.Settings = configuration.Init(filepath.Join("testdata", "arduino-cli.yaml"))
 }
 
 func reset() {
-	viper.Reset()
-	configuration.Init("testdata")
+	configuration.Settings = configuration.Init(filepath.Join("testdata", "arduino-cli.yaml"))
 }
 
 func TestGetAll(t *testing.T) {
 	resp, err := svc.GetAll(context.Background(), &rpc.GetAllRequest{})
 	require.Nil(t, err)
 
-	content, err := json.Marshal(viper.AllSettings())
+	content, err := json.Marshal(configuration.Settings.AllSettings())
 	require.Nil(t, err)
 
 	require.Equal(t, string(content), resp.GetJsonData())
@@ -53,8 +51,8 @@ func TestMerge(t *testing.T) {
 	_, err := svc.Merge(context.Background(), &rpc.RawData{JsonData: bulkSettings})
 	require.Nil(t, err)
 
-	require.Equal(t, "420", viper.GetString("daemon.port"))
-	require.Equal(t, "bar", viper.GetString("foo"))
+	require.Equal(t, "420", configuration.Settings.GetString("daemon.port"))
+	require.Equal(t, "bar", configuration.Settings.GetString("foo"))
 
 	reset()
 }
@@ -80,5 +78,5 @@ func TestSetValue(t *testing.T) {
 	}
 	_, err := svc.SetValue(context.Background(), val)
 	require.Nil(t, err)
-	require.Equal(t, "bar", viper.GetString("foo"))
+	require.Equal(t, "bar", configuration.Settings.GetString("foo"))
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -36,30 +36,26 @@ var Settings *viper.Viper
 // Init initialize defaults and read the configuration file.
 // Please note the logging system hasn't been configured yet,
 // so logging shouldn't be used here.
-func Init(configPath string) *viper.Viper {
-	// Config file metadata
+func Init(configFile string) *viper.Viper {
 	jww.SetStdoutThreshold(jww.LevelFatal)
+
+	// Create a new viper instance with default values for all the settings
 	settings := viper.New()
-	// Set default values for all the settings
 	SetDefaults(settings)
 
-	configDir := paths.New(configPath)
-	if configDir != nil && !configDir.IsDir() {
-		settings.SetConfigName(strings.TrimSuffix(configDir.Base(), configDir.Ext()))
+	// Set config name and config path
+	if configFilePath := paths.New(configFile); configFilePath != nil {
+		settings.SetConfigName(strings.TrimSuffix(configFilePath.Base(), configFilePath.Ext()))
+		settings.AddConfigPath(configFilePath.Parent().String())
 	} else {
-		settings.SetConfigName("arduino-cli")
-	}
-
-	if configPath == "" {
+		configDir := settings.GetString("directories.Data")
 		// Get default data path if none was provided
-		if configPath = settings.GetString("directories.Data"); configPath != "" {
-			settings.AddConfigPath(configPath)
-		} else {
-			configPath = getDefaultArduinoDataDir()
-			settings.AddConfigPath(configPath)
+		if configDir == "" {
+			configDir = getDefaultArduinoDataDir()
 		}
-	} else {
-		settings.AddConfigPath(filepath.Dir(configPath))
+
+		settings.SetConfigName("arduino-cli")
+		settings.AddConfigPath(configDir)
 	}
 
 	// Attempt to read config file

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -25,6 +25,7 @@ import (
 	paths "github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-win32-utils"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	jww "github.com/spf13/jwalterweatherman"
 	"github.com/spf13/viper"
 )
@@ -39,6 +40,8 @@ func Init(configPath string) *viper.Viper {
 	// Config file metadata
 	jww.SetStdoutThreshold(jww.LevelFatal)
 	settings := viper.New()
+	// Set default values for all the settings
+	SetDefaults(settings)
 
 	configDir := paths.New(configPath)
 	if configDir != nil && !configDir.IsDir() {
@@ -46,16 +49,6 @@ func Init(configPath string) *viper.Viper {
 	} else {
 		settings.SetConfigName("arduino-cli")
 	}
-
-	// Bind env vars
-	settings.SetEnvPrefix("ARDUINO")
-	settings.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	settings.AutomaticEnv()
-
-	// Bind env aliases to keep backward compatibility
-	settings.BindEnv("directories.User", "ARDUINO_SKETCHBOOK_DIR")
-	settings.BindEnv("directories.Downloads", "ARDUINO_DOWNLOADS_DIR")
-	settings.BindEnv("directories.Data", "ARDUINO_DATA_DIR")
 
 	if configPath == "" {
 		// Get default data path if none was provided
@@ -69,20 +62,6 @@ func Init(configPath string) *viper.Viper {
 		settings.AddConfigPath(filepath.Dir(configPath))
 	}
 
-	// Early access directories.Data and directories.User in case
-	// those were set through env vars or cli flags
-	dataDir := settings.GetString("directories.Data")
-	if dataDir == "" {
-		dataDir = getDefaultArduinoDataDir()
-	}
-	userDir := settings.GetString("directories.User")
-	if userDir == "" {
-		userDir = getDefaultUserDir()
-	}
-
-	// Set default values for all the settings
-	setDefaults(settings, dataDir, userDir)
-
 	// Attempt to read config file
 	if err := settings.ReadInConfig(); err != nil {
 		// ConfigFileNotFoundError is acceptable, anything else
@@ -93,6 +72,14 @@ func Init(configPath string) *viper.Viper {
 	}
 
 	return settings
+}
+
+// BindFlags creates all the flags binding between the cobra Command and the instance of viper
+func BindFlags(cmd *cobra.Command, settings *viper.Viper) {
+	settings.BindPFlag("logging.level", cmd.Flag("log-level"))
+	settings.BindPFlag("logging.file", cmd.Flag("log-file"))
+	settings.BindPFlag("logging.format", cmd.Flag("log-format"))
+	settings.BindPFlag("board_manager.additional_urls", cmd.Flag("additional-urls"))
 }
 
 // getDefaultArduinoDataDir returns the full path to the default arduino folder

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -71,3 +71,8 @@ func BenchmarkSearchConfigTree(b *testing.B) {
 	}
 	result = s
 }
+
+func TestInit(t *testing.T) {
+	settings := Init("")
+	require.NotNil(t, settings)
+}

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	paths "github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,7 +42,7 @@ func tmpDirOrDie() string {
 
 func TestSearchConfigTreeNotFound(t *testing.T) {
 	tmp := tmpDirOrDie()
-	require.Empty(t, searchConfigTree(tmp))
+	require.Empty(t, searchConfigTree(paths.New(tmp)))
 }
 
 func TestSearchConfigTreeSameFolder(t *testing.T) {
@@ -49,7 +50,7 @@ func TestSearchConfigTreeSameFolder(t *testing.T) {
 	defer os.RemoveAll(tmp)
 	_, err := os.Create(filepath.Join(tmp, "arduino-cli.yaml"))
 	require.Nil(t, err)
-	require.Equal(t, tmp, searchConfigTree(tmp))
+	require.Equal(t, tmp, searchConfigTree(paths.New(tmp)).String())
 }
 
 func TestSearchConfigTreeInParent(t *testing.T) {
@@ -60,10 +61,10 @@ func TestSearchConfigTreeInParent(t *testing.T) {
 	require.Nil(t, err)
 	_, err = os.Create(filepath.Join(tmp, "arduino-cli.yaml"))
 	require.Nil(t, err)
-	require.Equal(t, tmp, searchConfigTree(target))
+	require.Equal(t, tmp, searchConfigTree(paths.New(target)).String())
 }
 
-var result string
+var result *paths.Path
 
 func BenchmarkSearchConfigTree(b *testing.B) {
 	tmp := tmpDirOrDie()
@@ -71,9 +72,9 @@ func BenchmarkSearchConfigTree(b *testing.B) {
 	target := filepath.Join(tmp, "foo", "bar", "baz")
 	os.MkdirAll(target, os.ModePerm)
 
-	var s string
+	var s *paths.Path
 	for n := 0; n < b.N; n++ {
-		s = searchConfigTree(target)
+		s = searchConfigTree(paths.New(target))
 	}
 	result = s
 }
@@ -100,16 +101,16 @@ func TestInit(t *testing.T) {
 }
 
 func TestFindConfigFile(t *testing.T) {
-	configFile := FindConfigFile([]string{"--config-file"})
+	configFile := FindConfigFileInArgsOrWorkingDirectory([]string{"--config-file"})
 	require.Equal(t, "", configFile)
 
-	configFile = FindConfigFile([]string{"--config-file", "some/path/to/config"})
+	configFile = FindConfigFileInArgsOrWorkingDirectory([]string{"--config-file", "some/path/to/config"})
 	require.Equal(t, "some/path/to/config", configFile)
 
-	configFile = FindConfigFile([]string{"--config-file", "some/path/to/config/arduino-cli.yaml"})
+	configFile = FindConfigFileInArgsOrWorkingDirectory([]string{"--config-file", "some/path/to/config/arduino-cli.yaml"})
 	require.Equal(t, "some/path/to/config/arduino-cli.yaml", configFile)
 
-	configFile = FindConfigFile([]string{})
+	configFile = FindConfigFileInArgsOrWorkingDirectory([]string{})
 	require.Equal(t, "", configFile)
 
 	// Create temporary directories
@@ -124,7 +125,7 @@ func TestFindConfigFile(t *testing.T) {
 	require.Nil(t, err)
 	f.Close()
 
-	configFile = FindConfigFile([]string{})
+	configFile = FindConfigFileInArgsOrWorkingDirectory([]string{})
 	require.Equal(t, filepath.Join(tmp, "foo", "arduino-cli.yaml"), configFile)
 
 	// Create another config file
@@ -132,6 +133,6 @@ func TestFindConfigFile(t *testing.T) {
 	require.Nil(t, err)
 	f.Close()
 
-	configFile = FindConfigFile([]string{})
+	configFile = FindConfigFileInArgsOrWorkingDirectory([]string{})
 	require.Equal(t, filepath.Join(target, "arduino-cli.yaml"), configFile)
 }

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -17,11 +17,13 @@ package configuration
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/viper"
 )
 
-func setDefaults(settings *viper.Viper, dataDir, userDir string) {
+// SetDefaults sets the default values for certain keys
+func SetDefaults(settings *viper.Viper) {
 	// logging
 	settings.SetDefault("logging.level", "info")
 	settings.SetDefault("logging.format", "text")
@@ -30,9 +32,9 @@ func setDefaults(settings *viper.Viper, dataDir, userDir string) {
 	settings.SetDefault("board_manager.additional_urls", []string{})
 
 	// arduino directories
-	settings.SetDefault("directories.Data", dataDir)
-	settings.SetDefault("directories.Downloads", filepath.Join(dataDir, "staging"))
-	settings.SetDefault("directories.User", userDir)
+	settings.SetDefault("directories.Data", getDefaultArduinoDataDir())
+	settings.SetDefault("directories.Downloads", filepath.Join(getDefaultArduinoDataDir(), "staging"))
+	settings.SetDefault("directories.User", getDefaultUserDir())
 
 	// daemon settings
 	settings.SetDefault("daemon.port", "50051")
@@ -40,4 +42,14 @@ func setDefaults(settings *viper.Viper, dataDir, userDir string) {
 	//telemetry settings
 	settings.SetDefault("telemetry.enabled", true)
 	settings.SetDefault("telemetry.addr", ":9090")
+
+	// Bind env vars
+	settings.SetEnvPrefix("ARDUINO")
+	settings.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	settings.AutomaticEnv()
+
+	// Bind env aliases to keep backward compatibility
+	settings.BindEnv("directories.User", "ARDUINO_SKETCHBOOK_DIR")
+	settings.BindEnv("directories.Downloads", "ARDUINO_DOWNLOADS_DIR")
+	settings.BindEnv("directories.Data", "ARDUINO_DATA_DIR")
 }

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -21,23 +21,23 @@ import (
 	"github.com/spf13/viper"
 )
 
-func setDefaults(dataDir, userDir string) {
+func setDefaults(settings *viper.Viper, dataDir, userDir string) {
 	// logging
-	viper.SetDefault("logging.level", "info")
-	viper.SetDefault("logging.format", "text")
+	settings.SetDefault("logging.level", "info")
+	settings.SetDefault("logging.format", "text")
 
 	// Boards Manager
-	viper.SetDefault("board_manager.additional_urls", []string{})
+	settings.SetDefault("board_manager.additional_urls", []string{})
 
 	// arduino directories
-	viper.SetDefault("directories.Data", dataDir)
-	viper.SetDefault("directories.Downloads", filepath.Join(dataDir, "staging"))
-	viper.SetDefault("directories.User", userDir)
+	settings.SetDefault("directories.Data", dataDir)
+	settings.SetDefault("directories.Downloads", filepath.Join(dataDir, "staging"))
+	settings.SetDefault("directories.User", userDir)
 
 	// daemon settings
-	viper.SetDefault("daemon.port", "50051")
+	settings.SetDefault("daemon.port", "50051")
 
 	//telemetry settings
-	viper.SetDefault("telemetry.enabled", true)
-	viper.SetDefault("telemetry.addr", ":9090")
+	settings.SetDefault("telemetry.enabled", true)
+	settings.SetDefault("telemetry.addr", ":9090")
 }

--- a/configuration/directories.go
+++ b/configuration/directories.go
@@ -21,26 +21,26 @@ import (
 )
 
 // HardwareDirectories returns all paths that may contains hardware packages.
-func HardwareDirectories() paths.PathList {
+func HardwareDirectories(settings *viper.Viper) paths.PathList {
 	res := paths.PathList{}
 
-	if IsBundledInDesktopIDE() {
-		ideDir := paths.New(viper.GetString("IDE.Directory"))
+	if IsBundledInDesktopIDE(settings) {
+		ideDir := paths.New(settings.GetString("IDE.Directory"))
 		bundledHardwareDir := ideDir.Join("hardware")
 		if bundledHardwareDir.IsDir() {
 			res.Add(bundledHardwareDir)
 		}
 	}
 
-	if viper.IsSet("directories.Data") {
-		packagesDir := PackagesDir()
+	if settings.IsSet("directories.Data") {
+		packagesDir := PackagesDir(Settings)
 		if packagesDir.IsDir() {
 			res.Add(packagesDir)
 		}
 	}
 
-	if viper.IsSet("directories.User") {
-		skDir := paths.New(viper.GetString("directories.User"))
+	if settings.IsSet("directories.User") {
+		skDir := paths.New(settings.GetString("directories.User"))
 		hwDir := skDir.Join("hardware")
 		if hwDir.IsDir() {
 			res.Add(hwDir)
@@ -51,11 +51,11 @@ func HardwareDirectories() paths.PathList {
 }
 
 // BundleToolsDirectories returns all paths that may contains bundled-tools.
-func BundleToolsDirectories() paths.PathList {
+func BundleToolsDirectories(settings *viper.Viper) paths.PathList {
 	res := paths.PathList{}
 
-	if IsBundledInDesktopIDE() {
-		ideDir := paths.New(viper.GetString("IDE.Directory"))
+	if IsBundledInDesktopIDE(settings) {
+		ideDir := paths.New(settings.GetString("IDE.Directory"))
 		bundledToolsDir := ideDir.Join("hardware", "tools")
 		if bundledToolsDir.IsDir() {
 			res = append(res, bundledToolsDir)
@@ -68,9 +68,9 @@ func BundleToolsDirectories() paths.PathList {
 // IDEBundledLibrariesDir returns the libraries directory bundled in
 // the Arduino IDE. If there is no Arduino IDE or the directory doesn't
 // exists then nil is returned
-func IDEBundledLibrariesDir() *paths.Path {
-	if IsBundledInDesktopIDE() {
-		ideDir := paths.New(viper.GetString("IDE.Directory"))
+func IDEBundledLibrariesDir(settings *viper.Viper) *paths.Path {
+	if IsBundledInDesktopIDE(settings) {
+		ideDir := paths.New(Settings.GetString("IDE.Directory"))
 		libDir := ideDir.Join("libraries")
 		if libDir.IsDir() {
 			return libDir
@@ -82,11 +82,11 @@ func IDEBundledLibrariesDir() *paths.Path {
 
 // LibrariesDir returns the full path to the user directory containing
 // custom libraries
-func LibrariesDir() *paths.Path {
-	return paths.New(viper.GetString("directories.User")).Join("libraries")
+func LibrariesDir(settings *viper.Viper) *paths.Path {
+	return paths.New(settings.GetString("directories.User")).Join("libraries")
 }
 
 // PackagesDir returns the full path to the packages folder
-func PackagesDir() *paths.Path {
-	return paths.New(viper.GetString("directories.Data")).Join("packages")
+func PackagesDir(settings *viper.Viper) *paths.Path {
+	return paths.New(settings.GetString("directories.Data")).Join("packages")
 }

--- a/docsgen/main.go
+++ b/docsgen/main.go
@@ -29,7 +29,7 @@ func main() {
 		log.Fatal("Please provide output folder")
 	}
 
-	configuration.Settings = configuration.Init(configuration.FindConfigFile(os.Args))
+	configuration.Settings = configuration.Init(configuration.FindConfigFileInArgsOrWorkingDirectory(os.Args))
 	cli := cli.NewCommand()
 	cli.DisableAutoGenTag = true // Disable addition of auto-generated date stamp
 	err := doc.GenMarkdownTree(cli, os.Args[1])

--- a/docsgen/main.go
+++ b/docsgen/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/arduino/arduino-cli/cli"
+	"github.com/arduino/arduino-cli/configuration"
 	"github.com/spf13/cobra/doc"
 )
 
@@ -28,8 +29,9 @@ func main() {
 		log.Fatal("Please provide output folder")
 	}
 
+	configuration.Settings = configuration.Init(configuration.FindConfigFile(os.Args))
 	cli := cli.NewCommand()
-	cli.DisableAutoGenTag = true  // Disable addition of auto-generated date stamp
+	cli.DisableAutoGenTag = true // Disable addition of auto-generated date stamp
 	err := doc.GenMarkdownTree(cli, os.Args[1])
 	if err != nil {
 		log.Fatal(err)

--- a/httpclient/httpclient_config.go
+++ b/httpclient/httpclient_config.go
@@ -22,7 +22,7 @@ import (
 	"runtime"
 
 	"github.com/arduino/arduino-cli/cli/globals"
-	"github.com/spf13/viper"
+	"github.com/arduino/arduino-cli/configuration"
 )
 
 // Config is the configuration of the http client
@@ -35,8 +35,8 @@ type Config struct {
 func DefaultConfig() (*Config, error) {
 	var proxy *url.URL
 	var err error
-	if viper.IsSet("network.proxy") {
-		proxyConfig := viper.GetString("network.proxy")
+	if configuration.Settings.IsSet("network.proxy") {
+		proxyConfig := configuration.Settings.GetString("network.proxy")
 		if proxyConfig == "" {
 			// empty configuration
 			// this workaround must be here until viper can UnSet properties:
@@ -54,7 +54,7 @@ func DefaultConfig() (*Config, error) {
 
 // UserAgent returns the user agent for the cli http client
 func UserAgent() string {
-	subComponent := viper.GetString("network.user_agent_ext")
+	subComponent := configuration.Settings.GetString("network.user_agent_ext")
 	if subComponent != "" {
 		subComponent = " " + subComponent
 	}

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -15,9 +15,7 @@
 
 package i18n
 
-import (
-	"github.com/spf13/viper"
-)
+import "github.com/arduino/arduino-cli/configuration"
 
 // Init initializes the i18n module, setting the locale according to this order of preference:
 // 1. Configuration set in arduino-cli.yaml
@@ -27,7 +25,7 @@ func Init() {
 	initRiceBox()
 	locales := supportedLocales()
 
-	if configLocale := viper.GetString("locale"); configLocale != "" {
+	if configLocale := configuration.Settings.GetString("locale"); configLocale != "" {
 		if locale := findMatchingLocale(configLocale, locales); locale != "" {
 			setLocale(locale)
 			return

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	configuration.Init(configuration.FindConfigFile())
+	configuration.Settings = configuration.Init(configuration.FindConfigFile(os.Args))
 	i18n.Init()
 	arduinoCmd := cli.NewCommand()
 	if err := arduinoCmd.Execute(); err != nil {

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	configuration.Settings = configuration.Init(configuration.FindConfigFile(os.Args))
+	configuration.Settings = configuration.Init(configuration.FindConfigFileInArgsOrWorkingDirectory(os.Args))
 	i18n.Init()
 	arduinoCmd := cli.NewCommand()
 	if err := arduinoCmd.Execute(); err != nil {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -19,12 +19,13 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"net/http"
+
+	"github.com/arduino/arduino-cli/configuration"
 	"github.com/arduino/arduino-cli/inventory"
 	"github.com/segmentio/stats/v4"
 	"github.com/segmentio/stats/v4/prometheus"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
-	"net/http"
 )
 
 // serverPattern is the telemetry endpoint resource path for consume metrics
@@ -42,7 +43,7 @@ func Activate(metricPrefix string) {
 	stats.Register(ph)
 
 	// Configure using viper settings
-	serverAddr := viper.GetString("telemetry.addr")
+	serverAddr := configuration.Settings.GetString("telemetry.addr")
 	logrus.Infof("Setting up Prometheus telemetry on %s%s", serverAddr, serverPattern)
 	go func() {
 		http.Handle(serverPattern, ph)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -13,16 +13,216 @@
 # software without disclosing the source code of your own applications. To purchase
 # a commercial license, send an email to license@arduino.cc.
 from pathlib import Path
+import json
+import yaml
 
 
 def test_init(run_command, data_dir, working_dir):
     result = run_command("config init")
+    assert "" == result.stderr
     assert result.ok
     assert data_dir in result.stdout
 
 
-def test_init_dest(run_command, working_dir):
-    dest = str(Path(working_dir) / "config" / "test")
+def test_init_with_existing_custom_config(run_command, data_dir, working_dir, downloads_dir):
+    result = run_command("config init --additional-urls https://example.com")
+    assert result.ok
+    assert data_dir in result.stdout
+
+    config_file = open(Path(data_dir) / "arduino-cli.yaml", "r")
+    configs = yaml.load(config_file.read(), Loader=yaml.FullLoader)
+    config_file.close()
+    assert ["https://example.com"] == configs["board_manager"]["additional_urls"]
+    assert "50051" == configs["daemon"]["port"]
+    assert data_dir == configs["directories"]["data"]
+    assert downloads_dir == configs["directories"]["downloads"]
+    assert data_dir == configs["directories"]["user"]
+    assert "" == configs["logging"]["file"]
+    assert "text" == configs["logging"]["format"]
+    assert "info" == configs["logging"]["level"]
+    assert ":9090" == configs["telemetry"]["addr"]
+    assert configs["telemetry"]["enabled"]
+
+    config_file_path = Path(working_dir) / "config" / "test" / "config.yaml"
+    assert not config_file_path.exists()
+    result = run_command(f'config init --dest-file "{config_file_path}"')
+    assert result.ok
+    assert str(config_file_path) in result.stdout
+
+    config_file = open(config_file_path, "r")
+    configs = yaml.load(config_file.read(), Loader=yaml.FullLoader)
+    config_file.close()
+    assert [] == configs["board_manager"]["additional_urls"]
+    assert "50051" == configs["daemon"]["port"]
+    assert data_dir == configs["directories"]["data"]
+    assert downloads_dir == configs["directories"]["downloads"]
+    assert data_dir == configs["directories"]["user"]
+    assert "" == configs["logging"]["file"]
+    assert "text" == configs["logging"]["format"]
+    assert "info" == configs["logging"]["level"]
+    assert ":9090" == configs["telemetry"]["addr"]
+    assert configs["telemetry"]["enabled"]
+
+
+def test_init_overwrite_existing_custom_file(run_command, data_dir, working_dir, downloads_dir):
+    result = run_command("config init --additional-urls https://example.com")
+    assert result.ok
+    assert data_dir in result.stdout
+
+    config_file = open(Path(data_dir) / "arduino-cli.yaml", "r")
+    configs = yaml.load(config_file.read(), Loader=yaml.FullLoader)
+    config_file.close()
+    assert ["https://example.com"] == configs["board_manager"]["additional_urls"]
+    assert "50051" == configs["daemon"]["port"]
+    assert data_dir == configs["directories"]["data"]
+    assert downloads_dir == configs["directories"]["downloads"]
+    assert data_dir == configs["directories"]["user"]
+    assert "" == configs["logging"]["file"]
+    assert "text" == configs["logging"]["format"]
+    assert "info" == configs["logging"]["level"]
+    assert ":9090" == configs["telemetry"]["addr"]
+    assert configs["telemetry"]["enabled"]
+
+    result = run_command("config init --overwrite")
+    assert result.ok
+    assert data_dir in result.stdout
+
+    config_file = open(Path(data_dir) / "arduino-cli.yaml", "r")
+    configs = yaml.load(config_file.read(), Loader=yaml.FullLoader)
+    config_file.close()
+    assert [] == configs["board_manager"]["additional_urls"]
+    assert "50051" == configs["daemon"]["port"]
+    assert data_dir == configs["directories"]["data"]
+    assert downloads_dir == configs["directories"]["downloads"]
+    assert data_dir == configs["directories"]["user"]
+    assert "" == configs["logging"]["file"]
+    assert "text" == configs["logging"]["format"]
+    assert "info" == configs["logging"]["level"]
+    assert ":9090" == configs["telemetry"]["addr"]
+    assert configs["telemetry"]["enabled"]
+
+
+def test_init_dest_absolute_path(run_command, working_dir):
+    dest = Path(working_dir) / "config" / "test"
+    expected_config_file = dest / "arduino-cli.yaml"
+    assert not expected_config_file.exists()
     result = run_command(f'config init --dest-dir "{dest}"')
     assert result.ok
-    assert dest in result.stdout
+    assert str(expected_config_file) in result.stdout
+    assert expected_config_file.exists()
+
+
+def test_init_dest_relative_path(run_command, working_dir):
+    dest = Path(working_dir) / "config" / "test"
+    expected_config_file = dest / "arduino-cli.yaml"
+    assert not expected_config_file.exists()
+    result = run_command('config init --dest-dir "config/test"')
+    assert result.ok
+    assert str(expected_config_file) in result.stdout
+    assert expected_config_file.exists()
+
+
+def test_init_dest_flag_with_overwrite_flag(run_command, working_dir):
+    dest = Path(working_dir) / "config" / "test"
+
+    expected_config_file = dest / "arduino-cli.yaml"
+    assert not expected_config_file.exists()
+
+    result = run_command(f'config init --dest-dir "{dest}"')
+    assert result.ok
+    assert expected_config_file.exists()
+
+    result = run_command(f'config init --dest-dir "{dest}"')
+    assert result.failed
+    assert "Config file already exists, use --overwrite to discard the existing one." in result.stderr
+
+    result = run_command(f'config init --dest-dir "{dest}" --overwrite')
+    assert result.ok
+    assert str(expected_config_file) in result.stdout
+
+
+def test_init_dest_and_config_file_flags(run_command, working_dir):
+    result = run_command('config init --dest-file "some_other_path" --dest-dir "some_path"')
+    assert result.failed
+    assert "Can't use both --dest-file and --dest-dir flags at the same time." in result.stderr
+
+
+def test_init_config_file_flag_absolute_path(run_command, working_dir):
+    config_file = Path(working_dir) / "config" / "test" / "config.yaml"
+    assert not config_file.exists()
+    result = run_command(f'config init --dest-file "{config_file}"')
+    assert result.ok
+    assert str(config_file) in result.stdout
+    assert config_file.exists()
+
+
+def test_init_config_file_flag_relative_path(run_command, working_dir):
+    config_file = Path(working_dir) / "config.yaml"
+    assert not config_file.exists()
+    result = run_command('config init --dest-file "config.yaml"')
+    assert result.ok
+    assert str(config_file) in result.stdout
+    assert config_file.exists()
+
+
+def test_init_config_file_flag_with_overwrite_flag(run_command, working_dir):
+    config_file = Path(working_dir) / "config" / "test" / "config.yaml"
+    assert not config_file.exists()
+
+    result = run_command(f'config init --dest-file "{config_file}"')
+    assert result.ok
+    assert config_file.exists()
+
+    result = run_command(f'config init --dest-file "{config_file}"')
+    assert result.failed
+    assert "Config file already exists, use --overwrite to discard the existing one." in result.stderr
+
+    result = run_command(f'config init --dest-file "{config_file}" --overwrite')
+    assert result.ok
+    assert str(config_file) in result.stdout
+
+
+def test_dump(run_command, data_dir, working_dir):
+    # Create a config file first
+    config_file = Path(working_dir) / "config" / "test" / "config.yaml"
+    assert not config_file.exists()
+    result = run_command(f'config init --dest-file "{config_file}"')
+    assert result.ok
+    assert config_file.exists()
+
+    result = run_command(f'config dump --config-file "{config_file}" --format json')
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert [] == settings_json["board_manager"]["additional_urls"]
+
+    result = run_command('config init --additional-urls "https://example.com"')
+    assert result.ok
+    config_file = Path(data_dir) / "arduino-cli.yaml"
+    assert str(config_file) in result.stdout
+    assert config_file.exists()
+
+    result = run_command("config dump --format json")
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert ["https://example.com"] == settings_json["board_manager"]["additional_urls"]
+
+
+def test_dump_with_config_file_flag(run_command, working_dir):
+    # Create a config file first
+    config_file = Path(working_dir) / "config" / "test" / "config.yaml"
+    assert not config_file.exists()
+    result = run_command(f'config init --dest-file "{config_file}" --additional-urls=https://example.com')
+    assert result.ok
+    assert config_file.exists()
+
+    result = run_command(f'config dump --config-file "{config_file}" --format json')
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert ["https://example.com"] == settings_json["board_manager"]["additional_urls"]
+
+    result = run_command(
+        f'config dump --config-file "{config_file}" --additional-urls=https://another-url.com --format json'
+    )
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert ["https://another-url.com"] == settings_json["board_manager"]["additional_urls"]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
Refactors how the configs are initialized and fixes `config init`.

- **What is the current behavior?**
Configs are managed using the `viper` package singleton, `config init` command reads from existing settings when initializing a new config file.

* **What is the new behavior?**
Configs are not managed anymore with the `viper` package singleton but using a global variable internal to the `configuration` package of the `arduino-cli`.
The `config init` command now initializes new config files using the default values without reading from existing files.

- **Does this PR introduce a breaking change?**
Yes.

* **Other information**:
None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
