### PR TITLE
Add flag to board list command to watch for connected and disconnected boards

### DIFF
--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -63,7 +63,7 @@ func runListCommand(cmd *cobra.Command, args []string) {
 			feedback.Errorf("Error detecting boards: %v", err)
 			os.Exit(errorcodes.ErrGeneric)
 		}
-		watchList(inst)
+		watchList(cmd, inst)
 		os.Exit(0)
 	}
 
@@ -89,7 +89,7 @@ func runListCommand(cmd *cobra.Command, args []string) {
 	feedback.PrintResult(result{ports})
 }
 
-func watchList(inst *rpc.Instance) {
+func watchList(cmd *cobra.Command, inst *rpc.Instance) {
 	pm := commands.GetPackageManager(inst.Id)
 	eventsChan, err := commands.WatchListBoards(pm)
 	if err != nil {
@@ -97,37 +97,37 @@ func watchList(inst *rpc.Instance) {
 		os.Exit(errorcodes.ErrNetwork)
 	}
 
-	boardPorts := map[string]*commands.BoardPort{}
+	// This is done to avoid printing the header each time a new event is received
+	if feedback.GetFormat() == feedback.Text {
+		t := table.New()
+		t.SetHeader("Port", "Type", "Event", "Board Name", "FQBN", "Core")
+		feedback.Print(t.Render())
+	}
+
 	for event := range eventsChan {
-		switch event.Type {
-		case "add":
-			boardPorts[event.Port.Address] = &commands.BoardPort{
+		boards := []*rpc.BoardListItem{}
+		if event.Type == "add" {
+			boards, err = board.Identify(pm, &commands.BoardPort{
 				Address:             event.Port.Address,
 				Label:               event.Port.AddressLabel,
 				Prefs:               event.Port.Properties,
 				IdentificationPrefs: event.Port.IdentificationProperties,
 				Protocol:            event.Port.Protocol,
 				ProtocolLabel:       event.Port.ProtocolLabel,
-			}
-		case "remove":
-			delete(boardPorts, event.Port.Address)
-		}
-
-		ports := []*rpc.DetectedPort{}
-		for _, p := range boardPorts {
-			boardList, err := board.Identify(pm, p)
+			})
 			if err != nil {
 				feedback.Errorf("Error identifying board: %v", err)
 				os.Exit(errorcodes.ErrNetwork)
 			}
-			ports = append(ports, &rpc.DetectedPort{
-				Address:       p.Address,
-				Protocol:      p.Protocol,
-				ProtocolLabel: p.ProtocolLabel,
-				Boards:        boardList,
-			})
 		}
-		feedback.PrintResult(result{ports})
+
+		feedback.PrintResult(watchEvent{
+			Type:          event.Type,
+			Address:       event.Port.Address,
+			Protocol:      event.Port.Protocol,
+			ProtocolLabel: event.Port.ProtocolLabel,
+			Boards:        boards,
+		})
 	}
 }
 
@@ -188,6 +188,62 @@ func (dr result) String() string {
 			coreName := ""
 			t.AddRow(address, protocol, board, fqbn, coreName)
 		}
+	}
+	return t.Render()
+}
+
+type watchEvent struct {
+	Type          string               `json:"type"`
+	Address       string               `json:"address,omitempty"`
+	Protocol      string               `json:"protocol,omitempty"`
+	ProtocolLabel string               `json:"protocol_label,omitempty"`
+	Boards        []*rpc.BoardListItem `json:"boards,omitempty"`
+}
+
+func (dr watchEvent) Data() interface{} {
+	return dr
+}
+
+func (dr watchEvent) String() string {
+	t := table.New()
+
+	event := map[string]string{
+		"add":    "Connected",
+		"remove": "Disconnected",
+	}[dr.Type]
+
+	address := fmt.Sprintf("%s://%s", dr.Protocol, dr.Address)
+	if dr.Protocol == "serial" || dr.Protocol == "" {
+		address = dr.Address
+	}
+	protocol := dr.ProtocolLabel
+	if boards := dr.Boards; len(boards) > 0 {
+		sort.Slice(boards, func(i, j int) bool {
+			x, y := boards[i], boards[j]
+			return x.GetName() < y.GetName() || (x.GetName() == y.GetName() && x.GetFQBN() < y.GetFQBN())
+		})
+		for _, b := range boards {
+			board := b.GetName()
+
+			// to improve the user experience, show on a dedicated column
+			// the name of the core supporting the board detected
+			var coreName = ""
+			fqbn, err := cores.ParseFQBN(b.GetFQBN())
+			if err == nil {
+				coreName = fmt.Sprintf("%s:%s", fqbn.Package, fqbn.PlatformArch)
+			}
+
+			t.AddRow(address, protocol, event, board, fqbn, coreName)
+
+			// reset address and protocol, we only show them on the first row
+			address = ""
+			protocol = ""
+		}
+	} else {
+		board := ""
+		fqbn := ""
+		coreName := ""
+		t.AddRow(address, protocol, event, board, fqbn, coreName)
 	}
 	return t.Render()
 }

--- a/cli/feedback/exported.go
+++ b/cli/feedback/exported.go
@@ -34,6 +34,11 @@ func SetFormat(f OutputFormat) {
 	fb.SetFormat(f)
 }
 
+// GetFormat returns the currently set output format
+func GetFormat() OutputFormat {
+	return fb.GetFormat()
+}
+
 // OutputWriter returns the underlying io.Writer to be used when the Print*
 // api is not enough
 func OutputWriter() io.Writer {

--- a/cli/feedback/feedback.go
+++ b/cli/feedback/feedback.go
@@ -68,6 +68,11 @@ func (fb *Feedback) SetFormat(f OutputFormat) {
 	fb.format = f
 }
 
+// GetFormat returns the output format currently set
+func (fb *Feedback) GetFormat() OutputFormat {
+	return fb.format
+}
+
 // OutputWriter returns the underlying io.Writer to be used when the Print*
 // api is not enough.
 func (fb *Feedback) OutputWriter() io.Writer {

--- a/commands/bundled_tools_serial_discovery.go
+++ b/commands/bundled_tools_serial_discovery.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
+	"github.com/arduino/arduino-cli/arduino/discovery"
 	"github.com/arduino/arduino-cli/arduino/resources"
 	"github.com/arduino/arduino-cli/executils"
 	"github.com/arduino/go-properties-orderedmap"
@@ -191,6 +192,33 @@ func ListBoards(pm *packagemanager.PackageManager) ([]*BoardPort, error) {
 	cmd.Wait()
 
 	return retVal, finalError
+}
+
+// WatchListBoards returns a channel that receives events from the bundled discovery tool
+func WatchListBoards(pm *packagemanager.PackageManager) (<-chan *discovery.Event, error) {
+	t, err := getBuiltinSerialDiscoveryTool(pm)
+	if err != nil {
+		return nil, err
+	}
+
+	if !t.IsInstalled() {
+		return nil, fmt.Errorf("missing serial-discovery tool")
+	}
+
+	disc, err := discovery.New("serial-discovery", t.InstallDir.Join(t.Tool.Name).String())
+	if err != nil {
+		return nil, err
+	}
+
+	if err = disc.Start(); err != nil {
+		return nil, fmt.Errorf("starting discovery: %v", err)
+	}
+
+	if err = disc.StartSync(); err != nil {
+		return nil, fmt.Errorf("starting sync: %v", err)
+	}
+
+	return disc.EventChannel(10), nil
 }
 
 func getBuiltinSerialDiscoveryTool(pm *packagemanager.PackageManager) (*cores.ToolRelease, error) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
Adds a new flag to an existing command.

- **What is the current behavior?**
`board list` command shows only the connected boards when called.

* **What is the new behavior?**
`board list` can now be called with the `--watch` or `-w` flag to keep it running and print an updated list of connected boards as soon as the discovery tools detects a change.

- **Does this PR introduce a breaking change?**
No.

* **Other information**:
I don't we have a reliable way of testing this with automated tests.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
