### PR TITLE
Core and lib search command now update indexes first

### DIFF
--- a/cli/core/search.go
+++ b/cli/core/search.go
@@ -16,6 +16,7 @@
 package core
 
 import (
+	"context"
 	"os"
 	"sort"
 	"strings"
@@ -23,6 +24,8 @@ import (
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/arduino/arduino-cli/cli/instance"
+	"github.com/arduino/arduino-cli/cli/output"
+	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/commands/core"
 	rpc "github.com/arduino/arduino-cli/rpc/commands"
 	"github.com/arduino/arduino-cli/table"
@@ -52,6 +55,14 @@ func runSearchCommand(cmd *cobra.Command, args []string) {
 	inst, err := instance.CreateInstance()
 	if err != nil {
 		feedback.Errorf("Error searching for platforms: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
+	_, err = commands.UpdateIndex(context.Background(), &rpc.UpdateIndexReq{
+		Instance: inst,
+	}, output.ProgressBar())
+	if err != nil {
+		feedback.Errorf("Error updating index: %v", err)
 		os.Exit(errorcodes.ErrGeneric)
 	}
 

--- a/cli/lib/search.go
+++ b/cli/lib/search.go
@@ -25,6 +25,8 @@ import (
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/arduino/arduino-cli/cli/instance"
+	"github.com/arduino/arduino-cli/cli/output"
+	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/commands/lib"
 	rpc "github.com/arduino/arduino-cli/rpc/commands"
 	"github.com/sirupsen/logrus"
@@ -51,6 +53,15 @@ var searchFlags struct {
 
 func runSearchCommand(cmd *cobra.Command, args []string) {
 	instance := instance.CreateInstanceIgnorePlatformIndexErrors()
+
+	err := commands.UpdateLibrariesIndex(context.Background(), &rpc.UpdateLibrariesIndexReq{
+		Instance: instance,
+	}, output.ProgressBar())
+	if err != nil {
+		feedback.Errorf("Error updating library index: %v", err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
 	logrus.Info("Executing `arduino lib search`")
 	searchResp, err := lib.LibrarySearch(context.Background(), &rpc.LibrarySearchReq{
 		Instance: instance,

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -204,12 +204,9 @@ def test_search(run_command):
 
     result = run_command("lib search --names")
     assert result.ok
-    out_lines = result.stdout.strip().splitlines()
-    # Create an array with just the name of the vars
-    libs = []
-    for line in out_lines:
-        start = line.find('"') + 1
-        libs.append(line[start:-1])
+    lines = [l.strip() for l in result.stdout.strip().splitlines()]
+    assert "Updating index: library_index.json downloaded" in lines
+    libs = [l[6:].strip('"') for l in lines if "Name:" in l]
 
     expected = {"WiFi101", "WiFi101OTA", "Firebase Arduino based on WiFi101"}
     assert expected == {lib for lib in libs if "WiFi101" in lib}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
Enhances existing commands.

- **What is the current behavior?**
Calling `core search` or `lib search` doesn't update indexes before searching.

* **What is the new behavior?**
Calling `core search` or `lib search` now updates indexes before searching.

- **Does this PR introduce a breaking change?**
No.

* **Other information**:
This fixes #984.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
