### PR TITLE
Add alpha to version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -23,6 +23,7 @@ var (
 	defaultVersionString = "0.0.0-git"
 	versionString        = ""
 	commit               = ""
+	status               = "alpha"
 )
 
 // Info FIXMEDOC
@@ -30,6 +31,7 @@ type Info struct {
 	Application   string `json:"Application"`
 	VersionString string `json:"VersionString"`
 	Commit        string `json:"Commit"`
+	Status        string `json:"Status"`
 }
 
 // NewInfo FIXMEDOC
@@ -38,11 +40,12 @@ func NewInfo(application string) *Info {
 		Application:   application,
 		VersionString: versionString,
 		Commit:        commit,
+		Status:        status,
 	}
 }
 
 func (i *Info) String() string {
-	return fmt.Sprintf("%s Version: %s Commit: %s", i.Application, i.VersionString, i.Commit)
+	return fmt.Sprintf("%s %s Version: %s Commit: %s", i.Application, i.Status, i.VersionString, i.Commit)
 }
 
 //nolint:gochecknoinits


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**

Updates `version` command.

- **What is the current behavior?**

Alpha is not specified when printing version.

* **What is the new behavior?**

Calling `version` command specifies that we're in alpha.
Example: `arduino-cli alpha Version: 0.0.0-git Commit: 83abde23`

- **Does this PR introduce a breaking change?**

No.

* **Other information**:

None.
---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
