### PR TITLE
Change lib list --updatable output to be clearer if no lib is updatable

### DIFF
--- a/cli/lib/list.go
+++ b/cli/lib/list.go
@@ -109,6 +109,9 @@ func (ir installedResult) Data() interface{} {
 
 func (ir installedResult) String() string {
 	if ir.installedLibs == nil || len(ir.installedLibs) == 0 {
+		if listFlags.updatable {
+			return "No updates available."
+		}
 		return "No libraries installed."
 	}
 	sort.Slice(ir.installedLibs, func(i, j int) bool {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**

Clarifies output of an existing command.

- **What is the current behavior?**

Calling `lib list --updatable` command outputs `No libraries installed.`.

* **What is the new behavior?**

Calling `lib list --updatable` command outputs `No updates available.`.

- **Does this PR introduce a breaking change?**

No.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
