### PR TITLE
[skip changelog] Correct command name command reference page title

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,7 +83,7 @@ nav:
       - core list: commands/arduino-cli_core_list.md
       - core search: commands/arduino-cli_core_search.md
       - core uninstall: commands/arduino-cli_core_uninstall.md
-      - core update index: commands/arduino-cli_core_update-index.md
+      - core update-index: commands/arduino-cli_core_update-index.md
       - core upgrade: commands/arduino-cli_core_upgrade.md
       - daemon: commands/arduino-cli_daemon.md
       - debug: commands/arduino-cli_debug.md


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs fix.

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The `core update-index` command is incorrectly written as "core update index" in the title of the command reference documentation page:
https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_core_update-index/

* **What is the new behavior?**
<!-- if this is a feature change -->
The command is correctly written `core update-index` in the title of the page.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No.
