### PR TITLE
Fix binaries not being exported when using settings or env var

### DIFF
--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -340,3 +340,74 @@ def test_compile_with_custom_build_path(run_command, data_dir):
     assert not (build_dir / f"{sketch_name}.ino.hex").exists()
     assert not (build_dir / f"{sketch_name}.ino.with_bootloader.bin").exists()
     assert not (build_dir / f"{sketch_name}.ino.with_bootloader.hex").exists()
+
+
+def test_compile_with_export_binaries_env_var(run_command, data_dir, downloads_dir):
+    # Init the environment explicitly
+    run_command("core update-index")
+
+    # Download latest AVR
+    run_command("core install arduino:avr")
+
+    sketch_name = "CompileWithExportBinariesEnvVar"
+    sketch_path = Path(data_dir, sketch_name)
+    fqbn = "arduino:avr:uno"
+
+    # Create a test sketch
+    assert run_command("sketch new {}".format(sketch_path))
+
+    env = {
+        "ARDUINO_DATA_DIR": data_dir,
+        "ARDUINO_DOWNLOADS_DIR": downloads_dir,
+        "ARDUINO_SKETCHBOOK_DIR": data_dir,
+        "ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES": "true",
+    }
+    # Test compilation with export binaries env var set
+    result = run_command(f"compile -b {fqbn} {sketch_path}", custom_env=env)
+    assert result.ok
+    assert Path(sketch_path, "build").exists()
+    assert Path(sketch_path, "build").is_dir()
+
+    # Verifies binaries are exported when export binaries env var is set
+    assert (sketch_path / "build" / fqbn.replace(":", ".") / f"{sketch_name}.ino.eep").exists()
+    assert (sketch_path / "build" / fqbn.replace(":", ".") / f"{sketch_name}.ino.elf").exists()
+    assert (sketch_path / "build" / fqbn.replace(":", ".") / f"{sketch_name}.ino.hex").exists()
+    assert (sketch_path / "build" / fqbn.replace(":", ".") / f"{sketch_name}.ino.with_bootloader.bin").exists()
+    assert (sketch_path / "build" / fqbn.replace(":", ".") / f"{sketch_name}.ino.with_bootloader.hex").exists()
+
+
+def test_compile_with_export_binaries_config(run_command, data_dir, downloads_dir):
+    # Init the environment explicitly
+    run_command("core update-index")
+
+    # Download latest AVR
+    run_command("core install arduino:avr")
+
+    sketch_name = "CompileWithExportBinariesConfig"
+    sketch_path = Path(data_dir, sketch_name)
+    fqbn = "arduino:avr:uno"
+
+    # Create a test sketch
+    assert run_command("sketch new {}".format(sketch_path))
+
+    # Create settings with export binaries set to true
+    env = {
+        "ARDUINO_DATA_DIR": data_dir,
+        "ARDUINO_DOWNLOADS_DIR": downloads_dir,
+        "ARDUINO_SKETCHBOOK_DIR": data_dir,
+        "ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES": "true",
+    }
+    assert run_command("config init --dest-dir .", custom_env=env)
+
+    # Test compilation with export binaries env var set
+    result = run_command(f"compile -b {fqbn} {sketch_path}")
+    assert result.ok
+    assert Path(sketch_path, "build").exists()
+    assert Path(sketch_path, "build").is_dir()
+
+    # Verifies binaries are exported when export binaries env var is set
+    assert (sketch_path / "build" / fqbn.replace(":", ".") / f"{sketch_name}.ino.eep").exists()
+    assert (sketch_path / "build" / fqbn.replace(":", ".") / f"{sketch_name}.ino.elf").exists()
+    assert (sketch_path / "build" / fqbn.replace(":", ".") / f"{sketch_name}.ino.hex").exists()
+    assert (sketch_path / "build" / fqbn.replace(":", ".") / f"{sketch_name}.ino.with_bootloader.bin").exists()
+    assert (sketch_path / "build" / fqbn.replace(":", ".") / f"{sketch_name}.ino.with_bootloader.hex").exists()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**

Bug fix.

- **What is the current behavior?**

Setting either `sketch.always_export_binaries` in config file or `ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES` as env var to `true` would not export binaries when `compile` command is run.

* **What is the new behavior?**

Setting both `sketch.always_export_binaries` in config file and `ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES` as env var to `true` works as expected and binaries are export when `compile` command is run.

- **Does this PR introduce a breaking change?**

No.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
