### PR TITLE
Fixed discovery tests timeouts

### DIFF
--- a/arduino/discovery/testdata/cat/.gitignore
+++ b/arduino/discovery/testdata/cat/.gitignore
@@ -1,0 +1,2 @@
+cat
+cat.exe


### PR DESCRIPTION
Running command through `go run ...` will introduce artificial delays and this affects the test on `discoveries` because it relies on timeouts.

Now the test program is built for real instead of being run through `go run ...`
