### PR TITLE
[skip changelog] Update arduino.cc links to https://www.arduino.cc in documentation

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -21,7 +21,7 @@ code to specific architectures.
 
 ## See also
 
-- [Arduino library style guide](http://arduino.cc/en/Reference/APIStyleGuide)
+- [Arduino library style guide](https://www.arduino.cc/en/Reference/APIStyleGuide)
 - [Library dependency resolution process documentation](sketch-build-process.md#dependency-resolution)
 
 ## 1.5 library format (rev. 2.2)
@@ -205,7 +205,7 @@ Editor.
 More information:
 
 - [Arduino sketch specification](sketch-specification.md)
-- [Style guide for Arduino examples](http://arduino.cc/en/Reference/StyleGuide)
+- [Style guide for Arduino examples](https://www.arduino.cc/en/Reference/StyleGuide)
 
 #### Extra documentation
 

--- a/docs/sketch-specification.md
+++ b/docs/sketch-specification.md
@@ -152,4 +152,4 @@ This feature was added in Arduino IDE 1.6.9.
 ## See also
 
 - [Sketch build process documentation](sketch-build-process.md)
-- [Style guide for example sketches](http://arduino.cc/en/Reference/StyleGuide)
+- [Style guide for example sketches](https://www.arduino.cc/en/Reference/StyleGuide)


### PR DESCRIPTION
The recent implementation of DDoS countermeasures required the update of `arduino.cc` links in the documentation that caused CI checks t fail

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Link updates for Arduino Reference pages

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
