### PR TITLE
[skip changelog] Update notarization job, now usable with p12 cert format

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -58,10 +58,10 @@ jobs:
           security import ${{ env.INSTALLER_CERT_MAC_PATH }} -k ${{ env.KEYCHAIN }} -f pkcs12 -A -T /usr/bin/codesign -P ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
           security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
 
-      - name: Install gon via HomeBrew for code signing and app notarization
+      - name: Install gon for code signing and app notarization
         run: |
-          brew tap mitchellh/gon
-          brew install mitchellh/gon/gon
+          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.zip
+          unzip gon_macos.zip -d /usr/local/bin
 
       - name: Sign and notarize binary
         env:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -46,27 +46,31 @@ jobs:
         with:
           name: dist
 
-      - name: Download Gon
-        run: |
-          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.2/gon_0.2.2_macos.zip
-          unzip gon_0.2.2_macos.zip -d /usr/local/bin
-          rm -f gon_0.2.2_macos.zip
+      - name: Import Code-Signing Certificates
+        uses: Apple-Actions/import-codesign-certs@v1
+        with:
+          # The certificates in a PKCS12 file encoded as a base64 string
+          p12-file-base64: ${{ secrets.INSTALLER_CERT_MAC_P12 }}
+          # The password used to import the PKCS12 file.
+          p12-password: ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
 
-      - name: Notarize binary, re-package it and update checksum
+      - name: Install gon via HomeBrew for code signing and app notarization
+        run: |
+          brew tap mitchellh/gon
+          brew install mitchellh/gon/gon
+
+      - name: Sign and notarize binary
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-        # This step performs the following:
-        # 1. Download keychain from GH secrets and decode it from base64
-        # 2. Add the keychain to the system keychains and unlock it
-        # 3. Call Gon to start notarization process (using AC_USERNAME and AC_PASSWORD)
-        # 4. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
-        # 5. Recalculate package checksum and replace it in the goreleaser nnnnnn-checksums.txt file
         run: |
-          echo "${{ secrets.KEYCHAIN }}" | base64 --decode  > ~/Library/Keychains/apple-developer.keychain-db
-          security list-keychains -s ~/Library/Keychains/apple-developer.keychain-db
-          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" ~/Library/Keychains/apple-developer.keychain-db
           gon gon.config.hcl
+
+      - name: Re-package binary and update checksum
+        # This step performs the following:
+        # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
+        # 2. Recalculate package checksum and replace it in the goreleaser nnnnnn-checksums.txt file
+        run: |
           # GitHub's upload/download-artifact@v1 actions don't preserve file permissions,
           # so we need to add execution permission back until @v2 actions are released.
           chmod +x dist/arduino_cli_osx_darwin_amd64/arduino-cli

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -47,12 +47,16 @@ jobs:
           name: dist
 
       - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@v1
-        with:
-          # The certificates in a PKCS12 file encoded as a base64 string
-          p12-file-base64: ${{ secrets.INSTALLER_CERT_MAC_P12 }}
-          # The password used to import the PKCS12 file.
-          p12-password: ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
+        env:
+          KEYCHAIN: "sign.keychain"
+          INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
+        run: |
+          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > ${{ env.INSTALLER_CERT_MAC_PATH }}
+          security create-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
+          security default-keychain -s ${{ env.KEYCHAIN }}
+          security unlock-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
+          security import ${{ env.INSTALLER_CERT_MAC_PATH }} -k ${{ env.KEYCHAIN }} -f pkcs12 -A -T /usr/bin/codesign -P ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
+          security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
 
       - name: Install gon via HomeBrew for code signing and app notarization
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,9 +31,6 @@ jobs:
   notarize-macos:
     runs-on: macos-latest
     needs: create-release-artifacts
-    env:
-      INSTALLER_CERT_MAC_PASSWORD: ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
-      INSTALLER_CERT_MAC_P12: "/tmp/ArduinoCerts2020.p12"
 
     steps:
       - name: Checkout
@@ -64,7 +61,7 @@ jobs:
         run: |
           gon gon.config.hcl
 
-      - name: Notarize binary, re-package it and update checksum
+      - name: Re-package binary and update checksum
         # This step performs the following:
         # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         # 2. Recalculate package checksum and replace it in the goreleaser nnnnnn-checksums.txt file

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,9 @@ jobs:
   notarize-macos:
     runs-on: macos-latest
     needs: create-release-artifacts
+    env:
+      INSTALLER_CERT_MAC_PASSWORD: ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
+      INSTALLER_CERT_MAC_P12: "/tmp/ArduinoCerts2020.p12"
 
     steps:
       - name: Checkout
@@ -41,27 +44,31 @@ jobs:
         with:
           name: dist
 
-      - name: Download Gon
-        run: |
-          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.2/gon_0.2.2_macos.zip
-          unzip gon_0.2.2_macos.zip -d /usr/local/bin
-          rm -f gon_0.2.2_macos.zip
+      - name: Import Code-Signing Certificates
+        uses: Apple-Actions/import-codesign-certs@v1
+        with:
+          # The certificates in a PKCS12 file encoded as a base64 string
+          p12-file-base64: ${{ secrets.INSTALLER_CERT_MAC_P12 }}
+          # The password used to import the PKCS12 file.
+          p12-password: ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
 
-      - name: Notarize binary, re-package it and update checksum
+      - name: Install gon via HomeBrew for code signing and app notarization
+        run: |
+          brew tap mitchellh/gon
+          brew install mitchellh/gon/gon
+
+      - name: Sign and notarize binary
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-        # This step performs the following:
-        # 1. Download keychain from GH secrets and decode it from base64
-        # 2. Add the keychain to the system keychains and unlock it
-        # 3. Call Gon to start notarization process (using AC_USERNAME and AC_PASSWORD)
-        # 4. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
-        # 5. Recalculate package checksum and replace it in the goreleaser nnnnnn-checksums.txt file
         run: |
-          echo "${{ secrets.KEYCHAIN }}" | base64 --decode  > ~/Library/Keychains/apple-developer.keychain-db
-          security list-keychains -s ~/Library/Keychains/apple-developer.keychain-db
-          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" ~/Library/Keychains/apple-developer.keychain-db
           gon gon.config.hcl
+
+      - name: Notarize binary, re-package it and update checksum
+        # This step performs the following:
+        # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
+        # 2. Recalculate package checksum and replace it in the goreleaser nnnnnn-checksums.txt file
+        run: |
           # GitHub's upload/download-artifact@v1 actions don't preserve file permissions,
           # so we need to add execution permission back until @v2 actions are released.
           chmod +x dist/arduino_cli_osx_darwin_amd64/arduino-cli

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,12 +42,16 @@ jobs:
           name: dist
 
       - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@v1
-        with:
-          # The certificates in a PKCS12 file encoded as a base64 string
-          p12-file-base64: ${{ secrets.INSTALLER_CERT_MAC_P12 }}
-          # The password used to import the PKCS12 file.
-          p12-password: ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
+        env:
+          KEYCHAIN: "sign.keychain"
+          INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
+        run: |
+          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > ${{ env.INSTALLER_CERT_MAC_PATH }}
+          security create-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
+          security default-keychain -s ${{ env.KEYCHAIN }}
+          security unlock-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
+          security import ${{ env.INSTALLER_CERT_MAC_PATH }} -k ${{ env.KEYCHAIN }} -f pkcs12 -A -T /usr/bin/codesign -P ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
+          security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
 
       - name: Install gon via HomeBrew for code signing and app notarization
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
           security import ${{ env.INSTALLER_CERT_MAC_PATH }} -k ${{ env.KEYCHAIN }} -f pkcs12 -A -T /usr/bin/codesign -P ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
           security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
 
-      - name: Install gon via HomeBrew for code signing and app notarization
+      - name: Install gon for code signing and app notarization
         run: |
           wget -q https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.zip
           unzip gon_macos.zip -d /usr/local/bin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,8 +55,8 @@ jobs:
 
       - name: Install gon via HomeBrew for code signing and app notarization
         run: |
-          brew tap mitchellh/gon
-          brew install mitchellh/gon/gon
+          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.zip
+          unzip gon_macos.zip -d /usr/local/bin
 
       - name: Sign and notarize binary
         env:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
update the CI
- **What is the current behavior?**
<!-- You can also link to an open issue here -->

* **What is the new behavior?**
<!-- if this is a feature change -->
The CI now uses a `.p12` certificates and uses an action to handle keychain unlocking. Other improvements have been added.
Now gon is installed through homebrew.
The `Notarize binary, re-package it and update checksum` step has been split in two different steps: one simple step to notarize and sign and the other one to change permission, calculate the checksum and repackage the binary
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
It's necessary to add `INSTALLER_CERT_MAC_P12` and `INSTALLER_CERT_MAC_PASSWORD` as secrets
