### PR TITLE
lib install --git-url and --zip-file must now be esplicitly enabled

### DIFF
--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -28,6 +28,9 @@ func SetDefaults(settings *viper.Viper) {
 	settings.SetDefault("logging.level", "info")
 	settings.SetDefault("logging.format", "text")
 
+	// Libraries
+	settings.SetDefault("library.enable_unsafe_install", false)
+
 	// Boards Manager
 	settings.SetDefault("board_manager.additional_urls", []string{})
 
@@ -52,6 +55,7 @@ func SetDefaults(settings *viper.Viper) {
 	settings.AutomaticEnv()
 
 	// Bind env aliases to keep backward compatibility
+	settings.BindEnv("library.enable_unsafe_install", "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL")
 	settings.BindEnv("directories.User", "ARDUINO_SKETCHBOOK_DIR")
 	settings.BindEnv("directories.Downloads", "ARDUINO_DOWNLOADS_DIR")
 	settings.BindEnv("directories.Data", "ARDUINO_DATA_DIR")


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**

Changes an existing command flags.

- **What is the current behavior?**

`--git-url` and `--zip-file` flags can be freely used in `lib install`.

* **What is the new behavior?**

`--git-url` and `--zip-file` flags are now hidden by default and must be explicitly enabled by setting `library.enable_unsafe_install` to `true` in `arduino-cli.yaml` or by using the env var `ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL`. 

- **Does this PR introduce a breaking change?**

Yes, but I suppose it won't be an issue since the feature has been added recently and released only on nightlies.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
