### PR TITLE
Extended support for various OS / CPU

### DIFF
--- a/arduino/cores/tools.go
+++ b/arduino/cores/tools.go
@@ -146,8 +146,10 @@ var (
 	regexpLinux64    = regexp.MustCompile("x86_64-.*linux-gnu")
 	regexpLinux32    = regexp.MustCompile("i[3456]86-.*linux-gnu")
 	regexpWindows32  = regexp.MustCompile("i[3456]86-.*(mingw32|cygwin)")
-	regexpMac64Bit   = regexp.MustCompile("x86_64-apple-darwin.*")
-	regexpMac32Bit   = regexp.MustCompile("i[3456]86-apple-darwin.*")
+	regexpWindows64  = regexp.MustCompile("(amd64|x86_64)-.*(mingw32|cygwin)")
+	regexpMac64      = regexp.MustCompile("x86_64-apple-darwin.*")
+	regexpMac32      = regexp.MustCompile("i[3456]86-apple-darwin.*")
+	regexpMacArm64   = regexp.MustCompile("arm64-apple-darwin.*")
 	regexpFreeBSDArm = regexp.MustCompile("arm.*-freebsd[0-9]*")
 	regexpFreeBSD32  = regexp.MustCompile("i?[3456]86-freebsd[0-9]*")
 	regexpFreeBSD64  = regexp.MustCompile("amd64-freebsd[0-9]*")
@@ -177,10 +179,12 @@ func (f *Flavor) isExactMatchWith(osName, osArch string) bool {
 		return regexpLinux32.MatchString(f.OS)
 	case "windows,386":
 		return regexpWindows32.MatchString(f.OS)
+	case "darwin,arm64":
+		return regexpMacArm64.MatchString(f.OS)
 	case "darwin,amd64":
-		return regexpMac64Bit.MatchString(f.OS)
+		return regexpMac64.MatchString(f.OS)
 	case "darwin,386":
-		return regexpMac32Bit.MatchString(f.OS)
+		return regexpMac32.MatchString(f.OS)
 	case "freebsd,arm":
 		return regexpFreeBSDArm.MatchString(f.OS)
 	case "freebsd,386":
@@ -200,7 +204,10 @@ func (f *Flavor) isCompatibleWith(osName, osArch string) bool {
 	case "windows,amd64":
 		return regexpWindows32.MatchString(f.OS)
 	case "darwin,amd64":
-		return regexpMac32Bit.MatchString(f.OS)
+		return regexpMac32.MatchString(f.OS)
+	case "darwin,arm64":
+		// Compatibility guaranteed through Rosetta emulation
+		return regexpMac64.MatchString(f.OS) || regexpMac32.MatchString(f.OS)
 	}
 	return false
 }

--- a/arduino/cores/tools.go
+++ b/arduino/cores/tools.go
@@ -148,7 +148,9 @@ var (
 	regexpWindows32  = regexp.MustCompile("i[3456]86-.*(mingw32|cygwin)")
 	regexpMac64Bit   = regexp.MustCompile("x86_64-apple-darwin.*")
 	regexpMac32Bit   = regexp.MustCompile("i[3456]86-apple-darwin.*")
-	regexpArmBSD     = regexp.MustCompile("arm.*-freebsd[0-9]*")
+	regexpFreeBSDArm = regexp.MustCompile("arm.*-freebsd[0-9]*")
+	regexpFreeBSD32  = regexp.MustCompile("i?[3456]86-freebsd[0-9]*")
+	regexpFreeBSD64  = regexp.MustCompile("amd64-freebsd[0-9]*")
 )
 
 func (f *Flavor) isExactMatchWithCurrentMachine() bool {
@@ -180,10 +182,11 @@ func (f *Flavor) isExactMatchWith(osName, osArch string) bool {
 	case "darwin,386":
 		return regexpMac32Bit.MatchString(f.OS)
 	case "freebsd,arm":
-		return regexpArmBSD.MatchString(f.OS)
-	case "freebsd,386", "freebsd,amd64":
-		genericFreeBSDexp := regexp.MustCompile(osArch + "%s-freebsd[0-9]*")
-		return genericFreeBSDexp.MatchString(f.OS)
+		return regexpFreeBSDArm.MatchString(f.OS)
+	case "freebsd,386":
+		return regexpFreeBSD32.MatchString(f.OS)
+	case "freebsd,amd64":
+		return regexpFreeBSD64.MatchString(f.OS)
 	}
 	return false
 }

--- a/arduino/cores/tools.go
+++ b/arduino/cores/tools.go
@@ -141,13 +141,13 @@ func (tr *ToolRelease) RuntimeProperties() *properties.Map {
 }
 
 var (
-	regexpArmLinux   = regexp.MustCompile("arm.*-linux-gnueabihf")
-	regexpArm64Linux = regexp.MustCompile("(aarch64|arm64)-linux-gnu")
-	regexpAmd64      = regexp.MustCompile("x86_64-.*linux-gnu")
-	regexpi386       = regexp.MustCompile("i[3456]86-.*linux-gnu")
-	regexpWindows    = regexp.MustCompile("i[3456]86-.*(mingw32|cygwin)")
-	regexpMac64Bit   = regexp.MustCompile("(i[3456]86|x86_64)-apple-darwin.*")
-	regexpmac32Bit   = regexp.MustCompile("i[3456]86-apple-darwin.*")
+	regexpLinuxArm   = regexp.MustCompile("arm.*-linux-gnueabihf")
+	regexpLinuxArm64 = regexp.MustCompile("(aarch64|arm64)-linux-gnu")
+	regexpLinux64    = regexp.MustCompile("x86_64-.*linux-gnu")
+	regexpLinux32    = regexp.MustCompile("i[3456]86-.*linux-gnu")
+	regexpWindows32  = regexp.MustCompile("i[3456]86-.*(mingw32|cygwin)")
+	regexpMac64Bit   = regexp.MustCompile("x86_64-apple-darwin.*")
+	regexpMac32Bit   = regexp.MustCompile("i[3456]86-apple-darwin.*")
 	regexpArmBSD     = regexp.MustCompile("arm.*-freebsd[0-9]*")
 )
 
@@ -162,19 +162,19 @@ func (f *Flavor) isCompatibleWith(osName, osArch string) bool {
 
 	switch osName + "," + osArch {
 	case "linux,arm", "linux,armbe":
-		return regexpArmLinux.MatchString(f.OS)
+		return regexpLinuxArm.MatchString(f.OS)
 	case "linux,arm64":
-		return regexpArm64Linux.MatchString(f.OS)
+		return regexpLinuxArm64.MatchString(f.OS)
 	case "linux,amd64":
-		return regexpAmd64.MatchString(f.OS)
+		return regexpLinux64.MatchString(f.OS)
 	case "linux,386":
-		return regexpi386.MatchString(f.OS)
+		return regexpLinux32.MatchString(f.OS)
 	case "windows,386", "windows,amd64":
-		return regexpWindows.MatchString(f.OS)
+		return regexpWindows32.MatchString(f.OS)
 	case "darwin,amd64":
-		return regexpmac32Bit.MatchString(f.OS) || regexpMac64Bit.MatchString(f.OS)
+		return regexpMac32Bit.MatchString(f.OS) || regexpMac64Bit.MatchString(f.OS)
 	case "darwin,386":
-		return regexpmac32Bit.MatchString(f.OS)
+		return regexpMac32Bit.MatchString(f.OS)
 	case "freebsd,arm":
 		return regexpArmBSD.MatchString(f.OS)
 	case "freebsd,386", "freebsd,amd64":

--- a/arduino/cores/tools.go
+++ b/arduino/cores/tools.go
@@ -179,6 +179,8 @@ func (f *Flavor) isExactMatchWith(osName, osArch string) bool {
 		return regexpLinux32.MatchString(f.OS)
 	case "windows,386":
 		return regexpWindows32.MatchString(f.OS)
+	case "windows,amd64":
+		return regexpWindows64.MatchString(f.OS)
 	case "darwin,arm64":
 		return regexpMacArm64.MatchString(f.OS)
 	case "darwin,amd64":

--- a/arduino/cores/tools_test.go
+++ b/arduino/cores/tools_test.go
@@ -26,29 +26,29 @@ func TestFlavorCompatibility(t *testing.T) {
 		Os   string
 		Arch string
 	}
-	windowsi386 := &os{"windows", "386"}
-	windowsx8664 := &os{"windows", "amd64"}
-	linuxi386 := &os{"linux", "386"}
-	linuxamd64 := &os{"linux", "amd64"}
-	linuxarm := &os{"linux", "arm"}
-	linuxarmbe := &os{"linux", "armbe"}
-	linuxarm64 := &os{"linux", "arm64"}
-	darwini386 := &os{"darwin", "386"}
-	darwinamd64 := &os{"darwin", "amd64"}
-	freebsdi386 := &os{"freebsd", "386"}
-	freebsdamd64 := &os{"freebsd", "amd64"}
+	windows32 := &os{"windows", "386"}
+	windows64 := &os{"windows", "amd64"}
+	linux32 := &os{"linux", "386"}
+	linux64 := &os{"linux", "amd64"}
+	linuxArm := &os{"linux", "arm"}
+	linuxArmbe := &os{"linux", "armbe"}
+	linuxArm64 := &os{"linux", "arm64"}
+	darwin32 := &os{"darwin", "386"}
+	darwin64 := &os{"darwin", "amd64"}
+	freebsd32 := &os{"freebsd", "386"}
+	freebsd64 := &os{"freebsd", "amd64"}
 	oses := []*os{
-		windowsi386,
-		windowsx8664,
-		linuxi386,
-		linuxamd64,
-		linuxarm,
-		linuxarmbe,
-		linuxarm64,
-		darwini386,
-		darwinamd64,
-		freebsdi386,
-		freebsdamd64,
+		windows32,
+		windows64,
+		linux32,
+		linux64,
+		linuxArm,
+		linuxArmbe,
+		linuxArm64,
+		darwin32,
+		darwin64,
+		freebsd32,
+		freebsd64,
 	}
 
 	type test struct {
@@ -56,9 +56,9 @@ func TestFlavorCompatibility(t *testing.T) {
 		Positives []*os
 	}
 	tests := []*test{
-		{&Flavor{OS: "i686-mingw32"}, []*os{windowsi386, windowsx8664}},
-		{&Flavor{OS: "i386-apple-darwin11"}, []*os{darwini386, darwinamd64}},
-		{&Flavor{OS: "x86_64-apple-darwin"}, []*os{darwinamd64}},
+		{&Flavor{OS: "i686-mingw32"}, []*os{windows32, windows64}},
+		{&Flavor{OS: "i386-apple-darwin11"}, []*os{darwin32, darwin64}},
+		{&Flavor{OS: "x86_64-apple-darwin"}, []*os{darwin64}},
 
 		// Raspberry PI, BBB or other ARM based host
 		// PI: "arm-linux-gnueabihf"
@@ -66,25 +66,27 @@ func TestFlavorCompatibility(t *testing.T) {
 		// Ubuntu Mate on PI2: "arm-linux-gnueabihf"
 		// Debian 7.9 on BBB: "arm-linux-gnueabihf"
 		// Raspbian on PI Zero: "arm-linux-gnueabihf"
-		{&Flavor{OS: "arm-linux-gnueabihf"}, []*os{linuxarm, linuxarmbe}},
+		{&Flavor{OS: "arm-linux-gnueabihf"}, []*os{linuxArm, linuxArmbe}},
 		// Arch-linux on PI2: "armv7l-unknown-linux-gnueabihf"
-		{&Flavor{OS: "armv7l-unknown-linux-gnueabihf"}, []*os{linuxarm, linuxarmbe}},
+		{&Flavor{OS: "armv7l-unknown-linux-gnueabihf"}, []*os{linuxArm, linuxArmbe}},
 
-		{&Flavor{OS: "i686-linux-gnu"}, []*os{linuxi386}},
-		{&Flavor{OS: "i686-pc-linux-gnu"}, []*os{linuxi386}},
-		{&Flavor{OS: "x86_64-linux-gnu"}, []*os{linuxamd64}},
-		{&Flavor{OS: "x86_64-pc-linux-gnu"}, []*os{linuxamd64}},
-		{&Flavor{OS: "aarch64-linux-gnu"}, []*os{linuxarm64}},
-		{&Flavor{OS: "arm64-linux-gnu"}, []*os{linuxarm64}},
+		{&Flavor{OS: "i686-linux-gnu"}, []*os{linux32}},
+		{&Flavor{OS: "i686-pc-linux-gnu"}, []*os{linux32}},
+		{&Flavor{OS: "x86_64-linux-gnu"}, []*os{linux64}},
+		{&Flavor{OS: "x86_64-pc-linux-gnu"}, []*os{linux64}},
+		{&Flavor{OS: "aarch64-linux-gnu"}, []*os{linuxArm64}},
+		{&Flavor{OS: "arm64-linux-gnu"}, []*os{linuxArm64}},
 	}
 
 	check := func(test *test, os *os) {
+		// if the os is in the "positive" set CompatibleWith must return true...
 		for _, positiveOs := range test.Positives {
 			if positiveOs == os {
 				require.True(t, test.Flavour.isCompatibleWith(os.Os, os.Arch), "'%s' tag compatible with '%s,%s' pair", test.Flavour.OS, os.Os, os.Arch)
 				return
 			}
 		}
+		// ...otherwise false
 		require.False(t, test.Flavour.isCompatibleWith(os.Os, os.Arch), "'%s' tag compatible with '%s,%s' pair", test.Flavour.OS, os.Os, os.Arch)
 	}
 

--- a/arduino/cores/tools_test.go
+++ b/arduino/cores/tools_test.go
@@ -60,6 +60,7 @@ func TestFlavorCompatibility(t *testing.T) {
 	}
 	tests := []*test{
 		{&Flavor{OS: "i686-mingw32"}, []*os{windows32, windows64}, []*os{windows32}},
+		{&Flavor{OS: "x86_64-mingw32"}, []*os{windows64}, []*os{windows64}},
 		{&Flavor{OS: "i386-apple-darwin11"}, []*os{darwin32, darwin64, darwinArm64}, []*os{darwin32}},
 		{&Flavor{OS: "x86_64-apple-darwin"}, []*os{darwin64, darwinArm64}, []*os{darwin64}},
 		{&Flavor{OS: "arm64-apple-darwin"}, []*os{darwinArm64}, []*os{darwinArm64}},

--- a/arduino/cores/tools_test.go
+++ b/arduino/cores/tools_test.go
@@ -35,6 +35,7 @@ func TestFlavorCompatibility(t *testing.T) {
 	linuxArm64 := &os{"linux", "arm64"}
 	darwin32 := &os{"darwin", "386"}
 	darwin64 := &os{"darwin", "amd64"}
+	darwinArm64 := &os{"darwin", "arm64"}
 	freebsd32 := &os{"freebsd", "386"}
 	freebsd64 := &os{"freebsd", "amd64"}
 	oses := []*os{
@@ -47,6 +48,7 @@ func TestFlavorCompatibility(t *testing.T) {
 		linuxArm64,
 		darwin32,
 		darwin64,
+		darwinArm64,
 		freebsd32,
 		freebsd64,
 	}
@@ -58,8 +60,9 @@ func TestFlavorCompatibility(t *testing.T) {
 	}
 	tests := []*test{
 		{&Flavor{OS: "i686-mingw32"}, []*os{windows32, windows64}, []*os{windows32}},
-		{&Flavor{OS: "i386-apple-darwin11"}, []*os{darwin32, darwin64}, []*os{darwin32}},
-		{&Flavor{OS: "x86_64-apple-darwin"}, []*os{darwin64}, []*os{darwin64}},
+		{&Flavor{OS: "i386-apple-darwin11"}, []*os{darwin32, darwin64, darwinArm64}, []*os{darwin32}},
+		{&Flavor{OS: "x86_64-apple-darwin"}, []*os{darwin64, darwinArm64}, []*os{darwin64}},
+		{&Flavor{OS: "arm64-apple-darwin"}, []*os{darwinArm64}, []*os{darwinArm64}},
 
 		// Raspberry PI, BBB or other ARM based host
 		// PI: "arm-linux-gnueabihf"


### PR DESCRIPTION
This PR adds support for installing native tools for:

- `windows,amd64`
- `darwin,arm64`

it also adds compatibility fallback for:

- `windows,amd64` if not available will try to fallback to `windows,386`
- `darwin,arm64` if not available will try to fallback to `darwin,amd64` and, if still missing, with `darwin,386`
