### PR TITLE
[skip changelog] Document `library.enable_unsafe_install` configuration key

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,10 @@
   - `downloads` - directory used to stage downloaded archives during Boards/Library Manager installations.
   - `user` - the equivalent of the Arduino IDE's ["sketchbook" directory][sketchbook directory]. Library Manager
     installations are made to the `libraries` subdirectory of the user directory.
+- `library` - configuration options relating to Arduino libraries.
+  - `enable_unsafe_install` - set to `true` to enable the use of the `--git-url` and `--zip-file` flags with
+    [`arduino-cli lib install`][arduino cli lib install]. These are considered "unsafe" installation methods because
+    they allow installing files that have not passed through the Library Manager submission process.
 - `logging` - configuration options for Arduino CLI's logs.
   - `file` - path to the file where logs will be written.
   - `format` - output format for the logs. Allowed values are `text` or `json`.
@@ -126,6 +130,7 @@ additional_urls = [ "https://downloads.arduino.cc/packages/package_staging_index
 
 [grpc]: https://grpc.io
 [sketchbook directory]: sketch-specification.md#sketchbook
+[arduino cli lib install]: commands/arduino-cli_lib_install.md
 [arduino-cli config dump]: commands/arduino-cli_config_dump.md
 [arduino cli command reference]: commands/arduino-cli.md
 [arduino-cli global flags]: commands/arduino-cli_config.md#options-inherited-from-parent-commands


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The  `library.enable_unsafe_install` configuration key is undocumented.
* **What is the new behavior?**
<!-- if this is a feature change -->
The  `library.enable_unsafe_install` configuration key is documented in the configuration documentation page.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
Reference: https://github.com/arduino/arduino-cli/pull/1075
