### PR TITLE
Add build datetime to version command output

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,10 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - -s -w
+      - -X github.com/arduino/arduino-cli/version.versionString={{.Tag}}
+      - -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - -X github.com/arduino/arduino-cli/version.date={{.Date}}
   - # ARM
     id: arduino_cli_arm
     binary: arduino-cli
@@ -45,7 +48,10 @@ builds:
     goarm:
       - 6
     ldflags:
-      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - -s -w
+      - -X github.com/arduino/arduino-cli/version.versionString={{.Tag}}
+      - -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - -X github.com/arduino/arduino-cli/version.date={{.Date}}
       - "-extldflags '-static'"
   - # ARMv7
     id: arduino_cli_armv7
@@ -60,7 +66,10 @@ builds:
     goarm:
       - 7
     ldflags:
-      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - -s -w
+      - -X github.com/arduino/arduino-cli/version.versionString={{.Tag}}
+      - -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - -X github.com/arduino/arduino-cli/version.date={{.Date}}
       - "-extldflags '-static'"
   - # ARM64
     id: arduino_cli_arm64
@@ -73,7 +82,10 @@ builds:
     goarch:
       - arm64
     ldflags:
-      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - -s -w
+      - -X github.com/arduino/arduino-cli/version.versionString={{.Tag}}
+      - -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - -X github.com/arduino/arduino-cli/version.date={{.Date}}
       - "-extldflags '-static'"
   - # All the other platforms
     id: arduino_cli
@@ -87,7 +99,10 @@ builds:
       - amd64
       - 386
     ldflags:
-      - -s -w -X github.com/arduino/arduino-cli/version.versionString={{.Tag}} -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - -s -w
+      - -X github.com/arduino/arduino-cli/version.versionString={{.Tag}}
+      - -X github.com/arduino/arduino-cli/version.commit={{ .ShortCommit }}
+      - -X github.com/arduino/arduino-cli/version.date={{.Date}}
       - "-extldflags '-static'"
 
 archives:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -202,15 +202,19 @@ vars:
   # build vars
   COMMIT:
     sh: echo ${TRAVIS_COMMIT:-`git log -n 1 --format=%h`}
+  TIMESTAMP:
+    sh: echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   LDFLAGS: >
-    -ldflags '-X github.com/arduino/arduino-cli/version.commit={{.COMMIT}}'
+    -ldflags '-X github.com/arduino/arduino-cli/version.commit={{.COMMIT}}
+    -X github.com/arduino/arduino-cli/version.date={{.TIMESTAMP}}'
   # test vars
   GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"
   TEST_VERSIONSTRING: "0.0.0-test.preview"
   TEST_COMMIT: "deadbeef"
   TEST_LDFLAGS: >
     -ldflags  '-X github.com/arduino/arduino-cli/version.versionString={{.TEST_VERSIONSTRING}}
-    -X github.com/arduino/arduino-cli/version.commit={{.TEST_COMMIT}}'
+    -X github.com/arduino/arduino-cli/version.commit={{.TEST_COMMIT}}
+    -X github.com/arduino/arduino-cli/version.date={{.TIMESTAMP}}'
   # check-lint vars
   GOLINTBIN:
     sh: go list -f {{"{{"}}".Target{{"}}"}}" golang.org/x/lint/golint

--- a/version/version.go
+++ b/version/version.go
@@ -24,6 +24,7 @@ var (
 	versionString        = ""
 	commit               = ""
 	status               = "alpha"
+	date                 = ""
 )
 
 // Info FIXMEDOC
@@ -32,6 +33,7 @@ type Info struct {
 	VersionString string `json:"VersionString"`
 	Commit        string `json:"Commit"`
 	Status        string `json:"Status"`
+	Date          string `json:"Date"`
 }
 
 // NewInfo FIXMEDOC
@@ -41,11 +43,12 @@ func NewInfo(application string) *Info {
 		VersionString: versionString,
 		Commit:        commit,
 		Status:        status,
+		Date:          date,
 	}
 }
 
 func (i *Info) String() string {
-	return fmt.Sprintf("%s %s Version: %s Commit: %s", i.Application, i.Status, i.VersionString, i.Commit)
+	return fmt.Sprintf("%s %s Version: %s Commit: %s Date: %s", i.Application, i.Status, i.VersionString, i.Commit, i.Date)
 }
 
 //nolint:gochecknoinits


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**

Enhanced an existing command.

- **What is the current behavior?**

`version` command doesn't print datetime of the build in use.

* **What is the new behavior?**

`version` command prints datetime of the build in use if set. 
`ldflags` are used to set build datetime with `-X github.com/arduino/arduino-cli/version.date`.

- **Does this PR introduce a breaking change?**

No.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
