### PR TITLE
Fix JSON output not printing newline

### DIFF
--- a/cli/feedback/feedback.go
+++ b/cli/feedback/feedback.go
@@ -118,7 +118,7 @@ func (fb *Feedback) printJSON(v interface{}) {
 	if d, err := json.MarshalIndent(v, "", "  "); err != nil {
 		fb.Errorf("Error during JSON encoding of the output: %v", err)
 	} else {
-		fmt.Fprint(fb.out, string(d))
+		fmt.Fprintf(fb.out, "%v\n", string(d))
 	}
 }
 

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -442,7 +442,7 @@ def test_board_details(run_command):
     # Test board listall with and without showing hidden elements
     result = run_command("board listall MIPS --format json")
     assert result.ok
-    assert result.stdout == "{}"
+    assert result.stdout == "{}\n"
 
     result = run_command("board listall MIPS -a --format json")
     assert result.ok


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**

Fixes all commands output.

- **What is the current behavior?**

JSON output doesn't print a newline at the end.

* **What is the new behavior?**

JSON output prints a newline at the end.

- **Does this PR introduce a breaking change?**

No.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
