### PR TITLE
Provide package indexes from file paths using "additional-paths" flag

### DIFF
--- a/arduino/cores/packageindex/index.go
+++ b/arduino/cores/packageindex/index.go
@@ -312,3 +312,20 @@ func LoadIndex(jsonIndexFile *paths.Path) (*Index, error) {
 	}
 	return &index, nil
 }
+
+// LoadIndex reads a package_index.json from a file and returns the corresponding Index structure.
+func LoadIndexNoSign(jsonIndexFile *paths.Path, valid_signature bool) (*Index, error) {
+	buff, err := jsonIndexFile.ReadFile()
+	if err != nil {
+		return nil, err
+	}
+	var index Index
+	err = json.Unmarshal(buff, &index)
+	if err != nil {
+		return nil, err
+	}
+
+	index.IsTrusted = true
+
+	return &index, nil
+}

--- a/arduino/cores/packageindex/index.go
+++ b/arduino/cores/packageindex/index.go
@@ -313,7 +313,7 @@ func LoadIndex(jsonIndexFile *paths.Path) (*Index, error) {
 	return &index, nil
 }
 
-// LoadIndex reads a package_index.json from a file and returns the corresponding Index structure.
+// LoadIndexNoSign reads a package_index.json from a file and returns the corresponding Index structure.
 func LoadIndexNoSign(jsonIndexFile *paths.Path) (*Index, error) {
 	buff, err := jsonIndexFile.ReadFile()
 	if err != nil {

--- a/arduino/cores/packageindex/index.go
+++ b/arduino/cores/packageindex/index.go
@@ -314,7 +314,7 @@ func LoadIndex(jsonIndexFile *paths.Path) (*Index, error) {
 }
 
 // LoadIndex reads a package_index.json from a file and returns the corresponding Index structure.
-func LoadIndexNoSign(jsonIndexFile *paths.Path, valid_signature bool) (*Index, error) {
+func LoadIndexNoSign(jsonIndexFile *paths.Path) (*Index, error) {
 	buff, err := jsonIndexFile.ReadFile()
 	if err != nil {
 		return nil, err

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -104,6 +104,7 @@ func createCliCommandTree(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&outputFormat, "format", "text", "The output format, can be {text|json}.")
 	cmd.PersistentFlags().StringVar(&configFile, "config-file", "", "The custom config file (if not specified the default will be used).")
 	cmd.PersistentFlags().StringSlice("additional-urls", []string{}, "Comma-separated list of additional URLs for the Boards Manager.")
+	cmd.PersistentFlags().StringSlice("additional-paths", []string{}, "Comma-separated list of additional file paths for the Boards Manager.")
 	configuration.BindFlags(cmd, configuration.Settings)
 }
 

--- a/cli/config/validate.go
+++ b/cli/config/validate.go
@@ -21,18 +21,19 @@ import (
 )
 
 var validMap = map[string]reflect.Kind{
-	"board_manager.additional_urls": reflect.Slice,
-	"daemon.port":                   reflect.String,
-	"directories.data":              reflect.String,
-	"directories.downloads":         reflect.String,
-	"directories.user":              reflect.String,
-	"library.enable_unsafe_install": reflect.Bool,
-	"logging.file":                  reflect.String,
-	"logging.format":                reflect.String,
-	"logging.level":                 reflect.String,
-	"sketch.always_export_binaries": reflect.Bool,
-	"telemetry.addr":                reflect.String,
-	"telemetry.enabled":             reflect.Bool,
+	"board_manager.additional_urls":  reflect.Slice,
+	"board_manager.additional_paths": reflect.Slice,
+	"daemon.port":                    reflect.String,
+	"directories.data":               reflect.String,
+	"directories.downloads":          reflect.String,
+	"directories.user":               reflect.String,
+	"library.enable_unsafe_install":  reflect.Bool,
+	"logging.file":                   reflect.String,
+	"logging.format":                 reflect.String,
+	"logging.level":                  reflect.String,
+	"sketch.always_export_binaries":  reflect.Bool,
+	"telemetry.addr":                 reflect.String,
+	"telemetry.enabled":              reflect.Bool,
 }
 
 func typeOf(key string) (reflect.Kind, error) {

--- a/commands/daemon/testdata/arduino-cli.yml
+++ b/commands/daemon/testdata/arduino-cli.yml
@@ -2,6 +2,7 @@ board_manager:
   additional_urls:
     - http://foobar.com
     - http://example.com
+  additional_paths: []
 
 daemon:
   port: "50051"

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -200,9 +200,30 @@ func UpdateIndex(ctx context.Context, req *rpc.UpdateIndexReq, downloadCB Downlo
 	}
 
 	indexpath := paths.New(configuration.Settings.GetString("directories.Data"))
+	json_paths := []string{}
+	json_paths = append(json_paths, configuration.Settings.GetStringSlice("board_manager.additional_paths")...)
+	for _, x := range json_paths {
+		//path_to_json, err := paths.New(x).Abs()
+		path_to_json := indexpath.Join(x)
+
+		if _, err := packageindex.LoadIndex(path_to_json); err != nil {
+			return nil, fmt.Errorf("invalid package index in %s: %s", path_to_json, err)
+		}
+
+		if err := indexpath.MkdirAll(); err != nil {
+			return nil, fmt.Errorf("can't create data directory %s: %s", indexpath, err)
+		}
+
+		//may not be necessary
+		//coreIndexPath := indexpath.Join(path.Base(path_to_json.Path))
+		//if err := tmp.CopyTo(coreIndexPath); err != nil {
+		//	return nil, fmt.Errorf("saving downloaded index %s: %s", path_to_json, err)
+		//}
+	}
 	urls := []string{globals.DefaultIndexURL}
 	urls = append(urls, configuration.Settings.GetStringSlice("board_manager.additional_urls")...)
 	for _, u := range urls {
+		logrus.Info("URL: %s", u)
 		URL, err := url.Parse(u)
 		if err != nil {
 			logrus.Warnf("unable to parse additional URL: %s", u)
@@ -238,7 +259,7 @@ func UpdateIndex(ctx context.Context, req *rpc.UpdateIndexReq, downloadCB Downlo
 		// Check for signature
 		var tmpSig *paths.Path
 		var coreIndexSigPath *paths.Path
-		if URL.Hostname() == "downloads.arduino.cc" {
+		if URL.Hostname() == "downloads.WRONG.net" {
 			URLSig, err := url.Parse(URL.String())
 			if err != nil {
 				return nil, fmt.Errorf("parsing url for index signature check: %s", err)
@@ -645,6 +666,19 @@ func createInstance(ctx context.Context, getLibOnly bool) (*createInstanceResult
 			}
 
 			if err := res.Pm.LoadPackageIndex(URL); err != nil {
+				res.PlatformIndexErrors = append(res.PlatformIndexErrors, err.Error())
+			}
+		}
+
+		indexpath := paths.New(configuration.Settings.GetString("directories.Data"))
+		json_paths := []string{}
+		json_paths = append(json_paths, configuration.Settings.GetStringSlice("board_manager.additional_paths")...)
+		for _, x := range json_paths {
+			//path_to_json, err := paths.New(x).Abs()
+			path_to_json := indexpath.Join(x)
+
+			_, err := res.Pm.LoadPackageIndexFromFile(path_to_json)
+			if err != nil {
 				res.PlatformIndexErrors = append(res.PlatformIndexErrors, err.Error())
 			}
 		}

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -203,27 +203,19 @@ func UpdateIndex(ctx context.Context, req *rpc.UpdateIndexReq, downloadCB Downlo
 	json_paths := []string{}
 	json_paths = append(json_paths, configuration.Settings.GetStringSlice("board_manager.additional_paths")...)
 	for _, x := range json_paths {
+		logrus.Info("JSON_PATH: ", x)
 		//path_to_json, err := paths.New(x).Abs()
 		path_to_json := indexpath.Join(x)
 
-		if _, err := packageindex.LoadIndex(path_to_json); err != nil {
+		if _, err := packageindex.LoadIndexNoSign(path_to_json, false); err != nil {
 			return nil, fmt.Errorf("invalid package index in %s: %s", path_to_json, err)
 		}
 
-		if err := indexpath.MkdirAll(); err != nil {
-			return nil, fmt.Errorf("can't create data directory %s: %s", indexpath, err)
-		}
-
-		//may not be necessary
-		//coreIndexPath := indexpath.Join(path.Base(path_to_json.Path))
-		//if err := tmp.CopyTo(coreIndexPath); err != nil {
-		//	return nil, fmt.Errorf("saving downloaded index %s: %s", path_to_json, err)
-		//}
 	}
 	urls := []string{globals.DefaultIndexURL}
 	urls = append(urls, configuration.Settings.GetStringSlice("board_manager.additional_urls")...)
 	for _, u := range urls {
-		logrus.Info("URL: %s", u)
+		logrus.Info("URL: ", u)
 		URL, err := url.Parse(u)
 		if err != nil {
 			logrus.Warnf("unable to parse additional URL: %s", u)
@@ -259,7 +251,7 @@ func UpdateIndex(ctx context.Context, req *rpc.UpdateIndexReq, downloadCB Downlo
 		// Check for signature
 		var tmpSig *paths.Path
 		var coreIndexSigPath *paths.Path
-		if URL.Hostname() == "downloads.WRONG.net" {
+		if URL.Hostname() == "downloads.arduino.cc" {
 			URLSig, err := url.Parse(URL.String())
 			if err != nil {
 				return nil, fmt.Errorf("parsing url for index signature check: %s", err)

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -201,24 +201,22 @@ func UpdateIndex(ctx context.Context, req *rpc.UpdateIndexReq, downloadCB Downlo
 	}
 
 	indexpath := paths.New(configuration.Settings.GetString("directories.Data"))
-	json_paths := []string{}
-	json_paths = append(json_paths, configuration.Settings.GetStringSlice("board_manager.additional_paths")...)
 
-	for _, x := range json_paths {
-		logrus.Info("JSON_PATH: ", x)
+	for _, x := range configuration.Settings.GetStringSlice("board_manager.additional_paths") {
+		logrus.Info("JSON PATH: ", x)
 
-		path_to_json, _ := paths.New(x).Abs()
+		pathJSON, _ := paths.New(x).Abs()
 
-		if _, err := packageindex.LoadIndexNoSign(path_to_json); err != nil {
-			return nil, fmt.Errorf("invalid package index in %s: %s", path_to_json, err)
-		} else {
-			fi, _ := os.Stat(x)
-			downloadCB(&rpc.DownloadProgress{
-				File:      "Updating index: " + path_to_json.Base(),
-				TotalSize: fi.Size(),
-			})
-			downloadCB(&rpc.DownloadProgress{Completed: true})
+		if _, err := packageindex.LoadIndexNoSign(pathJSON); err != nil {
+			return nil, fmt.Errorf("invalid package index in %s: %s", pathJSON, err)
 		}
+
+		fi, _ := os.Stat(x)
+		downloadCB(&rpc.DownloadProgress{
+			File:      "Updating index: " + pathJSON.Base(),
+			TotalSize: fi.Size(),
+		})
+		downloadCB(&rpc.DownloadProgress{Completed: true})
 
 	}
 
@@ -672,14 +670,10 @@ func createInstance(ctx context.Context, getLibOnly bool) (*createInstanceResult
 			}
 		}
 
-		//indexpath := paths.New(configuration.Settings.GetString("directories.Data"))
-		json_paths := []string{}
-		json_paths = append(json_paths, configuration.Settings.GetStringSlice("board_manager.additional_paths")...)
-		for _, x := range json_paths {
-			//path_to_json, err := paths.New(x).Abs()
-			path_to_json, _ := paths.New(x).Abs()
+		for _, x := range configuration.Settings.GetStringSlice("board_manager.additional_paths") {
+			pathJSON, _ := paths.New(x).Abs()
 
-			_, err := res.Pm.LoadPackageIndexFromFile(path_to_json)
+			_, err := res.Pm.LoadPackageIndexFromFile(pathJSON)
 			if err != nil {
 				res.PlatformIndexErrors = append(res.PlatformIndexErrors, err.Error())
 			}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -76,6 +76,7 @@ func BindFlags(cmd *cobra.Command, settings *viper.Viper) {
 	settings.BindPFlag("logging.file", cmd.Flag("log-file"))
 	settings.BindPFlag("logging.format", cmd.Flag("log-format"))
 	settings.BindPFlag("board_manager.additional_urls", cmd.Flag("additional-urls"))
+	settings.BindPFlag("board_manager.additional_paths", cmd.Flag("additional-paths"))
 }
 
 // getDefaultArduinoDataDir returns the full path to the default arduino folder

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -89,6 +89,7 @@ func TestInit(t *testing.T) {
 	require.Equal(t, "text", settings.GetString("logging.format"))
 
 	require.Empty(t, settings.GetStringSlice("board_manager.additional_urls"))
+	require.Empty(t, settings.GetStringSlice("board_manager.additional_paths"))
 
 	require.NotEmpty(t, settings.GetString("directories.Data"))
 	require.NotEmpty(t, settings.GetString("directories.Downloads"))

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -33,6 +33,7 @@ func SetDefaults(settings *viper.Viper) {
 
 	// Boards Manager
 	settings.SetDefault("board_manager.additional_urls", []string{})
+	settings.SetDefault("board_manager.additional_paths", []string{})
 
 	// arduino directories
 	settings.SetDefault("directories.Data", getDefaultArduinoDataDir())

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,8 @@
 
 - `board_manager`
   - `additional_urls` - the URLs to any additional Boards Manager package index files needed for your boards platforms.
-  - `additional_paths` - the file paths to any additional Boards Manager package index files needed for your boards platforms.
+  - `additional_paths` - the absolute file paths to any additional Boards Manager package index files needed for your
+    boards platforms.
 - `daemon` - options related to running Arduino CLI as a [gRPC] server.
   - `port` - TCP port used for gRPC client connections.
 - `directories` - directories used by Arduino CLI.
@@ -67,10 +68,10 @@ Setting an additional Boards Manager URL using the `ARDUINO_BOARD_MANAGER_ADDITI
 $ export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS=https://downloads.arduino.cc/packages/package_staging_index.json
 ```
 
-Setting an additional Boards Manager URL using the `ARDUINO_BOARD_MANAGER_ADDITIONAL_PATHS` environment variable:
+Setting an additional Boards Manager file using the `ARDUINO_BOARD_MANAGER_ADDITIONAL_PATHS` environment variable:
 
 ```sh
-$ export ARDUINO_BOARD_MANAGER_ADDITIONAL_PATHS=packages/package_staging_index.json
+$ export ARDUINO_BOARD_MANAGER_ADDITIONAL_PATHS=/path/to/your/package_staging_index.json
 ```
 
 ### Configuration file
@@ -133,6 +134,21 @@ Doing the same using a TOML format file:
 ```toml
 [board_manager]
 additional_urls = [ "https://downloads.arduino.cc/packages/package_staging_index.json" ]
+```
+
+Setting an additional Boards Manager File using a YAML format configuration file:
+
+```yaml
+board_manager:
+  additional_paths:
+    - /path/to/your/package_staging_index.json
+```
+
+Doing the same using a TOML format file:
+
+```toml
+[board_manager]
+additional_paths = [ "/path/to/your/package_staging_index.json" ]
 ```
 
 [grpc]: https://grpc.io

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,7 @@
 
 - `board_manager`
   - `additional_urls` - the URLs to any additional Boards Manager package index files needed for your boards platforms.
+  - `additional_paths` - the file paths to any additional Boards Manager package index files needed for your boards platforms.
 - `daemon` - options related to running Arduino CLI as a [gRPC] server.
   - `port` - TCP port used for gRPC client connections.
 - `directories` - directories used by Arduino CLI.
@@ -64,6 +65,12 @@ Setting an additional Boards Manager URL using the `ARDUINO_BOARD_MANAGER_ADDITI
 
 ```sh
 $ export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS=https://downloads.arduino.cc/packages/package_staging_index.json
+```
+
+Setting an additional Boards Manager URL using the `ARDUINO_BOARD_MANAGER_ADDITIONAL_PATHS` environment variable:
+
+```sh
+$ export ARDUINO_BOARD_MANAGER_ADDITIONAL_PATHS=packages/package_staging_index.json
 ```
 
 ### Configuration file

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -177,12 +177,24 @@ board_manager:
     - https://arduino.esp8266.com/stable/package_esp8266com_index.json
 ```
 
-From now on, commands supporting custom cores will automatically use the additional URL from the configuration file:
+If you have your package indexes locally installed, you can list their file path in the Arduino CLI configuration file.
+
+For example, to add the NRF52832 core, edit the configuration file and change the `board_manager` settings as follows:
+
+```yaml
+board_manager:
+  additional_paths:
+    - /absolute/path/to/your/package_nrf52832_index.json
+```
+
+From now on, commands supporting custom cores will automatically use the additional URL and additional paths from the
+configuration file:
 
 ```sh
 $ arduino-cli core update-index
 Updating index: package_index.json downloaded
 Updating index: package_esp8266com_index.json downloaded
+Updating index: package_nrf52832_index.json
 Updating index: package_index.json downloaded
 
 $ arduino-cli core search esp8266
@@ -198,6 +210,18 @@ $ arduino-cli  core update-index --additional-urls https://arduino.esp8266.com/s
 Updating index: package_esp8266com_index.json downloaded
 
 $ arduino-cli core search esp8266 --additional-urls https://arduino.esp8266.com/stable/package_esp8266com_index.json
+ID              Version Name
+esp8266:esp8266 2.5.2   esp8266
+```
+
+The same applies to the additional package index file provided by file paths. Use the `--additional-paths` option, that
+has to be specified every time and for every command that operates on a 3rd party platform core, for example:
+
+```sh
+$ arduino-cli  core update-index --additional-paths /absolute/path/to/your/package_esp8266com_index.json
+Updating index: package_esp8266com_index.json downloaded
+
+$ arduino-cli core search esp8266 --additional-paths /absolute/path/to/your/package_esp8266com_index.json
 ID              Version Name
 esp8266:esp8266 2.5.2   esp8266
 ```


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?**
It introduces a new flag `additional-paths` that allows to provide package indexes from absolute file paths. In this case, the signature will not be checked. This can be useful for third party cores, since they will not be requested to upload their package indexes to a server. However it can also be useful for Arduino internal usage during testing phases.

- **What is the current behavior?**
Package indexes can be downloaded only from URL. In case of Arduino cores, the signature is always checked and if a valid signature is not found, the core installation fails. There is no way to test a new Arduino package index that has no signature yet.

* **What is the new behavior?**
Package indexes can be provided also from the absolute file path and the signature will not be checked. An Arduino package index without a signature can be provided in this way.

- **Does this PR introduce a breaking change?**
No, it does not. It introduces a new feature that should not impact on the already implemented ones.

* **Other information**:
This PR will be needed for the Arduino core release automation workflow. Tests on the core with arduino-cli will need to run when there is no signature yet.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
