### PR TITLE
[skip changelog] Improve wording of FAQ re: boards w/o dedicated VID/PID

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,11 +1,11 @@
-## Arduino Uno/Mega/Duemilanove is not detected
+## Arduino Nano/Uno/Mega is not detected
 
 When you run [`arduino-cli board list`][arduino cli board list], your board doesn't show up. Possible causes:
 
 - Your board is a cheaper derivative, or
-- It uses a USB to serial converter like FTDI FT232 or CH340. These chips always report the same USB VID/PID to the
-  operating system, so the only thing we know is that the board mounts that specific USB2Serial chip, but we don’t know
-  which board that chip is on.
+- It's a board, such the classic Nano, that uses a USB to serial converter like FTDI FT232 or CH340. These chips always
+  report the same USB VID/PID to the operating system, so the only thing we know is that the board mounts that specific
+  USB2Serial chip, but we don’t know which board that chip is on.
 
 ## What's the FQBN string?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,11 +1,11 @@
 ## Arduino Uno/Mega/Duemilanove is not detected
 
-When you run `arduino-cli board list`, your board doesn't show up. Possible causes:
+When you run [`arduino-cli board list`][arduino cli board list], your board doesn't show up. Possible causes:
 
-- Your board is a cheaper clone, or
-- It mounts a USB2Serial converter like FT232 or CH340: these chips always report the same USB VID/PID to the operating
-  system, so the only thing we know is that the board mounts that specific USB2Serial chip, but we don’t know which
-  board that chip is on.
+- Your board is a cheaper derivative, or
+- It uses a USB to serial converter like FTDI FT232 or CH340. These chips always report the same USB VID/PID to the
+  operating system, so the only thing we know is that the board mounts that specific USB2Serial chip, but we don’t know
+  which board that chip is on.
 
 ## What's the FQBN string?
 
@@ -33,6 +33,7 @@ the [Monitor service documentation][monitor service].
 
 If your question wasn't answered, feel free to ask on [Arduino CLI's forum board][1].
 
+[arduino cli board list]: commands/arduino-cli_board_list.md
 [0]: platform-specification.md
 [1]: https://forum.arduino.cc/index.php?board=145.0
 [screen]: https://www.gnu.org/software/screen/manual/screen.html


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Despite the Arduino Nano being the sole active official Arduino board without a custom VID/PID, it is not mentioned in the FAQ item about this type of board.
* **What is the new behavior?**
<!-- if this is a feature change -->
The classic Nano is explicitely mentioned in the FAQ item and the wording is slightly improved.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
Related:
- https://github.com/arduino/arduino-cli/issues/986
- https://github.com/arduino/arduino-cli/issues/933
- https://github.com/arduino/arduino-cli/issues/41
- https://github.com/arduino/arduino-cli/issues/37