### PR TITLE
Fix debug command not finding sketch build folder

### DIFF
--- a/arduino/sketches/sketches.go
+++ b/arduino/sketches/sketches.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/arduino/arduino-cli/arduino/builder"
 	"github.com/arduino/go-paths-helper"
 	"github.com/pkg/errors"
 )
@@ -97,4 +98,13 @@ func (s *Sketch) ExportMetadata() error {
 		return fmt.Errorf("writing sketch metadata %s: %s", sketchJSON, err)
 	}
 	return nil
+}
+
+// BuildPath returns this Sketch build path in the temp directory of the system.
+// Returns an error if the Sketch's FullPath is not set
+func (s *Sketch) BuildPath() (*paths.Path, error) {
+	if s.FullPath == nil {
+		return nil, fmt.Errorf("sketch path is empty")
+	}
+	return builder.GenBuildPath(s.FullPath), nil
 }

--- a/arduino/sketches/sketches_test.go
+++ b/arduino/sketches/sketches_test.go
@@ -43,3 +43,19 @@ func TestSketchLoadingFromFolderOrMainFile(t *testing.T) {
 		require.True(t, sk.FullPath.EquivalentTo(skFolder))
 	}
 }
+
+func TestSketchBuildPath(t *testing.T) {
+	// Verifies build path is returned if sketch path is set
+	sketchPath := paths.New("testdata/Sketch1")
+	sketch, err := NewSketchFromPath(sketchPath)
+	require.NoError(t, err)
+	buildPath, err := sketch.BuildPath()
+	require.NoError(t, err)
+	require.Contains(t, buildPath.String(), "arduino-sketch-")
+
+	// Verifies error is returned if sketch path is not set
+	sketch = &Sketch{}
+	buildPath, err = sketch.BuildPath()
+	require.Nil(t, buildPath)
+	require.Error(t, err, "sketch path is empty")
+}

--- a/commands/debug/debug_info.go
+++ b/commands/debug/debug_info.go
@@ -120,10 +120,10 @@ func getDebugProperties(req *debug.DebugConfigReq, pm *packagemanager.PackageMan
 		importPath = paths.New(importDir)
 	} else {
 		// TODO: Create a function to obtain importPath from sketch
-		importPath = sketch.FullPath
-		// Add FQBN (without configs part) to export path
-		fqbnSuffix := strings.Replace(fqbn.StringWithoutConfig(), ":", ".", -1)
-		importPath = importPath.Join("build").Join(fqbnSuffix)
+		importPath, err = sketch.BuildPath()
+		if err != nil {
+			return nil, fmt.Errorf("can't find build path for sketch: %v", err)
+		}
 	}
 	if !importPath.Exist() {
 		return nil, fmt.Errorf("compiled sketch not found in %s", importPath)

--- a/commands/debug/debug_test.go
+++ b/commands/debug/debug_test.go
@@ -51,6 +51,7 @@ func TestGetCommandLine(t *testing.T) {
 		Instance:   &rpc.Instance{Id: 1},
 		Fqbn:       "arduino-test:samd:arduino_zero_edbg",
 		SketchPath: sketchPath.String(),
+		ImportDir:  sketchPath.Join("build", "arduino-test.samd.arduino_zero_edbg").String(),
 	}
 
 	goldCommand := fmt.Sprintf("%s/arduino-test/tools/arm-none-eabi-gcc/7-2017q4/bin/arm-none-eabi-gdb%s", dataDir, toolExtension) +
@@ -72,6 +73,7 @@ func TestGetCommandLine(t *testing.T) {
 		Fqbn:        "arduino-test:samd:mkr1000",
 		SketchPath:  sketchPath.String(),
 		Interpreter: "mi1",
+		ImportDir:   sketchPath.Join("build", "arduino-test.samd.mkr1000").String(),
 	}
 
 	goldCommand2 := fmt.Sprintf("%s/arduino-test/tools/arm-none-eabi-gcc/7-2017q4/bin/arm-none-eabi-gdb%s", dataDir, toolExtension) +

--- a/test/test_debug.py
+++ b/test/test_debug.py
@@ -1,0 +1,39 @@
+# This file is part of arduino-cli.
+#
+# Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+#
+# This software is released under the GNU General Public License version 3,
+# which covers the main part of arduino-cli.
+# The terms of this license can be found at:
+# https://www.gnu.org/licenses/gpl-3.0.en.html
+#
+# You can be released from the requirements of the above licenses by purchasing
+# a commercial license. Buying such a license is mandatory if you want to modify or
+# otherwise use the software for commercial activities involving the Arduino
+# software without disclosing the source code of your own applications. To purchase
+# a commercial license, send an email to license@arduino.cc.
+
+
+from pathlib import Path
+
+
+def test_debugger_starts(run_command, data_dir):
+    # Init the environment explicitly
+    assert run_command("core update-index")
+
+    # Install cores
+    assert run_command("core install arduino:samd")
+
+    # Create sketch for testing
+    sketch_name = "DebuggerStartTest"
+    sketch_path = Path(data_dir, sketch_name)
+    fqbn = "arduino:samd:mkr1000"
+
+    assert run_command(f"sketch new {sketch_path}")
+
+    # Build sketch
+    assert run_command(f"compile -b {fqbn} {sketch_path}")
+
+    programmer = "atmel_ice"
+    # Starts debugger
+    assert run_command(f"debug -b {fqbn} -P {programmer} {sketch_path} --info")


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes an existing feature.

- **What is the current behavior?**

`debug` command doesn't work if binaries are not exported to sketch folder.

* **What is the new behavior?**

`debug` command works correctly even if binaries are not exported to sketch folder.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

No.

* **Other information**:

Fixes #1102.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
