### PR TITLE
Always set the versioned runtime.tool property for all installed tools

### DIFF
--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -213,6 +213,9 @@ func runProgramAction(pm *packagemanager.PackageManager,
 		uploadProperties.Merge(programmer.Properties)
 	}
 
+	for _, tool := range pm.GetAllInstalledToolsReleases() {
+		uploadProperties.Merge(tool.RuntimeProperties())
+	}
 	if requiredTools, err := pm.FindToolsRequiredForBoard(board); err == nil {
 		for _, requiredTool := range requiredTools {
 			logrus.WithField("tool", requiredTool).Info("Tool required for upload")


### PR DESCRIPTION
For example if we have bossac 1.7.1 and 1.9.0 installed, this will result in the following properties available during upload:

`{runtime.tools.bossac-1.7.0-arduino3.path} => /path/to/bossac/1.7.0`
`{runtime.tools.bossac-1.9.0-arduino3.path} => /path/to/bossac/1.9.0`
`{runtime.tools.bossac.path} => /path/to/bossac/1.9.0`

some platforms fail to correctly specify the version of the tool in the package_index.json but they do the correct specification in the recipes. This patch allows to not fail in this latter case.
