### PR TITLE
[breaking] Rename telemetry to metrics

### DIFF
--- a/cli/config/validate.go
+++ b/cli/config/validate.go
@@ -31,8 +31,8 @@ var validMap = map[string]reflect.Kind{
 	"logging.format":                reflect.String,
 	"logging.level":                 reflect.String,
 	"sketch.always_export_binaries": reflect.Bool,
-	"telemetry.addr":                reflect.String,
-	"telemetry.enabled":             reflect.Bool,
+	"metrics.addr":                  reflect.String,
+	"metrics.enabled":               reflect.Bool,
 }
 
 func typeOf(key string) (reflect.Kind, error) {

--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -29,11 +29,11 @@ import (
 	"github.com/arduino/arduino-cli/cli/globals"
 	"github.com/arduino/arduino-cli/commands/daemon"
 	"github.com/arduino/arduino-cli/configuration"
+	"github.com/arduino/arduino-cli/metrics"
 	srv_commands "github.com/arduino/arduino-cli/rpc/commands"
 	srv_debug "github.com/arduino/arduino-cli/rpc/debug"
 	srv_monitor "github.com/arduino/arduino-cli/rpc/monitor"
 	srv_settings "github.com/arduino/arduino-cli/rpc/settings"
-	"github.com/arduino/arduino-cli/telemetry"
 	"github.com/segmentio/stats/v4"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -60,8 +60,8 @@ var daemonize bool
 
 func runDaemonCommand(cmd *cobra.Command, args []string) {
 
-	if configuration.Settings.GetBool("telemetry.enabled") {
-		telemetry.Activate("daemon")
+	if configuration.Settings.GetBool("metrics.enabled") {
+		metrics.Activate("daemon")
 		stats.Incr("daemon", stats.T("success", "true"))
 		defer stats.Flush()
 	}
@@ -90,7 +90,7 @@ func runDaemonCommand(cmd *cobra.Command, args []string) {
 		go func() {
 			// Stdin is closed when the controlling parent process ends
 			_, _ = io.Copy(ioutil.Discard, os.Stdin)
-			// Flush telemetry stats (this is a no-op if telemetry is disabled)
+			// Flush metrics stats (this is a no-op if metrics is disabled)
 			stats.Flush()
 			os.Exit(0)
 		}()

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -33,8 +33,8 @@ import (
 	"github.com/arduino/arduino-cli/legacy/builder"
 	"github.com/arduino/arduino-cli/legacy/builder/i18n"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
+	"github.com/arduino/arduino-cli/metrics"
 	rpc "github.com/arduino/arduino-cli/rpc/commands"
-	"github.com/arduino/arduino-cli/telemetry"
 	paths "github.com/arduino/go-paths-helper"
 	properties "github.com/arduino/go-properties-orderedmap"
 	"github.com/pkg/errors"
@@ -47,7 +47,7 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 
 	tags := map[string]string{
 		"fqbn":            req.Fqbn,
-		"sketchPath":      telemetry.Sanitize(req.SketchPath),
+		"sketchPath":      metrics.Sanitize(req.SketchPath),
 		"showProperties":  strconv.FormatBool(req.ShowProperties),
 		"preprocess":      strconv.FormatBool(req.Preprocess),
 		"buildProperties": strings.Join(req.BuildProperties, ","),
@@ -55,7 +55,7 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 		"verbose":         strconv.FormatBool(req.Verbose),
 		"quiet":           strconv.FormatBool(req.Quiet),
 		"vidPid":          req.VidPid,
-		"exportDir":       telemetry.Sanitize(req.GetExportDir()),
+		"exportDir":       metrics.Sanitize(req.GetExportDir()),
 		"jobs":            strconv.FormatInt(int64(req.Jobs), 10),
 		"libraries":       strings.Join(req.Libraries, ","),
 		"clean":           strconv.FormatBool(req.GetClean()),

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -96,8 +96,8 @@ func TestInit(t *testing.T) {
 
 	require.Equal(t, "50051", settings.GetString("daemon.port"))
 
-	require.Equal(t, true, settings.GetBool("telemetry.enabled"))
-	require.Equal(t, ":9090", settings.GetString("telemetry.addr"))
+	require.Equal(t, true, settings.GetBool("metrics.enabled"))
+	require.Equal(t, ":9090", settings.GetString("metrics.addr"))
 }
 
 func TestFindConfigFile(t *testing.T) {

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -45,9 +45,9 @@ func SetDefaults(settings *viper.Viper) {
 	// daemon settings
 	settings.SetDefault("daemon.port", "50051")
 
-	//telemetry settings
-	settings.SetDefault("telemetry.enabled", true)
-	settings.SetDefault("telemetry.addr", ":9090")
+	// metrics settings
+	settings.SetDefault("metrics.enabled", true)
+	settings.SetDefault("metrics.addr", ":9090")
 
 	// Bind env vars
 	settings.SetEnvPrefix("ARDUINO")

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -2,6 +2,23 @@
 
 Here you can find a list of migration guides to handle breaking changes between releases of the CLI.
 
+## Unreleased
+
+### Rename `telemetry` settings to `metrics`
+
+All instances of the term `telemetry` in the code and the documentation has been changed to `metrics`. This has been
+done to clarify that no data is currently gathered from users of the CLI.
+
+To handle this change the users must edit their config file, usually `arduino-cli.yaml`, and change the `telemetry` key
+to `metrics`. The modification must be done by manually editing the file using a text editor, it can't be done via CLI.
+No other action is necessary.
+
+The default folders for the `arduino-cli.yaml` are:
+
+- Linux: `/home/<your_username>/.arduino15/arduino-cli.yaml`
+- OS X: `/Users/<your_username>/Library/Arduino15/arduino-cli.yaml`
+- Windows: `C:\Users\<your_username>\AppData\Arduino15\arduino-cli.yaml`
+
 ## 0.14.0
 
 ### Changes in `debug` command

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,9 +18,9 @@
   - `format` - output format for the logs. Allowed values are `text` or `json`.
   - `level` - messages with this level and above will be logged. Valid levels are: `trace`, `debug`, `info`, `warn`,
     `error`, `fatal`, `panic`.
-- `telemetry` - settings related to the collection of data used for continued improvement of Arduino CLI.
-  - `addr` - TCP port used for telemetry communication.
-  - `enabled` - controls the use of telemetry.
+- `metrics` - settings related to the collection of data used for continued improvement of Arduino CLI.
+  - `addr` - TCP port used for metrics communication.
+  - `enabled` - controls the use of metrics.
 
 ## Configuration methods
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -329,7 +329,7 @@ The [client_example] folder contains a sample client code that shows how to inte
 services and messages are detailed in the [gRPC reference] pages.
 
 To provide observability for the gRPC server activities besides logs, the `daemon` mode activates and exposes by default
-a [Prometheus](https://prometheus.io/) endpoint (http://localhost:9090/metrics) that can be fetched for telemetry data
+a [Prometheus](https://prometheus.io/) endpoint (http://localhost:9090/metrics) that can be fetched for metrics data
 like:
 
 ```text
@@ -340,10 +340,10 @@ daemon_compile{buildProperties="",exportFile="",fqbn="arduino:samd:mkr1000",inst
 daemon_board_list{installationID="ed6f1f22-1fbe-4b1f-84be-84d035b6369c",success="true"} 1 1580385724833
 ```
 
-The telemetry settings are exposed via the `telemetry` section in the CLI configuration:
+The metrics settings are exposed via the `metrics` section in the CLI configuration:
 
 ```yaml
-telemetry:
+metrics:
   enabled: true
   addr: :9090
 ```

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -13,7 +13,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-package telemetry
+package metrics
 
 import (
 	"crypto/hmac"
@@ -28,10 +28,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// serverPattern is the telemetry endpoint resource path for consume metrics
+// serverPattern is the metrics endpoint resource path for consume metrics
 var serverPattern = "/metrics"
 
-// Activate configures and starts the telemetry server exposing a Prometheus resource
+// Activate configures and starts the metrics server exposing a Prometheus resource
 func Activate(metricPrefix string) {
 	// Create a Prometheus default handler
 	ph := prometheus.DefaultHandler
@@ -43,8 +43,8 @@ func Activate(metricPrefix string) {
 	stats.Register(ph)
 
 	// Configure using viper settings
-	serverAddr := configuration.Settings.GetString("telemetry.addr")
-	logrus.Infof("Setting up Prometheus telemetry on %s%s", serverAddr, serverPattern)
+	serverAddr := configuration.Settings.GetString("metrics.addr")
+	logrus.Infof("Setting up Prometheus metrics on %s%s", serverAddr, serverPattern)
 	go func() {
 		http.Handle(serverPattern, ph)
 		logrus.Error(http.ListenAndServe(serverAddr, nil))

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -40,8 +40,8 @@ def test_init_with_existing_custom_config(run_command, data_dir, working_dir, do
     assert "" == configs["logging"]["file"]
     assert "text" == configs["logging"]["format"]
     assert "info" == configs["logging"]["level"]
-    assert ":9090" == configs["telemetry"]["addr"]
-    assert configs["telemetry"]["enabled"]
+    assert ":9090" == configs["metrics"]["addr"]
+    assert configs["metrics"]["enabled"]
 
     config_file_path = Path(working_dir) / "config" / "test" / "config.yaml"
     assert not config_file_path.exists()
@@ -60,8 +60,8 @@ def test_init_with_existing_custom_config(run_command, data_dir, working_dir, do
     assert "" == configs["logging"]["file"]
     assert "text" == configs["logging"]["format"]
     assert "info" == configs["logging"]["level"]
-    assert ":9090" == configs["telemetry"]["addr"]
-    assert configs["telemetry"]["enabled"]
+    assert ":9090" == configs["metrics"]["addr"]
+    assert configs["metrics"]["enabled"]
 
 
 def test_init_overwrite_existing_custom_file(run_command, data_dir, working_dir, downloads_dir):
@@ -80,8 +80,8 @@ def test_init_overwrite_existing_custom_file(run_command, data_dir, working_dir,
     assert "" == configs["logging"]["file"]
     assert "text" == configs["logging"]["format"]
     assert "info" == configs["logging"]["level"]
-    assert ":9090" == configs["telemetry"]["addr"]
-    assert configs["telemetry"]["enabled"]
+    assert ":9090" == configs["metrics"]["addr"]
+    assert configs["metrics"]["enabled"]
 
     result = run_command("config init --overwrite")
     assert result.ok
@@ -98,8 +98,8 @@ def test_init_overwrite_existing_custom_file(run_command, data_dir, working_dir,
     assert "" == configs["logging"]["file"]
     assert "text" == configs["logging"]["format"]
     assert "info" == configs["logging"]["level"]
-    assert ":9090" == configs["telemetry"]["addr"]
-    assert configs["telemetry"]["enabled"]
+    assert ":9090" == configs["metrics"]["addr"]
+    assert configs["metrics"]["enabled"]
 
 
 def test_init_dest_absolute_path(run_command, working_dir):

--- a/test/test_daemon.py
+++ b/test/test_daemon.py
@@ -25,7 +25,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 
 @pytest.mark.timeout(60)
-def test_telemetry_prometheus_endpoint(daemon_runner, data_dir):
+def test_metrics_prometheus_endpoint(daemon_runner, data_dir):
     # Wait for the inventory file to be created and then parse it
     # in order to check the generated ids
     inventory_file = os.path.join(data_dir, "inventory.yaml")
@@ -35,7 +35,7 @@ def test_telemetry_prometheus_endpoint(daemon_runner, data_dir):
         inventory = yaml.safe_load(stream)
 
         # Check if :9090/metrics endpoint is alive,
-        # telemetry is enabled by default in daemon mode
+        # metrics is enabled by default in daemon mode
         s = requests.Session()
         retries = Retry(total=3, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
         s.mount("http://", HTTPAdapter(max_retries=retries))


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Changes all occurences of the term `telemetry` to `metrics`.

- **What is the current behavior?**

No behaviour changed.

* **What is the new behavior?**

Same as before.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Yes, the `UPGRADING.md` file has been updated accordingly.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
