### PR TITLE
ARDUIFINE: global compiler options extracted from ctags parsing

### DIFF
--- a/docs/sketch-build-process.md
+++ b/docs/sketch-build-process.md
@@ -27,6 +27,9 @@ compiler:
   rare cases, prototype generation may fail for some functions. To work around this, you can provide your own prototypes
   for these functions.
 - `#line` directives are added to make warning or error messages reflect the original sketch layout.
+- Special and optional sketch variables named ARDUIFINE and ARDUINOGLOBAL are parsed, and their content is used to
+  provide more arguments to the compiler commands. Those arguments are used for every compiled source file, including
+  the core, internal and external libraries. Their content is displayed in the message area.
 
 No pre-processing is done to files in a sketch with any extension other than .ino or .pde. Additionally, .h files in the
 sketch are not automatically #included from the main sketch file. Further, if you want to call functions defined in a .c

--- a/legacy/builder/builder_utils/utils.go
+++ b/legacy/builder/builder_utils/utils.go
@@ -229,7 +229,9 @@ func compileFileWithRecipe(ctx *types.Context, sourcePath *paths.Path, source *p
 	properties := buildProperties.Clone()
 	properties.Set(constants.BUILD_PROPERTIES_COMPILER_WARNING_FLAGS, properties.Get(constants.BUILD_PROPERTIES_COMPILER_WARNING_FLAGS+"."+ctx.WarningsLevel))
 	properties.Set(constants.BUILD_PROPERTIES_INCLUDES, strings.Join(includes, constants.SPACE))
-	properties.Set(constants.BUILD_PROPERTIES_INCLUDES, properties.Get(constants.BUILD_PROPERTIES_INCLUDES) + " " + ctx.Arduifines + " ")
+	if len(ctx.Arduifines) > 0 {
+		properties.Set(constants.BUILD_PROPERTIES_INCLUDES, properties.Get(constants.BUILD_PROPERTIES_INCLUDES) + " " + ctx.Arduifines + " ")
+	}
 	properties.SetPath(constants.BUILD_PROPERTIES_SOURCE_FILE, source)
 	relativeSource, err := sourcePath.RelTo(source)
 	if err != nil {

--- a/legacy/builder/builder_utils/utils.go
+++ b/legacy/builder/builder_utils/utils.go
@@ -229,6 +229,7 @@ func compileFileWithRecipe(ctx *types.Context, sourcePath *paths.Path, source *p
 	properties := buildProperties.Clone()
 	properties.Set(constants.BUILD_PROPERTIES_COMPILER_WARNING_FLAGS, properties.Get(constants.BUILD_PROPERTIES_COMPILER_WARNING_FLAGS+"."+ctx.WarningsLevel))
 	properties.Set(constants.BUILD_PROPERTIES_INCLUDES, strings.Join(includes, constants.SPACE))
+	properties.Set(constants.BUILD_PROPERTIES_INCLUDES, properties.Get(constants.BUILD_PROPERTIES_INCLUDES) + " " + ctx.Arduifines + " ")
 	properties.SetPath(constants.BUILD_PROPERTIES_SOURCE_FILE, source)
 	relativeSource, err := sourcePath.RelTo(source)
 	if err != nil {

--- a/legacy/builder/constants/constants.go
+++ b/legacy/builder/constants/constants.go
@@ -124,6 +124,7 @@ const MSG_USING_CACHED_INCLUDES = "Using cached library dependencies for file: {
 const MSG_WARNING_LIB_INVALID_CATEGORY = "WARNING: Category '{0}' in library {1} is not valid. Setting to '{2}'"
 const MSG_WARNING_PLATFORM_OLD_VALUES = "Warning: platform.txt from core '{0}' contains deprecated {1}, automatically converted to {2}. Consider upgrading this core."
 const MSG_WARNING_SPURIOUS_FILE_IN_LIB = "WARNING: Spurious {0} folder in '{1}' library"
+const MSG_ADDITIONAL_OPTIONS = "Additional compiler options provided by user sketch: {0}"
 const PACKAGE_NAME = "name"
 const PACKAGE_TOOLS = "tools"
 const PLATFORM_ARCHITECTURE = "architecture"

--- a/legacy/builder/ctags/ctags_parser.go
+++ b/legacy/builder/ctags/ctags_parser.go
@@ -263,9 +263,11 @@ func toCompilerCmdLine (define string) string {
 	// transforms ` A `         to `-DA`
 	elts := strings.SplitAfterN(define, "=", 2)
 	ret := ""
-	if len(elts) > 0 {
-		ret += "-D"+strings.TrimSpace(elts[0][:len(elts[0])-1])
-		if len(elts) > 1 {
+	eltsLength := len(elts)
+	if eltsLength > 0 {
+		equalsLength := eltsLength - 1
+		ret += "-D"+strings.TrimSpace(elts[0][:len(elts[0])-equalsLength])
+		if equalsLength > 0 {
 			ret += "="+strings.TrimSpace(elts[1])
 		}
 	}

--- a/legacy/builder/ctags/ctags_parser_test.go
+++ b/legacy/builder/ctags/ctags_parser_test.go
@@ -30,7 +30,9 @@ func produceTags(t *testing.T, filename string) []*types.CTag {
 	require.NoError(t, err)
 
 	parser := CTagsParser{}
-	return parser.Parse(string(bytes), nil)
+	tags, Arduifines := parser.Parse(string(bytes), nil)
+	_ = Arduifines
+	return tags
 }
 
 func TestCTagsParserShouldListPrototypes(t *testing.T) {

--- a/legacy/builder/ctags_runner.go
+++ b/legacy/builder/ctags_runner.go
@@ -56,7 +56,7 @@ func (s *CTagsRunner) Run(ctx *types.Context) error {
 
 	parser := &ctags.CTagsParser{}
 
-	ctx.CTagsOfPreprocessedSource = parser.Parse(ctx.CTagsOutput, ctx.Sketch.MainFile.Name)
+	ctx.CTagsOfPreprocessedSource, ctx.Arduifines = parser.Parse(ctx.CTagsOutput, ctx.Sketch.MainFile.Name)
 	parser.FixCLinkageTagsDeclarations(ctx.CTagsOfPreprocessedSource)
 
 	protos, line := parser.GeneratePrototypes()

--- a/legacy/builder/phases/libraries_builder.go
+++ b/legacy/builder/phases/libraries_builder.go
@@ -45,7 +45,7 @@ func (s *LibrariesBuilder) Run(ctx *types.Context) error {
 	}
 
 	if len(ctx.Arduifines) > 0 {
-		ctx.GetLogger().Fprintln(os.Stdout, constants.LOG_LEVEL_DEBUG, "Additional compiler options provided by User sketch: "+ctx.Arduifines)
+		ctx.GetLogger().Println(constants.LOG_LEVEL_DEBUG, constants.MSG_ADDITIONAL_OPTIONS, ctx.Arduifines)
 	}
 
 	objectFiles, err := compileLibraries(ctx, libs, librariesBuildPath, buildProperties, includes)

--- a/legacy/builder/phases/libraries_builder.go
+++ b/legacy/builder/phases/libraries_builder.go
@@ -44,6 +44,10 @@ func (s *LibrariesBuilder) Run(ctx *types.Context) error {
 		return errors.WithStack(err)
 	}
 
+	if len(ctx.Arduifines) > 0 {
+		ctx.GetLogger().Fprintln(os.Stdout, constants.LOG_LEVEL_DEBUG, "Additional compiler options provided by User sketch: "+ctx.Arduifines)
+	}
+
 	objectFiles, err := compileLibraries(ctx, libs, librariesBuildPath, buildProperties, includes)
 	if err != nil {
 		return errors.WithStack(err)

--- a/legacy/builder/test/builder_test.go
+++ b/legacy/builder/test/builder_test.go
@@ -43,6 +43,25 @@ func prepareBuilderTestContext(t *testing.T, sketchPath *paths.Path, fqbn string
 	}
 }
 
+func TestBuilderArduifine(t *testing.T) {
+	DownloadCoresAndToolsAndLibraries(t)
+
+	ctx := prepareBuilderTestContext(t, paths.New("sketch_arduifine", "sketch_arduifine.ino"), "arduino:avr:uno")
+	ctx.DebugLevel = 10
+
+	buildPath := SetupBuildPath(t, ctx)
+	defer buildPath.RemoveAll()
+
+	// Run builder
+	command := builder.Builder{}
+	err := command.Run(ctx)
+	NoError(t, err)
+
+	exist, err := buildPath.Join("sketch_arduifine.ino.hex").ExistCheck()
+	NoError(t, err)
+	require.True(t, exist)
+}
+
 func TestBuilderEmptySketch(t *testing.T) {
 	DownloadCoresAndToolsAndLibraries(t)
 

--- a/legacy/builder/test/libraries/lib4arduifine/lib4arduifine.cpp
+++ b/legacy/builder/test/libraries/lib4arduifine/lib4arduifine.cpp
@@ -1,0 +1,8 @@
+
+#include <lib4arduifine.h>
+
+#if MYVERSION == 1337
+#pragma message "arduifine: MYVERSION is correctly defined"
+#else
+#error arduifine: MYVERSION is not correctly defined
+#endif

--- a/legacy/builder/test/libraries_loader_test.go
+++ b/legacy/builder/test/libraries_loader_test.go
@@ -66,7 +66,7 @@ func TestLoadLibrariesAVR(t *testing.T) {
 	require.True(t, Abs(t, paths.New("libraries")).EquivalentTo(librariesFolders[2].Path))
 
 	libs := extractLibraries(ctx)
-	require.Equal(t, 24, len(libs))
+	require.Equal(t, 25, len(libs))
 
 	sort.Sort(ByLibraryName(libs))
 
@@ -176,7 +176,7 @@ func TestLoadLibrariesSAM(t *testing.T) {
 	require.True(t, Abs(t, paths.New("libraries")).EquivalentTo(librariesFolders[2].Path))
 
 	libraries := extractLibraries(ctx)
-	require.Equal(t, 22, len(libraries))
+	require.Equal(t, 23, len(libraries))
 
 	sort.Sort(ByLibraryName(libraries))
 

--- a/legacy/builder/test/sketch_arduifine/sketch_arduifine.ino
+++ b/legacy/builder/test/sketch_arduifine/sketch_arduifine.ino
@@ -1,0 +1,7 @@
+
+#include <lib4arduifine.h>
+
+const char* ARDUIFINEtest = "MYVERSION = 1337";
+
+void setup() {}
+void loop() {}

--- a/legacy/builder/types/context.go
+++ b/legacy/builder/types/context.go
@@ -174,6 +174,10 @@ type Context struct {
 	// The provided source data is used instead of reading it from disk.
 	// The keys of the map are paths relative to sketch folder.
 	SourceOverride map[string]string
+
+	// compiler options from ctags extraction
+	// example: 'char ARDUIFINEyyy = "<compiler options like> -DMYLIB_BUFFER_LEN=1234 -include \"somefile.h\"";'
+	Arduifines string
 }
 
 // ExecutableSectionSize represents a section of the executable output file

--- a/legacy/builder/types/context.go
+++ b/legacy/builder/types/context.go
@@ -176,7 +176,8 @@ type Context struct {
 	SourceOverride map[string]string
 
 	// compiler options from ctags extraction
-	// example: 'char ARDUIFINEyyy = "<compiler options like> -DMYLIB_BUFFER_LEN=1234 -include \"somefile.h\"";'
+	// example: 'char ARDUIFINExxx = "MYLIB_BUFFER_LEN = 1234";'
+	// example: 'char ARDUINOGLOBALyyy = "-DMYLIB_BUFFER2_LEN=1234 -free -fipa-pta";'
 	Arduifines string
 }
 


### PR DESCRIPTION
- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

----------------

Example: these lines in the `.ino` file:
```
    const char* ARDUIFINE_abc = "MYLIB_BUFFER_LEN=1234";
    const char* ARDUIFINE_def = "MYLIB_PARAM";
    const char* ARDUINOGLOBAL_ghi = "-DMYLIB2_BUFFER_LEN=1234";
    const char* ARDUINOGLOBAL_jkl = "-DMYLIB2_PARAM";
```
will globally enable the following options in the compiler command line:
```
        -DMYLIB_BUFFER_LEN=1234 -DMYLIB_PARAM -DMYLIB2_BUFFER_LEN=1234 -DMYLIB2_PARAM
```

That, ***including during compilation of the core and libraries***.

If they are not otherwise used by the sketch, the symbols `ARDUIFINExxx` and `ARDUINOGLOBALyyy` are excluded from the final binary at link time.

This PR aims at giving a solution to https://github.com/arduino/Arduino/issues/421
and is maybe related to #846.

---------

![arduifine](https://user-images.githubusercontent.com/4800356/103324529-2a237680-4a48-11eb-9d0d-67082e94feb2.png)
(the missing `M` is fixed)