### PR TITLE
Enhance error messages if config paths are not valid

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -136,7 +136,11 @@ func preRun(cmd *cobra.Command, args []string) {
 	configFile := configuration.Settings.ConfigFileUsed()
 
 	// initialize inventory
-	inventory.Init(configuration.Settings.GetString("directories.Data"))
+	err := inventory.Init(configuration.Settings.GetString("directories.Data"))
+	if err != nil {
+		feedback.Errorf("Error: %v", err)
+		os.Exit(errorcodes.ErrBadArgument)
+	}
 
 	//
 	// Prepare logging


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Enhances error messages.

- **What is the current behavior?**

If there are invalid paths for certain settings in the config file multiple errors are returned but are not clear enough, also certain commands still keep going forward.

* **What is the new behavior?**

Full invalid paths in the config file are now printed in full and only one error is shown, execution also stops for all commands if an error is returned.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

No breaking change.

* **Other information**:

Solves #1114.
---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
