### PR TITLE
[skip changelog] Fix workflow collecting GH download stats

### DIFF
--- a/.github/workflows/github-stats.yaml
+++ b/.github/workflows/github-stats.yaml
@@ -34,7 +34,7 @@ jobs:
               const baseName = `arduino-cli_${rel.name}_`
 
               // Get a list of assets for this release
-              const opts = github.repos.listAssetsForRelease.endpoint.merge({
+              const opts = github.repos.listReleaseAssets.endpoint.merge({
                 ...context.repo,
                 release_id: rel.id
               })


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes an outdated API request in a workflow.

- **What is the current behavior?**

Workflow fails.

* **What is the new behavior?**

Hopefully it doesn't fail anymore.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
