### PR TITLE
Precompiled libraries: only select a folder if it contains files

### DIFF
--- a/legacy/builder/phases/libraries_builder.go
+++ b/legacy/builder/phases/libraries_builder.go
@@ -53,16 +53,12 @@ func (s *LibrariesBuilder) Run(ctx *types.Context) error {
 	return nil
 }
 
-func containsFile(folder *paths.Path) bool {
-	res, _ := folder.ReadDir()
-	hasfiles := false
-	for _, el := range res {
-		if !el.IsDir() {
-			hasfiles = true
-			break
-		}
+func directoryContainsFile(folder *paths.Path) bool {
+	if files, err := folder.ReadDir(); err == nil {
+		files.FilterOutDirs()
+		return len(files) > 0
 	}
-	return hasfiles
+	return false
 }
 
 func findExpectedPrecompiledLibFolder(ctx *types.Context, library *libraries.Library) *paths.Path {
@@ -98,7 +94,7 @@ func findExpectedPrecompiledLibFolder(ctx *types.Context, library *libraries.Lib
 	if len(fpuSpecs) > 0 {
 		fpuSpecs = strings.TrimRight(fpuSpecs, "-")
 		fullPrecompDir := library.SourceDir.Join(mcu).Join(fpuSpecs)
-		if fullPrecompDir.Exist() && containsFile(fullPrecompDir) {
+		if fullPrecompDir.Exist() && directoryContainsFile(fullPrecompDir) {
 			logger.Fprintln(os.Stdout, constants.LOG_LEVEL_INFO, "Using precompiled library in {0}", fullPrecompDir)
 			return fullPrecompDir
 		}
@@ -106,7 +102,7 @@ func findExpectedPrecompiledLibFolder(ctx *types.Context, library *libraries.Lib
 	}
 
 	precompDir := library.SourceDir.Join(mcu)
-	if precompDir.Exist() && containsFile(precompDir) {
+	if precompDir.Exist() && directoryContainsFile(precompDir) {
 		logger.Fprintln(os.Stdout, constants.LOG_LEVEL_INFO, "Using precompiled library in {0}", precompDir)
 		return precompDir
 	}

--- a/legacy/builder/phases/libraries_builder.go
+++ b/legacy/builder/phases/libraries_builder.go
@@ -53,6 +53,18 @@ func (s *LibrariesBuilder) Run(ctx *types.Context) error {
 	return nil
 }
 
+func containsFile(folder *paths.Path) bool {
+	res, _ := folder.ReadDir()
+	hasfiles := false
+	for _, el := range res {
+		if !el.IsDir() {
+			hasfiles = true
+			break
+		}
+	}
+	return hasfiles
+}
+
 func findExpectedPrecompiledLibFolder(ctx *types.Context, library *libraries.Library) *paths.Path {
 	mcu := ctx.BuildProperties.Get(constants.BUILD_PROPERTIES_BUILD_MCU)
 	// Add fpu specifications if they exist
@@ -86,7 +98,7 @@ func findExpectedPrecompiledLibFolder(ctx *types.Context, library *libraries.Lib
 	if len(fpuSpecs) > 0 {
 		fpuSpecs = strings.TrimRight(fpuSpecs, "-")
 		fullPrecompDir := library.SourceDir.Join(mcu).Join(fpuSpecs)
-		if fullPrecompDir.Exist() {
+		if fullPrecompDir.Exist() && containsFile(fullPrecompDir) {
 			logger.Fprintln(os.Stdout, constants.LOG_LEVEL_INFO, "Using precompiled library in {0}", fullPrecompDir)
 			return fullPrecompDir
 		}
@@ -94,7 +106,7 @@ func findExpectedPrecompiledLibFolder(ctx *types.Context, library *libraries.Lib
 	}
 
 	precompDir := library.SourceDir.Join(mcu)
-	if precompDir.Exist() {
+	if precompDir.Exist() && containsFile(precompDir) {
 		logger.Fprintln(os.Stdout, constants.LOG_LEVEL_INFO, "Using precompiled library in {0}", precompDir)
 		return precompDir
 	}

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -184,60 +184,36 @@ def test_compile_blacklisted_sketchname(run_command, data_dir):
 def test_compile_without_precompiled_libraries(run_command, data_dir):
     # Init the environment explicitly
     url = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json"
-    result = run_command("core update-index --additional-urls={}".format(url))
-    assert result.ok
-    result = run_command("core install arduino:mbed@1.3.1 --additional-urls={}".format(url))
-    assert result.ok
-    result = run_command("core install arduino:samd@1.8.7 --additional-urls={}".format(url))
-    assert result.ok
-    result = run_command("core install adafruit:samd@1.6.0 --additional-urls={}".format(url))
-    assert result.ok
+    assert run_command(f"core update-index --additional-urls={url}")
+    assert run_command(f"core install arduino:mbed@1.3.1 --additional-urls={url}")
 
     # Precompiled version of Arduino_TensorflowLite
-    result = run_command("lib install Arduino_TensorflowLite@2.1.1-ALPHA-precompiled")
-    assert result.ok
-    result = run_command(
-        "compile -b arduino:mbed:nano33ble {}/libraries/Arduino_TensorFlowLite/examples/magic_wand/".format(data_dir)
-    )
-    assert result.ok
+    assert run_command("lib install Arduino_LSM9DS1")
+    assert run_command("lib install Arduino_TensorflowLite@2.1.1-ALPHA-precompiled")
+
+    sketch_path = Path(data_dir, "libraries", "Arduino_TensorFlowLite", "examples", "hello_world")
+    assert run_command(f"compile -b arduino:mbed:nano33ble {sketch_path}")
+
+    assert run_command(f"core install arduino:samd@1.8.7 --additional-urls={url}")
+    assert run_command(f"core install adafruit:samd@1.6.4 --additional-urls={url}")
     # should work on adafruit too after https://github.com/arduino/arduino-cli/pull/1134
-    result = run_command(
-        "compile -b adafruit:samd:adafruit_feather_m4 {}/libraries/Arduino_TensorFlowLite/examples/magic_wand/".format(
-            data_dir
-        )
-    )
-    assert result.ok
+    assert run_command(f"compile -b adafruit:samd:adafruit_feather_m4 {sketch_path}")
 
     # Non-precompiled version of Arduino_TensorflowLite
-    result = run_command("lib install Arduino_TensorflowLite@2.1.0-ALPHA")
-    assert result.ok
-    result = run_command(
-        "compile -b arduino:mbed:nano33ble {}/libraries/Arduino_TensorFlowLite/examples/magic_wand/".format(data_dir)
-    )
-    assert result.ok
-    result = run_command(
-        "compile -b adafruit:samd:adafruit_feather_m4 {}/libraries/Arduino_TensorFlowLite/examples/magic_wand/".format(
-            data_dir
-        )
-    )
-    assert result.ok
+    assert run_command("lib install Arduino_TensorflowLite@2.1.0-ALPHA")
+    assert run_command(f"compile -b arduino:mbed:nano33ble {sketch_path}")
+    assert run_command(f"compile -b adafruit:samd:adafruit_feather_m4 {sketch_path}")
 
     # Bosch sensor library
-    result = run_command('lib install "BSEC Software Library@1.5.1474"')
-    assert result.ok
-    result = run_command(
-        "compile -b arduino:samd:mkr1000 {}/libraries/BSEC_Software_Library/examples/basic/".format(data_dir)
-    )
-    assert result.ok
-    result = run_command(
-        "compile -b arduino:mbed:nano33ble {}/libraries/BSEC_Software_Library/examples/basic/".format(data_dir)
-    )
-    assert result.ok
+    assert run_command('lib install "BSEC Software Library@1.5.1474"')
+    sketch_path = Path(data_dir, "libraries", "BSEC_Software_Library", "examples", "basic")
+    assert run_command(f"compile -b arduino:samd:mkr1000 {sketch_path}")
+    assert run_command(f"compile -b arduino:mbed:nano33ble {sketch_path}")
 
     # USBBlaster library
-    result = run_command('lib install "USBBlaster@1.0.0"')
-    assert result.ok
-    result = run_command(f"compile -b arduino:samd:mkrvidor4000 {data_dir}/libraries/USBBlaster/examples/USB_Blaster/")
+    assert run_command('lib install "USBBlaster@1.0.0"')
+    sketch_path = Path(data_dir, "libraries", "USBBlaster", "examples", "USB_Blaster")
+    assert run_command(f"compile -b arduino:samd:mkrvidor4000 {sketch_path}")
 
 
 def test_compile_with_build_properties_flag(run_command, data_dir, copy_sketch):

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -237,9 +237,8 @@ def test_compile_without_precompiled_libraries(run_command, data_dir):
     # USBBlaster library
     result = run_command('lib install "USBBlaster@1.0.0"')
     assert result.ok
-    result = run_command(
-        "compile -b arduino:samd:mkrvidor4000 {}/libraries/USBBlaster/examples/USB_Blaster/".format(data_dir)
-    )
+    result = run_command(f"compile -b arduino:samd:mkrvidor4000 {data_dir}/libraries/USBBlaster/examples/USB_Blaster/")
+
 
 def test_compile_with_build_properties_flag(run_command, data_dir, copy_sketch):
     # Init the environment explicitly

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -181,33 +181,26 @@ def test_compile_blacklisted_sketchname(run_command, data_dir):
     assert result.ok
 
 
-@pytest.mark.skip()
 def test_compile_without_precompiled_libraries(run_command, data_dir):
     # Init the environment explicitly
     url = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json"
     result = run_command("core update-index --additional-urls={}".format(url))
     assert result.ok
-    # arduino:mbed 1.1.5 is incompatible with the Arduino_TensorFlowLite library
-    # see: https://github.com/arduino/ArduinoCore-nRF528x-mbedos/issues/93
-    result = run_command("core install arduino:mbed@1.1.4 --additional-urls={}".format(url))
+    result = run_command("core install arduino:mbed@1.3.1 --additional-urls={}".format(url))
     assert result.ok
     result = run_command("core install arduino:samd@1.8.7 --additional-urls={}".format(url))
     assert result.ok
     result = run_command("core install adafruit:samd@1.6.0 --additional-urls={}".format(url))
     assert result.ok
 
-    # Install pre-release version of Arduino_TensorFlowLite (will be officially released
-    # via lib manager after https://github.com/arduino/arduino-builder/issues/353 is in)
-    import zipfile
-
-    with zipfile.ZipFile("test/testdata/Arduino_TensorFlowLite.zip", "r") as zip_ref:
-        zip_ref.extractall("{}/libraries/".format(data_dir))
-    result = run_command("lib install Arduino_LSM9DS1@1.1.0")
+    # Precompiled version of Arduino_TensorflowLite
+    result = run_command("lib install Arduino_TensorflowLite@2.1.1-ALPHA-precompiled")
     assert result.ok
     result = run_command(
         "compile -b arduino:mbed:nano33ble {}/libraries/Arduino_TensorFlowLite/examples/magic_wand/".format(data_dir)
     )
     assert result.ok
+    # should work on adafruit too after https://github.com/arduino/arduino-cli/pull/1134
     result = run_command(
         "compile -b adafruit:samd:adafruit_feather_m4 {}/libraries/Arduino_TensorFlowLite/examples/magic_wand/".format(
             data_dir
@@ -216,7 +209,7 @@ def test_compile_without_precompiled_libraries(run_command, data_dir):
     assert result.ok
 
     # Non-precompiled version of Arduino_TensorflowLite
-    result = run_command("lib install Arduino_TensorflowLite@1.15.0-ALPHA")
+    result = run_command("lib install Arduino_TensorflowLite@2.1.0-ALPHA")
     assert result.ok
     result = run_command(
         "compile -b arduino:mbed:nano33ble {}/libraries/Arduino_TensorFlowLite/examples/magic_wand/".format(data_dir)
@@ -241,6 +234,12 @@ def test_compile_without_precompiled_libraries(run_command, data_dir):
     )
     assert result.ok
 
+    # USBBlaster library
+    result = run_command('lib install "USBBlaster@1.0.0"')
+    assert result.ok
+    result = run_command(
+        "compile -b arduino:samd:mkrvidor4000 {}/libraries/USBBlaster/examples/USB_Blaster/".format(data_dir)
+    )
 
 def test_compile_with_build_properties_flag(run_command, data_dir, copy_sketch):
     # Init the environment explicitly


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
If a folder meant to contain precompiled libraries is empty (or only contains other folders) it can be safely skipped

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The folder is not skipped, so libraries with `src/$architecture/$fp_specs` will try to use `src/$architecture/` as precompiled base folder, even if it doesn't contain any library

* **What is the new behavior?**
<!-- if this is a feature change -->
The folder is skipped and the library can be compiled from sources

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
