### PR TITLE
[skip changelog] Make the command documentation of cache clean more clear

### DIFF
--- a/cli/cache/clean.go
+++ b/cli/cache/clean.go
@@ -28,8 +28,8 @@ import (
 func initCleanCommand() *cobra.Command {
 	cleanCommand := &cobra.Command{
 		Use:     "clean",
-		Short:   "Clean arduino cache.",
-		Long:    "Clean the files i.e. `~/arduino15/staging` in Linux.",
+		Short:   "Delete Boards/Library Manager download cache.",
+		Long:    "Delete contents of the `directories.downloads` folder, where archive files are staged during installation of libraries and boards platforms.",
 		Example: "  " + os.Args[0] + " cache clean",
 		Args:    cobra.NoArgs,
 		Run:     runCleanCommand,


### PR DESCRIPTION
The terms "cache" and "clean" might bring compilation to mind, but the `arduino-cli cache clean` command has nothing to
do with compilation. Many users will likely not even be aware of the existence or purpose of the `directories.downloads`
folder. For this reason, it's important to make the purpose of this command clear.

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
 docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The terms "cache" and "clean" might bring compilation to mind, but the `arduino-cli cache clean` command has nothing to
do with compilation. Many users will likely not even be aware of the existence or purpose of the `directories.downloads`
folder. It's not very clear from [the command documentation for `arduino-cli cache clean`](https://arduino.github.io/arduino-cli/dev/commands/arduino-cli_cache_clean/) what it does.

For example:
https://github.com/arduino/arduino-cli/issues/969#issue-707229064
>At first glance arduino-cli cache clean might do this, but the --help output does not specify what it cleans exactly, cache clean -v does not show what is removed either, and a quick test suggests that it does not clean the build directory.

* **What is the new behavior?**
<!-- if this is a feature change -->
The purpose of the `arduino-cli cache clean` is more clearly described in the command line documentation.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
