### PR TITLE
[skip changelog] Allow library names to start with a number

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -40,8 +40,8 @@ The library.properties file is a key=value properties list. Every field in this 
 otherwise below, **all fields are required**. The available fields are:
 
 - **name** - the name of the library. Library names must contain only basic letters (A-Z or a-z) and numbers (0-9),
-  spaces ( ), underscores (\_), dots (.) and dashes (-). They cannot start with a number. Note that libraries with a
-  `name` value starting with `Arduino` will no longer be allowed
+  spaces ( ), underscores (\_), dots (.) and dashes (-). They must start with a letter or number. They must contain at
+  least one letter. Note that libraries with a `name` value starting with `Arduino` will no longer be allowed
   [addition to the Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ) as these names
   are now reserved for official Arduino libraries.
 - **version** - version of the library. Version should be [semver](http://semver.org/) compliant. 1.2.0 is correct; 1.2


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Previously, the Arduino library specification required the library.properties `name` field value to start with a letter.
Before Arduino IDE 1.8.4, library folder names starting with a number were not supported (https://github.com/arduino/Arduino/commit/4545283ae773b6351d089e37b6d4080905ea8fd5). Because the library folder for
Library Manager installations is named according to the library.properties name value, it was necessary to apply the
same restriction to the name value.
* **What is the new behavior?**
<!-- if this is a feature change -->
It was determined that enough time has passed since the Arduino IDE 1.8.4 release to
reflect this change in the Arduino library specification.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No