### PR TITLE
[skip changelog] Use generally applicable name for package index specification

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,7 +121,7 @@ nav:
   - sketch-specification.md
   - library-specification.md
   - platform-specification.md
-  - package_index.json specification: package_index_json-specification.md
+  - Package index specification: package_index_json-specification.md
 
 extra_css:
   - css/version-select.css


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The name of [the specification is "package_index.json specification"](https://arduino.github.io/arduino-cli/dev/package_index_json-specification/). Only the primary official package index
is allowed to be named package_index.json, but this specification applies to all package indexes. So the current naming might cause confusion. It also doesn't roll off the toungue so well when speaking about this topic.
* **What is the new behavior?**
<!-- if this is a feature change -->
The specification is renamed to "Arduino package index specification" (shortened to "Package index specification" in the documentation website navigaion pane). This name is less likely to cause confusion and also easier to remember and talk about.

The filename of the specification was not changed in order to avoid breaking links.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No