### PR TITLE
Add multiple libraries installation when using --git-url or --zip-path flags

### DIFF
--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -540,3 +540,58 @@ def test_install_with_git_url_does_not_create_git_repo(run_command, downloads_di
 
     # Verifies installed library is not a git repository
     assert not Path(lib_install_dir, ".git").exists()
+
+
+def test_install_with_git_url_multiple_libraries(run_command, downloads_dir, data_dir):
+    assert run_command("update")
+
+    env = {
+        "ARDUINO_DATA_DIR": data_dir,
+        "ARDUINO_DOWNLOADS_DIR": downloads_dir,
+        "ARDUINO_SKETCHBOOK_DIR": data_dir,
+        "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL": "true",
+    }
+
+    wifi_install_dir = Path(data_dir, "libraries", "WiFi101")
+    ble_install_dir = Path(data_dir, "libraries", "ArduinoBLE")
+    # Verifies libraries are not installed
+    assert not wifi_install_dir.exists()
+    assert not ble_install_dir.exists()
+
+    wifi_url = "https://github.com/arduino-libraries/WiFi101.git"
+    ble_url = "https://github.com/arduino-libraries/ArduinoBLE.git"
+
+    assert run_command(f"lib install --git-url {wifi_url} {ble_url}", custom_env=env)
+
+    # Verifies library are installed
+    assert wifi_install_dir.exists()
+    assert ble_install_dir.exists()
+
+
+def test_install_with_zip_path_multiple_libraries(run_command, downloads_dir, data_dir):
+    assert run_command("update")
+
+    env = {
+        "ARDUINO_DATA_DIR": data_dir,
+        "ARDUINO_DOWNLOADS_DIR": downloads_dir,
+        "ARDUINO_SKETCHBOOK_DIR": data_dir,
+        "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL": "true",
+    }
+
+    # Downloads zip to be installed later
+    assert run_command("lib download WiFi101@0.16.1")
+    assert run_command("lib download ArduinoBLE@1.1.3")
+    wifi_zip_path = Path(downloads_dir, "libraries", "WiFi101-0.16.1.zip")
+    ble_zip_path = Path(downloads_dir, "libraries", "ArduinoBLE-1.1.3.zip")
+
+    wifi_install_dir = Path(data_dir, "libraries", "WiFi101-0.16.1")
+    ble_install_dir = Path(data_dir, "libraries", "ArduinoBLE-1.1.3")
+    # Verifies libraries are not installed
+    assert not wifi_install_dir.exists()
+    assert not ble_install_dir.exists()
+
+    assert run_command(f"lib install --zip-path {wifi_zip_path} {ble_zip_path}", custom_env=env)
+
+    # Verifies library are installed
+    assert wifi_install_dir.exists()
+    assert ble_install_dir.exists()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Enhances an existing command.

- **What is the current behavior?**

When calling `lib install` with the `--git-url` or `--zip-path` flags only one library at a time can be installed, subsequent arguments are ignored.

```
# This would install only WiFi101 library
arduino-cli lib install --git-url https://github.com/arduino-libraries/WiFi101.git https://github.com/arduino-libraries/ArduinoBLE.git
# This would install only ArduinoBLE library
arduino-cli lib install --zip-path /path/to/ArduinoBLE.zip /path/to/WiFi101.zip
```

* **What is the new behavior?**

Calling `lib install` with `--git-url` or `--zip-path` flags will install all libraries specified.

```
# This will install only WiFi101 and ArduinoBLE libraries
arduino-cli lib install --git-url https://github.com/arduino-libraries/WiFi101.git https://github.com/arduino-libraries/ArduinoBLE.git
# This will do the same
arduino-cli lib install --zip-path /path/to/ArduinoBLE.zip /path/to/WiFi101.zip
```

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

No.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
