### PR TITLE
Fix lib list --all not returning library includes in json output

### DIFF
--- a/commands/lib/list.go
+++ b/commands/lib/list.go
@@ -103,8 +103,12 @@ func LibraryList(ctx context.Context, req *rpc.LibraryListReq) (*rpc.LibraryList
 		if lib.Available != nil {
 			release = lib.Available.ToRPCLibraryRelease()
 		}
+		rpcLib, err := lib.Library.ToRPCLibrary()
+		if err != nil {
+			return nil, fmt.Errorf("converting library %s to rpc struct: %w", lib.Library.Name, err)
+		}
 		instaledLib = append(instaledLib, &rpc.InstalledLibrary{
-			Library: lib.Library.ToRPCLibrary(),
+			Library: rpcLib,
 			Release: release,
 		})
 	}

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -145,6 +145,27 @@ def test_list_with_fqbn(run_command):
     assert data[0]["library"]["compatible_with"]["arduino:avr:uno"]
 
 
+def test_list_all_with_fqbn(run_command):
+    assert run_command("update")
+
+    # Install core
+    assert run_command("core install arduino:avr")
+
+    result = run_command("lib list --all --fqbn arduino:avr:uno --format json")
+    assert result.ok
+    assert "" == result.stderr
+
+    data = json.loads(result.stdout)
+    assert 5 == len(data)
+
+    libs = {l["library"]["name"]: l["library"]["provides_includes"] for l in data}
+    assert ["SoftwareSerial.h"] == libs["SoftwareSerial"]
+    assert ["Wire.h"] == libs["Wire"]
+    assert ["EEPROM.h"] == libs["EEPROM"]
+    assert ["HID.h"] == libs["HID"]
+    assert ["SPI.h"] == libs["SPI"]
+
+
 def test_lib_download(run_command, downloads_dir):
 
     # Download a specific lib version

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -145,18 +145,22 @@ def test_list_with_fqbn(run_command):
     assert data[0]["library"]["compatible_with"]["arduino:avr:uno"]
 
 
-def test_list_all_with_fqbn(run_command):
+def test_list_provides_includes_fallback(run_command):
+    # Verifies "provides_includes" field is returned even if libraries don't declare
+    # the "includes" property in their "library.properties" file
     assert run_command("update")
 
     # Install core
-    assert run_command("core install arduino:avr")
+    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command("lib install ArduinoJson@6.17.2")
 
+    # List all libraries, even the ones installed with the above core
     result = run_command("lib list --all --fqbn arduino:avr:uno --format json")
     assert result.ok
     assert "" == result.stderr
 
     data = json.loads(result.stdout)
-    assert 5 == len(data)
+    assert 6 == len(data)
 
     libs = {l["library"]["name"]: l["library"]["provides_includes"] for l in data}
     assert ["SoftwareSerial.h"] == libs["SoftwareSerial"]
@@ -164,6 +168,7 @@ def test_list_all_with_fqbn(run_command):
     assert ["EEPROM.h"] == libs["EEPROM"]
     assert ["HID.h"] == libs["HID"]
     assert ["SPI.h"] == libs["SPI"]
+    assert ["ArduinoJson.h", "ArduinoJson.hpp"] == libs["ArduinoJson"]
 
 
 def test_lib_download(run_command, downloads_dir):


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes a regression when calling `lib list`.

- **What is the current behavior?**

`lib list --all --fqbn arduino:avr:uno --format json` doesn't return the `provides_includes` property for the libraries installed together with the specified core, `arduino:avr` in this case.

If the `includes` property found in the `library.properties` file is empty we would return nothing.

* **What is the new behavior?**

`lib list --all --fqbn arduino:avr:uno --format json` now correctly return `provides_includes` property for all libraries.

Now if the `includes` property in the `library.properties` file is empty we walk the library's folders to gather the headers file names.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
