### PR TITLE
Manually installed platforms are now shown in core search output

### DIFF
--- a/commands/core/search.go
+++ b/commands/core/search.go
@@ -48,7 +48,7 @@ func PlatformSearch(instanceID int32, searchArgs string, allVersions bool) (*rpc
 		for _, targetPackage := range pm.Packages {
 			for _, platform := range targetPackage.Platforms {
 				// discard invalid platforms
-				if platform == nil || platform.Name == "" {
+				if platform == nil {
 					continue
 				}
 


### PR DESCRIPTION
This also updates the json output and the gRPC interface

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes a command and related gRPC interface not returning the expected output.

- **What is the current behavior?**

Calling `core search` doesn't return platforms installed manually in `~/Arduino/hardware` folder.
Same thing for the related gRPC interface call.

* **What is the new behavior?**

Calling `core search` returns platforms installed manually in `~/Arduino/hardware` folder. This now works also in the related gRPC interface call.

The issue was caused by filtering out platforms that didn't have a name set.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

Nope.

* **Other information**:

Fixes arduino/arduino-pro-ide#355.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
