### PR TITLE
Always output build path in compile json-output / Always write a valid compilation database

### DIFF
--- a/arduino/builder/compilation_database.go
+++ b/arduino/builder/compilation_database.go
@@ -41,7 +41,8 @@ type CompilationCommand struct {
 // NewCompilationDatabase creates an empty CompilationDatabase
 func NewCompilationDatabase(filename *paths.Path) *CompilationDatabase {
 	return &CompilationDatabase{
-		File: filename,
+		File:     filename,
+		Contents: []CompilationCommand{},
 	}
 }
 
@@ -51,10 +52,7 @@ func LoadCompilationDatabase(file *paths.Path) (*CompilationDatabase, error) {
 	if err != nil {
 		return nil, err
 	}
-	res := &CompilationDatabase{
-		File:     file,
-		Contents: []CompilationCommand{},
-	}
+	res := NewCompilationDatabase(file)
 	return res, json.Unmarshal(f, &res.Contents)
 }
 


### PR DESCRIPTION
* BuildPath field in `compile` json output is always populated, even if the build is not successful.
* `compile_commands.json` now always contains a json array, even if the Contents field array is empty. (before `null` was written in the file)

