### PR TITLE
Add back support for sketches with .pde extension and deprecate it

### DIFF
--- a/arduino/globals/globals.go
+++ b/arduino/globals/globals.go
@@ -18,9 +18,13 @@ package globals
 var (
 	empty struct{}
 
+	// MainFileValidExtension is the extension that must be used for files in new sketches
+	MainFileValidExtension string = ".ino"
+
 	// MainFileValidExtensions lists valid extensions for a sketch file
 	MainFileValidExtensions = map[string]struct{}{
-		".ino": empty,
+		MainFileValidExtension: empty,
+		// .pde extension is deprecated and must not be used for new sketches
 		".pde": empty,
 	}
 

--- a/arduino/libraries/loader.go
+++ b/arduino/libraries/loader.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/arduino/arduino-cli/arduino/sketches"
 	"github.com/arduino/go-paths-helper"
 	properties "github.com/arduino/go-properties-orderedmap"
 	"github.com/pkg/errors"
@@ -172,7 +173,8 @@ func addExamplesToPathList(examplesPath *paths.Path, list *paths.PathList) error
 		return err
 	}
 	for _, file := range files {
-		if isExample(file) {
+		_, err := sketches.NewSketchFromPath(file)
+		if err == nil {
 			list.Add(file)
 		} else if file.IsDir() {
 			if err := addExamplesToPathList(file, list); err != nil {
@@ -181,10 +183,4 @@ func addExamplesToPathList(examplesPath *paths.Path, list *paths.PathList) error
 		}
 	}
 	return nil
-}
-
-// isExample returns true if examplePath contains an example
-func isExample(examplePath *paths.Path) bool {
-	mainIno := examplePath.Join(examplePath.Base() + ".ino")
-	return mainIno.Exist() && mainIno.IsNotDir()
 }

--- a/arduino/sketches/sketches.go
+++ b/arduino/sketches/sketches.go
@@ -138,14 +138,10 @@ func CheckForPdeFiles(sketch *paths.Path) []*paths.Path {
 		sketch = sketch.Parent()
 	}
 
-	// It's not a problem if we can't read files right now
-	files, _ := sketch.ReadDirRecursive()
-	files.FilterOutDirs()
-	res := []*paths.Path{}
-	for _, f := range files {
-		if f.Ext() == ".pde" {
-			res = append(res, f)
-		}
+	files, err := sketch.ReadDirRecursive()
+	if err != nil {
+		return []*paths.Path{}
 	}
-	return res
+	files.FilterSuffix(".pde")
+	return files
 }

--- a/arduino/sketches/sketches.go
+++ b/arduino/sketches/sketches.go
@@ -20,15 +20,17 @@ import (
 	"fmt"
 
 	"github.com/arduino/arduino-cli/arduino/builder"
+	"github.com/arduino/arduino-cli/arduino/globals"
 	"github.com/arduino/go-paths-helper"
 	"github.com/pkg/errors"
 )
 
 // Sketch is a sketch for Arduino
 type Sketch struct {
-	Name     string
-	FullPath *paths.Path
-	Metadata *Metadata
+	Name              string
+	MainFileExtension string
+	FullPath          *paths.Path
+	Metadata          *Metadata
 }
 
 // Metadata is the kind of data associated to a project such as the connected board
@@ -52,14 +54,32 @@ func NewSketchFromPath(path *paths.Path) (*Sketch, error) {
 	if !path.IsDir() {
 		path = path.Parent()
 	}
-	sketchFile := path.Join(path.Base() + ".ino")
-	if !sketchFile.Exist() {
-		return nil, errors.Errorf("no valid sketch found in %s: missing %s", path, sketchFile.Base())
+
+	var mainSketchFile *paths.Path
+	for ext := range globals.MainFileValidExtensions {
+		candidateSketchMainFile := path.Join(path.Base() + ext)
+		if candidateSketchMainFile.Exist() {
+			if mainSketchFile == nil {
+				mainSketchFile = candidateSketchMainFile
+			} else {
+				return nil, errors.Errorf("multiple main sketch files found (%v, %v)",
+					mainSketchFile,
+					candidateSketchMainFile,
+				)
+			}
+		}
 	}
+
+	if mainSketchFile == nil {
+		sketchFile := path.Join(path.Base() + globals.MainFileValidExtension)
+		return nil, errors.Errorf("no valid sketch found in %s: missing %s", path, sketchFile)
+	}
+
 	sketch := &Sketch{
-		FullPath: path,
-		Name:     path.Base(),
-		Metadata: &Metadata{},
+		FullPath:          path,
+		MainFileExtension: mainSketchFile.Ext(),
+		Name:              path.Base(),
+		Metadata:          &Metadata{},
 	}
 	sketch.ImportMetadata()
 	return sketch, nil
@@ -107,4 +127,25 @@ func (s *Sketch) BuildPath() (*paths.Path, error) {
 		return nil, fmt.Errorf("sketch path is empty")
 	}
 	return builder.GenBuildPath(s.FullPath), nil
+}
+
+// CheckForPdeFiles returns all files ending with .pde extension
+// in dir, this is mainly used to warn the user that these files
+// must be changed to .ino extension.
+// When .pde files won't be supported anymore this function must be removed.
+func CheckForPdeFiles(sketch *paths.Path) []*paths.Path {
+	if sketch.IsNotDir() {
+		sketch = sketch.Parent()
+	}
+
+	// It's not a problem if we can't read files right now
+	files, _ := sketch.ReadDirRecursive()
+	files.FilterOutDirs()
+	res := []*paths.Path{}
+	for _, f := range files {
+		if f.Ext() == ".pde" {
+			res = append(res, f)
+		}
+	}
+	return res
 }

--- a/arduino/sketches/testdata/SketchMultipleMainFiles/SketchMultipleMainFiles.ino
+++ b/arduino/sketches/testdata/SketchMultipleMainFiles/SketchMultipleMainFiles.ino
@@ -1,0 +1,3 @@
+
+void setup() {}
+void loop() {}

--- a/arduino/sketches/testdata/SketchMultipleMainFiles/SketchMultipleMainFiles.pde
+++ b/arduino/sketches/testdata/SketchMultipleMainFiles/SketchMultipleMainFiles.pde
@@ -1,0 +1,3 @@
+
+void setup() {}
+void loop() {}

--- a/arduino/sketches/testdata/SketchPde/SketchPde.pde
+++ b/arduino/sketches/testdata/SketchPde/SketchPde.pde
@@ -1,0 +1,3 @@
+
+void setup() {}
+void loop() {}

--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/arduino/arduino-cli/arduino/sketches"
 	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/arduino/arduino-cli/cli/output"
 	"github.com/arduino/arduino-cli/configuration"
@@ -127,6 +128,15 @@ func run(cmd *cobra.Command, args []string) {
 	}
 
 	sketchPath := initSketchPath(path)
+
+	// .pde files are still supported but deprecated, this warning urges the user to rename them
+	if files := sketches.CheckForPdeFiles(sketchPath); len(files) > 0 {
+		feedback.Error("Sketches with .pde extension are deprecated, please rename the following files to .ino:")
+		for _, f := range files {
+			feedback.Error(f)
+		}
+	}
+
 	// We must read this from settings since the value is set when the binding is accessed from viper,
 	// accessing it from cobra would only read it if the flag is explicitly set by the user and ignore
 	// the config file and the env vars.

--- a/cli/sketch/archive.go
+++ b/cli/sketch/archive.go
@@ -19,10 +19,12 @@ import (
 	"context"
 	"os"
 
+	"github.com/arduino/arduino-cli/arduino/sketches"
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/arduino/arduino-cli/commands/sketch"
 	rpc "github.com/arduino/arduino-cli/rpc/commands"
+	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -53,9 +55,17 @@ func initArchiveCommand() *cobra.Command {
 func runArchiveCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino sketch archive`")
 
-	sketchPath := ""
+	sketchPath := "."
 	if len(args) >= 1 {
 		sketchPath = args[0]
+	}
+
+	// .pde files are still supported but deprecated, this warning urges the user to rename them
+	if files := sketches.CheckForPdeFiles(paths.New(sketchPath)); len(files) > 0 {
+		feedback.Error("Sketches with .pde extension are deprecated, please rename the following files to .ino:")
+		for _, f := range files {
+			feedback.Error(f)
+		}
 	}
 
 	archivePath := ""

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/arduino/arduino-cli/arduino/sketches"
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/arduino/arduino-cli/cli/instance"
@@ -82,6 +83,14 @@ func run(command *cobra.Command, args []string) {
 		path = paths.New(args[0])
 	}
 	sketchPath := initSketchPath(path)
+
+	// .pde files are still supported but deprecated, this warning urges the user to rename them
+	if files := sketches.CheckForPdeFiles(sketchPath); len(files) > 0 {
+		feedback.Error("Sketches with .pde extension are deprecated, please rename the following files to .ino:")
+		for _, f := range files {
+			feedback.Error(f)
+		}
+	}
 
 	if _, err := upload.Upload(context.Background(), &rpc.UploadReq{
 		Instance:   instance,

--- a/docs/sketch-specification.md
+++ b/docs/sketch-specification.md
@@ -18,7 +18,10 @@ Support for sketch folder names starting with a number was added in Arduino IDE 
 
 ### Primary sketch file
 
-Every sketch must contain a .ino or .pde file with a file name matching the sketch root folder name.
+Every sketch must contain a `.ino` file with a file name matching the sketch root folder name.
+
+`.pde` is also supported but **deprecated** and will be removed in the future, using the `.ino` extension is strongly
+recommended.
 
 ### Additional code files
 
@@ -28,7 +31,7 @@ The following extensions are supported:
 
 - .ino - [Arduino language](https://www.arduino.cc/reference/en/) files.
 - .pde - Alternate extension for Arduino language files. This file extension is also used by Processing sketches. .ino
-  is recommended to avoid confusion.
+  is recommended to avoid confusion. **`.pde` extension is deprecated and will be removed in the future.**
 - .cpp - C++ files.
 - .c - C Files.
 - .S - Assembly language files.

--- a/test/test_debug.py
+++ b/test/test_debug.py
@@ -37,3 +37,27 @@ def test_debugger_starts(run_command, data_dir):
     programmer = "atmel_ice"
     # Starts debugger
     assert run_command(f"debug -b {fqbn} -P {programmer} {sketch_path} --info")
+
+
+def test_debugger_with_pde_sketch_starts(run_command, data_dir):
+    assert run_command("update")
+
+    # Install core
+    assert run_command("core install arduino:samd")
+
+    # Create sketch for testing
+    sketch_name = "DebuggerPdeSketchStartTest"
+    sketch_path = Path(data_dir, sketch_name)
+    fqbn = "arduino:samd:mkr1000"
+
+    assert run_command(f"sketch new {sketch_path}")
+
+    # Renames sketch file to pde
+    Path(sketch_path, f"{sketch_name}.ino").rename(sketch_path / f"{sketch_name}.pde")
+
+    # Build sketch
+    assert run_command(f"compile -b {fqbn} {sketch_path}")
+
+    programmer = "atmel_ice"
+    # Starts debugger
+    assert run_command(f"debug -b {fqbn} -P {programmer} {sketch_path} --info")

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -621,3 +621,36 @@ def test_install_with_zip_path_multiple_libraries(run_command, downloads_dir, da
     # Verifies library are installed
     assert wifi_install_dir.exists()
     assert ble_install_dir.exists()
+
+
+def test_lib_examples(run_command, data_dir):
+    assert run_command("update")
+
+    assert run_command("lib install Arduino_JSON@0.1.0")
+
+    res = run_command("lib examples Arduino_JSON --format json")
+    assert res.ok
+    data = json.loads(res.stdout)
+    assert len(data) == 1
+    examples = data[0]["examples"]
+
+    assert str(Path(data_dir, "libraries", "Arduino_JSON", "examples", "JSONArray")) in examples
+    assert str(Path(data_dir, "libraries", "Arduino_JSON", "examples", "JSONKitchenSink")) in examples
+    assert str(Path(data_dir, "libraries", "Arduino_JSON", "examples", "JSONObject")) in examples
+
+
+def test_lib_examples_with_pde_file(run_command, data_dir):
+    assert run_command("update")
+
+    assert run_command("lib install Encoder@1.4.1")
+
+    res = run_command("lib examples Encoder --format json")
+    assert res.ok
+    data = json.loads(res.stdout)
+    assert len(data) == 1
+    examples = data[0]["examples"]
+
+    assert str(Path(data_dir, "libraries", "Encoder", "examples", "Basic")) in examples
+    assert str(Path(data_dir, "libraries", "Encoder", "examples", "NoInterrupts")) in examples
+    assert str(Path(data_dir, "libraries", "Encoder", "examples", "SpeedTest")) in examples
+    assert str(Path(data_dir, "libraries", "Encoder", "examples", "TwoKnobs")) in examples

--- a/test/test_sketch.py
+++ b/test/test_sketch.py
@@ -818,3 +818,31 @@ def test_sketch_archive_absolute_sketch_path_with_absolute_zip_path_and_name_wit
     verify_zip_contains_sketch_including_build_dir(archive_files)
 
     archive.close()
+
+
+def test_sketch_archive_with_pde_main_file(run_command, copy_sketch, working_dir):
+    sketch_name = "sketch_pde_main_file"
+    sketch_dir = copy_sketch(sketch_name)
+    sketch_file = Path(sketch_dir, f"{sketch_name}.pde")
+    res = run_command("sketch archive", sketch_dir)
+    assert res.ok
+    assert "Sketches with .pde extension are deprecated, please rename the following files to .ino" in res.stderr
+    assert str(sketch_file.relative_to(sketch_dir)) in res.stderr
+
+    archive = zipfile.ZipFile(f"{working_dir}/{sketch_name}.zip")
+    archive_files = archive.namelist()
+
+    assert f"{sketch_name}/{sketch_name}.pde" in archive_files
+
+    archive.close()
+
+
+def test_sketch_archive_with_multiple_main_files(run_command, copy_sketch, working_dir):
+    sketch_name = "sketch_multiple_main_files"
+    sketch_dir = copy_sketch(sketch_name)
+    sketch_file = Path(sketch_dir, f"{sketch_name}.pde")
+    res = run_command("sketch archive", sketch_dir)
+    assert res.failed
+    assert "Sketches with .pde extension are deprecated, please rename the following files to .ino" in res.stderr
+    assert str(sketch_file.relative_to(sketch_dir)) in res.stderr
+    assert "Error archiving: multiple main sketch files found" in res.stderr

--- a/test/test_upload.py
+++ b/test/test_upload.py
@@ -13,6 +13,9 @@
 # software without disclosing the source code of your own applications. To purchase
 # a commercial license, send an email to license@arduino.cc.
 import os
+import hashlib
+import tempfile
+import shutil
 from pathlib import Path
 
 import pytest
@@ -195,3 +198,143 @@ def test_compile_and_upload_combo_with_custom_build_path(run_command, data_dir, 
         assert f"Compile {sketch_name} for {board.fqbn} successful" in traces
         assert f"Upload {sketch_path} on {board.fqbn} started" in traces
         assert "Upload successful" in traces
+
+
+def test_compile_and_upload_combo_sketch_with_pde_extension(run_command, data_dir, detected_boards, wait_for_board):
+    assert run_command("update")
+
+    sketch_name = "CompileAndUploadPdeSketch"
+    sketch_path = Path(data_dir, sketch_name)
+
+    # Create a test sketch
+    assert run_command(f"sketch new {sketch_path}")
+
+    # Renames sketch file to pde
+    sketch_file = Path(sketch_path, f"{sketch_name}.ino").rename(sketch_path / f"{sketch_name}.pde")
+
+    for board in detected_boards:
+        # Install core
+        core = ":".join(board.fqbn.split(":")[:2])
+        assert run_command(f"core install {core}")
+
+        # Build sketch and upload from folder
+        wait_for_board()
+        res = run_command(f"compile --clean -b {board.fqbn} -u -p {board.address} {sketch_path}")
+        assert res.ok
+        assert "Sketches with .pde extension are deprecated, please rename the following files to .ino" in res.stderr
+        assert str(sketch_file) in res.stderr
+
+        # Build sketch and upload from file
+        wait_for_board()
+        res = run_command(f"compile --clean -b {board.fqbn} -u -p {board.address} {sketch_file}")
+        assert res.ok
+        assert "Sketches with .pde extension are deprecated, please rename the following files to .ino" in res.stderr
+        assert str(sketch_file) in res.stderr
+
+
+def test_upload_sketch_with_pde_extension(run_command, data_dir, detected_boards, wait_for_board):
+    assert run_command("update")
+
+    sketch_name = "UploadPdeSketch"
+    sketch_path = Path(data_dir, sketch_name)
+
+    # Create a test sketch
+    assert run_command(f"sketch new {sketch_path}")
+
+    # Renames sketch file to pde
+    sketch_file = Path(sketch_path, f"{sketch_name}.ino").rename(sketch_path / f"{sketch_name}.pde")
+
+    for board in detected_boards:
+        # Install core
+        core = ":".join(board.fqbn.split(":")[:2])
+        assert run_command(f"core install {core}")
+
+        # Compile sketch first
+        assert run_command(f"compile --clean -b {board.fqbn} {sketch_path}")
+
+        # Upload from sketch folder
+        wait_for_board()
+        assert run_command(f"upload -b {board.fqbn} -p {board.address} {sketch_path}")
+
+        # Upload from sketch file
+        wait_for_board()
+        assert run_command(f"upload -b {board.fqbn} -p {board.address} {sketch_file}")
+
+        # Upload from build folder
+        sketch_path_md5 = hashlib.md5(bytes(sketch_path)).hexdigest().upper()
+        build_dir = Path(tempfile.gettempdir(), f"arduino-sketch-{sketch_path_md5}")
+        wait_for_board()
+        res = run_command(f"upload -b {board.fqbn} -p {board.address} --input-dir {build_dir}")
+        assert (
+            "Sketches with .pde extension are deprecated, please rename the following files to .ino:" not in res.stderr
+        )
+
+        # Upload from binary file
+        wait_for_board()
+        # We don't need a specific file when using the --input-file flag to upload since
+        # it's just used to calculate the directory, so it's enough to get a random file
+        # that's inside that directory
+        binary_file = next(build_dir.glob(f"{sketch_name}.pde.*"))
+        res = run_command(f"upload -b {board.fqbn} -p {board.address} --input-file {binary_file}")
+        assert (
+            "Sketches with .pde extension are deprecated, please rename the following files to .ino:" not in res.stderr
+        )
+
+
+def test_upload_with_input_dir_containing_multiple_binaries(run_command, data_dir, detected_boards, wait_for_board):
+    # This tests verifies the behaviour outlined in this issue:
+    # https://github.com/arduino/arduino-cli/issues/765#issuecomment-699678646
+    assert run_command("update")
+
+    # Create a two different sketches
+    sketch_one_name = "UploadMultipleBinariesSketchOne"
+    sketch_one_path = Path(data_dir, sketch_one_name)
+    assert run_command(f"sketch new {sketch_one_path}")
+
+    sketch_two_name = "UploadMultipleBinariesSketchTwo"
+    sketch_two_path = Path(data_dir, sketch_two_name)
+    assert run_command(f"sketch new {sketch_two_path}")
+
+    for board in detected_boards:
+        # Install core
+        core = ":".join(board.fqbn.split(":")[:2])
+        assert run_command(f"core install {core}")
+
+        # Compile both sketches and copy binaries in the same directory same build directory
+        assert run_command(f"compile --clean -b {board.fqbn} {sketch_one_path}")
+        assert run_command(f"compile --clean -b {board.fqbn} {sketch_two_path}")
+
+        sketch_path_md5 = hashlib.md5(bytes(sketch_one_path)).hexdigest().upper()
+        build_dir_one = Path(tempfile.gettempdir(), f"arduino-sketch-{sketch_path_md5}")
+
+        sketch_path_md5 = hashlib.md5(bytes(sketch_two_path)).hexdigest().upper()
+        build_dir_two = Path(tempfile.gettempdir(), f"arduino-sketch-{sketch_path_md5}")
+
+        # Copy binaries to same folder
+        binaries_dir = Path(data_dir, "build", "BuiltBinaries")
+        shutil.copytree(build_dir_one, binaries_dir, dirs_exist_ok=True)
+        shutil.copytree(build_dir_two, binaries_dir, dirs_exist_ok=True)
+
+        wait_for_board()
+        # Verifies upload fails because multiple binaries are found
+        res = run_command(f"upload -b {board.fqbn} -p {board.address} --input-dir {binaries_dir}")
+        assert res.failed
+        assert (
+            "Error during Upload: "
+            + "retrieving build artifacts: "
+            + "autodetect build artifact: "
+            + "multiple build artifacts found:"
+            in res.stderr
+        )
+
+        # Copy binaries to folder with same name of a sketch
+        binaries_dir = Path(data_dir, "build", "UploadMultipleBinariesSketchOne")
+        shutil.copytree(build_dir_one, binaries_dir, dirs_exist_ok=True)
+        shutil.copytree(build_dir_two, binaries_dir, dirs_exist_ok=True)
+
+        wait_for_board()
+        # Verifies upload is successful using the binaries with the same name of the containing folder
+        res = run_command(f"upload -b {board.fqbn} -p {board.address} --input-dir {binaries_dir}")
+        assert (
+            "Sketches with .pde extension are deprecated, please rename the following files to .ino:" not in res.stderr
+        )

--- a/test/testdata/sketch_multiple_main_files/sketch_multiple_main_files.ino
+++ b/test/testdata/sketch_multiple_main_files/sketch_multiple_main_files.ino
@@ -1,0 +1,3 @@
+void setup() { }
+
+void loop() { }

--- a/test/testdata/sketch_multiple_main_files/sketch_multiple_main_files.pde
+++ b/test/testdata/sketch_multiple_main_files/sketch_multiple_main_files.pde
@@ -1,0 +1,3 @@
+void setup() { }
+
+void loop() { }

--- a/test/testdata/sketch_pde_main_file/sketch_pde_main_file.pde
+++ b/test/testdata/sketch_pde_main_file/sketch_pde_main_file.pde
@@ -1,0 +1,3 @@
+void setup() { }
+
+void loop() { }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

This PR brings back the support for sketches ending with `.pde` extension. 
Also we deprecate it.

- **What is the current behavior?**

Trying to `compile`, `upload`, or `archive` a sketch with a `.pde` main file always fails.
Also examples' libraries with `.pde` extensions are not shown when calling `lib examples`.

* **What is the new behavior?**

`compile`, `upload`, or `archive` a sketch with a `.pde` main file now works correctly and shows a warning message recommending the user to rename all `.pde` files `.ino`.
Examples' libraries with `.pde` extensions are now correctly shown when calling `lib examples`.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

No.

* **Other information**:

Each commit fixes a different command, it should be easier to review each commit separately.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
