### PR TITLE
Fix lib install --zip-path not preserving folders structure

### DIFF
--- a/arduino/libraries/librariesmanager/install.go
+++ b/arduino/libraries/librariesmanager/install.go
@@ -144,16 +144,8 @@ func (lm *LibrariesManager) InstallZipLib(ctx context.Context, archivePath strin
 		WithField("zip file", archivePath).
 		Trace("Installing library")
 
-	files, err := tmpDir.Join(libraryName).ReadDirRecursive()
-	files.FilterOutDirs()
-	for _, f := range files {
-		finalPath := installPath.Join(f.Base())
-		if err := finalPath.Parent().MkdirAll(); err != nil {
-			return fmt.Errorf("creating directory: %w", err)
-		}
-		if err := f.CopyTo(finalPath); err != nil {
-			return fmt.Errorf("copying library: %w", err)
-		}
+	if err := tmpDir.Join(libraryName).CopyDirTo(installPath); err != nil {
+		return fmt.Errorf("copying library: %w", err)
 	}
 
 	return nil

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -297,12 +297,26 @@ def test_install_with_zip_path(run_command, data_dir, downloads_dir):
 
     # Verifies library is installed in expected path
     assert lib_install_dir.exists()
+    files = list(lib_install_dir.glob("**/*"))
+    assert lib_install_dir / "examples" / "SimpleAudioPlayerZero" / "SimpleAudioPlayerZero.ino" in files
+    assert lib_install_dir / "src" / "AudioZero.h" in files
+    assert lib_install_dir / "src" / "AudioZero.cpp" in files
+    assert lib_install_dir / "keywords.txt" in files
+    assert lib_install_dir / "library.properties" in files
+    assert lib_install_dir / "README.adoc" in files
 
     # Reinstall library
     assert run_command(f"lib install --zip-path {zip_path}")
 
     # Verifies library remains installed
     assert lib_install_dir.exists()
+    files = list(lib_install_dir.glob("**/*"))
+    assert lib_install_dir / "examples" / "SimpleAudioPlayerZero" / "SimpleAudioPlayerZero.ino" in files
+    assert lib_install_dir / "src" / "AudioZero.h" in files
+    assert lib_install_dir / "src" / "AudioZero.cpp" in files
+    assert lib_install_dir / "keywords.txt" in files
+    assert lib_install_dir / "library.properties" in files
+    assert lib_install_dir / "README.adoc" in files
 
 
 def test_update_index(run_command):


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes a bug when installing libraries.

- **What is the current behavior?**

`lib install --zip-path` doesn't keep a library folder structure when installing it.

* **What is the new behavior?**

`lib install --zip-path` now keeps the library folder structure when installing.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

No.

* **Other information**:

Fixes #1150.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
