### PR TITLE
[skip changelog] Upgrade workflow ubuntu env

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
   test-matrix:
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+        operating-system: [ubuntu-20.04, windows-latest, macOS-latest]
 
     runs-on: ${{ matrix.operating-system }}
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run unit tests on the legacy package
         # Run legacy tests on one platform only
-        if: matrix.operating-system == 'ubuntu-latest'
+        if: matrix.operating-system == 'ubuntu-20.04'
         run: task test-legacy
 
       - name: Run integration tests
@@ -77,7 +77,7 @@ jobs:
 
       - name: Send unit tests coverage to Codecov
         if: >
-          matrix.operating-system == 'ubuntu-latest' &&
+          matrix.operating-system == 'ubuntu-20.04' &&
           github.event_name == 'push'
         uses: codecov/codecov-action@v1
         with:
@@ -86,7 +86,7 @@ jobs:
 
       - name: Send legacy tests coverage to Codecov
         if: >
-          matrix.operating-system == 'ubuntu-latest' &&
+          matrix.operating-system == 'ubuntu-20.04' &&
           github.event_name == 'push'
         uses: codecov/codecov-action@v1
         with:
@@ -95,7 +95,7 @@ jobs:
 
       - name: Send integration tests coverage to Codecov
         if: >
-          matrix.operating-system == 'ubuntu-latest' &&
+          matrix.operating-system == 'ubuntu-20.04' &&
           github.event_name == 'push'
         uses: codecov/codecov-action@v1
         with:
@@ -103,7 +103,7 @@ jobs:
           flags: integ
 
   create-test-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: test-matrix
 
     steps:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Changes the environment used for testing in workflows from `ubuntu-latest` to `ubuntu-20.04`.

- **What is the current behavior?**

Integration tests are failing when running on `ubuntu-latest`/ `ubuntu-18.04`.

* **What is the new behavior?**

Integrations tests are now running successfully.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

No.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
