### PR TITLE
[skip changelog] Fix release process

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -212,7 +212,7 @@ vars:
   TIMESTAMP_SHORT:
     sh: echo "{{now | date "20060102"}}"
   TAG:
-    sh: echo "`git tag --points-at=HEAD 2> /dev/null`"
+    sh: echo "`git tag --points-at=HEAD 2> /dev/null | head -n1`"
   VERSION: "{{ if .NIGHTLY }}nightly-{{ .TIMESTAMP_SHORT }}{{ else if .TAG }}{{ .TAG }}{{ else }}{{ .PACKAGE_NAME_PREFIX }}git-snapshot{{ end }}"
   LDFLAGS: >
     -ldflags


### PR DESCRIPTION
The current release process uses git to get the tag at the current
commit. It might happen that are are multiple tags when calling that
command, in cases the rc and the final release are done on the same
commit, that would make the build process to fail.

This fixes that issue by taking only one tag.
