### PR TITLE
Fix gRPC interface function to merge configs

### DIFF
--- a/client_example/main.go
+++ b/client_example/main.go
@@ -83,8 +83,11 @@ func main() {
 	callGetAll(settingsClient)
 
 	// Merge applies multiple settings values at once.
-	log.Println("calling Merge(`{\"foo\": \"bar\", \"daemon\":{\"port\":\"422\"}}`)")
+	log.Println("calling Merge()")
 	callMerge(settingsClient)
+
+	log.Println("calling GetAll()")
+	callGetAll(settingsClient)
 
 	// Get the value of the foo key.
 	log.Println("calling GetValue(foo)")
@@ -263,7 +266,7 @@ func callUnsetProxy(client settings.SettingsClient) {
 }
 
 func callMerge(client settings.SettingsClient) {
-	bulkSettings := `{"foo": "bar", "daemon":{"port":"422"}}`
+	bulkSettings := `{"foo": "bar", "daemon":{"port":"422"}, "board_manager": {"additional_urls":["https://example.com"]}}`
 	_, err := client.Merge(context.Background(),
 		&settings.RawData{
 			JsonData: bulkSettings,

--- a/client_example/main.go
+++ b/client_example/main.go
@@ -84,10 +84,19 @@ func main() {
 
 	// Merge applies multiple settings values at once.
 	log.Println("calling Merge()")
-	callMerge(settingsClient)
+	callMerge(settingsClient, `{"foo": {"value": "bar"}, "daemon":{"port":"422"}, "board_manager": {"additional_urls":["https://example.com"]}}`)
 
 	log.Println("calling GetAll()")
 	callGetAll(settingsClient)
+
+	log.Println("calling Merge()")
+	callMerge(settingsClient, `{"foo": {} }`)
+
+	log.Println("calling GetAll()")
+	callGetAll(settingsClient)
+
+	log.Println("calling Merge()")
+	callMerge(settingsClient, `{"foo": "bar" }`)
 
 	// Get the value of the foo key.
 	log.Println("calling GetValue(foo)")
@@ -265,11 +274,10 @@ func callUnsetProxy(client settings.SettingsClient) {
 	}
 }
 
-func callMerge(client settings.SettingsClient) {
-	bulkSettings := `{"foo": "bar", "daemon":{"port":"422"}, "board_manager": {"additional_urls":["https://example.com"]}}`
+func callMerge(client settings.SettingsClient, jsonData string) {
 	_, err := client.Merge(context.Background(),
 		&settings.RawData{
-			JsonData: bulkSettings,
+			JsonData: jsonData,
 		})
 
 	if err != nil {

--- a/commands/daemon/settings.go
+++ b/commands/daemon/settings.go
@@ -50,9 +50,8 @@ func (s *SettingsService) GetAll(ctx context.Context, req *rpc.GetAllRequest) (*
 func mapper(toMap map[string]interface{}) map[string]interface{} {
 	res := map[string]interface{}{}
 	for k, v := range toMap {
-		switch v.(type) {
+		switch data := v.(type) {
 		case map[string]interface{}:
-			data := v.(map[string]interface{})
 			for mK, mV := range mapper(data) {
 				// Concatenate keys
 				res[fmt.Sprintf("%s.%s", k, mK)] = mV

--- a/commands/daemon/settings.go
+++ b/commands/daemon/settings.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/arduino/arduino-cli/configuration"
 	rpc "github.com/arduino/arduino-cli/rpc/settings"
@@ -40,6 +42,32 @@ func (s *SettingsService) GetAll(ctx context.Context, req *rpc.GetAllRequest) (*
 	return nil, err
 }
 
+// mapper converts a map of nested maps to a map of scalar values.
+// For example:
+//    {"foo": "bar", "daemon":{"port":"420"}, "sketch": {"always_export_binaries": "true"}}
+// would convert to:
+//    {"foo": "bar", "daemon.port":"420", "sketch.always_export_binaries": "true"}
+func mapper(toMap map[string]interface{}) map[string]interface{} {
+	res := map[string]interface{}{}
+	for k, v := range toMap {
+		switch v.(type) {
+		case map[string]interface{}:
+			data := v.(map[string]interface{})
+			for mK, mV := range mapper(data) {
+				// Concatenate keys
+				res[fmt.Sprintf("%s.%s", k, mK)] = mV
+			}
+			// This is done to avoid skipping keys containing empty maps
+			if len(data) == 0 {
+				res[k] = map[string]interface{}{}
+			}
+		default:
+			res[k] = v
+		}
+	}
+	return res
+}
+
 // Merge applies multiple settings values at once.
 func (s *SettingsService) Merge(ctx context.Context, req *rpc.RawData) (*rpc.MergeResponse, error) {
 	var toMerge map[string]interface{}
@@ -47,8 +75,13 @@ func (s *SettingsService) Merge(ctx context.Context, req *rpc.RawData) (*rpc.Mer
 		return nil, err
 	}
 
-	if err := configuration.Settings.MergeConfigMap(toMerge); err != nil {
-		return nil, err
+	mapped := mapper(toMerge)
+
+	// Set each value individually.
+	// This is done because Viper ignores empty strings or maps when
+	// using the MergeConfigMap function.
+	for k, v := range mapped {
+		configuration.Settings.Set(k, v)
 	}
 
 	return &rpc.MergeResponse{}, nil
@@ -61,7 +94,17 @@ func (s *SettingsService) GetValue(ctx context.Context, req *rpc.GetValueRequest
 	key := req.GetKey()
 	value := &rpc.Value{}
 
-	if !configuration.Settings.InConfig(key) {
+	// Check if settings key actually existing, we don't use Viper.InConfig()
+	// since that doesn't check for keys formatted like daemon.port or those set
+	// with Viper.Set(). This way we check for all existing settings for sure.
+	keyExists := false
+	for _, k := range configuration.Settings.AllKeys() {
+		if k == key || strings.HasPrefix(k, key) {
+			keyExists = true
+			break
+		}
+	}
+	if !keyExists {
 		return nil, errors.New("key not found in settings")
 	}
 

--- a/commands/daemon/settings_test.go
+++ b/commands/daemon/settings_test.go
@@ -77,6 +77,9 @@ func TestMerge(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "", configuration.Settings.GetString("daemon.port"))
+	// Verifies other values are not changed
+	require.Equal(t, "", configuration.Settings.GetString("foo"))
+	require.Equal(t, false, configuration.Settings.GetBool("sketch.always_export_binaries"))
 
 	reset()
 }


### PR DESCRIPTION
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Bug fix.

- **What is the current behavior?**

Calling the gRPC interface Merge function to merge existing configs with new ones would ignored empty values.

* **What is the new behavior?**

This fix adds the possibility to set empty values with the Merge gRPC function, previously they would have been ignored.

Because of this change I had also to modify the GetValue() function since it would first check if the value was set using the Viper.InConfig() function that wouldn't check for values set with Viper.Set().

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

No.

* **Other information**:

Fixes #1161 

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
