### PR TITLE
[skip changelog] Fix core commands skipping gRPC interface

### DIFF
--- a/cli/core/list.go
+++ b/cli/core/list.go
@@ -19,11 +19,11 @@ import (
 	"os"
 	"sort"
 
-	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
 	"github.com/arduino/arduino-cli/cli/instance"
 	"github.com/arduino/arduino-cli/commands/core"
+	rpc "github.com/arduino/arduino-cli/rpc/commands"
 	"github.com/arduino/arduino-cli/table"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -55,7 +55,10 @@ func runListCommand(cmd *cobra.Command, args []string) {
 
 	logrus.Info("Executing `arduino core list`")
 
-	platforms, err := core.GetPlatforms(inst.Id, listFlags.updatableOnly)
+	platforms, err := core.GetPlatforms(&rpc.PlatformListReq{
+		Instance:      inst,
+		UpdatableOnly: listFlags.updatableOnly,
+	})
 	if err != nil {
 		feedback.Errorf("Error listing platforms: %v", err)
 		os.Exit(errorcodes.ErrGeneric)
@@ -67,7 +70,7 @@ func runListCommand(cmd *cobra.Command, args []string) {
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type installedResult struct {
-	platforms []*cores.PlatformRelease
+	platforms []*rpc.Platform
 }
 
 func (ir installedResult) Data() interface{} {
@@ -82,10 +85,10 @@ func (ir installedResult) String() string {
 	t := table.New()
 	t.SetHeader("ID", "Installed", "Latest", "Name")
 	sort.Slice(ir.platforms, func(i, j int) bool {
-		return ir.platforms[i].Platform.String() < ir.platforms[j].Platform.String()
+		return ir.platforms[i].ID < ir.platforms[j].ID
 	})
 	for _, p := range ir.platforms {
-		t.AddRow(p.Platform.String(), p.Version.String(), p.Platform.GetLatestRelease().Version.String(), p.Platform.Name)
+		t.AddRow(p.ID, p.Installed, p.Latest, p.Name)
 	}
 
 	return t.Render()

--- a/cli/core/search.go
+++ b/cli/core/search.go
@@ -69,7 +69,11 @@ func runSearchCommand(cmd *cobra.Command, args []string) {
 	arguments := strings.ToLower(strings.Join(args, " "))
 	logrus.Infof("Executing `arduino core search` with args: '%s'", arguments)
 
-	resp, err := core.PlatformSearch(inst.GetId(), arguments, allVersions)
+	resp, err := core.PlatformSearch(&rpc.PlatformSearchReq{
+		Instance:    inst,
+		SearchArgs:  arguments,
+		AllVersions: allVersions,
+	})
 	if err != nil {
 		feedback.Errorf("Error searching for platforms: %v", err)
 		os.Exit(errorcodes.ErrGeneric)

--- a/cli/core/upgrade.go
+++ b/cli/core/upgrade.go
@@ -57,7 +57,10 @@ func runUpgradeCommand(cmd *cobra.Command, args []string) {
 
 	// if no platform was passed, upgrade allthethings
 	if len(args) == 0 {
-		targets, err := core.GetPlatforms(inst.Id, true)
+		targets, err := core.GetPlatforms(&rpc.PlatformListReq{
+			Instance:      inst,
+			UpdatableOnly: true,
+		})
 		if err != nil {
 			feedback.Errorf("Error retrieving core list: %v", err)
 			os.Exit(errorcodes.ErrGeneric)
@@ -69,7 +72,7 @@ func runUpgradeCommand(cmd *cobra.Command, args []string) {
 		}
 
 		for _, t := range targets {
-			args = append(args, t.Platform.String())
+			args = append(args, t.ID)
 		}
 	}
 

--- a/commands/core/search.go
+++ b/commands/core/search.go
@@ -34,8 +34,10 @@ func exactMatch(line, searchArgs string) bool {
 }
 
 // PlatformSearch FIXMEDOC
-func PlatformSearch(instanceID int32, searchArgs string, allVersions bool) (*rpc.PlatformSearchResp, error) {
-	pm := commands.GetPackageManager(instanceID)
+func PlatformSearch(req *rpc.PlatformSearchReq) (*rpc.PlatformSearchResp, error) {
+	searchArgs := req.SearchArgs
+	allVersions := req.AllVersions
+	pm := commands.GetPackageManager(req.Instance.Id)
 	if pm == nil {
 		return nil, errors.New("invalid instance")
 	}

--- a/commands/core/search_test.go
+++ b/commands/core/search_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/arduino/arduino-cli/cli/instance"
 	"github.com/arduino/arduino-cli/configuration"
 	"github.com/arduino/arduino-cli/rpc/commands"
+	rpc "github.com/arduino/arduino-cli/rpc/commands"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,7 +53,11 @@ func TestPlatformSearch(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, inst)
 
-	res, err := PlatformSearch(inst.GetId(), "retrokit", true)
+	res, err := PlatformSearch(&rpc.PlatformSearchReq{
+		Instance:    inst,
+		SearchArgs:  "retrokit",
+		AllVersions: true,
+	})
 	require.Nil(t, err)
 	require.NotNil(t, res)
 
@@ -78,7 +83,11 @@ func TestPlatformSearch(t *testing.T) {
 		Boards:     []*commands.Board{{Name: "RK002"}},
 	})
 
-	res, err = PlatformSearch(inst.GetId(), "retrokit", false)
+	res, err = PlatformSearch(&rpc.PlatformSearchReq{
+		Instance:    inst,
+		SearchArgs:  "retrokit",
+		AllVersions: false,
+	})
 	require.Nil(t, err)
 	require.NotNil(t, res)
 	require.Len(t, res.SearchOutput, 1)
@@ -94,7 +103,11 @@ func TestPlatformSearch(t *testing.T) {
 	})
 
 	// Search the Package Maintainer
-	res, err = PlatformSearch(inst.GetId(), "Retrokits (www.retrokits.com)", true)
+	res, err = PlatformSearch(&rpc.PlatformSearchReq{
+		Instance:    inst,
+		SearchArgs:  "Retrokits (www.retrokits.com)",
+		AllVersions: true,
+	})
 	require.Nil(t, err)
 	require.NotNil(t, res)
 	require.Len(t, res.SearchOutput, 2)
@@ -120,7 +133,11 @@ func TestPlatformSearch(t *testing.T) {
 	})
 
 	// Search using the Package name
-	res, err = PlatformSearch(inst.GetId(), "Retrokits-RK002", true)
+	res, err = PlatformSearch(&rpc.PlatformSearchReq{
+		Instance:    inst,
+		SearchArgs:  "Retrokits-RK002",
+		AllVersions: true,
+	})
 	require.Nil(t, err)
 	require.NotNil(t, res)
 	require.Len(t, res.SearchOutput, 2)
@@ -146,7 +163,11 @@ func TestPlatformSearch(t *testing.T) {
 	})
 
 	// Search using the Platform name
-	res, err = PlatformSearch(inst.GetId(), "rk002", true)
+	res, err = PlatformSearch(&rpc.PlatformSearchReq{
+		Instance:    inst,
+		SearchArgs:  "rk002",
+		AllVersions: true,
+	})
 	require.Nil(t, err)
 	require.NotNil(t, res)
 	require.Len(t, res.SearchOutput, 2)
@@ -172,7 +193,11 @@ func TestPlatformSearch(t *testing.T) {
 	})
 
 	// Search using a board name
-	res, err = PlatformSearch(inst.GetId(), "Yún", true)
+	res, err = PlatformSearch(&rpc.PlatformSearchReq{
+		Instance:    inst,
+		SearchArgs:  "Yún",
+		AllVersions: true,
+	})
 	require.Nil(t, err)
 	require.NotNil(t, res)
 	require.Len(t, res.SearchOutput, 1)

--- a/commands/daemon/daemon.go
+++ b/commands/daemon/daemon.go
@@ -259,24 +259,16 @@ func (s *ArduinoCoreServerImpl) PlatformUpgrade(req *rpc.PlatformUpgradeReq, str
 
 // PlatformSearch FIXMEDOC
 func (s *ArduinoCoreServerImpl) PlatformSearch(ctx context.Context, req *rpc.PlatformSearchReq) (*rpc.PlatformSearchResp, error) {
-	return core.PlatformSearch(req.GetInstance().GetId(), req.GetSearchArgs(), req.GetAllVersions())
+	return core.PlatformSearch(req)
 }
 
 // PlatformList FIXMEDOC
 func (s *ArduinoCoreServerImpl) PlatformList(ctx context.Context, req *rpc.PlatformListReq) (*rpc.PlatformListResp, error) {
-	platforms, err := core.GetPlatforms(req.Instance.Id, req.UpdatableOnly)
+	platforms, err := core.GetPlatforms(req)
 	if err != nil {
 		return nil, err
 	}
-
-	installed := []*rpc.Platform{}
-	for _, p := range platforms {
-		rpcPlatform := commands.PlatformReleaseToRPC(p)
-		rpcPlatform.Installed = p.Version.String()
-		installed = append(installed, rpcPlatform)
-	}
-
-	return &rpc.PlatformListResp{InstalledPlatform: installed}, nil
+	return &rpc.PlatformListResp{InstalledPlatform: platforms}, nil
 }
 
 // Upload FIXMEDOC


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Refactors some commands internals.

- **What is the current behavior?**

`cli/core` commands are currently calling `commands/core` function without using `rpc` Requests structs.

* **What is the new behavior?**

All `cli/core` commands now call `commands/core` functions using the `rpc` Requests structs.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

We don't fix any issue with this PR but we'll avoid breaking the CLI and the gRPC interface alignment.

This adds more output to `core list --format json` but it doesn't break anything.

This change started out from a comment by @cmaglie on #1166, we should rebase that branch on top of this and another subsequent PR that will fix some legacy tests to verify that hardware loading works as expected.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
