### PR TITLE
Better error message for boards without bootloader

### DIFF
--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -228,6 +228,10 @@ func runProgramAction(pm *packagemanager.PackageManager,
 		}
 	}
 
+	if !uploadProperties.ContainsKey("upload.protocol") && programmer == nil {
+		return fmt.Errorf("a programmer is required to upload for this board")
+	}
+
 	// Set properties for verbose upload
 	if verbose {
 		if v, ok := uploadProperties.GetOk("upload.params.verbose"); ok {


### PR DESCRIPTION
Before:

```
$ arduino-cli upload -b arduino:avr:gemma -p /dev/ttyACM0
avrdude: invalid baud rate specified '{upload.speed}'
Error during Upload: uploading error: uploading error: exit status 1
$
```

After:

```
$ arduino-cli upload -b arduino:avr:gemma -p /dev/ttyACM0
Error during Upload: a programmer is required to upload for this board
$
```
