### PR TITLE
librariesindex: Fix nil pointer. Refs #1176

### DIFF
--- a/arduino/libraries/librariesindex/index.go
+++ b/arduino/libraries/librariesindex/index.go
@@ -16,6 +16,7 @@
 package librariesindex
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/arduino/arduino-cli/arduino/libraries"
@@ -135,6 +136,10 @@ func (idx *Index) FindLibraryUpdate(lib *libraries.Library) *Release {
 	indexLib := idx.FindIndexedLibrary(lib)
 	if indexLib == nil {
 		return nil
+	}
+	if lib.Version == nil {
+		fmt.Printf("[WARN] version for library loaded from %s is nil\n", lib.InstallDir)
+		return indexLib.Latest
 	}
 	if indexLib.Latest.Version.GreaterThan(lib.Version) {
 		return indexLib.Latest

--- a/arduino/libraries/librariesindex/index.go
+++ b/arduino/libraries/librariesindex/index.go
@@ -136,6 +136,8 @@ func (idx *Index) FindLibraryUpdate(lib *libraries.Library) *Release {
 	if indexLib == nil {
 		return nil
 	}
+	// library.Version is nil when when the version field in
+	// a library descriptor is malformed and could not be parsed.
 	if lib.Version == nil {
 		return indexLib.Latest
 	}

--- a/arduino/libraries/librariesindex/index.go
+++ b/arduino/libraries/librariesindex/index.go
@@ -16,7 +16,6 @@
 package librariesindex
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/arduino/arduino-cli/arduino/libraries"
@@ -138,7 +137,6 @@ func (idx *Index) FindLibraryUpdate(lib *libraries.Library) *Release {
 		return nil
 	}
 	if lib.Version == nil {
-		fmt.Printf("[WARN] version for library loaded from %s is nil\n", lib.InstallDir)
 		return indexLib.Latest
 	}
 	if indexLib.Latest.Version.GreaterThan(lib.Version) {

--- a/arduino/libraries/librariesindex/index_test.go
+++ b/arduino/libraries/librariesindex/index_test.go
@@ -78,6 +78,10 @@ func TestIndexer(t *testing.T) {
 	require.NotNil(t, rtcUpdate)
 	require.Equal(t, "RTCZero@1.6.0", rtcUpdate.String())
 
+	rtcUpdateNoVersion := index.FindLibraryUpdate(&libraries.Library{Name: "RTCZero", Version: nil})
+	require.NotNil(t, rtcUpdateNoVersion)
+	require.Equal(t, "RTCZero@1.6.0", rtcUpdateNoVersion.String())
+
 	rtcNoUpdate := index.FindLibraryUpdate(&libraries.Library{Name: "RTCZero", Version: semver.MustParse("3.0.0")})
 	require.Nil(t, rtcNoUpdate)
 


### PR DESCRIPTION
Let the library index return the latest known version,
if a library without a version is updated.

Signed-off-by: Ruben Jenster <r.jenster@drachenfels.de>