### PR TITLE
Do not try to export binaries if --only-compilation-database is set

### DIFF
--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -239,10 +239,9 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 		if exportDir := req.GetExportDir(); exportDir != "" {
 			exportPath = paths.New(exportDir)
 		} else {
-			exportPath = sketch.FullPath
 			// Add FQBN (without configs part) to export path
 			fqbnSuffix := strings.Replace(fqbn.StringWithoutConfig(), ":", ".", -1)
-			exportPath = exportPath.Join("build").Join(fqbnSuffix)
+			exportPath = sketch.FullPath.Join("build", fqbnSuffix)
 		}
 		logrus.WithField("path", exportPath).Trace("Saving sketch to export path.")
 		if err := exportPath.MkdirAll(); err != nil {

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -227,7 +227,14 @@ func Compile(ctx context.Context, req *rpc.CompileReq, outStream, errStream io.W
 	}
 
 	// If the export directory is set we assume you want to export the binaries
-	if exportBinaries || req.GetExportDir() != "" {
+	if req.GetExportDir() != "" {
+		exportBinaries = true
+	}
+	// If CreateCompilationDatabaseOnly is set, we do not need to export anything
+	if req.GetCreateCompilationDatabaseOnly() {
+		exportBinaries = false
+	}
+	if exportBinaries {
 		var exportPath *paths.Path
 		if exportDir := req.GetExportDir(); exportDir != "" {
 			exportPath = paths.New(exportDir)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -726,3 +726,35 @@ def test_compile_sketch_case_mismatch_fails(run_command, data_dir):
     res = run_command(f"compile --clean -b {fqbn}", custom_working_dir=sketch_path)
     assert res.failed
     assert "Error during build: opening sketch: no valid sketch found" in res.stderr
+
+
+def test_compile_with_only_compilation_database_flag(run_command, data_dir):
+    assert run_command("update")
+
+    assert run_command("core install arduino:avr@1.8.3")
+
+    sketch_name = "CompileSketchOnlyCompilationDatabaseFlag"
+    sketch_path = Path(data_dir, sketch_name)
+    fqbn = "arduino:avr:uno"
+
+    assert run_command(f"sketch new {sketch_path}")
+
+    # Verifies no binaries exist
+    build_path = Path(sketch_path, "build")
+    assert not build_path.exists()
+
+    # Compile with both --export-binaries and --only-compilation-database flags
+    assert run_command(f"compile --export-binaries --only-compilation-database --clean -b {fqbn} {sketch_path}")
+
+    # Verifies no binaries are exported
+    assert not build_path.exists()
+
+    # Verifies no binaries exist
+    build_path = Path(data_dir, "export-dir")
+    assert not build_path.exists()
+
+    # Compile by setting the --output-dir flag and --only-compilation-database flags
+    assert run_command(f"compile --output-dir {build_path} --only-compilation-database --clean -b {fqbn} {sketch_path}")
+
+    # Verifies no binaries are exported
+    assert not build_path.exists()


### PR DESCRIPTION
Otherwise an empty `build/fqbn/...` folder is created if `always-export-binaries` option is set via config file.