### PR TITLE
[skip changelog] Fix integration tests not deleting folders when test finishes

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -56,11 +56,11 @@ def data_dir(tmpdir_factory):
     if platform.system() == "Windows":
         with tempfile.TemporaryDirectory() as tmp:
             yield tmp
-            # shutil.rmtree(tmp, ignore_errors=True)
+            shutil.rmtree(tmp, ignore_errors=True)
     else:
         data = tmpdir_factory.mktemp("ArduinoTest")
         yield str(data)
-        # shutil.rmtree(data, ignore_errors=True)
+        shutil.rmtree(data, ignore_errors=True)
 
 
 @pytest.fixture(scope="session")
@@ -81,7 +81,7 @@ def downloads_dir(tmpdir_factory, worker_id):
                 lock.touch()
 
     yield str(download_dir)
-    # shutil.rmtree(download_dir, ignore_errors=True)
+    shutil.rmtree(download_dir, ignore_errors=True)
 
 
 @pytest.fixture(scope="function")
@@ -93,7 +93,7 @@ def working_dir(tmpdir_factory):
     """
     work_dir = tmpdir_factory.mktemp("ArduinoTestWork")
     yield str(work_dir)
-    # shutil.rmtree(work_dir, ignore_errors=True)
+    shutil.rmtree(work_dir, ignore_errors=True)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes integration tests failing on CI.

- **What is the current behavior?**

Folders used by integration tests are not deleted, this causes disk space filling up in the CI and make it fail.

* **What is the new behavior?**

Folders are now deleted when they reach the end of their scope. This way the disk space won't fill up and the CI won't fail.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

I actually thought that this was already done with #943 but turns out that I commented out the folders removal. :facepalm: 

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
