### PR TITLE
Added flag to disable check for sketch foldername matching sketch name

### DIFF
--- a/arduino/sketch/sketch.go
+++ b/arduino/sketch/sketch.go
@@ -16,6 +16,7 @@
 package sketch
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"sort"
@@ -124,17 +125,13 @@ func New(sketchFolderPath, mainFilePath, buildPath string, allFilesPaths []strin
 	sort.Sort(ItemByPath(otherSketchFiles))
 	sort.Sort(ItemByPath(rootFolderFiles))
 
-	if err := CheckSketchCasing(sketchFolderPath); err != nil {
-		return nil, err
-	}
-
 	return &Sketch{
 		MainFile:         mainFile,
 		LocationPath:     sketchFolderPath,
 		OtherSketchFiles: otherSketchFiles,
 		AdditionalFiles:  additionalFiles,
 		RootFolderFiles:  rootFolderFiles,
-	}, nil
+	}, CheckSketchCasing(sketchFolderPath)
 }
 
 // CheckSketchCasing returns an error if the casing of the sketch folder and the main file are different.
@@ -160,8 +157,17 @@ func CheckSketchCasing(sketchFolder string) error {
 	if files.Len() == 0 {
 		sketchFolderPath := paths.New(sketchFolder)
 		sketchFile := sketchFolderPath.Join(sketchFolderPath.Base() + globals.MainFileValidExtension)
-		return errors.Errorf("no valid sketch found in %s: missing %s", sketchFolderPath, sketchFile)
+		return &InvalidSketchFoldernameError{SketchFolder: sketchFolderPath, SketchFile: sketchFile}
 	}
 
 	return nil
+}
+
+type InvalidSketchFoldernameError struct {
+	SketchFolder *paths.Path
+	SketchFile   *paths.Path
+}
+
+func (e *InvalidSketchFoldernameError) Error() string {
+	return fmt.Sprintf("no valid sketch found in %s: missing %s", e.SketchFolder, e.SketchFile)
 }

--- a/arduino/sketch/sketch.go
+++ b/arduino/sketch/sketch.go
@@ -163,6 +163,7 @@ func CheckSketchCasing(sketchFolder string) error {
 	return nil
 }
 
+// InvalidSketchFoldernameError is returned when the sketch directory doesn't match the sketch name
 type InvalidSketchFoldernameError struct {
 	SketchFolder *paths.Path
 	SketchFile   *paths.Path

--- a/arduino/sketch/sketch.go
+++ b/arduino/sketch/sketch.go
@@ -125,13 +125,22 @@ func New(sketchFolderPath, mainFilePath, buildPath string, allFilesPaths []strin
 	sort.Sort(ItemByPath(otherSketchFiles))
 	sort.Sort(ItemByPath(rootFolderFiles))
 
-	return &Sketch{
+	sk := &Sketch{
 		MainFile:         mainFile,
 		LocationPath:     sketchFolderPath,
 		OtherSketchFiles: otherSketchFiles,
 		AdditionalFiles:  additionalFiles,
 		RootFolderFiles:  rootFolderFiles,
-	}, CheckSketchCasing(sketchFolderPath)
+	}
+	err := CheckSketchCasing(sketchFolderPath)
+	if e, ok := err.(*InvalidSketchFoldernameError); ok {
+		e.Sketch = sk
+		return nil, e
+	}
+	if err != nil {
+		return nil, err
+	}
+	return sk, nil
 }
 
 // CheckSketchCasing returns an error if the casing of the sketch folder and the main file are different.
@@ -167,6 +176,7 @@ func CheckSketchCasing(sketchFolder string) error {
 type InvalidSketchFoldernameError struct {
 	SketchFolder *paths.Path
 	SketchFile   *paths.Path
+	Sketch       *Sketch
 }
 
 func (e *InvalidSketchFoldernameError) Error() string {

--- a/arduino/sketch/sketch_test.go
+++ b/arduino/sketch/sketch_test.go
@@ -13,7 +13,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-package sketch_test
+package sketch
 
 import (
 	"fmt"
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/arduino/arduino-cli/arduino/sketch"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +28,7 @@ import (
 
 func TestNewItem(t *testing.T) {
 	sketchItem := filepath.Join("testdata", t.Name()+".ino")
-	item := sketch.NewItem(sketchItem)
+	item := NewItem(sketchItem)
 	assert.Equal(t, sketchItem, item.Path)
 	sourceBytes, err := item.GetSourceBytes()
 	assert.Nil(t, err)
@@ -38,20 +37,20 @@ func TestNewItem(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "#include <testlib.h>", sourceStr)
 
-	item = sketch.NewItem("doesnt/exist")
+	item = NewItem("doesnt/exist")
 	sourceBytes, err = item.GetSourceBytes()
 	assert.Nil(t, sourceBytes)
 	assert.NotNil(t, err)
 }
 
 func TestSort(t *testing.T) {
-	items := []*sketch.Item{
+	items := []*Item{
 		{"foo"},
 		{"baz"},
 		{"bar"},
 	}
 
-	sort.Sort(sketch.ItemByPath(items))
+	sort.Sort(ItemByPath(items))
 
 	assert.Equal(t, "bar", items[0].Path)
 	assert.Equal(t, "baz", items[1].Path)
@@ -67,7 +66,7 @@ func TestNew(t *testing.T) {
 		otherFile,
 	}
 
-	sketch, err := sketch.New(sketchFolderPath, mainFilePath, "", allFilesPaths)
+	sketch, err := New(sketchFolderPath, mainFilePath, "", allFilesPaths)
 	assert.Nil(t, err)
 	assert.Equal(t, mainFilePath, sketch.MainFile.Path)
 	assert.Equal(t, sketchFolderPath, sketch.LocationPath)
@@ -81,7 +80,7 @@ func TestNew(t *testing.T) {
 func TestNewSketchCasingWrong(t *testing.T) {
 	sketchPath := paths.New("testdata", "SketchCasingWrong")
 	mainFilePath := paths.New("testadata", "sketchcasingwrong.ino").String()
-	sketch, err := sketch.New(sketchPath.String(), mainFilePath, "", []string{mainFilePath})
+	sketch, err := New(sketchPath.String(), mainFilePath, "", []string{mainFilePath})
 	assert.Nil(t, sketch)
 	expectedError := fmt.Sprintf("no valid sketch found in %s: missing %s", sketchPath.String(), sketchPath.Join(sketchPath.Base()+".ino"))
 	assert.EqualError(t, err, expectedError)
@@ -90,7 +89,7 @@ func TestNewSketchCasingWrong(t *testing.T) {
 func TestNewSketchCasingCorrect(t *testing.T) {
 	sketchPath := paths.New("testdata", "SketchCasingCorrect").String()
 	mainFilePath := paths.New("testadata", "SketchCasingCorrect.ino").String()
-	sketch, err := sketch.New(sketchPath, mainFilePath, "", []string{mainFilePath})
+	sketch, err := New(sketchPath, mainFilePath, "", []string{mainFilePath})
 	assert.NotNil(t, sketch)
 	assert.NoError(t, err)
 	assert.Equal(t, sketchPath, sketch.LocationPath)
@@ -102,13 +101,13 @@ func TestNewSketchCasingCorrect(t *testing.T) {
 
 func TestCheckSketchCasingWrong(t *testing.T) {
 	sketchFolder := paths.New("testdata", "SketchCasingWrong")
-	err := sketch.CheckSketchCasing(sketchFolder.String())
+	err := CheckSketchCasing(sketchFolder.String())
 	expectedError := fmt.Sprintf("no valid sketch found in %s: missing %s", sketchFolder, sketchFolder.Join(sketchFolder.Base()+".ino"))
 	assert.EqualError(t, err, expectedError)
 }
 
 func TestCheckSketchCasingCorrect(t *testing.T) {
 	sketchFolder := paths.New("testdata", "SketchCasingCorrect").String()
-	err := sketch.CheckSketchCasing(sketchFolder)
+	err := CheckSketchCasing(sketchFolder)
 	require.NoError(t, err)
 }

--- a/arduino/sketch/sketch_test.go
+++ b/arduino/sketch/sketch_test.go
@@ -81,9 +81,11 @@ func TestNewSketchCasingWrong(t *testing.T) {
 	sketchPath := paths.New("testdata", "SketchCasingWrong")
 	mainFilePath := paths.New("testadata", "sketchcasingwrong.ino").String()
 	sketch, err := New(sketchPath.String(), mainFilePath, "", []string{mainFilePath})
-	assert.NotNil(t, sketch)
+	assert.Nil(t, sketch)
 	assert.Error(t, err)
 	assert.IsType(t, &InvalidSketchFoldernameError{}, err)
+	e := err.(*InvalidSketchFoldernameError)
+	assert.NotNil(t, e.Sketch)
 	expectedError := fmt.Sprintf("no valid sketch found in %s: missing %s", sketchPath.String(), sketchPath.Join(sketchPath.Base()+".ino"))
 	assert.EqualError(t, err, expectedError)
 }

--- a/arduino/sketch/sketch_test.go
+++ b/arduino/sketch/sketch_test.go
@@ -81,7 +81,9 @@ func TestNewSketchCasingWrong(t *testing.T) {
 	sketchPath := paths.New("testdata", "SketchCasingWrong")
 	mainFilePath := paths.New("testadata", "sketchcasingwrong.ino").String()
 	sketch, err := New(sketchPath.String(), mainFilePath, "", []string{mainFilePath})
-	assert.Nil(t, sketch)
+	assert.NotNil(t, sketch)
+	assert.Error(t, err)
+	assert.IsType(t, &InvalidSketchFoldernameError{}, err)
 	expectedError := fmt.Sprintf("no valid sketch found in %s: missing %s", sketchPath.String(), sketchPath.Join(sketchPath.Base()+".ino"))
 	assert.EqualError(t, err, expectedError)
 }

--- a/legacy/builder/container_setup.go
+++ b/legacy/builder/container_setup.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	bldr "github.com/arduino/arduino-cli/arduino/builder"
+	sk "github.com/arduino/arduino-cli/arduino/sketch"
 	"github.com/arduino/arduino-cli/legacy/builder/builder_utils"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/arduino/go-paths-helper"
@@ -63,7 +64,9 @@ func (s *ContainerSetupHardwareToolsLibsSketchAndProps) Run(ctx *types.Context) 
 
 		// load sketch
 		sketch, err := bldr.SketchLoad(sketchLocation.String(), ctx.BuildPath.String())
-		if err != nil {
+		if _, ok := err.(*sk.InvalidSketchFoldernameError); ctx.IgnoreSketchFolderNameErrors && ok {
+			// ignore error
+		} else if err != nil {
 			return errors.WithStack(err)
 		}
 		if sketch.MainFile == nil {

--- a/legacy/builder/container_setup.go
+++ b/legacy/builder/container_setup.go
@@ -64,8 +64,9 @@ func (s *ContainerSetupHardwareToolsLibsSketchAndProps) Run(ctx *types.Context) 
 
 		// load sketch
 		sketch, err := bldr.SketchLoad(sketchLocation.String(), ctx.BuildPath.String())
-		if _, ok := err.(*sk.InvalidSketchFoldernameError); ctx.IgnoreSketchFolderNameErrors && ok {
+		if e, ok := err.(*sk.InvalidSketchFoldernameError); ctx.IgnoreSketchFolderNameErrors && ok {
 			// ignore error
+			sketch = e.Sketch
 		} else if err != nil {
 			return errors.WithStack(err)
 		}

--- a/legacy/builder/types/context.go
+++ b/legacy/builder/types/context.go
@@ -91,19 +91,20 @@ type Context struct {
 	PlatformKeyRewrites    PlatforKeysRewrite
 	HardwareRewriteResults map[*cores.PlatformRelease][]PlatforKeyRewrite
 
-	BuildProperties      *properties.Map
-	BuildCore            string
-	BuildPath            *paths.Path
-	BuildCachePath       *paths.Path
-	SketchBuildPath      *paths.Path
-	CoreBuildPath        *paths.Path
-	CoreBuildCachePath   *paths.Path
-	CoreArchiveFilePath  *paths.Path
-	CoreObjectsFiles     paths.PathList
-	LibrariesBuildPath   *paths.Path
-	LibrariesObjectFiles paths.PathList
-	PreprocPath          *paths.Path
-	SketchObjectFiles    paths.PathList
+	BuildProperties              *properties.Map
+	BuildCore                    string
+	BuildPath                    *paths.Path
+	BuildCachePath               *paths.Path
+	SketchBuildPath              *paths.Path
+	CoreBuildPath                *paths.Path
+	CoreBuildCachePath           *paths.Path
+	CoreArchiveFilePath          *paths.Path
+	CoreObjectsFiles             paths.PathList
+	LibrariesBuildPath           *paths.Path
+	LibrariesObjectFiles         paths.PathList
+	PreprocPath                  *paths.Path
+	SketchObjectFiles            paths.PathList
+	IgnoreSketchFolderNameErrors bool
 
 	CollectedSourceFiles *UniqueSourceFileQueue
 


### PR DESCRIPTION
This is required to ensure backward compatibility for `arduino-builder` that doesn't enforce this check.

In particular, since `arduino-builder` is used in the Arduino IDE, if the user tries to compile an unsaved sketch, the Arduino IDE will create a temporary copy of the sketch in a temp dir with a random name: in this case if the folder name check is enabled the compile will fail.

This flag is for internal use only (basically only on `arduino-builder`) it will be removed once `arduino-builder` will be completely replaced by `arduino-cli` in the Arduino IDE.