### PR TITLE
Fix some commands crashing when an installed library has invalid version

### DIFF
--- a/arduino/libraries/librariesindex/index.go
+++ b/arduino/libraries/librariesindex/index.go
@@ -16,6 +16,7 @@
 package librariesindex
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/arduino/arduino-cli/arduino/libraries"
@@ -135,6 +136,10 @@ func (idx *Index) FindLibraryUpdate(lib *libraries.Library) *Release {
 	indexLib := idx.FindIndexedLibrary(lib)
 	if indexLib == nil {
 		return nil
+	}
+	if lib.Version == nil {
+		fmt.Printf("[WARN] version for library loaded from %s is nil\n", lib.InstallDir)
+		return indexLib.Latest
 	}
 	if indexLib.Latest.Version.GreaterThan(lib.Version) {
 		return indexLib.Latest

--- a/arduino/libraries/librariesindex/index.go
+++ b/arduino/libraries/librariesindex/index.go
@@ -136,6 +136,8 @@ func (idx *Index) FindLibraryUpdate(lib *libraries.Library) *Release {
 	if indexLib == nil {
 		return nil
 	}
+	// library.Version is nil when when the version field in
+	// a library descriptor is malformed and could not be parsed.
 	if lib.Version == nil {
 		return indexLib.Latest
 	}

--- a/arduino/libraries/librariesindex/index.go
+++ b/arduino/libraries/librariesindex/index.go
@@ -136,12 +136,9 @@ func (idx *Index) FindLibraryUpdate(lib *libraries.Library) *Release {
 	if indexLib == nil {
 		return nil
 	}
-	// library.Version is nil when when the version field in
-	// a library descriptor is malformed and could not be parsed.
-	if lib.Version == nil {
-		return indexLib.Latest
-	}
-	if indexLib.Latest.Version.GreaterThan(lib.Version) {
+	// If a library.properties has an invalid version property, usually empty or malformed,
+	// the latest available version is returned
+	if lib.Version == nil || indexLib.Latest.Version.GreaterThan(lib.Version) {
 		return indexLib.Latest
 	}
 	return nil

--- a/arduino/libraries/librariesindex/index.go
+++ b/arduino/libraries/librariesindex/index.go
@@ -16,7 +16,6 @@
 package librariesindex
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/arduino/arduino-cli/arduino/libraries"
@@ -138,7 +137,6 @@ func (idx *Index) FindLibraryUpdate(lib *libraries.Library) *Release {
 		return nil
 	}
 	if lib.Version == nil {
-		fmt.Printf("[WARN] version for library loaded from %s is nil\n", lib.InstallDir)
 		return indexLib.Latest
 	}
 	if indexLib.Latest.Version.GreaterThan(lib.Version) {

--- a/arduino/libraries/librariesindex/index_test.go
+++ b/arduino/libraries/librariesindex/index_test.go
@@ -78,6 +78,10 @@ func TestIndexer(t *testing.T) {
 	require.NotNil(t, rtcUpdate)
 	require.Equal(t, "RTCZero@1.6.0", rtcUpdate.String())
 
+	rtcUpdateNoVersion := index.FindLibraryUpdate(&libraries.Library{Name: "RTCZero", Version: nil})
+	require.NotNil(t, rtcUpdateNoVersion)
+	require.Equal(t, "RTCZero@1.6.0", rtcUpdateNoVersion.String())
+
 	rtcNoUpdate := index.FindLibraryUpdate(&libraries.Library{Name: "RTCZero", Version: semver.MustParse("3.0.0")})
 	require.Nil(t, rtcNoUpdate)
 

--- a/arduino/libraries/librariesmanager/install.go
+++ b/arduino/libraries/librariesmanager/install.go
@@ -50,7 +50,7 @@ func (lm *LibrariesManager) InstallPrerequisiteCheck(indexLibrary *librariesinde
 			if installedLib.Location != libraries.User {
 				continue
 			}
-			if installedLib.Version.Equal(indexLibrary.Version) {
+			if installedLib.Version != nil && installedLib.Version.Equal(indexLibrary.Version) {
 				return installedLib.InstallDir, nil, ErrAlreadyInstalled
 			}
 			replaced = installedLib

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -703,3 +703,65 @@ def test_lib_examples_with_case_mismatch(run_command, data_dir):
     # Verifies sketches with wrong casing are not returned
     assert str(examples_path / "NonBlocking" / "OnDemandNonBlocking") not in examples
     assert str(examples_path / "OnDemand" / "OnDemandWebPortal") not in examples
+
+
+def test_lib_list_using_library_with_invalid_version(run_command, data_dir):
+    assert run_command("update")
+
+    # Install a library
+    assert run_command("lib install WiFi101@0.16.1")
+
+    # Verifies library is correctly returned
+    res = run_command("lib list --format json")
+    assert res.ok
+    data = json.loads(res.stdout)
+    assert len(data) == 1
+    assert "0.16.1" == data[0]["library"]["version"]
+
+    # Changes the version of the currently installed library so that it's
+    # invalid
+    lib_path = Path(data_dir, "libraries", "WiFi101")
+    Path(lib_path, "library.properties").write_text("version=1.0001")
+
+    # Verifies version is now empty
+    res = run_command("lib list --format json")
+    assert res.ok
+    data = json.loads(res.stdout)
+    assert len(data) == 1
+    assert "version" not in data[0]["library"]
+
+
+def test_lib_upgrade_using_library_with_invalid_version(run_command, data_dir):
+    assert run_command("update")
+
+    # Install a library
+    assert run_command("lib install WiFi101@0.16.1")
+
+    # Verifies library is correctly returned
+    res = run_command("lib list --format json")
+    assert res.ok
+    data = json.loads(res.stdout)
+    assert len(data) == 1
+    assert "0.16.1" == data[0]["library"]["version"]
+
+    # Changes the version of the currently installed library so that it's
+    # invalid
+    lib_path = Path(data_dir, "libraries", "WiFi101")
+    Path(lib_path, "library.properties").write_text("version=1.0001")
+
+    # Verifies version is now empty
+    res = run_command("lib list --format json")
+    assert res.ok
+    data = json.loads(res.stdout)
+    assert len(data) == 1
+    assert "version" not in data[0]["library"]
+
+    # Upgrade library
+    assert run_command("lib upgrade WiFi101")
+
+    # Verifies library has been updated
+    res = run_command("lib list --format json")
+    assert res.ok
+    data = json.loads(res.stdout)
+    assert len(data) == 1
+    assert "" != data[0]["library"]["version"]

--- a/test/test_outdated.py
+++ b/test/test_outdated.py
@@ -13,6 +13,8 @@
 # software without disclosing the source code of your own applications. To purchase
 # a commercial license, send an email to license@arduino.cc.
 
+from pathlib import Path
+
 
 def test_outdated(run_command):
     # Updates index for cores and libraries
@@ -33,3 +35,26 @@ def test_outdated(run_command):
     lines = [l.strip() for l in result.stdout.splitlines()]
     assert lines[1].startswith("Arduino AVR Boards")
     assert lines[4].startswith("USBHost")
+
+
+def test_outdated_using_library_with_invalid_version(run_command, data_dir):
+    assert run_command("update")
+
+    # Install latest version of a library library
+    assert run_command("lib install WiFi101")
+
+    # Verifies library is correctly returned
+    res = run_command("outdated")
+    assert res.ok
+    assert "WiFi101" not in res.stdout
+
+    # Changes the version of the currently installed library so that it's
+    # invalid
+    lib_path = Path(data_dir, "libraries", "WiFi101")
+    Path(lib_path, "library.properties").write_text("version=1.0001")
+
+    # Verifies library is correctly returned
+    res = run_command("outdated")
+    assert res.ok
+    lines = [l.strip().split() for l in res.stdout.splitlines()]
+    assert "WiFi101" == lines[1][0]

--- a/test/test_upgrade.py
+++ b/test/test_upgrade.py
@@ -13,6 +13,8 @@
 # software without disclosing the source code of your own applications. To purchase
 # a commercial license, send an email to license@arduino.cc.
 
+from pathlib import Path
+
 
 def test_upgrade(run_command):
     # Updates index for cores and libraries
@@ -41,3 +43,25 @@ def test_upgrade(run_command):
     result = run_command("outdated")
     assert result.ok
     assert result.stdout == ""
+
+
+def test_upgrade_using_library_with_invalid_version(run_command, data_dir):
+    assert run_command("update")
+
+    # Install latest version of a library
+    assert run_command("lib install WiFi101")
+
+    # Verifies library is not shown
+    res = run_command("outdated")
+    assert res.ok
+    assert "WiFi101" not in res.stdout
+
+    # Changes the version of the currently installed library so that it's
+    # invalid
+    lib_path = Path(data_dir, "libraries", "WiFi101")
+    Path(lib_path, "library.properties").write_text("version=1.0001")
+
+    # Verifies library gets upgraded
+    res = run_command("upgrade")
+    assert res.ok
+    assert "WiFi101" in res.stdout


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes a bug that caused several commands to crash.

- **What is the current behavior?**

Some commands crash with a `nil` pointer dereference when an installed library has an invalid or empty version in its `library.properties` file.

* **What is the new behavior?**

Installed libraries with invalid or empty version in `library.properties` file won't cause those commands to crash with a `nil` pointer deference. Also if a library version can't be determined we assume it's outdated.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

No breaking changes here.

* **Other information**:

This PR includes commits from #1177, I had to cherry-pick them to a separate branch since they were commit to the fork's `master` branch.

Fixes #1176.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
