### PR TITLE
[skip changelog] Correct library+sketch specifications re: spaces in folder name

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -121,7 +121,7 @@ may be added as needed to future revisions.
 #### Library Root folder
 
 The library root folder name must start with a basic letter (A-Z or a-z) or number (0-9), followed by basic letters,
-numbers, spaces ( ), underscores (\_), dots (.) and dashes (-). The maximum length is 63 characters.
+numbers, underscores (\_), dots (.) and dashes (-). The maximum length is 63 characters.
 
 #### Source code
 

--- a/docs/sketch-specification.md
+++ b/docs/sketch-specification.md
@@ -11,8 +11,8 @@ Because many Arduino sketches only contain a single .ino file, it's easy to thin
 it is the folder that is the sketch. The reason is that sketches may consist of multiple code files and the folder is
 what groups those files into a single program.
 
-<!-- prettier-ignore -->
-The sketch root folder name must start with a basic letter (`A`-`Z` or `a`-`z`) or number (`0`-`9`), followed by basic letters, numbers, spaces (` `), underscores (`_`), dots (`.`) and dashes (`-`). The maximum length is 63 characters.
+The sketch root folder name must start with a basic letter (`A`-`Z` or `a`-`z`) or number (`0`-`9`), followed by basic
+letters, numbers, underscores (`_`), dots (`.`) and dashes (`-`). The maximum length is 63 characters.
 
 Support for sketch folder names starting with a number was added in Arduino IDE 1.8.4.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The library and sketch specifications say that spaces are allowed in library and sketch folder names, but this is not supported by the Arduino IDE. Use of spaces in the folder name will result in a warning on IDE startup and the project not being recognized.

The previous mention of spaces as one of the characters allowed in library and sketch folder names was a copy/paste
error originating in the allowed characters in library.properties `name` properties. This specific part of the `name`
property specification doesn't apply to folder names. The reason it is allowed in the `name` property is because that
value is "sanitized" before being used by Library Manager for the library installation folder name by replacing all
spaces with underscores.
* **What is the new behavior?**
The erroneous mention of spaces as one of the allowed characters for library and sketch folder names is removed.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
It was previously necessary to disable Prettier formatting of the sentence in question in the sketch specification:
```
<!-- prettier-ignore -->
```
The reason for this was that prettier removed the space from between the backticks in that sentence. Now that the space has been removed from the sentence, it can be safely formatted by Prettier.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
