### PR TITLE
[skip changelog] Improve wording of docs introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![cli-logo](./docs/img/CLI_Logo_small.png)
 
-Arduino CLI is an all-in-one solution that provides builder, Boards/Library Manager, uploader, discovery and many other
-tools needed to use any Arduino compatible board and platforms.
+Arduino CLI is an all-in-one solution that provides Boards/Library Managers, sketch builder, board detection, uploader,
+and many other tools needed to use any Arduino compatible board and platform.
 
 [![tests-badge]](https://github.com/Arduino/arduino-cli/actions?workflow=test)
 [![nightly-badge]](https://github.com/Arduino/arduino-cli/actions?workflow=nightly)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
-Arduino CLI is an all-in-one solution that provides builder, Boards/Library Manager, uploader, discovery and many other
-tools needed to use any Arduino compatible board and platforms.
+Arduino CLI is an all-in-one solution that provides Boards/Library Managers, sketch builder, board detection, uploader,
+and many other tools needed to use any Arduino compatible board and platform.
 
 ## Installation
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The introductory sentence of the documentation homepage is the first thing the user may see when discovering Arduino
CLI. For this reason, it's important for it to quickly and clearly convey what Arduino CLI is. It's possible the current wording could be improved to do a better job of this.
* **What is the new behavior?**
<!-- if this is a feature change -->
The wording of the sentence is improved via the following changes:

- Use more understandable terms
- Rearrange features list in the order of typical usage (install dependencies, compile, upload)
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
>Does this PR introduce a breaking change

No
> is titled accordingly
Yes
* **Other information**:
<!-- Any additional information that could help the review process -->
I have changed the term "discovery" to "board detection". I feel that the meaning of "discovery" in this context is not widely known. The only uses of "discovery" in the documentation refer to library discovery, which is not the meaning of "discovery" in this sentence.

---
Credit for the suggested changes goes to @ubidefeo 