### PR TITLE
Skip unused broken symlinks

### DIFF
--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -197,7 +197,8 @@ func SketchLoad(sketchPath, buildPath string) (*sketch.Sketch, error) {
 		// check if file is readable
 		f, err := os.Open(path)
 		if err != nil {
-			return nil
+			feedback.Errorf("Failed to open sketch file: %v", err)
+			os.Exit(errorcodes.ErrGeneric)
 		}
 		f.Close()
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
Bug fix

- **What is the current behavior?**
1. When a sketch file (i.e. `.ino`, `.cpp`, etc.) is unreadable, it is silently skipped when loading the sketch.
2. When a sketch contains a broken symlink, sketch loading fails even when the file would not be otherwise loaded (i.e. not a `.ino`, `.cpp`, etc type of file).

* **What is the new behavior?**
1. When a sketch file (i.e. `.ino`, `.cpp`, etc.) is unreadable (i.e. no permission or otherwise unreadable), an error is thrown.
2. When a sketch contains a broken symlink, it is skipped if the file would not be otherwise loaded (i.e. not a `.ino`, `.cpp`, etc type of file).

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
Sketches that contain unreadable files that are not actually needed can no longer be compiled (they show an error instead of silently skipping the unreadable file), but I would consider such sketches an unsupported corner case.

* **Other information**:
The trigger for this PR was that I had a symlink in my sketch to the `compile_commands.json` in the build folder, so my editor would find that file and use it for code completion. However, after a reboot, the symlink would become broken, and `arduino-cli compile` (even with `--only-compilation-database` would fail, requiring me to remove the symlink and then recreate it afterwards.

The first commit was not strictly required for this problem, but it seemed like a good idea to not silently ignore unreadable files, and raising this error simplifies the second commit, while still raising an error as before on symlinks that would be loaded.

I've omitted testcases from this PR, since a significant of the code paths to test would result in `os.Exit`, which I think is not supported directly in the test framework. Are there any strategies in place for handling this already (see [this post](https://stackoverflow.com/questions/26225513/how-to-test-os-exit-scenarios-in-go) for some suggestions if not)?