### PR TITLE
[skip changelog] Remove outdated information re: debug system from platform spec

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -594,7 +594,6 @@ used for different purposes:
 - **program** a sketch to the target board using an external programmer
 - **erase** the target board's flash memory using an external programmer
 - burn a **bootloader** into the target board using an external programmer
-- **debug** a sketch
 
 Each action has its own recipe and its configuration is done through a set of properties having key starting with
 **tools** prefix followed by the tool ID and the action:
@@ -806,11 +805,8 @@ platform's platform.txt is done as usual.
 Starting from Arduino CLI 0.9.0 / Arduino Pro IDE v0.0.5-alpha.preview, sketch debugging support is available for
 platforms.
 
-The debug action is triggered when the user clicks **Debug > Start Debugging** in the Arduino Pro IDE or runs the
+The debug action is triggered when the user clicks the Debug button in the Arduino Pro IDE or runs the
 [`arduino-cli debug`](commands/arduino-cli_debug.md) command.
-
-The **debug.tool** property specifies the tool ID of the tool to be used for debugging. A **debug.tool** property may be
-defined for each board in boards.txt.
 
 The compiler optimization level that is appropriate for normal usage will often not provide a good experience while
 debugging. For this reason, it may be helpful to use different compiler flags when compiling a sketch for use with the
@@ -819,13 +815,6 @@ property, and those for normal use via the **compiler.optimization_flags.release
 **compiler.optimization_flags** property will be defined according to one or the other depending on the Arduino Pro
 IDE's **Sketch > Optimize for Debugging** setting or [`arduino-cli compile`](commands/arduino-cli_compile.md)'s
 `--optimize-for-debug` option.
-
-The debug recipe is defined via **tools.TOOL_NAME.debug.pattern**. It can be built concatenating the following
-automatically generated properties:
-
-- `{interpreter}`: the GDB command interpreter to use. It is configurable via
-  [`arduino-cli debug --interpreter`](commands/arduino-cli_debug.md). This property was added in Arduino CLI 0.10.0 /
-  Arduino Pro IDE v0.0.7-alpha.preview.
 
 ## Custom board options
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Since the time the documentation for the initial experimental debugging configuration system was added to the Arduino
Platform Specification (https://github.com/arduino/arduino-cli/pull/882), the system has changed significantly, resulting in some of the documentation no longer being applicable to the current version of Arduino CLI.
* **What is the new behavior?**
<!-- if this is a feature change -->
The outdated information is removed, leaving the parts that are still correct.
Since the documentation is versioned, users of older Arduino CLI versions from before the system change still have easy access to that information.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
>Does this PR introduce a breaking change

no

>is titled accordingly

yes
* **Other information**:
<!-- Any additional information that could help the review process -->
 The new debug system will be fully documented at a later time.