### PR TITLE
[skip changelog] Update automation configs to use new label format

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,4 +7,4 @@ update_configs:
       - match:
           update_type: "security"
     default_labels:
-      - "component/dependencies"
+      - "topic: dependencies"

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,6 +7,10 @@ on:
   issue_comment:
     types: ["created"]
 
+env:
+  # Name of the label used to mark issues as stale.
+  STALE_LABEL: "status: stale"
+
 jobs:
   stale-bot:
     runs-on: ubuntu-latest
@@ -41,7 +45,7 @@ jobs:
               github.issues.addLabels({
                 ...context.repo,
                 issue_number: issue.number,
-                labels: ['stale']
+                labels: ['${{ env.STALE_LABEL }}']
               });
             }
 
@@ -52,7 +56,7 @@ jobs:
           github-token: ${{github.token}}
           script: |
             // Every time a comment is added to an issue, close it if it contains
-            // the `stale` label.
+            // the stale label.
 
             // Load issue's labels.
             const opts = github.issues.listLabelsOnIssue.endpoint.merge({
@@ -61,13 +65,13 @@ jobs:
             });
             const labels = await github.paginate(opts);
 
-            // Search for `stale`.
+            // Search for stale label.
             for (const label of labels) {
-              if (label.name === 'stale') {
+              if (label.name === '${{ env.STALE_LABEL }}') {
                 await github.issues.removeLabel({
                   ...context.repo,
                   issue_number: context.issue.number,
-                  name: 'stale'
+                  name: '${{ env.STALE_LABEL }}'
                 })
                 return;
               }
@@ -79,11 +83,11 @@ jobs:
         with:
           github-token: ${{github.token}}
           script: |
-            // Load all the `stale` issues
+            // Load all the stale issues
             const opts = github.issues.listForRepo.endpoint.merge({
               ...context.repo,
               state: 'open',
-              labels: ['stale'],
+              labels: ['${{ env.STALE_LABEL }}'],
             });
             const issues = await github.paginate(opts);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The Arduino Tooling repositories now use a "category: name" format for all repository labels. Dependabot and the
"stale-bot" workflow use label names that do not comply with the new format ("component/dependencies" and "stale").

* **What is the new behavior?**
<!-- if this is a feature change -->
The Dependabot and "stale-bot" configurations are updated to use the standardized label name format.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
>Does this PR introduce a breaking change

no

> is titled accordingly

yes
* **Other information**:
<!-- Any additional information that could help the review process -->
I took the liberty of de-"magic string"ing the "stale-bot" workflow.