### PR TITLE
[skip changelog] Document `sketch.always_export_binaries` configuration key

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,9 @@
 - `metrics` - settings related to the collection of data used for continued improvement of Arduino CLI.
   - `addr` - TCP port used for metrics communication.
   - `enabled` - controls the use of metrics.
+- `sketch` - configuration options relating to [Arduino sketches][sketch specification].
+  - `always_export_binaries` - set to `true` to make [`arduino-cli compile`][arduino-cli compile] always save binaries
+    to the sketch folder. This is the equivalent of using the [`--export-binaries`][arduino-cli compile options] flag.
 
 ## Configuration methods
 
@@ -131,6 +134,9 @@ additional_urls = [ "https://downloads.arduino.cc/packages/package_staging_index
 [grpc]: https://grpc.io
 [sketchbook directory]: sketch-specification.md#sketchbook
 [arduino cli lib install]: commands/arduino-cli_lib_install.md
+[sketch specification]: sketch-specification.md
+[arduino-cli compile]: commands/arduino-cli_compile.md
+[arduino-cli compile options]: commands/arduino-cli_compile.md#options
 [arduino-cli config dump]: commands/arduino-cli_config_dump.md
 [arduino cli command reference]: commands/arduino-cli.md
 [arduino-cli global flags]: commands/arduino-cli_config.md#options-inherited-from-parent-commands


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The existence and meaning of the `sketch.always_export_binaries` configuration key (https://github.com/arduino/arduino-cli/pull/1042) is undocumented.
* **What is the new behavior?**
<!-- if this is a feature change -->
The `sketch.always_export_binaries` configuration key is documented in the Arduino CLI Configuration page of the documentation website:
https://arduino.github.io/arduino-cli/dev/configuration/

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No