### PR TITLE
Bubble platform download error

### DIFF
--- a/commands/core/install.go
+++ b/commands/core/install.go
@@ -91,7 +91,10 @@ func installPlatform(pm *packagemanager.PackageManager,
 			return err
 		}
 	}
-	downloadPlatform(pm, platformRelease, downloadCB)
+	err := downloadPlatform(pm, platformRelease, downloadCB)
+	if err != nil {
+		return err
+	}
 	taskCB(&rpc.TaskProgress{Completed: true})
 
 	// Install tools first
@@ -114,7 +117,7 @@ func installPlatform(pm *packagemanager.PackageManager,
 	}
 
 	// Install
-	err := pm.InstallPlatform(platformRelease)
+	err = pm.InstallPlatform(platformRelease)
 	if err != nil {
 		log.WithError(err).Error("Cannot install platform")
 		return err


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
User experience improvement

- **What is the current behavior?**
Trying to install packages with `core install <fqdn>` is not helpful when downloading of the core file fails

* **What is the new behavior?**
Download errors are displayed to the user

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
no

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
