### PR TITLE
[skip changelog] Update "stale bot" GHA workflow to use new enabling label

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -8,6 +8,8 @@ on:
     types: ["created"]
 
 env:
+  # Name of the label that makes issues subject to the stale bot.
+  STALE_ENABLE_LABEL: "status: waiting for information"
   # Name of the label used to mark issues as stale.
   STALE_LABEL: "status: stale"
 
@@ -21,11 +23,11 @@ jobs:
         with:
           github-token: ${{github.token}}
           script: |
-            // Get a list of all open issues labeled `waiting for feedback`
+            // Get a list of all open issues labeled as waiting for feedback
             const opts = github.issues.listForRepo.endpoint.merge({
               ...context.repo,
               state: 'open',
-              labels: ['waiting for feedback'],
+              labels: ['${{ env.STALE_ENABLE_LABEL }}'],
             });
             const issues = await github.paginate(opts);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The "waiting for feedback" label was renamed "status: waiting for information" to comply with the standardized tooling
label system, but this label name was missed when updating the workflow to reflect the change (https://github.com/arduino/arduino-cli/pull/1213).

* **What is the new behavior?**
<!-- if this is a feature change -->
The correct issue label is used to enable the stale bot.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No breaking change.
* **Other information**:
<!-- Any additional information that could help the review process -->
https://github.com/arduino/arduino-cli/labels?q=%22status%3A+waiting+for+information%22