### PR TITLE
Fix core name not showing if installed.json is not found

### DIFF
--- a/arduino/cores/packagemanager/loader.go
+++ b/arduino/cores/packagemanager/loader.go
@@ -172,7 +172,6 @@ func (pm *PackageManager) loadPlatforms(targetPackage *cores.Package, packageDir
 				return fmt.Errorf("loading platform.txt: %w", err)
 			}
 
-			platformName := platformProperties.Get("name")
 			version := semver.MustParse(platformProperties.Get("version"))
 
 			// check if package_bundled_index.json exists
@@ -207,9 +206,6 @@ func (pm *PackageManager) loadPlatforms(targetPackage *cores.Package, packageDir
 			}
 
 			platform := targetPackage.GetOrCreatePlatform(architecture)
-			if platform.Name == "" {
-				platform.Name = platformName
-			}
 			if !isIDEBundled {
 				platform.ManuallyInstalled = true
 			}
@@ -287,6 +283,10 @@ func (pm *PackageManager) loadPlatformRelease(platform *cores.PlatformRelease, p
 		platform.Properties.Merge(p)
 	} else {
 		return fmt.Errorf("loading %s: %s", platformTxtLocalPath, err)
+	}
+
+	if platform.Platform.Name == "" {
+		platform.Platform.Name = platform.Properties.Get("name")
 	}
 
 	// Create programmers properties

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -469,3 +469,41 @@ def test_core_install_removes_unused_tools(run_command, data_dir):
 
     # Verifies tool is uninstalled since it's not used by newer core version
     assert not tool_path.exists()
+
+
+def test_core_list_with_installed_json(run_command, data_dir):
+    assert run_command("update")
+
+    # Install core
+    url = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json"
+    assert run_command(f"core update-index --additional-urls={url}")
+    assert run_command(f"core install adafruit:avr@1.4.13 --additional-urls={url}")
+
+    # Verifies installed core is correctly found and name is set
+    res = run_command("core list --format json")
+    assert res.ok
+    cores = json.loads(res.stdout)
+    mapped = {core["ID"]: core for core in cores}
+    assert len(mapped) == 1
+    assert "adafruit:avr" in mapped
+    assert mapped["adafruit:avr"]["Name"] == "Adafruit AVR Boards"
+
+    # Deletes installed.json file, this file stores information about the core,
+    # that is used mostly when removing package indexes and their cores are still installed;
+    # this way we don't lose much information about it.
+    # It might happen that the user has old cores installed before the addition of
+    # the installed.json file so we need to handle those cases.
+    installed_json = Path(data_dir, "packages", "adafruit", "hardware", "avr", "1.4.13", "installed.json")
+    installed_json.unlink()
+
+    # Verifies installed core is still found and name is set
+    res = run_command("core list --format json")
+    assert res.ok
+    cores = json.loads(res.stdout)
+    mapped = {core["ID"]: core for core in cores}
+    assert len(mapped) == 1
+    assert "adafruit:avr" in mapped
+    # Name for this core changes since if there's installed.json file we read it from
+    # platform.txt, turns out that this core has different names used in different files
+    # thus the change.
+    assert mapped["adafruit:avr"]["Name"] == "Adafruit Boards"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes a bug when loading installed cores.

- **What is the current behavior?**

`core list` doesn't return a core's name if that core folder doesn't contain an `installed.json` file and has been installed via CLI. Manually installed cores have their name correctly shown.

This also affects the gRPC interface.

* **What is the new behavior?**

`core list` now returns all cores' names even if `installed.json` file is not found. This also fixes the gRPC interface.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

It might happen that `platform.txt` and `installed.json` have different names for the same platform, thus it's not guaranted the name will be the same if those two files are not aligned. 
Fixing those platforms falls on their maintainers.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
