### PR TITLE
Fix casing of assembly sketch files

### DIFF
--- a/arduino/builder/sketch.go
+++ b/arduino/builder/sketch.go
@@ -187,7 +187,7 @@ func SketchLoad(sketchPath, buildPath string) (*sketch.Sketch, error) {
 		}
 
 		// ignore if file extension doesn't match
-		ext := strings.ToLower(filepath.Ext(path))
+		ext := filepath.Ext(path)
 		_, isMain := globals.MainFileValidExtensions[ext]
 		_, isAdditional := globals.AdditionalFileValidExtensions[ext]
 		if !(isMain || isAdditional) {

--- a/arduino/globals/globals.go
+++ b/arduino/globals/globals.go
@@ -35,13 +35,13 @@ var (
 		".hpp": empty,
 		".hh":  empty,
 		".cpp": empty,
-		".s":   empty,
+		".S":   empty,
 	}
 
 	// SourceFilesValidExtensions lists valid extensions for source files (no headers)
 	SourceFilesValidExtensions = map[string]struct{}{
 		".c":   empty,
 		".cpp": empty,
-		".s":   empty,
+		".S":   empty,
 	}
 )

--- a/arduino/sketch/sketch.go
+++ b/arduino/sketch/sketch.go
@@ -99,7 +99,7 @@ func New(sketchFolderPath, mainFilePath, buildPath string, allFilesPaths []strin
 	otherSketchFiles := []*Item{}
 	rootFolderFiles := []*Item{}
 	for p, item := range pathToItem {
-		ext := strings.ToLower(filepath.Ext(p))
+		ext := filepath.Ext(p)
 		if _, found := globals.MainFileValidExtensions[ext]; found {
 			// item is a valid main file, see if it's stored at the
 			// sketch root and ignore if it's not.

--- a/legacy/builder/builder.go
+++ b/legacy/builder/builder.go
@@ -31,8 +31,8 @@ import (
 )
 
 var MAIN_FILE_VALID_EXTENSIONS = map[string]bool{".ino": true, ".pde": true}
-var ADDITIONAL_FILE_VALID_EXTENSIONS = map[string]bool{".h": true, ".c": true, ".hpp": true, ".hh": true, ".cpp": true, ".s": true}
-var ADDITIONAL_FILE_VALID_EXTENSIONS_NO_HEADERS = map[string]bool{".c": true, ".cpp": true, ".s": true}
+var ADDITIONAL_FILE_VALID_EXTENSIONS = map[string]bool{".h": true, ".c": true, ".hpp": true, ".hh": true, ".cpp": true, ".S": true}
+var ADDITIONAL_FILE_VALID_EXTENSIONS_NO_HEADERS = map[string]bool{".c": true, ".cpp": true, ".S": true}
 
 const DEFAULT_DEBUG_LEVEL = 5
 const DEFAULT_WARNINGS_LEVEL = "none"

--- a/legacy/builder/create_cmake_rule.go
+++ b/legacy/builder/create_cmake_rule.go
@@ -32,7 +32,7 @@ import (
 	"github.com/arduino/arduino-cli/legacy/builder/utils"
 )
 
-var VALID_EXPORT_EXTENSIONS = map[string]bool{".h": true, ".c": true, ".hpp": true, ".hh": true, ".cpp": true, ".s": true, ".a": true, ".properties": true}
+var VALID_EXPORT_EXTENSIONS = map[string]bool{".h": true, ".c": true, ".hpp": true, ".hh": true, ".cpp": true, ".S": true, ".a": true, ".properties": true}
 var DOTHEXTENSION = map[string]bool{".h": true, ".hh": true, ".hpp": true}
 var DOTAEXTENSION = map[string]bool{".a": true}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes a bug with sketch files parsing.

- **What is the current behavior?**

Both `.s` and `.S` extensions are accepted as Sketch assembly files.

* **What is the new behavior?**

Now only `.S` extensions are accepted as Sketch files.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

This will also enforce lowercase for other files extensions.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
