### PR TITLE
Change `core search` to update indexes only after 24h from last edit

### DIFF
--- a/cli/core/search.go
+++ b/cli/core/search.go
@@ -18,17 +18,23 @@ package core
 import (
 	"context"
 	"os"
+	"path"
 	"sort"
 	"strings"
+	"time"
 
+	"github.com/arduino/arduino-cli/arduino/utils"
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
+	"github.com/arduino/arduino-cli/cli/globals"
 	"github.com/arduino/arduino-cli/cli/instance"
 	"github.com/arduino/arduino-cli/cli/output"
 	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/commands/core"
+	"github.com/arduino/arduino-cli/configuration"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/arduino-cli/table"
+	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -51,6 +57,9 @@ func initSearchCommand() *cobra.Command {
 	return searchCommand
 }
 
+// indexUpdateInterval specifies the time threshold over which indexes are updated
+const indexUpdateInterval = "24h"
+
 func runSearchCommand(cmd *cobra.Command, args []string) {
 	inst, err := instance.CreateInstance()
 	if err != nil {
@@ -58,12 +67,14 @@ func runSearchCommand(cmd *cobra.Command, args []string) {
 		os.Exit(errorcodes.ErrGeneric)
 	}
 
-	_, err = commands.UpdateIndex(context.Background(), &rpc.UpdateIndexRequest{
-		Instance: inst,
-	}, output.ProgressBar())
-	if err != nil {
-		feedback.Errorf("Error updating index: %v", err)
-		os.Exit(errorcodes.ErrGeneric)
+	if indexesNeedUpdating(indexUpdateInterval) {
+		_, err = commands.UpdateIndex(context.Background(), &rpc.UpdateIndexRequest{
+			Instance: inst,
+		}, output.ProgressBar())
+		if err != nil {
+			feedback.Errorf("Error updating index: %v", err)
+			os.Exit(errorcodes.ErrGeneric)
+		}
 	}
 
 	arguments := strings.ToLower(strings.Join(args, " "))
@@ -106,4 +117,50 @@ func (sr searchResults) String() string {
 		return t.Render()
 	}
 	return "No platforms matching your search."
+}
+
+// indexesNeedUpdating returns whether one or more index files need updating.
+// A duration string must be provided to calculate the time threshold
+// used to update the indexes, if the duration is not valid a default
+// of 24 hours is used.
+// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+func indexesNeedUpdating(duration string) bool {
+	indexpath := paths.New(configuration.Settings.GetString("directories.Data"))
+
+	now := time.Now()
+	modTimeThreshold, err := time.ParseDuration(duration)
+	// Not the most elegant way of handling this error
+	// but it does its job
+	if err != nil {
+		modTimeThreshold, _ = time.ParseDuration("24h")
+	}
+
+	urls := []string{globals.DefaultIndexURL}
+	urls = append(urls, configuration.Settings.GetStringSlice("board_manager.additional_urls")...)
+	for _, u := range urls {
+		URL, err := utils.URLParse(u)
+		if err != nil {
+			continue
+		}
+
+		if URL.Scheme == "file" {
+			// No need to update local files
+			continue
+		}
+
+		coreIndexPath := indexpath.Join(path.Base(URL.Path))
+		if coreIndexPath.NotExist() {
+			return true
+		}
+
+		info, err := coreIndexPath.Stat()
+		if err != nil {
+			return true
+		}
+
+		if now.After(info.ModTime().Add(modTimeThreshold)) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Changes an existing command.

- **What is the current behavior?**

Calling `core search` always updates the indexes.

* **What is the new behavior?**

Calling `core search` now only updates indexes if one or more of them are older than 24 hours. 

It's still possible to force an update by calling `core update-index` or `update`.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
