### PR TITLE
Fix sorting of platforms and boards

### DIFF
--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
@@ -151,7 +152,7 @@ func identify(pm *packagemanager.PackageManager, port *commands.BoardPort) ([]*r
 
 	// Sort by FQBN alphabetically
 	sort.Slice(boards, func(i, j int) bool {
-		return boards[i].Fqbn < boards[j].Fqbn
+		return strings.ToLower(boards[i].Fqbn) < strings.ToLower(boards[j].Fqbn)
 	})
 
 	// Put Arduino boards before others in case there are non Arduino boards with identical VID:PID combination

--- a/commands/core/list.go
+++ b/commands/core/list.go
@@ -17,6 +17,7 @@ package core
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/arduino/arduino-cli/commands"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
@@ -71,7 +72,7 @@ func GetPlatforms(req *rpc.PlatformListRequest) ([]*rpc.Platform, error) {
 	}
 	// Sort result alphabetically and put deprecated platforms at the bottom
 	sort.Slice(res, func(i, j int) bool {
-		return res[i].Name < res[j].Name
+		return strings.ToLower(res[i].Name) < strings.ToLower(res[j].Name)
 	})
 	sort.SliceStable(res, func(i, j int) bool {
 		if !res[i].Deprecated && res[j].Deprecated {

--- a/commands/core/search.go
+++ b/commands/core/search.go
@@ -117,7 +117,7 @@ func PlatformSearch(req *rpc.PlatformSearchRequest) (*rpc.PlatformSearchResponse
 	// Sort result alphabetically and put deprecated platforms at the bottom
 	sort.Slice(
 		out, func(i, j int) bool {
-			return out[i].Name < out[j].Name
+			return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
 		})
 	sort.SliceStable(
 		out, func(i, j int) bool {

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -550,8 +550,8 @@ def test_core_search_sorted_results(run_command, httpserver):
     deprecated = [l for l in lines if l[2].startswith("[DEPRECATED]")]
 
     # verify that results are already sorted correctly
-    assert not_deprecated == sorted(not_deprecated, key=lambda tokens: tokens[2])
-    assert deprecated == sorted(deprecated, key=lambda tokens: tokens[2])
+    assert not_deprecated == sorted(not_deprecated, key=lambda tokens: tokens[2].lower())
+    assert deprecated == sorted(deprecated, key=lambda tokens: tokens[2].lower())
 
     # verify that deprecated platforms are the last ones
     assert lines == not_deprecated + deprecated
@@ -565,8 +565,8 @@ def test_core_search_sorted_results(run_command, httpserver):
     deprecated = [p for p in platforms if p.get("deprecated")]
 
     # verify that results are already sorted correctly
-    assert not_deprecated == sorted(not_deprecated, key=lambda keys: keys["name"])
-    assert deprecated == sorted(deprecated, key=lambda keys: keys["name"])
+    assert not_deprecated == sorted(not_deprecated, key=lambda keys: keys["name"].lower())
+    assert deprecated == sorted(deprecated, key=lambda keys: keys["name"].lower())
     # verify that deprecated platforms are the last ones
     assert platforms == not_deprecated + deprecated
 
@@ -593,8 +593,8 @@ def test_core_list_sorted_results(run_command, httpserver):
     deprecated = [l for l in lines if l[3].startswith("[DEPRECATED]")]
 
     # verify that results are already sorted correctly
-    assert not_deprecated == sorted(not_deprecated, key=lambda tokens: tokens[3])
-    assert deprecated == sorted(deprecated, key=lambda tokens: tokens[3])
+    assert not_deprecated == sorted(not_deprecated, key=lambda tokens: tokens[3].lower())
+    assert deprecated == sorted(deprecated, key=lambda tokens: tokens[3].lower())
 
     # verify that deprecated platforms are the last ones
     assert lines == not_deprecated + deprecated
@@ -609,8 +609,8 @@ def test_core_list_sorted_results(run_command, httpserver):
     deprecated = [p for p in platforms if p.get("deprecated")]
 
     # verify that results are already sorted correctly
-    assert not_deprecated == sorted(not_deprecated, key=lambda keys: keys["name"])
-    assert deprecated == sorted(deprecated, key=lambda keys: keys["name"])
+    assert not_deprecated == sorted(not_deprecated, key=lambda keys: keys["name"].lower())
+    assert deprecated == sorted(deprecated, key=lambda keys: keys["name"].lower())
     # verify that deprecated platforms are the last ones
     assert platforms == not_deprecated + deprecated
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes an existing feature.

- **What is the current behavior?**

The `core list`, `core search` and `board list` commands return results sorted in alphabetical order but taking into account capitalized platform names and boards FQBNs.
For example:
```
$ arduino-cli core search
ID                    Version   Name                                                                    
arduino:avr           1.8.3     Arduino AVR Boards                                                                                    
arduino:sam           1.6.12    Arduino SAM Boards (32-bits ARM Cortex-M3)                                                   
arduino:megaavr       1.8.7     Arduino megaAVR Boards                                                  
arduino:nrf52         1.0.2     Arduino nRF52 Boards              
```


* **What is the new behavior?**

Now  `core list`, `core search` and `board list` commands return their results sorted in alphabetical order but in a case insensitive way.

This also affects the gRPC interface.

For  example:
```
$ arduino-cli core search
ID                    Version   Name                                                                    
arduino:avr           1.8.3     Arduino AVR Boards                                                      
arduino:megaavr       1.8.7     Arduino megaAVR Boards                                                  
arduino:nrf52         1.0.2     Arduino nRF52 Boards                                                    
arduino:sam           1.6.12    Arduino SAM Boards (32-bits ARM Cortex-M3)
```

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
