### PR TITLE
[skip changelog] Document sketch filename requirements

### DIFF
--- a/docs/sketch-specification.md
+++ b/docs/sketch-specification.md
@@ -5,16 +5,16 @@ The programs that run on Arduino boards are called "sketches". This term was inh
 
 ## Sketch folders and files
 
+The sketch root folder name and code file names must start with a basic letter (`A`-`Z` or `a`-`z`) or number (`0`-`9`),
+followed by basic letters, numbers, underscores (`_`), dots (`.`) and dashes (`-`). The maximum length is 63 characters.
+
+Support for names starting with a number was added in Arduino IDE 1.8.4.
+
 ### Sketch root folder
 
 Because many Arduino sketches only contain a single .ino file, it's easy to think of that file as the sketch. However,
 it is the folder that is the sketch. The reason is that sketches may consist of multiple code files and the folder is
 what groups those files into a single program.
-
-The sketch root folder name must start with a basic letter (`A`-`Z` or `a`-`z`) or number (`0`-`9`), followed by basic
-letters, numbers, underscores (`_`), dots (`.`) and dashes (`-`). The maximum length is 63 characters.
-
-Support for sketch folder names starting with a number was added in Arduino IDE 1.8.4.
 
 ### Primary sketch file
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
[The Arduino Sketch Specification](https://arduino.github.io/arduino-cli/latest/sketch-specification/#sketch-root-folder) only documents the requirements for sketch folder names. Since the primary sketch filename must match the folder name, this appears at a glance to be self-evident. However, sketches may consist of multiple code files, and so the specification was ambiguous regarding the naming requirements for additional files.
* **What is the new behavior?**
<!-- if this is a feature change -->
The specification documents that the same naming requirements apply to all sketch code files.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No breaking change.
* **Other information**:
<!-- Any additional information that could help the review process -->
Related: https://github.com/arduino/arduino-cli/pull/1194


---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
