### PR TITLE
Fix `network` settings uneditable with config command

### DIFF
--- a/cli/config/validate.go
+++ b/cli/config/validate.go
@@ -33,6 +33,8 @@ var validMap = map[string]reflect.Kind{
 	"sketch.always_export_binaries": reflect.Bool,
 	"metrics.addr":                  reflect.String,
 	"metrics.enabled":               reflect.Bool,
+	"network.proxy":                 reflect.String,
+	"network.user_agent_ext":        reflect.String,
 }
 
 func typeOf(key string) (reflect.Kind, error) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes a bug.

- **What is the current behavior?**

Calling `arduino-cli config add network.proxy http://<login>:<password>@myproxy.ext:port` returns `Settings key doesn't exist` error.

* **What is the new behavior?**

Calling `arduino-cli config add network.proxy http://<login>:<password>@myproxy.ext:port` sets correctly the `network.proxy` value.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

Fixes #1273

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
