### PR TITLE
Revert "Improved lib detection: check for matching name in library.properties (#1276)"

### DIFF
--- a/arduino/libraries/librariesresolver/cpp.go
+++ b/arduino/libraries/librariesresolver/cpp.go
@@ -121,7 +121,6 @@ func computePriority(lib *libraries.Library, header, arch string) int {
 	header = strings.TrimSuffix(header, filepath.Ext(header))
 	header = simplify(header)
 	name := simplify(lib.Name)
-	realName := simplify(lib.RealName)
 
 	priority := 0
 
@@ -138,17 +137,15 @@ func computePriority(lib *libraries.Library, header, arch string) int {
 		priority += 0
 	}
 
-	if realName == header && name == header {
-		priority += 600
-	} else if realName == header || name == header {
+	if name == header {
 		priority += 500
-	} else if realName == header+"-master" || name == header+"-master" {
+	} else if name == header+"-master" {
 		priority += 400
-	} else if strings.HasPrefix(realName, header) || strings.HasPrefix(name, header) {
+	} else if strings.HasPrefix(name, header) {
 		priority += 300
-	} else if strings.HasSuffix(realName, header) || strings.HasSuffix(name, header) {
+	} else if strings.HasSuffix(name, header) {
 		priority += 200
-	} else if strings.Contains(realName, header) || strings.Contains(name, header) {
+	} else if strings.Contains(name, header) {
 		priority += 100
 	}
 

--- a/arduino/libraries/librariesresolver/cpp_test.go
+++ b/arduino/libraries/librariesresolver/cpp_test.go
@@ -143,18 +143,3 @@ func TestCppHeaderResolver(t *testing.T) {
 	require.Equal(t, "Calculus Unified Lib", resolve("calculus_lib.h", l6, l7))
 	require.Equal(t, "Calculus Unified Lib", resolve("calculus_lib.h", l7, l6))
 }
-
-func TestCppHeaderResolverWithLibrariesInStrangeDirectoryNames(t *testing.T) {
-	resolver := NewCppResolver()
-	librarylist := libraries.List{}
-	librarylist.Add(&libraries.Library{Name: "onewire_2_3_4", RealName: "OneWire", Architectures: []string{"*"}})
-	librarylist.Add(&libraries.Library{Name: "onewireng_2_3_4", RealName: "OneWireNg", Architectures: []string{"avr"}})
-	resolver.headers["OneWire.h"] = librarylist
-	require.Equal(t, "onewire_2_3_4", resolver.ResolveFor("OneWire.h", "avr").Name)
-
-	librarylist2 := libraries.List{}
-	librarylist2.Add(&libraries.Library{Name: "OneWire", RealName: "OneWire", Architectures: []string{"*"}})
-	librarylist2.Add(&libraries.Library{Name: "onewire_2_3_4", RealName: "OneWire", Architectures: []string{"avr"}})
-	resolver.headers["OneWire.h"] = librarylist2
-	require.Equal(t, "OneWire", resolver.ResolveFor("OneWire.h", "avr").Name)
-}

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -998,31 +998,6 @@ def test_recompile_with_different_library(run_command, data_dir):
     assert f"Using previously compiled file: {obj_path}" not in res.stdout
 
 
-def test_compile_with_conflicting_libraries_include(run_command, data_dir, copy_sketch):
-    assert run_command("update")
-
-    assert run_command("core install arduino:avr@1.8.3")
-
-    # Install conflicting libraries
-    git_url = "https://github.com/pstolarz/OneWireNg.git"
-    one_wire_ng_lib_path = Path(data_dir, "libraries", "onewireng_0_8_1")
-    assert Repo.clone_from(git_url, one_wire_ng_lib_path, multi_options=["-b 0.8.1"])
-
-    git_url = "https://github.com/PaulStoffregen/OneWire.git"
-    one_wire_lib_path = Path(data_dir, "libraries", "onewire_2_3_5")
-    assert Repo.clone_from(git_url, one_wire_lib_path, multi_options=["-b v2.3.5"])
-
-    sketch_path = copy_sketch("sketch_with_conflicting_libraries_include")
-    fqbn = "arduino:avr:uno"
-
-    res = run_command(f"compile -b {fqbn} {sketch_path} --verbose")
-    assert res.ok
-    lines = [l.strip() for l in res.stdout.splitlines()]
-    assert 'Multiple libraries were found for "OneWire.h"' in lines
-    assert f"Used: {one_wire_lib_path}" in lines
-    assert f"Not used: {one_wire_ng_lib_path}" in lines
-
-
 def test_compile_with_invalid_build_options_json(run_command, data_dir):
     assert run_command("update")
 

--- a/test/testdata/sketch_with_conflicting_libraries_include/sketch_with_conflicting_libraries_include.ino
+++ b/test/testdata/sketch_with_conflicting_libraries_include/sketch_with_conflicting_libraries_include.ino
@@ -1,7 +1,0 @@
-#include "OneWire.h"
-
-void setup() {
-}
-
-void loop() {
-}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Reverts a fix that is causing unforeseen consequences.

- **What is the current behavior?**

Sketch compilation is broken for ESP32 boards when using a library that is installed both in the Sketchbook folder and the core folder. 

The reverted commit changed the way libraries are resolved so that the name set in the `library.properties` is checked to understand which library to included; the libraries included in the ESP32 core have a different name in `library.properties` because of legacy reasons from the Java IDE.

Compiling a Sketch that includes `OneWire.h` with both `OneWire` and `OneWireng` libraries installed compiles correctly.

* **What is the new behavior?**

Sketch compilation is not broken anymore for ESP32 boards when using a library that is installed both in the Sketchbook folder and the core folder. 

Compiling a Sketch that includes `OneWire.h` with both `OneWire` and `OneWireng` libraries installed doesn't compile anymore.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

No.

* **Other information**:

This reverts commit `15e81eddb96abfe99fe094db9a433965ea3c7ad7` from PR #1276.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
