### PR TITLE
[skip changelog] Add integration tests to avoid breaking compilation for esp cores

### DIFF
--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1022,3 +1022,83 @@ def test_compile_with_invalid_build_options_json(run_command, data_dir):
         f.write("invalid json")
 
     assert run_command(f"compile -b {fqbn} {sketch_path} --verbose")
+
+
+def test_compile_with_esp32_bundled_libraries(run_command, data_dir, copy_sketch):
+    # Some esp cores have have bundled libraries that are optimize for that architecture,
+    # it might happen that if the user has a library with the same name installed conflicts
+    # can ensue and the wrong library is used for compilation, thus it fails.
+    # This happens because for "historical" reasons these platform have their "name" key
+    # in the "library.properties" flag suffixed with "(esp32)" or similar even though that
+    # doesn't respect the libraries specification.
+    # https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format
+    #
+    # The reason those libraries have these suffixes is to avoid an annoying bug in the Java IDE
+    # that would have caused the libraries that are both bundled with the core and the Java IDE to be
+    # always marked as updatable. For more info see: https://github.com/arduino/Arduino/issues/4189
+    assert run_command("update")
+
+    # Update index with esp32 core and install it
+    url = "https://dl.espressif.com/dl/package_esp32_index.json"
+    core_version = "1.0.6"
+    assert run_command(f"core update-index --additional-urls={url}")
+    assert run_command(f"core install esp32:esp32@{core_version} --additional-urls={url}")
+
+    # Install a library with the same name as one bundled with the core
+    assert run_command("lib install SD")
+
+    sketch_path = copy_sketch("sketch_with_sd_library")
+    fqbn = "esp32:esp32:esp32"
+
+    res = run_command(f"compile -b {fqbn} {sketch_path} --verbose")
+    assert res.ok
+
+    core_bundled_lib_path = Path(data_dir, "packages", "esp32", "hardware", "esp32", core_version, "libraries", "SD")
+    cli_installed_lib_path = Path(data_dir, "libraries", "SD")
+    expected_output = [
+        'Multiple libraries were found for "SD.h"',
+        f" Used: {core_bundled_lib_path}",
+        f" Not used: {cli_installed_lib_path}",
+    ]
+    assert "\n".join(expected_output) in res.stdout
+
+
+def test_compile_with_esp8266_bundled_libraries(run_command, data_dir, copy_sketch):
+    # Some esp cores have have bundled libraries that are optimize for that architecture,
+    # it might happen that if the user has a library with the same name installed conflicts
+    # can ensue and the wrong library is used for compilation, thus it fails.
+    # This happens because for "historical" reasons these platform have their "name" key
+    # in the "library.properties" flag suffixed with "(esp32)" or similar even though that
+    # doesn't respect the libraries specification.
+    # https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format
+    #
+    # The reason those libraries have these suffixes is to avoid an annoying bug in the Java IDE
+    # that would have caused the libraries that are both bundled with the core and the Java IDE to be
+    # always marked as updatable. For more info see: https://github.com/arduino/Arduino/issues/4189
+    assert run_command("update")
+
+    # Update index with esp8266 core and install it
+    url = "http://arduino.esp8266.com/stable/package_esp8266com_index.json"
+    core_version = "2.7.4"
+    assert run_command(f"core update-index --additional-urls={url}")
+    assert run_command(f"core install esp8266:esp8266@{core_version} --additional-urls={url}")
+
+    # Install a library with the same name as one bundled with the core
+    assert run_command("lib install SD")
+
+    sketch_path = copy_sketch("sketch_with_sd_library")
+    fqbn = "esp8266:esp8266:generic"
+
+    res = run_command(f"compile -b {fqbn} {sketch_path} --verbose")
+    assert res.ok
+
+    core_bundled_lib_path = Path(
+        data_dir, "packages", "esp8266", "hardware", "esp8266", core_version, "libraries", "SD"
+    )
+    cli_installed_lib_path = Path(data_dir, "libraries", "SD")
+    expected_output = [
+        'Multiple libraries were found for "SD.h"',
+        f" Used: {core_bundled_lib_path}",
+        f" Not used: {cli_installed_lib_path}",
+    ]
+    assert "\n".join(expected_output) in res.stdout

--- a/test/testdata/sketch_with_sd_library/sketch_with_sd_library.ino
+++ b/test/testdata/sketch_with_sd_library/sketch_with_sd_library.ino
@@ -1,0 +1,8 @@
+
+#include <SD.h>
+
+void setup() {
+}
+
+void loop() {
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Adds some integrations tests.

- **What is the current behavior?**

N/A

* **What is the new behavior?**

N/A

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

These is related to #1290.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
