### PR TITLE
[skip changelog] Libraries install dir path is now canonical

### DIFF
--- a/arduino/libraries/loader.go
+++ b/arduino/libraries/loader.go
@@ -67,7 +67,7 @@ func makeNewLibrary(libraryDir *paths.Path, location LibraryLocation) (*Library,
 
 	library := &Library{}
 	library.Location = location
-	library.InstallDir = libraryDir
+	library.InstallDir = libraryDir.Canonical()
 	if libraryDir.Join("src").Exist() {
 		library.Layout = RecursiveLayout
 		library.SourceDir = libraryDir.Join("src")
@@ -127,7 +127,7 @@ func makeNewLibrary(libraryDir *paths.Path, location LibraryLocation) (*Library,
 
 func makeLegacyLibrary(path *paths.Path, location LibraryLocation) (*Library, error) {
 	library := &Library{
-		InstallDir:    path,
+		InstallDir:    path.Canonical(),
 		Location:      location,
 		SourceDir:     path,
 		Layout:        FlatLayout,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c
-	github.com/arduino/go-paths-helper v1.4.0
+	github.com/arduino/go-paths-helper v1.5.0
 	github.com/arduino/go-properties-orderedmap v1.3.0
 	github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b
 	github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/arduino/go-paths-helper v1.0.1/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3
 github.com/arduino/go-paths-helper v1.2.0/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3v5YYu35Yb+w31Ck=
 github.com/arduino/go-paths-helper v1.4.0 h1:ilnseAdxmN1bFnLxxXHRtcdmt9jBf3O4jtYfWfqule4=
 github.com/arduino/go-paths-helper v1.4.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
+github.com/arduino/go-paths-helper v1.5.0 h1:RVo189hD+GhUS1rQ3gixwK1nSbvVR8MGIGa7Gxv2bdM=
+github.com/arduino/go-paths-helper v1.5.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
 github.com/arduino/go-properties-orderedmap v1.3.0 h1:4No/vQopB36e7WUIk6H6TxiSEJPiMrVOCZylYmua39o=
 github.com/arduino/go-properties-orderedmap v1.3.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b h1:9hDi4F2st6dbLC3y4i02zFT5quS4X6iioWifGlVwfy4=

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -55,13 +55,13 @@ def data_dir(tmpdir_factory):
     # due to the above on Windows we cut the tmp path straight to /tmp/xxxxxxxx
     if platform.system() == "Windows":
         with tempfile.TemporaryDirectory() as tmp:
-            yield tmp
+            yield os.path.realpath(tmp)
             # We don't need to remove the directory since
             # tempfile.TemporaryDirectory deletes itself
             # automatically when exits its scope.
     else:
         data = tmpdir_factory.mktemp("ArduinoTest")
-        yield str(data)
+        yield os.path.realpath(data)
         shutil.rmtree(data, ignore_errors=True)
 
 
@@ -82,7 +82,7 @@ def downloads_dir(tmpdir_factory, worker_id):
             if not lock.is_file():
                 lock.touch()
 
-    yield str(download_dir)
+    yield os.path.realpath(download_dir)
     shutil.rmtree(download_dir, ignore_errors=True)
 
 
@@ -94,7 +94,7 @@ def working_dir(tmpdir_factory):
     at the end, this way all the tests work in isolation.
     """
     work_dir = tmpdir_factory.mktemp("ArduinoTestWork")
-    yield str(work_dir)
+    yield os.path.realpath(work_dir)
     shutil.rmtree(work_dir, ignore_errors=True)
 
 

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -928,7 +928,7 @@ def test_compile_with_library_priority(run_command, data_dir):
 
     # Manually installs a library
     git_url = "https://github.com/arduino-libraries/WiFi101.git"
-    manually_install_lib_path = os.path.realpath(Path(data_dir, "my-libraries", "WiFi101"))
+    manually_install_lib_path = Path(data_dir, "my-libraries", "WiFi101")
     assert Repo.clone_from(git_url, manually_install_lib_path, multi_options=["-b 0.16.1"])
 
     # Install the same library we installed manually
@@ -946,7 +946,7 @@ def test_compile_with_library_priority(run_command, data_dir):
 
     res = run_command(f"compile -b {fqbn} {sketch_path} --library {manually_install_lib_path} -v")
     assert res.ok
-    cli_installed_lib_path = os.path.realpath(Path(data_dir, "libraries", "WiFi101"))
+    cli_installed_lib_path = Path(data_dir, "libraries", "WiFi101")
     expected_output = [
         'Multiple libraries were found for "WiFi101.h"',
         f" Used: {manually_install_lib_path}",

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -928,7 +928,7 @@ def test_compile_with_library_priority(run_command, data_dir):
 
     # Manually installs a library
     git_url = "https://github.com/arduino-libraries/WiFi101.git"
-    manually_install_lib_path = Path(data_dir, "my-libraries", "WiFi101")
+    manually_install_lib_path = os.path.realpath(Path(data_dir, "my-libraries", "WiFi101"))
     assert Repo.clone_from(git_url, manually_install_lib_path, multi_options=["-b 0.16.1"])
 
     # Install the same library we installed manually
@@ -946,7 +946,7 @@ def test_compile_with_library_priority(run_command, data_dir):
 
     res = run_command(f"compile -b {fqbn} {sketch_path} --library {manually_install_lib_path} -v")
     assert res.ok
-    cli_installed_lib_path = Path(data_dir, "libraries", "WiFi101")
+    cli_installed_lib_path = os.path.realpath(Path(data_dir, "libraries", "WiFi101"))
     expected_output = [
         'Multiple libraries were found for "WiFi101.h"',
         f" Used: {manually_install_lib_path}",

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -581,7 +581,7 @@ def test_compile_with_archives_and_long_paths(run_command):
     assert run_command("update")
 
     # Install core to compile
-    assert run_command("core install esp8266:esp8266")
+    assert run_command("core install esp8266:esp8266@2.7.4")
 
     # Install test library
     assert run_command("lib install ArduinoIoTCloud")


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes issues with testing on Windows.

- **What is the current behavior?**

The Workflow runners use 8.3 style naming convention for paths on Windows, see an example below.

Libraries install directory path is saved using the 8.3 style, this causes problems when trying to verify that a certain path is returned in the output of certain commands on Windows.

```
# 8.3 style path
C:\\Users\\RUNNER~1\\AppData\\Local

# Canonical
C:\\Users\\runneradmin\\AppData\\Local
```

* **What is the new behavior?**

All libraries install directory paths are canonicalized so the 8.3 style path is not printed on Windows.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

No.

* **Other information**:

We'll need to rebase #1291 after this is merged.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
