### PR TITLE
[skip changelog] Use new arduino/setup-task action name in CI/CD workflows

### DIFF
--- a/.github/workflows/i18n-nightly-push.yaml
+++ b/.github/workflows/i18n-nightly-push.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version: "1.14"
 
       - name: Install Taskfile
-        uses: Arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/i18n-weekly-pull.yaml
+++ b/.github/workflows/i18n-weekly-pull.yaml
@@ -25,7 +25,7 @@ jobs:
           go get github.com/cmaglie/go.rice/rice
 
       - name: Install Taskfile
-        uses: Arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/link-validation.yaml
+++ b/.github/workflows/link-validation.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install Taskfile
-        uses: Arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: Arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: Arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           changelog-file-path: "dist/CHANGELOG.md"
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
 
       - name: Install Taskfile
-        uses: Arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -124,7 +124,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/validate-docs.yaml
+++ b/.github/workflows/validate-docs.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: Arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/verify-formatting.yaml
+++ b/.github/workflows/verify-formatting.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: Arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
enhancement
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
An unmaintained, deprecated, and outdated version of the action used to install Task is in use in the CI/CD workflows.
-  **What is the new behavior?**
<!-- if this is a feature change -->
The GitHub Actions action for installing [Task](https://taskfile.dev/#/) has graduated from its original home in [the experimental `arduino/action`repository](https://github.com/arduino/actions) with a move to a dedicated permanent repository at [`arduino/setup-task`](https://github.com/arduino/setup-task).

A [1.0.0 release](https://github.com/arduino/setup-task/releases/tag/v1.0.0) has been made and [a `v1` ref](https://github.com/arduino/setup-task/tree/v1) that will track all releases in the major version 1 series. Use of the action's major version ref will cause the workflow to benefit from ongoing development to the action at each [patch or minor release](https://semver.org/) up until such time as a new major release is made. At this time the user will be given the opportunity to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before manually updating the major ref in the workflows (e.g., `uses: arduino/setup-task@v2`).
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
