### PR TITLE
Add to docs install variant via MacPorts

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,9 +7,18 @@ brew update
 brew install arduino-cli
 ```
 
+### Install via MacPorts (macOS)
+
+The Arduino CLI is available as a MacPorts port since version `0.18.1`:
+
+```
+sudo port selfupdate
+sudo port install arduino-cli
+```
+
 #### Command line completion
 
-[Command line completion](command-line-completion.md#brew) files are already bundled in the homebrew installation.
+[Command line completion](command-line-completion.md#brew) files are already bundled in the Homebrew and MacPorts installation.
 
 ### Use the install script
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
[docs update] Add install variant via MacPorts to the docs/installation.md

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No

* **Other information**:
<!-- Any additional information that could help the review process -->

I'm a maintainer of the [arduino-cli](https://ports.macports.org/port/arduino-cli) port over at MacPorts. I've added the install variant via MacPorts to the docs/installation.md.

Thank you for maintaining this amazing project.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
