### PR TITLE
Fixes installation using wget

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -122,7 +122,8 @@ getFile() {
 	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
 		httpStatusCode=$(curl -s -w '%{http_code}' -L "$url" -o "$filePath")
 	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-		body=$(wget --server-response --content-on-error -q -O "$filePath" "$url")
+		tmpFile=$(mktemp)
+		body=$(wget --server-response --content-on-error -q -O "$filePath" "$url" 2> $tmpFile || true)
 		httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
 	fi
 	echo "$httpStatusCode"


### PR DESCRIPTION
Fixes an issue where during installation using wget an
uninitialized variable was read which caused the process to
get stuck.

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
Bug fix

- **What is the current behavior?**
When installing using wget the process gets stuck because output is redirected
incorrectly and an initialized variable is read.

* **What is the new behavior?**
Installation using wget now works properly.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
Does not introduce a breaking change.

* **Other information**:


---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
