### PR TITLE
[skip changelog] Document "Library Name Priority"

### DIFF
--- a/docs/sketch-build-process.md
+++ b/docs/sketch-build-process.md
@@ -54,7 +54,10 @@ following rules, one by one in this order, until a rule determines a winner:
 
 1. A library that is architecture compatible wins against a library that is not architecture compatible (see
    [**Architecture Matching**](#architecture-matching))
-1. A library that has better "folder name priority" wins (see [**Folder Name Priority**](#folder-name-priority))
+1. A library with both [library name](#library-name-priority) and [folder name](#folder-name-priority) matching the
+   include wins
+1. A library that has better "library name priority" or "folder name priority" wins (see
+   [**Library Name Priority**](#library-name-priority) and [**Folder Name Priority**](#folder-name-priority))
 1. A library that is architecture optimized wins against a library that is not architecture optimized (see
    [**Architecture Matching**](#architecture-matching))
 1. A library that has a better "location priority" wins (see [**Location Priority**](#location-priority))
@@ -85,6 +88,21 @@ Examples:
 | `architectures=*,esp8266`                     | YES                   | NO                  |
 | `architectures=avr,esp8266`                   | YES                   | YES                 |
 | `architectures=samd`                          | NO                    | NO                  |
+
+### Library Name Priority
+
+A library's name is defined by the [library.properties](library-specification.md#libraryproperties-file-format) `name`
+field. That value is sanitized by replacing spaces with `_` before comparing it to the file name of the include.
+
+The "library name priority" is determined as follows (in order of highest to lowest priority):
+
+| Rule                                                                      | Example for `Arduino_Low_Power.h` |
+| ------------------------------------------------------------------------- | --------------------------------- |
+| The library name matches the include 100%                                 | `Arduino Low Power`               |
+| The library name matches the include 100%, except with a `-master` suffix | `Arduino Low Power-master`        |
+| The library name has a matching prefix                                    | `Arduino Low Power Whatever`      |
+| The library name has a matching suffix                                    | `Awesome Arduino Low Power`       |
+| The library name contains the include                                     | `The Arduino Low Power Lib`       |
 
 ### Folder Name Priority
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
When multiple libraries contain files matching an `#include` directive, Arduino CLI must pick one. Multiple factors are
used in order to make an intelligent determination of which library is best. In order to enhance this determination, the
library.properties `name` value is now one of those factors (https://github.com/arduino/arduino-cli/pull/1300). The other factors are already documented in the "Sketch Build Process" documentation, but this newly added feature was previously undocumented.

* **What is the new behavior?**
<!-- if this is a feature change -->
The "Library Name Priority" dependency resolution factor is fully documented in the "Sketch Build Process" documentation,
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No breaking
* **Other information**:
<!-- Any additional information that could help the review process -->
I used the "Arduino Low Power" library in the examples rather than following the convention of using the "Servo" library because I wanted to make it clear how spaces are handled.

Related: https://github.com/arduino/arduino-cli/issues/1292