### PR TITLE
[skip changelog] Quote all variables in GitHub Actions workflow shell commands

### DIFF
--- a/.github/workflows/arduino-stats.yaml
+++ b/.github/workflows/arduino-stats.yaml
@@ -28,7 +28,7 @@ jobs:
           # Fetch jq 1.6 as VM has only 1.5 ATM
           wget -q https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O jq
           chmod +x jq
-          PATH=${{ github.workspace }}:$PATH
+          PATH="${{ github.workspace }}:$PATH"
           .github/tools/fetch_athena_stats.sh
 
       - name: Send metrics

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -55,12 +55,12 @@ jobs:
           KEYCHAIN: "sign.keychain"
           INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
         run: |
-          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > ${{ env.INSTALLER_CERT_MAC_PATH }}
-          security create-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
-          security default-keychain -s ${{ env.KEYCHAIN }}
-          security unlock-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
-          security import ${{ env.INSTALLER_CERT_MAC_PATH }} -k ${{ env.KEYCHAIN }} -f pkcs12 -A -T /usr/bin/codesign -P ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
-          security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
+          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > "${{ env.INSTALLER_CERT_MAC_PATH }}"
+          security create-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security default-keychain -s "${{ env.KEYCHAIN }}"
+          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security import "${{ env.INSTALLER_CERT_MAC_PATH }}" -k "${{ env.KEYCHAIN }}" -f pkcs12 -A -T /usr/bin/codesign -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${{ secrets.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
 
       - name: Install gon for code signing and app notarization
         run: |
@@ -83,10 +83,10 @@ jobs:
           # so we need to add execution permission back until @v2 actions are released.
           chmod +x dist/arduino-cli_osx_darwin_amd64/arduino-cli
           PACKAGE_FILENAME="$(basename dist/arduino-cli_${{ github.workflow }}-*_macOS_64bit.tar.gz)"
-          tar -czvf dist/$PACKAGE_FILENAME \
+          tar -czvf "dist/$PACKAGE_FILENAME" \
           -C dist/arduino-cli_osx_darwin_amd64/  arduino-cli   \
           -C ../../ LICENSE.txt
-          CLI_CHECKSUM=$(shasum -a 256 dist/$PACKAGE_FILENAME | cut -d " " -f 1)
+          CLI_CHECKSUM="$(shasum -a 256 "dist/$PACKAGE_FILENAME" | cut -d " " -f 1)"
           perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CLI_CHECKSUM}  ${PACKAGE_FILENAME}/g;" dist/*-checksums.txt
 
       - name: Upload artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,12 +58,12 @@ jobs:
           KEYCHAIN: "sign.keychain"
           INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
         run: |
-          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > ${{ env.INSTALLER_CERT_MAC_PATH }}
-          security create-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
-          security default-keychain -s ${{ env.KEYCHAIN }}
-          security unlock-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
-          security import ${{ env.INSTALLER_CERT_MAC_PATH }} -k ${{ env.KEYCHAIN }} -f pkcs12 -A -T /usr/bin/codesign -P ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
-          security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
+          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > "${{ env.INSTALLER_CERT_MAC_PATH }}"
+          security create-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security default-keychain -s "${{ env.KEYCHAIN }}"
+          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security import "${{ env.INSTALLER_CERT_MAC_PATH }}" -k "${{ env.KEYCHAIN }}" -f pkcs12 -A -T /usr/bin/codesign -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${{ secrets.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
 
       - name: Install gon for code signing and app notarization
         run: |
@@ -85,11 +85,11 @@ jobs:
           # GitHub's upload/download-artifact@v1 actions don't preserve file permissions,
           # so we need to add execution permission back until @v2 actions are released.
           chmod +x dist/arduino-cli_osx_darwin_amd64/arduino-cli
-          TAG=${GITHUB_REF/refs\/tags\//}
-          tar -czvf dist/arduino-cli_${TAG}_macOS_64bit.tar.gz \
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          tar -czvf "dist/arduino-cli_${TAG}_macOS_64bit.tar.gz" \
           -C dist/arduino-cli_osx_darwin_amd64/  arduino-cli   \
           -C ../../ LICENSE.txt
-          CLI_CHECKSUM=$(shasum -a 256 dist/arduino-cli_${TAG}_macOS_64bit.tar.gz | cut -d " " -f 1)
+          CLI_CHECKSUM="$(shasum -a 256 "dist/arduino-cli_${TAG}_macOS_64bit.tar.gz" | cut -d " " -f 1)"
           perl -pi -w -e "s/.*arduino-cli_${TAG}_macOS_64bit.tar.gz/${CLI_CHECKSUM}  arduino-cli_${TAG}_macOS_64bit.tar.gz/g;" dist/*-checksums.txt
 
       - name: Upload artifacts
@@ -116,11 +116,11 @@ jobs:
       - name: Read CHANGELOG
         id: changelog
         run: |
-          body=$(cat dist/CHANGELOG.md)
+          body="$(cat dist/CHANGELOG.md)"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
-          echo $body
+          echo "$body"
           echo "::set-output name=BODY::$body"
 
       - name: Identify Prerelease
@@ -130,7 +130,7 @@ jobs:
         run: |
           wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.0.0.zip
           unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
-          if [[ $(/tmp/semver get prerel ${GITHUB_REF/refs\/tags\//}) ]]; then echo "::set-output name=IS_PRE::true"; fi
+          if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 
       - name: Create Github Release
         id: create_release


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Unquoted variables in shell commands can result in very confusing bugs caused by unexpected interpretation of characters
in the variable contents by the shell, such as [globbing and word splitting](https://github.com/koalaman/shellcheck/wiki/SC2086).

The immediate motivation for this change is that the unquoted certificate password for the macOS notarization [guaranteed someone a headache](https://github.com/arduino/arduino-lint/pull/140) when the password wasn't so well behaved as the author of the previously fragile command had assumed:
```
security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)
```

* **What is the new behavior?**
<!-- if this is a feature change -->
All variables used in shell command of the GitHub Actions workflows are quoted.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No breaky.
* **Other information**:
<!-- Any additional information that could help the review process -->
I verified the changes by running the release workflows using my macOS certificate: 
- nightly: https://github.com/per1234/arduino-cli/actions/runs/890102262
- tagged: https://github.com/per1234/arduino-cli/releases/tag/0.42.0-rc1
