### PR TITLE
[skip changelog] Remove redundant artifact upload from test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -182,12 +182,6 @@ jobs:
           name: Linux_ARM64
           path: dist/*Linux_ARM64.tar.gz
 
-      - name: Upload Linux ARM64 bit artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: Linux_ARM64
-          path: dist/*Linux_ARM64.tar.gz
-
       - name: Upload MacOS 64 bit artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
There are two steps in the test workflow for the Linux ARM64 artifact upload:
- https://github.com/arduino/arduino-cli/blob/5115d44c70ebd1356fda7f3b5a8ca612e9499742/.github/workflows/test.yaml#L179
- https://github.com/arduino/arduino-cli/blob/5115d44c70ebd1356fda7f3b5a8ca612e9499742/.github/workflows/test.yaml#L185

Although it does no real harm since it simply replaces the artifact from the first upload with a duplicate, it does slow down the workflow and makes the workflow slightly more difficult to maintain.

* **What is the new behavior?**
<!-- if this is a feature change -->
There is only a single upload of the Linux ARM64 artifact.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No break.
