### PR TITLE
[skip changelog] Specify that `includes` field items should be in library

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -79,9 +79,9 @@ otherwise below, **all fields are required**. The available fields are:
     <!-- prettier-ignore -->
   files in the linker command directly, all .o files are saved into a .a file, which is then included in the linker
   command. [1.5 format library folder structure](#layout-of-folders-and-files) is required.
-- **includes** - **(available from Arduino IDE 1.6.10)** (optional) a comma separated list of files to be added to the
-  sketch as `#include <...>` lines. This property is used with the "Include library" command in the Arduino IDE. If the
-  `includes` property is missing, all the header files (.h) on the root source folder are included.
+- **includes** - **(available from Arduino IDE 1.6.10)** (optional) a comma separated list of files of the library to be
+  added to the sketch as `#include <...>` lines. This property is used with the "Include library" command in the Arduino
+  IDE. If the `includes` property is missing, all the header files (.h) on the root source folder are included.
 - **precompiled** - **(available from Arduino IDE 1.8.6/arduino-builder 1.4.0)** (optional) enables support for .a
   (archive) and .so (shared object) files. See the ["Precompiled binaries"](#precompiled-binaries) section for
   documentation of the required location in the library for these files. The static library should be linked as an


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The [library.properties](https://arduino.github.io/arduino-cli/dev/library-specification/#library-metadata) `includes` field specifies a custom list of files to be added to the sketch by the IDE as `#include` directives. Library authors sometimes add filenames from library dependencies to this field. However, that doesn't make any sense because all Arduino development software versions with support for the `includes` field also have support for resolution of the dependencies of libraries, meaning that there is no need for these library dependency `#include` directives to be placed in the sketch.

For this reason, Arduino Lint [rule `LP052`](https://github.com/arduino/arduino-lint/blob/1.1.3/internal/rule/ruleconfiguration/ruleconfiguration.go#L1089) ("library.properties includes field item(s) not found in library.") was configured to be an error when the tool's [compliance setting](https://arduino.github.io/arduino-lint/1.1/#compliance-setting) is at the default "specification" level.

The required rules in "specification" mode are intended to match [the official Arduino Library Specification](https://arduino.github.io/arduino-cli/dev/library-specification), however, the is currently no mention in the Arduino Library Specification of any restrictions on the contents of the library.properties `includes` field.

* **What is the new behavior?**
<!-- if this is a feature change -->
The Arduino Library Specification's documentation of the `includes` field mentions that it should contain files of the library itself.

Since this requirement is fairly common sense, and the format of the library.properties fields documentation somewhat
constraining, I attempted to document it with minimal verbosity.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
Not a breaking change.
