### PR TITLE
Replace "Arduino Pro IDE" with proper link to Arduino IDE 2.0

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -7,7 +7,9 @@ This is the specification for the Arduino library format, to be used with Arduin
 
 This new library format is intended to be used in tandem with **Library Manager**, available since Arduino IDE 1.6.2.
 The Library Manager allows users to automatically download and install libraries needed in their projects, with an easy
-to use graphical interface in the [Arduino IDE](https://www.arduino.cc/en/guide/libraries#toc3)/[Arduino IDE 2.0](https://www.arduino.cc/en/Tutorial/getting-started-with-ide-v2/ide-v2-installing-a-library#installing-a-library) and
+to use graphical interface in the
+[Arduino IDE](https://www.arduino.cc/en/guide/libraries#toc3)/[Arduino IDE 2.0](https://www.arduino.cc/en/Tutorial/getting-started-with-ide-v2/ide-v2-installing-a-library#installing-a-library)
+and
 [Arduino Web Editor](https://create.arduino.cc/projecthub/Arduino_Genuino/getting-started-with-arduino-web-editor-on-various-platforms-4b3e4a#toc-libraries-and-the-arduino-web-editor-11)
 as well as [`arduino-cli lib`](commands/arduino-cli_lib.md).
 

--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -7,7 +7,7 @@ This is the specification for the Arduino library format, to be used with Arduin
 
 This new library format is intended to be used in tandem with **Library Manager**, available since Arduino IDE 1.6.2.
 The Library Manager allows users to automatically download and install libraries needed in their projects, with an easy
-to use graphical interface in the [Arduino IDE](https://www.arduino.cc/en/guide/libraries#toc3)/Pro IDE and
+to use graphical interface in the [Arduino IDE](https://www.arduino.cc/en/guide/libraries#toc3)/[Arduino IDE 2.0](https://www.arduino.cc/en/Tutorial/getting-started-with-ide-v2/ide-v2-installing-a-library#installing-a-library) and
 [Arduino Web Editor](https://create.arduino.cc/projecthub/Arduino_Genuino/getting-started-with-arduino-web-editor-on-various-platforms-4b3e4a#toc-libraries-and-the-arduino-web-editor-11)
 as well as [`arduino-cli lib`](commands/arduino-cli_lib.md).
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

- **What is the current behavior?**
<!-- You can also link to an open issue here -->

* **What is the new behavior?**
<!-- if this is a feature change -->

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
