### PR TITLE
add runtime.os property in `upload` sub-command

### DIFF
--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -205,6 +205,7 @@ func runProgramAction(pm *packagemanager.PackageManager,
 	if uploadToolPlatform != nil {
 		uploadProperties.Merge(uploadToolPlatform.Properties)
 	}
+	uploadProperties.Set("runtime.os", properties.GetOSSuffix())
 	uploadProperties.Merge(boardPlatform.Properties)
 	uploadProperties.Merge(boardPlatform.RuntimeProperties())
 	uploadProperties.Merge(boardProperties)


### PR DESCRIPTION
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**

Bug fix for #1198

- **What is the current behavior?**

`arduino-cli upload` command failed.
`runtime.os` property is not substituted for properties in `upload` sub-command execution.

* **What is the new behavior?**

`arduino-cli upload` command will succeed.
`runtime.os` property substitute for properties.

* **Other information:**

When you upload a program, it works as expected within Arduino IDE (V1.18.X) environment.
This fix improves the compatibility of the Arduino IDE (V1.18.X).