### PR TITLE
Fix upload waiting for port without 1200bps touch

### DIFF
--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -292,13 +292,15 @@ func runProgramAction(pm *packagemanager.PackageManager,
 	// to set the board in bootloader mode
 	actualPort := port
 	if programmer == nil && !burnBootloader {
-		// Perform reset via 1200bps touch if requested and wait for upload port if requested.
 
+		// Perform reset via 1200bps touch if requested and wait for upload port also if requested.
 		touch := uploadProperties.GetBoolean("upload.use_1200bps_touch")
-		wait := uploadProperties.GetBoolean("upload.wait_for_upload_port")
+		wait := false
 		portToTouch := ""
 		if touch {
 			portToTouch = port
+			// Waits for upload port only if a 1200bps touch is done
+			wait = uploadProperties.GetBoolean("upload.wait_for_upload_port")
 		}
 
 		// if touch is requested but port is not specified, print a warning


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes an upload bug.

- **What is the current behavior?**

If a platform has set `upload.wait_for_upload_port` property to `true` in the `boards.txt` without setting also `upload.use_1200bps_touch` to `true` the CLI waits for the port anyway even if it's not necessary.

* **What is the new behavior?**

`upload.wait_for_upload_port` property now defaults to `false` and is set only if `upload.use_1200bps_touch` is `true` as is documented right now: https://arduino.github.io/arduino-cli/dev/platform-specification/#1200-bps-bootloader-reset

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

Fixes #1318.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
