### PR TITLE
Fix empty name on manually installed platforms without platform.txt

### DIFF
--- a/arduino/cores/packagemanager/loader.go
+++ b/arduino/cores/packagemanager/loader.go
@@ -320,7 +320,14 @@ func (pm *PackageManager) loadPlatformRelease(platform *cores.PlatformRelease, p
 	}
 
 	if platform.Platform.Name == "" {
-		platform.Platform.Name = platform.Properties.Get("name")
+		if name, ok := platform.Properties.GetOk("name"); ok {
+			platform.Platform.Name = name
+		} else {
+			// If the platform.txt file doesn't exist for this platform and it's not in any
+			// package index there is no way of retrieving its name, so we build one using
+			// the available information, that is the packager name and the architecture.
+			platform.Platform.Name = fmt.Sprintf("%s-%s", platform.Platform.Package.Name, platform.Platform.Architecture)
+		}
 	}
 
 	// Create programmers properties

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -648,3 +648,30 @@ def test_core_list_deprecated_platform_with_installed_json(run_command, httpserv
     platforms = json.loads(result.stdout)
     assert len(platforms) == 1
     assert platforms[0]["deprecated"]
+
+
+def test_core_list_platform_without_platform_txt(run_command, data_dir):
+    assert run_command("update")
+
+    # Verifies no core is installed
+    res = run_command("core list --format json")
+    assert res.ok
+    cores = json.loads(res.stdout)
+    assert len(cores) == 0
+
+    # Simulates creation of a new core in the sketchbook hardware folder
+    # without a platforms.txt
+    test_boards_txt = Path(__file__).parent / "testdata" / "boards.local.txt"
+    boards_txt = Path(data_dir, "hardware", "some-packager", "some-arch", "boards.txt")
+    boards_txt.parent.mkdir(parents=True, exist_ok=True)
+    boards_txt.touch()
+    boards_txt.write_bytes(test_boards_txt.read_bytes())
+
+    # Verifies no core is installed
+    res = run_command("core list --format json")
+    assert res.ok
+    cores = json.loads(res.stdout)
+    assert len(cores) == 1
+    core = cores[0]
+    assert core["id"] == "some-packager:some-arch"
+    assert core["name"] == "some-packager-some-arch"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Bug fix.

- **What is the current behavior?**

If a platform installed manually in the Sketchbook hardware folder doesn't have a `platform.txt` file its name will be empty.

```
$ arduino-cli core list                                                                                                                                                                                     
ID                            Installed Latest Name                                                                                                                                                 
arduino-beta-development:samd                                                                                                                                                                       
arduino:avr                   1.8.3     1.8.3  Arduino AVR Boards
```

The above `arduino-beta-development:samd` platform is installed in `~/Arduino/hardware/arduino-beta-development/samd`.

* **What is the new behavior?**

If a platform installed manually in the Sketchbook hardware folder doesn't have a `platform.txt` file its name will be composed by the packager name and the architecture separated by an hyphen (`-`).

```
$ arduino-cli core list
ID                            Installed Latest Name                         
arduino:avr                   1.8.3     1.8.3  Arduino AVR Boards           
arduino-beta-development:samd                  arduino-beta-development-samd
```

The above `arduino-beta-development:samd` platform is installed in `~/Arduino/hardware/arduino-beta-development/samd`, so `arduino-beta-development` is assumed to be the packager and `samd` the architecture.


- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

This is the same behaviour of the Java IDE and affects the gRPC interface so it will be fixed in the IDE 2 too.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
