### PR TITLE
[skip changelog] Fix burn-bootloader command example

### DIFF
--- a/cli/burnbootloader/burnbootloader.go
+++ b/cli/burnbootloader/burnbootloader.go
@@ -41,7 +41,7 @@ func NewCommand() *cobra.Command {
 		Use:     "burn-bootloader",
 		Short:   "Upload the bootloader.",
 		Long:    "Upload the bootloader on the board using an external programmer.",
-		Example: "  " + os.Args[0] + " burn-bootloader -b arduino:avr:uno -P atmel-ice",
+		Example: "  " + os.Args[0] + " burn-bootloader -b arduino:avr:uno -P atmel_ice",
 		Args:    cobra.MaximumNArgs(1),
 		Run:     run,
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes a command example.

- **What is the current behavior?**

`arduino-cli burn-bootloader --help` prints this as an example:

```
Examples:
  arduino-cli burn-bootloader -b arduino:avr:uno -P atmel-ice
```

The programmer ID `atmel-ice` doesn't exist.

* **What is the new behavior?**

`arduino-cli burn-bootloader --help` now prints the correct programmer ID in the example:

```
Examples:
  arduino-cli burn-bootloader -b arduino:avr:uno -P atmel_ice
```

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

Closes #1323.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
