### PR TITLE
[skip changelog] Change discoveries not starting when created

### DIFF
--- a/arduino/discovery/discovery.go
+++ b/arduino/discovery/discovery.go
@@ -89,9 +89,6 @@ func New(id string, args ...string) (*PluggableDiscovery, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := proc.Start(); err != nil {
-		return nil, err
-	}
 	messageChan := make(chan *discoveryMessage)
 	disc := &PluggableDiscovery{
 		id:                   id,
@@ -201,9 +198,20 @@ func (disc *PluggableDiscovery) sendCommand(command string) error {
 	}
 }
 
-// Hello sends the HELLO command to the discovery to agree on the pluggable discovery protocol. This
-// must be the first command to run in the communication with the discovery.
-func (disc *PluggableDiscovery) Hello() error {
+func (disc *PluggableDiscovery) runProcess() error {
+	if err := disc.process.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Run starts the discovery executable process and sends the HELLO command to the discovery to agree on the
+// pluggable discovery protocol. This must be the first command to run in the communication with the discovery.
+func (disc *PluggableDiscovery) Run() error {
+	if err := disc.runProcess(); err != nil {
+		return err
+	}
+
 	if err := disc.sendCommand("HELLO 1 \"arduino-cli " + globals.VersionInfo.VersionString + "\"\n"); err != nil {
 		return err
 	}

--- a/arduino/discovery/discovery_test.go
+++ b/arduino/discovery/discovery_test.go
@@ -35,6 +35,9 @@ func TestDiscoveryStdioHandling(t *testing.T) {
 	disc, err := New("test", "testdata/cat/cat") // copy stdin to stdout
 	require.NoError(t, err)
 
+	err = disc.runProcess()
+	require.NoError(t, err)
+
 	_, err = disc.outgoingCommandsPipe.Write([]byte(`{ "eventType":`)) // send partial JSON
 	require.NoError(t, err)
 	msg, err := disc.waitMessage(time.Millisecond * 100)

--- a/commands/bundled_tools_serial_discovery.go
+++ b/commands/bundled_tools_serial_discovery.go
@@ -128,7 +128,7 @@ func ListBoards(pm *packagemanager.PackageManager) ([]*discovery.Port, error) {
 	}
 	defer disc.Quit()
 
-	if err = disc.Hello(); err != nil {
+	if err = disc.Run(); err != nil {
 		return nil, fmt.Errorf("starting discovery: %v", err)
 	}
 
@@ -160,7 +160,7 @@ func WatchListBoards(pm *packagemanager.PackageManager) (<-chan *discovery.Event
 		return nil, err
 	}
 
-	if err = disc.Hello(); err != nil {
+	if err = disc.Run(); err != nil {
 		return nil, fmt.Errorf("starting discovery: %v", err)
 	}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Enhances pluggable discovery.

- **What is the current behavior?**

The discovery process is started when a `PluggableDiscovery` is created.

* **What is the new behavior?**

The discovery process is now started when calling `Run`.
This should avoid starting discoveries when not necessary, for example when running commands that don't need discoveries. It will also be easier to tests the loading and creation of third party pluggable discoveries.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
