### PR TITLE
[skip changelog] Update JSON output key name in integration test helper

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -196,7 +196,7 @@ def detected_boards(run_command):
     detected_boards = []
     for port in json.loads(result.stdout):
         for board in port.get("boards", []):
-            fqbn = board.get("FQBN")
+            fqbn = board.get("fqbn")
             package, architecture, _id = fqbn.split(":")
             detected_boards.append(
                 Board(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The key names used in Arduino CLI's JSON output were made consistent and standardized (https://github.com/arduino/arduino-cli/pull/1223). One of the helper functions for
the integration tests was not updated accordingly. This was missed because it is only used when running the tests locally
due to requiring a board to be connected to the computer. That caused the test to have a spurious failure:
```
ERROR test\test_upload.py::test_upload - AttributeError: 'NoneType' object has no attribute 'split'
```
* **What is the new behavior?**
<!-- if this is a feature change -->
The key name is updated to match [the new JSON output format](https://arduino.github.io/arduino-cli/latest/UPGRADING/#arduino-cli-json-output-breaking-changes) and the test is once more returning valid results.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No break.