### PR TITLE
[skip changelog] Remove obsolete go generate directive

### DIFF
--- a/commands/daemon/daemon.go
+++ b/commands/daemon/daemon.go
@@ -15,8 +15,6 @@
 
 package daemon
 
-//go:generate protoc -I arduino --go_out=plugins=grpc:arduino arduino/arduino.proto
-
 import (
 	"context"
 	"io"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
In the early days of Arduino CLI's gRPC interface, the protocol buffer compilation was done via[ `go generate`](https://golang.org/pkg/cmd/go/internal/generate/), configured
by a directive comment. [The `protoc:compile` task](https://github.com/arduino/arduino-cli/blob/35bec19a2576d63487363c6674e087a66fc20c9f/Taskfile.yml#L86) is now used instead, but the old directive was left in place, where it became outdated through changes to the repository structure.

This directive no longer functions or serves a purpose and might cause confusion to contributors. So it should be removed.
* **What is the new behavior?**
<!-- if this is a feature change -->
The useless directive is removed.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
no break