### PR TITLE
[skip changelog] Add missing file extensions to Sketch specifications docs

### DIFF
--- a/docs/sketch-specification.md
+++ b/docs/sketch-specification.md
@@ -36,6 +36,7 @@ The following extensions are supported:
 - .c - C Files.
 - .S - Assembly language files.
 - .h - Header files.
+- .tpp, .ipp - Header files (available from Arduino CLI 0.19.0).
 
 For information about how each of these files and other parts of the sketch are used during compilation, see the
 [Sketch build process documentation](sketch-build-process.md).


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Updates the Sketch specifications docs with missing information.

- **What is the current behavior?**

The Sketch specifications docs don't list `.tpp` and `.ipp` as supported code files extensions.

* **What is the new behavior?**
 
The Sketch specifications docs list `.tpp` and `.ipp` as supported code files extensions.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

These extensions have been added with #1316 but docs weren't updated accordingly.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
