### PR TITLE
task: Sanitize git log output when building COMMIT variable

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -224,7 +224,7 @@ vars:
     sh: echo `go list ./... | grep -v legacy | tr '\n' ' '`
   # build vars
   COMMIT:
-    sh: echo "$(git log -n 1 --format=%h)"
+    sh: echo "$(git log --no-show-signature -n 1 --format=%h)"
   TIMESTAMP:
     sh: echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   TIMESTAMP_SHORT:


### PR DESCRIPTION
This PR fixes a bug in `Taskfile.yml`.

If the user has configured `git` to always show commit signatures in `git log`, then `task` *could* emit malformed arguments to the `go build` command generated from `task build`.

For example, in my `git` config file:
```gitconfig
[log]
  showSignature = true
```

And then running `task build` you will see rather confusing output:
```sh
arduino-cli $ task build
task: [build] go build -v -ldflags ' -X github.com/arduino/arduino-cli/version.versionString=git-snapshot -X github.com/arduino/arduino-cli/version.commit=gpg: Signature made Thu Jul  1 12:22:24 2021 CDT
gpg:                using RSA key 4AEE18F83AFDEB23
gpg: Can't check signature: No public key
1b055e5e -X github.com/arduino/arduino-cli/version.date=2021-07-01T22:25:11Z '

task: Failed to run task "build": 4:78: reached EOF without closing quote '
```

This PR adds an argument to suppress signature output from the offending `git log` command in `Taskfile.yml`.

Now running `task build` completes as expected:
```sh
arduino-cli $ task build
task: [build] go build -v -ldflags ' -X github.com/arduino/arduino-cli/version.versionString=git-snapshot -X github.com/arduino/arduino-cli/version.commit=892a2ba1 -X github.com/arduino/arduino-cli/version.date=2021-07-01T23:10:16Z '

arduino-cli $ ./arduino-cli version
arduino-cli alpha Version: git-snapshot Commit: 892a2ba1 Date: 2021-07-01T23:10:16Z
```