### PR TITLE
Added discoveries support in package_index.json

### DIFF
--- a/arduino/cores/cores_test.go
+++ b/arduino/cores/cores_test.go
@@ -28,7 +28,7 @@ func TestRequiresToolRelease(t *testing.T) {
 	toolDependencyPackager := "arduino"
 
 	release := PlatformRelease{
-		Dependencies: ToolDependencies{
+		ToolDependencies: ToolDependencies{
 			{
 				ToolName:     toolDependencyName,
 				ToolVersion:  semver.ParseRelaxed(toolDependencyVersion),
@@ -53,5 +53,42 @@ func TestRequiresToolRelease(t *testing.T) {
 	toolRelease.Tool.Package.Name = toolDependencyPackager
 	require.False(t, release.RequiresToolRelease(toolRelease))
 	toolRelease.Version = semver.ParseRelaxed(toolDependencyVersion)
+	require.True(t, release.RequiresToolRelease(toolRelease))
+}
+
+func TestRequiresToolReleaseDiscovery(t *testing.T) {
+	toolDependencyName := "ble-discovery"
+	toolDependencyPackager := "arduino"
+
+	release := PlatformRelease{
+		DiscoveryDependencies: DiscoveryDependencies{
+			{
+				Name:     toolDependencyName,
+				Packager: toolDependencyPackager,
+			},
+		},
+	}
+
+	toolRelease := &ToolRelease{
+		Version: semver.ParseRelaxed("0.1.0"),
+		Tool: &Tool{
+			Name: toolDependencyName + "not",
+			Releases: map[string]*ToolRelease{
+				"1.0.0": {Version: semver.ParseRelaxed("1.0.0")},
+				"0.1.0": {Version: semver.ParseRelaxed("0.1.0")},
+				"0.0.1": {Version: semver.ParseRelaxed("0.0.1")},
+			},
+			Package: &Package{
+				Name: toolDependencyPackager + "not",
+			},
+		},
+	}
+
+	require.False(t, release.RequiresToolRelease(toolRelease))
+	toolRelease.Tool.Name = toolDependencyName
+	require.False(t, release.RequiresToolRelease(toolRelease))
+	toolRelease.Tool.Package.Name = toolDependencyPackager
+	require.False(t, release.RequiresToolRelease(toolRelease))
+	toolRelease.Version = semver.ParseRelaxed("1.0.0")
 	require.True(t, release.RequiresToolRelease(toolRelease))
 }

--- a/arduino/cores/packageindex/index_test.go
+++ b/arduino/cores/packageindex/index_test.go
@@ -54,7 +54,7 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 			{Name: "Arduino/Genuino Uno"},
 			{Name: "Arduino Uno WiFi"},
 		},
-		Dependencies: cores.ToolDependencies{
+		ToolDependencies: cores.ToolDependencies{
 			{
 				ToolPackager: "arduino",
 				ToolName:     "avr-gcc",
@@ -71,7 +71,16 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 				ToolVersion:  semver.ParseRelaxed("1.2.1"),
 			},
 		},
-
+		DiscoveryDependencies: cores.DiscoveryDependencies{
+			{
+				Packager: "arduino",
+				Name:     "ble-discovery",
+			},
+			{
+				Packager: "arduino",
+				Name:     "serial-discovery",
+			},
+		},
 		Platform: &cores.Platform{
 			Name:         "Arduino AVR Boards",
 			Architecture: "avr",
@@ -85,6 +94,109 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 				Email:      "packages@arduino.cc",
 				Help:       cores.PackageHelp{Online: "http://www.arduino.cc/en/Reference/HomePage"},
 				Tools: map[string]*cores.Tool{
+					"serial-discovery": {
+						Name: "serial-discovery",
+						Releases: map[string]*cores.ToolRelease{
+							"1.0.0": {
+								Version: semver.ParseRelaxed("1.0.0"),
+								Flavors: []*cores.Flavor{
+									{
+										OS: "arm-linux-gnueabihf",
+										Resource: &resources.DownloadResource{
+											URL:             "some-serial-discovery-1.0.0-url",
+											ArchiveFileName: "serial-discovery-1.0.0.tar.bz2",
+											Checksum:        "SHA-256:some-serial-discovery-1.0.0-sha",
+											Size:            201341,
+										},
+									},
+									{
+										OS: "i686-mingw32",
+										Resource: &resources.DownloadResource{
+											URL:             "some-serial-discovery-1.0.0-other-url",
+											ArchiveFileName: "serial-discovery-1.0.0.tar.gz",
+											Checksum:        "SHA-256:some-serial-discovery-1.0.0-other-sha",
+											Size:            222918,
+										},
+									},
+								},
+							},
+							"0.1.0": {
+								Version: semver.ParseRelaxed("0.1.0"),
+								Flavors: []*cores.Flavor{
+									{
+										OS: "arm-linux-gnueabihf",
+										Resource: &resources.DownloadResource{
+											URL:             "some-serial-discovery-0.1.0-url",
+											ArchiveFileName: "serial-discovery-0.1.0.tar.bz2",
+											Checksum:        "SHA-256:some-serial-discovery-0.1.0-sha",
+											Size:            201341,
+										},
+									},
+									{
+										OS: "i686-mingw32",
+										Resource: &resources.DownloadResource{
+											URL:             "some-serial-discovery-0.1.0-other-url",
+											ArchiveFileName: "serial-discovery-0.1.0.tar.gz",
+											Checksum:        "SHA-256:some-serial-discovery-0.1.0-other-sha",
+											Size:            222918,
+										},
+									},
+								},
+							},
+						},
+					},
+					"ble-discovery": {
+						Name: "ble-discovery",
+						Releases: map[string]*cores.ToolRelease{
+							"1.0.0": {
+								Version: semver.ParseRelaxed("1.0.0"),
+								Flavors: []*cores.Flavor{
+									{
+										OS: "arm-linux-gnueabihf",
+										Resource: &resources.DownloadResource{
+											URL:             "some-ble-discovery-1.0.0-url",
+											ArchiveFileName: "ble-discovery-1.0.0.tar.bz2",
+											Checksum:        "SHA-256:some-ble-discovery-1.0.0-sha",
+											Size:            201341,
+										},
+									},
+									{
+										OS: "i686-mingw32",
+										Resource: &resources.DownloadResource{
+											URL:             "some-ble-discovery-1.0.0-other-url",
+											ArchiveFileName: "ble-discovery-1.0.0.tar.gz",
+											Checksum:        "SHA-256:some-ble-discovery-1.0.0-other-sha",
+											Size:            222918,
+										},
+									},
+								},
+							},
+							"0.1.0": {
+								Version: semver.ParseRelaxed("0.1.0"),
+								Flavors: []*cores.Flavor{
+									{
+										OS: "arm-linux-gnueabihf",
+										Resource: &resources.DownloadResource{
+											URL:             "some-ble-discovery-0.1.0-url",
+											ArchiveFileName: "ble-discovery-0.1.0.tar.bz2",
+											Checksum:        "SHA-256:some-ble-discovery-0.1.0-sha",
+											Size:            201341,
+										},
+									},
+
+									{
+										OS: "i686-mingw32",
+										Resource: &resources.DownloadResource{
+											URL:             "some-ble-discovery-0.1.0-other-url",
+											ArchiveFileName: "ble-discovery-0.1.0.tar.gz",
+											Checksum:        "SHA-256:some-ble-discovery-0.1.0-other-sha",
+											Size:            222918,
+										},
+									},
+								},
+							},
+						},
+					},
 					"bossac": {
 						Name: "bossac",
 						Releases: map[string]*cores.ToolRelease{
@@ -233,8 +345,98 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 						Version:  semver.ParseRelaxed("1.2.1"),
 					},
 				},
+				DiscoveryDependencies: []indexDiscoveryDependency{
+					{
+						Packager: "arduino",
+						Name:     "ble-discovery",
+					},
+					{
+						Packager: "arduino",
+						Name:     "serial-discovery",
+					},
+				},
 			}},
 			Tools: []*indexToolRelease{
+				{
+					Name:    "serial-discovery",
+					Version: semver.ParseRelaxed("1.0.0"),
+					Systems: []indexToolReleaseFlavour{
+						{
+							OS:              "arm-linux-gnueabihf",
+							URL:             "some-serial-discovery-1.0.0-url",
+							ArchiveFileName: "serial-discovery-1.0.0.tar.bz2",
+							Checksum:        "SHA-256:some-serial-discovery-1.0.0-sha",
+							Size:            "201341",
+						},
+						{
+							OS:              "i686-mingw32",
+							URL:             "some-serial-discovery-1.0.0-other-url",
+							ArchiveFileName: "serial-discovery-1.0.0.tar.gz",
+							Checksum:        "SHA-256:some-serial-discovery-1.0.0-other-sha",
+							Size:            "222918",
+						},
+					},
+				},
+				{
+					Name:    "serial-discovery",
+					Version: semver.ParseRelaxed("0.1.0"),
+					Systems: []indexToolReleaseFlavour{
+						{
+							OS:              "arm-linux-gnueabihf",
+							URL:             "some-serial-discovery-0.1.0-url",
+							ArchiveFileName: "serial-discovery-0.1.0.tar.bz2",
+							Checksum:        "SHA-256:some-serial-discovery-0.1.0-sha",
+							Size:            "201341",
+						},
+						{
+							OS:              "i686-mingw32",
+							URL:             "some-serial-discovery-0.1.0-other-url",
+							ArchiveFileName: "serial-discovery-0.1.0.tar.gz",
+							Checksum:        "SHA-256:some-serial-discovery-0.1.0-other-sha",
+							Size:            "222918",
+						},
+					},
+				},
+				{
+					Name:    "ble-discovery",
+					Version: semver.ParseRelaxed("1.0.0"),
+					Systems: []indexToolReleaseFlavour{
+						{
+							OS:              "arm-linux-gnueabihf",
+							URL:             "some-ble-discovery-1.0.0-url",
+							ArchiveFileName: "ble-discovery-1.0.0.tar.bz2",
+							Checksum:        "SHA-256:some-ble-discovery-1.0.0-sha",
+							Size:            "201341",
+						},
+						{
+							OS:              "i686-mingw32",
+							URL:             "some-ble-discovery-1.0.0-other-url",
+							ArchiveFileName: "ble-discovery-1.0.0.tar.gz",
+							Checksum:        "SHA-256:some-ble-discovery-1.0.0-other-sha",
+							Size:            "222918",
+						},
+					},
+				},
+				{
+					Name:    "ble-discovery",
+					Version: semver.ParseRelaxed("0.1.0"),
+					Systems: []indexToolReleaseFlavour{
+						{
+							OS:              "arm-linux-gnueabihf",
+							URL:             "some-ble-discovery-0.1.0-url",
+							ArchiveFileName: "ble-discovery-0.1.0.tar.bz2",
+							Checksum:        "SHA-256:some-ble-discovery-0.1.0-sha",
+							Size:            "201341",
+						},
+						{
+							OS:              "i686-mingw32",
+							URL:             "some-ble-discovery-0.1.0-other-url",
+							ArchiveFileName: "ble-discovery-0.1.0.tar.gz",
+							Checksum:        "SHA-256:some-ble-discovery-0.1.0-other-sha",
+							Size:            "222918",
+						},
+					},
+				},
 				{
 					Name:    "bossac",
 					Version: semver.ParseRelaxed("1.6.1-arduino"),
@@ -349,6 +551,7 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 			require.Equal(t, expectedPlatform.Size, indexPlatform.Size)
 			require.ElementsMatch(t, expectedPlatform.Boards, indexPlatform.Boards)
 			require.ElementsMatch(t, expectedPlatform.ToolDependencies, indexPlatform.ToolDependencies)
+			require.ElementsMatch(t, expectedPlatform.DiscoveryDependencies, indexPlatform.DiscoveryDependencies)
 		}
 	}
 }

--- a/arduino/cores/packagemanager/download.go
+++ b/arduino/cores/packagemanager/download.go
@@ -91,11 +91,19 @@ func (pm *PackageManager) FindPlatformReleaseDependencies(item *PlatformReferenc
 	}
 
 	// replaces "latest" with latest version too
-	toolDeps, err := pm.Packages.GetDepsOfPlatformRelease(release)
+	toolDeps, err := pm.Packages.GetPlatformReleaseToolDependencies(release)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting tool dependencies for platform %s: %s", release.String(), err)
 	}
-	return release, toolDeps, nil
+
+	// discovery dependencies differ from normal tool since we always want to use the latest \
+	// available version for the platform package
+	discoveryDependencies, err := pm.Packages.GetPlatformReleaseDiscoveryDependencies(release)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting discovery dependencies for platform %s: %s", release.String(), err)
+	}
+
+	return release, append(toolDeps, discoveryDependencies...), nil
 }
 
 // DownloadToolRelease downloads a ToolRelease. If the tool is already downloaded a nil Downloader

--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -452,8 +452,8 @@ func (pm *PackageManager) FindToolsRequiredForBoard(board *cores.Board) ([]*core
 
 	// replace the default tools above with the specific required by the current platform
 	requiredTools := []*cores.ToolRelease{}
-	platform.Dependencies.Sort()
-	for _, toolDep := range platform.Dependencies {
+	platform.ToolDependencies.Sort()
+	for _, toolDep := range platform.ToolDependencies {
 		pm.Log.WithField("tool", toolDep).Infof("Required tool")
 		tool := pm.FindToolDependency(toolDep)
 		if tool == nil {

--- a/commands/board/details.go
+++ b/commands/board/details.go
@@ -115,7 +115,7 @@ func Details(ctx context.Context, req *rpc.BoardDetailsRequest) (*rpc.BoardDetai
 	}
 
 	details.ToolsDependencies = []*rpc.ToolsDependencies{}
-	for _, tool := range boardPlatform.Dependencies {
+	for _, tool := range boardPlatform.ToolDependencies {
 		toolRelease := pm.FindToolDependency(tool)
 		var systems []*rpc.Systems
 		if toolRelease != nil {


### PR DESCRIPTION
This PR adds the parsing of the `discoveryDependencies` field in `package_index.json` as specified in Pluggable Discovery RFC.
No breaking changes.
