### PR TITLE
[skip changelog] Make `i18n:generate` task Windows compatible

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -214,7 +214,7 @@ tasks:
     desc: Generate embedded i18n catalog files
     cmds:
       - git add -N ./i18n/data
-      - git diff --exit-code ./i18n/data &> /dev/null || (cd ./i18n && rice embed-go)
+      - git diff --exit-code ./i18n/data &> /dev/null || { cd ./i18n && rice embed-go; }
 
 vars:
   PROJECT_NAME: "arduino-cli"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
For the sake of portability of tasks, [Task](https://taskfile.dev/#/) uses[ `mvdan.cc/sh`](https://pkg.go.dev/mvdan.cc/sh/v3) to provide an command interpreter that is independent of the environment. While one of the great strengths of Task, this produces unexpected results in some rare cases. This is one of those cases. There is some unusual interaction between `mvdan.cc/sh`, Windows, and running the `rice embed-go` command from the subshell created by the parentheses in this command:

```
$ task i18n:update
←[32mtask: [i18n:update] go run ./i18n/cmd/main.go catalog generate . > ./i18n/data/en.po
←[0m←[32mtask: [i18n:generate] git add -N ./i18n/data
←[0m←[32mtask: [i18n:generate] git diff --exit-code ./i18n/data &> /dev/null || (cd ./i18n && rice embed-go)
←[0merror reading package: go/build: go list github.com/arduino/arduino-cli/i18n: exec: "go": executable file not found in %PATH%
```
(yes, Go is in my `PATH`).

* **What is the new behavior?**
<!-- if this is a feature change -->
The task runs on Windows without a strange error.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

It is my belief that the sole purpose of these [parentheses](https://ss64.com/bash/syntax-brackets.html) was to group the commands and that there is no need to run these commands in a subshell. If so, the change to using braces to group the commands without the creation of a subshell will have no functional effect on the commands, but will allow the task to run on Windows.
