### PR TITLE
[breaking] Pass user locale preference directly to i18n package

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -6,6 +6,21 @@ Here you can find a list of migration guides to handle breaking changes between 
 
 ### Change public library interface
 
+#### `github.com/arduino/arduino-cli/i18n` package
+
+The behavior of the `Init` function has changed. The user specified locale code is no longer read from the
+`github.com/arduino/arduino-cli/configuration` package and now must be passed directly to `Init` as a string:
+
+```go
+i18n.Init("it")
+```
+
+Omit the argument for automated locale detection:
+
+```go
+i18n.Init()
+```
+
 #### `github.com/arduino/arduino-cli/arduino/builder` package
 
 `GenBuildPath()` function has been moved to `github.com/arduino/arduino-cli/arduino/sketch` package. The signature is

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -15,18 +15,20 @@
 
 package i18n
 
-import "github.com/arduino/arduino-cli/configuration"
-
 // Init initializes the i18n module, setting the locale according to this order of preference:
-// 1. Configuration set in arduino-cli.yaml
+// 1. Locale specified via the function call
 // 2. OS Locale
 // 3. en (default)
-func Init() {
+func Init(configLocale ...string) {
 	initRiceBox()
 	locales := supportedLocales()
 
-	if configLocale := configuration.Settings.GetString("locale"); configLocale != "" {
-		if locale := findMatchingLocale(configLocale, locales); locale != "" {
+	if len(configLocale) > 1 {
+		panic("Multiple arguments not supported")
+	}
+
+	if len(configLocale) > 0 && configLocale[0] != "" {
+		if locale := findMatchingLocale(configLocale[0], locales); locale != "" {
 			setLocale(locale)
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 func main() {
 	configuration.Settings = configuration.Init(configuration.FindConfigFileInArgsOrWorkingDirectory(os.Args))
-	i18n.Init()
+	i18n.Init(configuration.Settings.GetString("locale"))
 	arduinoCmd := cli.NewCommand()
 	if err := arduinoCmd.Execute(); err != nil {
 		os.Exit(errorcodes.ErrGeneric)


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Code restructuring
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The user can configure their locale preference via the undocumented `locale` [configuration key](https://arduino.github.io/arduino-cli/dev/configuration/#configuration-keys). This information is given priority by the `github.com/arduino/arduino-cli/configuration` package over the automatically detected locale.

Previously, the `i18n` package got the configuration setting from the `github.com/arduino/arduino-cli/configuration` package, but this will result in an import cycle when the `i18n` package is used to enable translation of the output strings of the 
 `configuration` package.

* **What is the new behavior?**
<!-- if this is a feature change -->
To avoid this import cycle, the caller now reads the configuration and passes the locale code to the `i18n` package via the `Init`
function:
```go
i18n.Init("it")
```
The argument may be omitted if only automated locale detection is needed:
```go
i18n.Init()
```
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
>Does this PR introduce a breaking change

yes

>is titled accordingly

yes
