### PR TITLE
Fix nil dereference when core uninstall fails during upgrade

### DIFF
--- a/commands/core/install.go
+++ b/commands/core/install.go
@@ -145,7 +145,7 @@ func installPlatform(pm *packagemanager.PackageManager,
 		// In case of error try to rollback
 		if errUn != nil {
 			log.WithError(errUn).Error("Error upgrading platform.")
-			taskCB(&rpc.TaskProgress{Message: fmt.Sprintf(tr("Error upgrading platform: %s"), err)})
+			taskCB(&rpc.TaskProgress{Message: fmt.Sprintf(tr("Error upgrading platform: %s"), errUn)})
 
 			// Rollback
 			if err := pm.UninstallPlatform(platformRelease); err != nil {


### PR DESCRIPTION
The code tried to log the wrong error, which was nil, and resulted in a
nil dereference.

This would occur for example when a version of the core was already
installed manually in the sketchbook, and you would try to install
another version using arduino-cli, uninstalling the previous version
would fail (not managed by package manager) and the nil dereference
would happen:

    $ arduino-cli core install arduino:avr@1.8.2
    Tool arduino:avr-gcc@7.3.0-atmel3.6.1-arduino5 already installed
    Tool arduino:avrdude@6.3.0-arduino17 already installed
    Tool arduino:arduinoOTA@1.3.0 already installed
    Downloading packages...
    arduino:avr@1.8.2 already downloaded
    Upgrading arduino:avr@1.8.3 with arduino:avr@1.8.2...
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xde10dc]

    goroutine 1 [running]:
    github.com/arduino/arduino-cli/commands/core.installPlatform(0xc00038b600, 0xc0002406e0, 0xc0002ea560, 0x3, 0x4, 0xc0002ea540, 0xc0015c11d0, 0x0, 0x58, 0x68)
	    /home/matthijs/docs/Electronics/Arduino/arduino-cli/commands/core/install.go:148 +0x10fc
    github.com/arduino/arduino-cli/commands/core.PlatformInstall(0x1203c00, 0xc0000360f0, 0xc0000aef50, 0xc0002ea540, 0xc0015c11d0, 0x1, 0x1, 0x0)
	    /home/matthijs/docs/Electronics/Arduino/arduino-cli/commands/core/install.go:52 +0x2ce
    github.com/arduino/arduino-cli/cli/core.runInstallCommand(0xc000422840, 0xc0003b1a10, 0x1, 0x1)
	    /home/matthijs/docs/Electronics/Arduino/arduino-cli/cli/core/install.go:103 +0x2a5
    github.com/spf13/cobra.(*Command).execute(0xc000422840, 0xc0003b19f0, 0x1, 0x1, 0xc000422840, 0xc0003b19f0)
	    /home/matthijs/docs/src/go/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200710201246-675ae5f5a98c/command.go:846 +0x2c2
    github.com/spf13/cobra.(*Command).ExecuteC(0xc000322dc0, 0x3a, 0xc00037f680, 0xc0001f6a80)
	    /home/matthijs/docs/src/go/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200710201246-675ae5f5a98c/command.go:950 +0x375
    github.com/spf13/cobra.(*Command).Execute(...)
	    /home/matthijs/docs/src/go/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200710201246-675ae5f5a98c/command.go:887
    main.main()
	    /home/matthijs/docs/Electronics/Arduino/arduino-cli/main.go:31 +0x8a

With this fix applied, this produces a proper error message:

    $ arduino-cli core install arduino:avr@1.8.2
    Tool arduino:avr-gcc@7.3.0-atmel3.6.1-arduino5 already installed
    Tool arduino:avrdude@6.3.0-arduino17 already installed
    Tool arduino:arduinoOTA@1.3.0 already installed
    Downloading packages...
    arduino:avr@1.8.2 already downloaded
    Upgrading arduino:avr@1.8.3 with arduino:avr@1.8.2...
    Error upgrading platform: arduino:avr@1.8.3 is not managed by package manager...
    Error during install: upgrading platform: arduino:avr@1.8.3 is not managed by package manager

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~ Sorry, that would need quite a bit of work for such a trivial fix, no time for that.
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~ Not applicable
- [ ] ~~`UPGRADING.md` has been updated with a migration guide (for breaking changes)~~ Not applicable