### PR TITLE
[skip changelog] Add skip changelog prefix to Dependabot workflow update commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,7 @@ updates:
     directory: / # Check the repository's workflows under /.github/workflows/
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[skip changelog] "
     labels:
       - "topic: dependencies"


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure enhancement

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Dependabot is configured to submit pull requests for updates to the GitHub Actions actions used in the repository's workflows whenever a new version is available. These commits will create entries in the automatically generated draft changelog, but will not result in any user facing changes and so have no place there. The release manager's time will be wasted by cleaning them out of the raw changelog.

* **What is the new behavior?**
<!-- if this is a feature change -->
The message title of the commits generated by Dependabot will be prefixed with "[skip changelog]":
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#commit-message

The changelog generation system [automatically excludes](https://github.com/arduino/create-changelog#inputs) any commit that has this prefix.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

>Does this PR introduce a breaking change

No

>is titled accordingly

Yes
