### PR TITLE
Remove duplicate task for protobuf docs generation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,14 +4,6 @@ includes:
   dist: ./DistTasks.yml
 
 tasks:
-  docs:gen:protobuf:
-    desc: Generate markdown contents for protobuffers
-    cmds:
-      - '{{ default "protoc" .PROTOC_BINARY }} --doc_out=./docs/rpc --doc_opt=markdown,commands.md --proto_path=rpc ./rpc/cc/arduino/cli/commands/v1/*.proto'
-      - '{{ default "protoc" .PROTOC_BINARY }} --doc_out=./docs/rpc --doc_opt=markdown,monitor.md --proto_path=rpc ./rpc/cc/arduino/cli/monitor/v1/*.proto'
-      - '{{ default "protoc" .PROTOC_BINARY }} --doc_out=./docs/rpc --doc_opt=markdown,settings.md --proto_path=rpc ./rpc/cc/arduino/cli/settings/v1/*.proto'
-      - '{{ default "protoc" .PROTOC_BINARY }} --doc_out=./docs/rpc --doc_opt=markdown,debug.md --proto_path=rpc ./rpc/cc/arduino/cli/debug/v1/*.proto'
-
   docs:generate:
     desc: Create all generated documentation content
     deps:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure clean up
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The "gRPC reference" section of the documentation website is automatically generated from the repository's protocol
buffer files. In order to make this generation process easy for developers to run, the necessary commands are defined in
a task.

For some reason, there were two tasks for this purpose, with different names and descriptions, but identical commands.
This makes the taskfile more difficult to understand and more difficult to maintain.

* **What is the new behavior?**
<!-- if this is a feature change -->
One of the tasks, `protoc:docs` is called by the `docs:generate` task. The other, `docs:gen:protobuf`, is not used or
referenced anywhere in the repository. So I have removed `docs:gen:protobuf` from the taskfile.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

The removal of the `docs:gen:protobuf` task will disrupt the workflow of any developer who is accustomed to having it available.

This could be avoided by deprecating the task rather than doing an immediate removal. However, this removal unlikely to have a significant impact.

However, there is no change to the application's API.