### PR TITLE
[skip changelog] Revert "Add skip changelog prefix to Dependabot workflow update commits (#1381)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,5 @@ updates:
     directory: / # Check the repository's workflows under /.github/workflows/
     schedule:
       interval: daily
-    commit-message:
-      prefix: "[skip changelog] "
     labels:
       - "topic: dependencies"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The Dependabot configuration specifies that the message title of the commits generated by Dependabot will be prefixed with "[skip changelog]" in order to cause them to be automatically excluded from the generated changelog (https://github.com/arduino/arduino-cli/pull/1381).

It turns out there is an undocumented maximum length of 15 characters for the Dependabot commit prefix:

https://github.com/arduino/arduino-cli/network/updates

```
Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/0/commit-message/prefix' was not of a maximum string length of 15
Please update the config file to conform with Dependabot's specification.
```
Unfortunately, even though it is possible to reduce the prefix length by 1 with the removal of the trailing space, we
still end up with 16 characters.

* **What is the new behavior?**
<!-- if this is a feature change -->

The commit message prefix configuration is removed, making the file compliant once more. Dependabot's commits will follow the default message style.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No break