### PR TITLE
[skip changelog] Run formatting and linting CI checks on all Go modules

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -26,7 +26,19 @@ on:
 
 jobs:
   check-errors:
+    name: check-errors (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
+          - path: arduino/discovery/discovery_client
+          - path: client_example
+          - path: commands/daemon/term_example
+          - path: docsgen
 
     steps:
       - name: Checkout repository
@@ -44,10 +56,24 @@ jobs:
           version: 3.x
 
       - name: Check for errors
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:vet
 
   check-outdated:
+    name: check-outdated (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
+          - path: arduino/discovery/discovery_client
+          - path: client_example
+          - path: commands/daemon/term_example
+          - path: docsgen
 
     steps:
       - name: Checkout repository
@@ -65,13 +91,27 @@ jobs:
           version: 3.x
 
       - name: Modernize usages of outdated APIs
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:fix
 
       - name: Check if any fixes were needed
         run: git diff --color --exit-code
 
   check-style:
+    name: check-style (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
+          - path: arduino/discovery/discovery_client
+          - path: client_example
+          - path: commands/daemon/term_example
+          - path: docsgen
 
     steps:
       - name: Checkout repository
@@ -92,10 +132,24 @@ jobs:
         run: go install golang.org/x/lint/golint@latest
 
       - name: Check style
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task --silent go:lint
 
   check-formatting:
+    name: check-formatting (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
+          - path: arduino/discovery/discovery_client
+          - path: client_example
+          - path: commands/daemon/term_example
+          - path: docsgen
 
     steps:
       - name: Checkout repository
@@ -113,6 +167,8 @@ jobs:
           version: 3.x
 
       - name: Format code
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:format
 
       - name: Check formatting

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml
   go:build:
     desc: Build the Go code
+    dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
       - go build -v {{.LDFLAGS}}
 
@@ -37,18 +38,21 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:fix:
     desc: Modernize usages of outdated APIs
+    dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
       - go fix {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:format:
     desc: Format Go code
+    dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
       - go fmt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:lint:
     desc: Lint Go code
+    dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
       - |
         if ! which golint &>/dev/null; then
@@ -63,6 +67,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-task/Taskfile.yml
   go:test:
     desc: Run unit tests
+    dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
       - |
         go test \
@@ -86,6 +91,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:vet:
     desc: Check for errors in Go code
+    dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
       - go vet {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
@@ -289,7 +295,8 @@ vars:
   DIST_DIR: "dist"
   # all modules of this project except for "legacy/..." module
   DEFAULT_GO_PACKAGES:
-    sh: echo $(go list ./... | grep -v legacy | tr '\n' ' ')
+    sh: |
+      echo $(cd {{default "./" .GO_MODULE_PATH}} && go list ./... | grep -v legacy | tr '\n' ' ' || echo '"ERROR: Unable to discover Go packages"')
   # build vars
   COMMIT:
     sh: echo "$(git log --no-show-signature -n 1 --format=%h)"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure enhancement
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The repository contains multiple Go modules. The CI workflow that lints and checks the formatting of the repository's Go code only checks the primary module in the root of the repo.

* **What is the new behavior?**
<!-- if this is a feature change -->
This workflow is now expanded to cover all Go code through the use of a dedicated matrix job for each of the modules.

Arbitrary Go module paths can be specified to the tasks by defining the `GO_MODULE_PATH` environment variable. If this
variable is not defined, the default root module path is used as default, preserving the previous task behavior.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No break

* **Other information**:
<!-- Any additional information that could help the review process -->
Demo "Check Go" workflow run with intentionally introduced formatting and linting violations in the other modules:
https://github.com/per1234/arduino-cli/actions/runs/1120824859