### PR TITLE
[skip changelog] Add formatting check to "Check Protocol Buffers" workflow

### DIFF
--- a/.github/workflows/check-protobuf-task.yml
+++ b/.github/workflows/check-protobuf-task.yml
@@ -79,3 +79,22 @@ jobs:
 
       - name: Lint protocol buffers
         run: task protoc:check
+
+  check-formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Format protocol buffers
+        run: task protoc:format
+
+      - name: Check formatting
+        run: git diff --color --exit-code


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure enhancement
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The CI system checks the protocol buffers will compile and that they don't have any linting violations but it doesn't check for formatting style violations.
* **What is the new behavior?**
<!-- if this is a feature change -->
On every push and pull request that affects relevant files, the protocol buffer files are checked for compliance with the LLVM code style (default of the [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) formatter tool).
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No break
* **Other information**:
<!-- Any additional information that could help the review process -->
The version of ClangFormat pre-installed in the `ubuntu-latest` GitHub Actions runner is used for the check:
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#language-and-runtime