### PR TITLE
[skip changelog] Sync install script with template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,6 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
-[*.sh]
-indent_style = tab
-indent_size = 4
+[*.{bash,sh}]
+indent_size = 2
+indent_style = space

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,6 @@
-### Install via Homebrew (macOS/Linux)
+<!-- Source: https://github.com/arduino/tooling-project-assets/blob/main/other/installation-script/installation.md -->
+
+## Install via Homebrew (macOS/Linux)
 
 The Arduino CLI is available as a Homebrew formula since version `0.5.0`:
 
@@ -7,34 +9,34 @@ brew update
 brew install arduino-cli
 ```
 
-#### Command line completion
+### Command line completion
 
 [Command line completion](command-line-completion.md#brew) files are already bundled in the homebrew installation.
 
-### Use the install script
+## Use the install script
 
-The script requires `sh`. This is always available on Linux and macOS. `sh` is not available by default on Windows. The
-script may be run on Windows by installing [Git for Windows], then running it from Git Bash.
+The script requires `sh`, which is always available on Linux and macOS. `sh` is not available by default on Windows. The
+script can be run on Windows by installing [Git for Windows](https://gitforwindows.org/), then running it from Git Bash.
 
 This script will install the latest version of Arduino CLI to `$PWD/bin`:
 
-```sh
+```
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
 ```
 
 If you want to target a different directory, for example `~/local/bin`, set the `BINDIR` environment variable like this:
 
-```sh
+```
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=~/local/bin sh
 ```
 
 If you would like to use the `arduino-cli` command from any location, install Arduino CLI to a directory already in your
 `PATH` or add the Arduino CLI installation path to your `PATH` environment variable.
 
-If you want to download a specific arduino-cli version, for example `0.9.0`, pass the version number as a parameter like
-this:
+If you want to download a specific Arduino CLI version, for example `0.9.0` or `nightly-latest`, pass the version number
+as a parameter like this:
 
-```sh
+```
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s 0.9.0
 ```
 
@@ -45,22 +47,22 @@ Pre-built binaries for all the supported platforms are available for download fr
 If you would like to use the `arduino-cli` command from any location, extract the downloaded file to a directory already
 in your `PATH` or add the Arduino CLI installation path to your `PATH` environment variable.
 
-#### Latest packages
+#### Latest release
 
-| Platform  |                    |                    |
-| --------- | ------------------ | ------------------ |
-| Linux     | [Linux 32 bit]     | [Linux 64 bit]     |
-| Linux ARM | [Linux ARM 32 bit] | [Linux ARM 64 bit] |
-| Windows   | [Windows 32 bit]   | [Windows 64 bit]   |
-| Mac OSX   |                    | [Mac OSX]          |
+| Platform  |                      |                      |
+| --------- | -------------------- | -------------------- |
+| Linux     | [32 bit][linux32]    | [64 bit][linux64]    |
+| Linux ARM | [32 bit][linuxarm32] | [64 bit][linuxarm64] |
+| Windows   | [32 bit][windows32]  | [64 bit][windows64]  |
+| macOS     |                      | [64 bit][macos]      |
 
-[linux 64 bit]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_64bit.tar.gz
-[linux 32 bit]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_32bit.tar.gz
-[linux arm 64 bit]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_ARM64.tar.gz
-[linux arm 32 bit]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_ARMv7.tar.gz
-[windows 64 bit]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Windows_64bit.zip
-[windows 32 bit]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Windows_32bit.zip
-[mac osx]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_macOS_64bit.tar.gz
+[linux64]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_64bit.tar.gz
+[linux32]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_32bit.tar.gz
+[linuxarm64]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_ARM64.tar.gz
+[linuxarm32]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_ARMv7.tar.gz
+[windows64]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Windows_64bit.zip
+[windows32]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Windows_32bit.zip
+[macos]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_macOS_64bit.tar.gz
 
 > **Deprecation notice**: links in the form
 > `http://downloads.arduino.cc/arduino-cli/arduino-cli-latest-<platform>.tar.bz2` won’t be further updated. That URL
@@ -68,52 +70,35 @@ in your `PATH` or add the Arduino CLI installation path to your `PATH` environme
 
 #### Previous versions
 
-These are available from the [releases page](https://github.com/arduino/arduino-cli/releases)
+These are available from the "Assets" sections on the [releases page](https://github.com/arduino/arduino-cli/releases).
 
 #### Nightly builds
 
 These builds are generated every day at 01:00 GMT from the `master` branch and should be considered unstable. In order
 to get the latest nightly build available for the supported platform, use the following links:
 
-| Platform  |                            |                            |
-| --------- | -------------------------- | -------------------------- |
-| Linux     | [Nightly Linux 32 bit]     | [Nightly Linux 64 bit]     |
-| Linux ARM | [Nightly Linux ARM 32 bit] | [Nightly Linux ARM 64 bit] |
-| Windows   | [Nightly Windows 32 bit]   | [Nightly Windows 64 bit]   |
-| Mac OSX   |                            | [Nightly Mac OSX]          |
+| Platform  |                              |                              |
+| --------- | ---------------------------- | ---------------------------- |
+| Linux     | [32 bit][linux32-nightly]    | [64 bit][linux64-nightly]    |
+| Linux ARM | [32 bit][linuxarm32-nightly] | [64 bit][linuxarm64-nightly] |
+| Windows   | [32 bit][windows32-nightly]  | [64 bit][windows64-nightly]  |
+| macOS     |                              | [64 bit][macos-nightly]      |
 
-[nightly linux 64 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_64bit.tar.gz
-[nightly linux 32 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_32bit.tar.gz
-
-<!-- prettier-ignore -->
-[nightly linux arm 64 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_ARM64.tar.gz
-
-<!-- prettier-ignore -->
-[nightly linux arm 32 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_ARMv7.tar.gz
-[nightly windows 64 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Windows_64bit.zip
-[nightly windows 32 bit]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Windows_32bit.zip
-[nightly mac osx]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_macOS_64bit.tar.gz
+[linux64-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_64bit.tar.gz
+[linux32-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_32bit.tar.gz
+[linuxarm64-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_ARM64.tar.gz
+[linuxarm32-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_ARMv7.tar.gz
+[windows64-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Windows_64bit.zip
+[windows32-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Windows_32bit.zip
+[macos-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_macOS_64bit.tar.gz
 
 > These links return a `302: Found` response, redirecting to latest generated builds by replacing `latest` with the
-> latest available build date, using the format YYYYMMDD (i.e for 2019/Aug/06 `latest` is replaced with `20190806` )
+> latest available build date, using the format YYYYMMDD (i.e for 2019-08-06 `latest` is replaced with `20190806` )
 
 Checksums for the nightly builds are available at
 `https://downloads.arduino.cc/arduino-cli/nightly/nightly-<DATE>-checksums.txt`
 
 ### Build from source
 
-If you’re familiar with Golang or if you want to contribute to the project, you will probably build the `arduino-cli`
-locally with your Go toolchain. Please refer to the [CONTRIBUTING] document for setup instructions.
-
-If you don’t have a working Golang environment or if you want to build `arduino-cli` targeting different platforms, you
-can use [Task][task-site] to get a binary directly from sources. From the project folder run:
-
-```sh
-task dist:all
-```
-
-Once the build is over, you will find a `./dist/` folder containing the packages built out of the current source tree.
-
-[git for windows]: https://gitforwindows.org/
-[contributing]: CONTRIBUTING.md
-[task-site]: https://taskfile.dev/#/installation
+If you're familiar with Golang or if you want to contribute to the project, you will probably build Arduino CLI locally
+with your Go toolchain. See the ["How to contribute"](CONTRIBUTING.md#building-the-source-code) page for instructions.

--- a/install.sh
+++ b/install.sh
@@ -21,191 +21,190 @@ LBINDIR=""
 DEFAULT_BINDIR="$PWD/bin"
 
 fail() {
-	echo "$1"
-	exit 1
+  echo "$1"
+  exit 1
 }
 
 initDestination() {
-	if [ -n "$BINDIR" ]; then
-		if [ ! -d "$BINDIR" ]; then
-			fail "$BINDIR "'($BINDIR)'" folder not found. Please create it before continuing."
-		fi
-		LBINDIR="$BINDIR"
-	else
-		if [ ! -d "$DEFAULT_BINDIR" ]; then
-		mkdir "$DEFAULT_BINDIR"
-		fi
-		LBINDIR="$DEFAULT_BINDIR"
-	fi
-	echo "Installing in $LBINDIR"
+  if [ -n "$BINDIR" ]; then
+    if [ ! -d "$BINDIR" ]; then
+      fail "$BINDIR "'($BINDIR)'" folder not found. Please create it before continuing."
+    fi
+    LBINDIR="$BINDIR"
+  else
+    if [ ! -d "$DEFAULT_BINDIR" ]; then
+      mkdir "$DEFAULT_BINDIR"
+    fi
+    LBINDIR="$DEFAULT_BINDIR"
+  fi
+  echo "Installing in $LBINDIR"
 }
 
 initArch() {
-	ARCH=$(uname -m)
-	case $ARCH in
-		armv5*) ARCH="armv5";;
-		armv6*) ARCH="ARMv6";;
-		armv7*) ARCH="ARMv7";;
-		aarch64) ARCH="ARM64";;
-		x86) ARCH="32bit";;
-		x86_64) ARCH="64bit";;
-		i686) ARCH="32bit";;
-		i386) ARCH="32bit";;
-	esac
-	echo "ARCH=$ARCH"
+  ARCH=$(uname -m)
+  case $ARCH in
+  armv5*) ARCH="armv5" ;;
+  armv6*) ARCH="ARMv6" ;;
+  armv7*) ARCH="ARMv7" ;;
+  aarch64) ARCH="ARM64" ;;
+  x86) ARCH="32bit" ;;
+  x86_64) ARCH="64bit" ;;
+  i686) ARCH="32bit" ;;
+  i386) ARCH="32bit" ;;
+  esac
+  echo "ARCH=$ARCH"
 }
 
 initOS() {
-	OS=$(uname -s)
-	case "$OS" in
-		Linux*) OS='Linux' ;;
-		Darwin*) OS='macOS' ;;
-		MINGW*) OS='Windows';;
-		MSYS*) OS='Windows';;
-	esac
-	echo "OS=$OS"
+  OS=$(uname -s)
+  case "$OS" in
+  Linux*) OS='Linux' ;;
+  Darwin*) OS='macOS' ;;
+  MINGW*) OS='Windows' ;;
+  MSYS*) OS='Windows' ;;
+  esac
+  echo "OS=$OS"
 }
 
 initDownloadTool() {
-	if type "curl" > /dev/null; then
-		DOWNLOAD_TOOL="curl"
-	elif type "wget" > /dev/null; then
-		DOWNLOAD_TOOL="wget"
-	else
-		fail "You need curl or wget as download tool. Please install it first before continuing"
-	fi
-	echo "Using $DOWNLOAD_TOOL as download tool"
+  if type "curl" >/dev/null; then
+    DOWNLOAD_TOOL="curl"
+  elif type "wget" >/dev/null; then
+    DOWNLOAD_TOOL="wget"
+  else
+    fail "You need curl or wget as download tool. Please install it first before continuing"
+  fi
+  echo "Using $DOWNLOAD_TOOL as download tool"
 }
 
 checkLatestVersion() {
-	# Use the GitHub releases webpage to find the latest version for this project
-	# so we don't get rate-limited.
-	local tag
-	local regex="[0-9][A-Za-z0-9\.-]*"
-	local latest_url="https://github.com/arduino/arduino-cli/releases/latest"
-	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-		tag=$(curl -SsL $latest_url | grep -o "<title>Release $regex · arduino/arduino-cli" | grep -o "$regex")
-	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-		tag=$(wget -q -O - $latest_url | grep -o "<title>Release $regex · arduino/arduino-cli" | grep -o "$regex")
-	fi
-	if [ "x$tag" = "x" ]; then
-		echo "Cannot determine latest tag."
-		exit 1
-	fi
-	eval "$1='$tag'"
+  # Use the GitHub releases webpage to find the latest version for this project
+  # so we don't get rate-limited.
+  local tag
+  local regex="[0-9][A-Za-z0-9\.-]*"
+  local latest_url="https://github.com/arduino/arduino-cli/releases/latest"
+  if [ "$DOWNLOAD_TOOL" = "curl" ]; then
+    tag=$(curl -SsL $latest_url | grep -o "<title>Release $regex · arduino/arduino-cli" | grep -o "$regex")
+  elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
+    tag=$(wget -q -O - $latest_url | grep -o "<title>Release $regex · arduino/arduino-cli" | grep -o "$regex")
+  fi
+  if [ "x$tag" = "x" ]; then
+    echo "Cannot determine latest tag."
+    exit 1
+  fi
+  eval "$1='$tag'"
 }
 
 get() {
-	local url="$2"
-	local body
-	local httpStatusCode
-	echo "Getting $url"
-	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-		httpResponse=$(curl -sL --write-out HTTPSTATUS:%{http_code} "$url")
-		httpStatusCode=$(echo $httpResponse | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
-		body=$(echo "$httpResponse" | sed -e 's/HTTPSTATUS\:.*//g')
-	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-		tmpFile=$(mktemp)
-		body=$(wget --server-response --content-on-error -q -O - "$url" 2> $tmpFile || true)
-		httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
-	fi
-	if [ "$httpStatusCode" != 200 ]; then
-		echo "Request failed with HTTP status code $httpStatusCode"
-		fail "Body: $body"
-	fi
-	eval "$1='$body'"
+  local url="$2"
+  local body
+  local httpStatusCode
+  echo "Getting $url"
+  if [ "$DOWNLOAD_TOOL" = "curl" ]; then
+    httpResponse=$(curl -sL --write-out HTTPSTATUS:%{http_code} "$url")
+    httpStatusCode=$(echo $httpResponse | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+    body=$(echo "$httpResponse" | sed -e 's/HTTPSTATUS\:.*//g')
+  elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
+    tmpFile=$(mktemp)
+    body=$(wget --server-response --content-on-error -q -O - "$url" 2>$tmpFile || true)
+    httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
+  fi
+  if [ "$httpStatusCode" != 200 ]; then
+    echo "Request failed with HTTP status code $httpStatusCode"
+    fail "Body: $body"
+  fi
+  eval "$1='$body'"
 }
 
 getFile() {
-	local url="$1"
-	local filePath="$2"
-	if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-		httpStatusCode=$(curl -s -w '%{http_code}' -L "$url" -o "$filePath")
-	elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-		tmpFile=$(mktemp)
-		body=$(wget --server-response --content-on-error -q -O "$filePath" "$url" 2> $tmpFile || true)
-		httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
-	fi
-	echo "$httpStatusCode"
+  local url="$1"
+  local filePath="$2"
+  if [ "$DOWNLOAD_TOOL" = "curl" ]; then
+    httpStatusCode=$(curl -s -w '%{http_code}' -L "$url" -o "$filePath")
+  elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
+    tmpFile=$(mktemp)
+    body=$(wget --server-response --content-on-error -q -O "$filePath" "$url" 2>$tmpFile || true)
+    httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
+  fi
+  echo "$httpStatusCode"
 }
 
 downloadFile() {
-	if [ -z $1 ]; then
-		checkLatestVersion TAG
-	else
-		TAG=$1
-	fi
-	echo "TAG=$TAG"
-	#  arduino-cli_0.4.0-rc1_Linux_64bit.[tar.gz, zip]
-	if [ "$OS" = "Windows" ]; then
-		CLI_DIST="arduino-cli_${TAG}_${OS}_${ARCH}.zip"
-	else
-		CLI_DIST="arduino-cli_${TAG}_${OS}_${ARCH}.tar.gz"
-	fi
-	echo "CLI_DIST=$CLI_DIST"
-	DOWNLOAD_URL="https://downloads.arduino.cc/arduino-cli/$CLI_DIST"
-	CLI_TMP_FILE="/tmp/$CLI_DIST"
-	echo "Downloading $DOWNLOAD_URL"
-	httpStatusCode=$(getFile "$DOWNLOAD_URL" "$CLI_TMP_FILE")
-	if [ "$httpStatusCode" -ne 200 ]; then
-		echo "Did not find a release for your system: $OS $ARCH"
-		echo "Trying to find a release using the GitHub API."
-		LATEST_RELEASE_URL="https://api.github.com/repos/arduino/$PROJECT_NAME/releases/tags/$TAG"
-		echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
-		get LATEST_RELEASE_JSON $LATEST_RELEASE_URL
-		# || true forces this command to not catch error if grep does not find anything
-		DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | grep 'browser_' | cut -d\" -f4 | grep "$CLI_DIST") || true
-		if [ -z "$DOWNLOAD_URL" ]; then
-			echo "Sorry, we dont have a dist for your system: $OS $ARCH"
-			fail "You can request one here: https://github.com/Arduino/$PROJECT_NAME/issues"
-		else
-			echo "Downloading $DOWNLOAD_URL"
-			getFile "$DOWNLOAD_URL" "$CLI_TMP_FILE"
-		fi
-	fi
+  if [ -z $1 ]; then
+    checkLatestVersion TAG
+  else
+    TAG=$1
+  fi
+  echo "TAG=$TAG"
+  #  arduino-cli_0.4.0-rc1_Linux_64bit.[tar.gz, zip]
+  if [ "$OS" = "Windows" ]; then
+    CLI_DIST="arduino-cli_${TAG}_${OS}_${ARCH}.zip"
+  else
+    CLI_DIST="arduino-cli_${TAG}_${OS}_${ARCH}.tar.gz"
+  fi
+  echo "CLI_DIST=$CLI_DIST"
+  DOWNLOAD_URL="https://downloads.arduino.cc/arduino-cli/$CLI_DIST"
+  CLI_TMP_FILE="/tmp/$CLI_DIST"
+  echo "Downloading $DOWNLOAD_URL"
+  httpStatusCode=$(getFile "$DOWNLOAD_URL" "$CLI_TMP_FILE")
+  if [ "$httpStatusCode" -ne 200 ]; then
+    echo "Did not find a release for your system: $OS $ARCH"
+    echo "Trying to find a release using the GitHub API."
+    LATEST_RELEASE_URL="https://api.github.com/repos/arduino/$PROJECT_NAME/releases/tags/$TAG"
+    echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
+    get LATEST_RELEASE_JSON $LATEST_RELEASE_URL
+    # || true forces this command to not catch error if grep does not find anything
+    DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | grep 'browser_' | cut -d\" -f4 | grep "$CLI_DIST") || true
+    if [ -z "$DOWNLOAD_URL" ]; then
+      echo "Sorry, we dont have a dist for your system: $OS $ARCH"
+      fail "You can request one here: https://github.com/Arduino/$PROJECT_NAME/issues"
+    else
+      echo "Downloading $DOWNLOAD_URL"
+      getFile "$DOWNLOAD_URL" "$CLI_TMP_FILE"
+    fi
+  fi
 }
 
 installFile() {
-	CLI_TMP="/tmp/$PROJECT_NAME"
-	mkdir -p "$CLI_TMP"
-	if [ "$OS" = "Windows" ]; then
-		unzip -d "$CLI_TMP" "$CLI_TMP_FILE"
-	else
-		tar xf "$CLI_TMP_FILE" -C "$CLI_TMP"
-	fi
-	CLI_TMP_BIN="$CLI_TMP/$PROJECT_NAME"
-	cp "$CLI_TMP_BIN" "$LBINDIR"
-	rm -rf $CLI_TMP
-	rm -f $CLI_TMP_FILE
+  CLI_TMP="/tmp/$PROJECT_NAME"
+  mkdir -p "$CLI_TMP"
+  if [ "$OS" = "Windows" ]; then
+    unzip -d "$CLI_TMP" "$CLI_TMP_FILE"
+  else
+    tar xf "$CLI_TMP_FILE" -C "$CLI_TMP"
+  fi
+  CLI_TMP_BIN="$CLI_TMP/$PROJECT_NAME"
+  cp "$CLI_TMP_BIN" "$LBINDIR"
+  rm -rf $CLI_TMP
+  rm -f $CLI_TMP_FILE
 }
 
 bye() {
-	result=$?
-	if [ "$result" != "0" ]; then
-		echo "Failed to install $PROJECT_NAME"
-	fi
-	exit $result
+  result=$?
+  if [ "$result" != "0" ]; then
+    echo "Failed to install $PROJECT_NAME"
+  fi
+  exit $result
 }
 
 testVersion() {
-	set +e
-	CLI="$(which $PROJECT_NAME)"
-	if [ "$?" = "1" ]; then
-		echo "$PROJECT_NAME not found. You might want to add "$LBINDIR" to your "'$PATH'
-	else
-		# Convert to resolved, absolute paths before comparison
-		CLI_REALPATH="$(cd -- "$(dirname -- "$CLI")" && pwd -P)"
-		LBINDIR_REALPATH="$(cd -- "$LBINDIR" && pwd -P)"
-		if [ "$CLI_REALPATH" != "$LBINDIR_REALPATH" ]; then
-			echo "An existing $PROJECT_NAME was found at $CLI. Please prepend "$LBINDIR" to your "'$PATH'" or remove the existing one."
-		fi
-	fi
+  set +e
+  CLI="$(which $PROJECT_NAME)"
+  if [ "$?" = "1" ]; then
+    echo "$PROJECT_NAME not found. You might want to add "$LBINDIR" to your "'$PATH'
+  else
+    # Convert to resolved, absolute paths before comparison
+    CLI_REALPATH="$(cd -- "$(dirname -- "$CLI")" && pwd -P)"
+    LBINDIR_REALPATH="$(cd -- "$LBINDIR" && pwd -P)"
+    if [ "$CLI_REALPATH" != "$LBINDIR_REALPATH" ]; then
+      echo "An existing $PROJECT_NAME was found at $CLI. Please prepend "$LBINDIR" to your "'$PATH'" or remove the existing one."
+    fi
+  fi
 
-	set -e
-	CLI_VERSION=$($LBINDIR/$PROJECT_NAME version)
-	echo "$CLI_VERSION installed successfully in $LBINDIR"
+  set -e
+  CLI_VERSION=$($LBINDIR/$PROJECT_NAME version)
+  echo "$CLI_VERSION installed successfully in $LBINDIR"
 }
-
 
 # Execution
 

--- a/install.sh
+++ b/install.sh
@@ -1,23 +1,14 @@
 #!/bin/sh
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/other/installation-script/install.sh
 
-# The original version of this script is licensed under the MIT license.
-# See https://github.com/Masterminds/glide/blob/master/LICENSE for more details
-# and copyright notice.
+# The original version of this script (https://github.com/Masterminds/glide.sh/blob/master/get) is licensed under the
+# MIT license. See https://github.com/Masterminds/glide/blob/master/LICENSE for more details and copyright notice.
 
-#
-# Usage:
-#
-# To install the latest version of the CLI:
-#    ./install.sh
-#
-# To pin a specific release of the CLI:
-#    ./install.sh 0.9.0
-#
-
+PROJECT_OWNER="arduino"
 PROJECT_NAME="arduino-cli"
 
 # BINDIR represents the local bin location, defaults to ./bin.
-LBINDIR=""
+EFFECTIVE_BINDIR=""
 DEFAULT_BINDIR="$PWD/bin"
 
 fail() {
@@ -28,16 +19,18 @@ fail() {
 initDestination() {
   if [ -n "$BINDIR" ]; then
     if [ ! -d "$BINDIR" ]; then
+      # The second instance of $BINDIR is intentionally a literal in this message.
+      # shellcheck disable=SC2016
       fail "$BINDIR "'($BINDIR)'" folder not found. Please create it before continuing."
     fi
-    LBINDIR="$BINDIR"
+    EFFECTIVE_BINDIR="$BINDIR"
   else
     if [ ! -d "$DEFAULT_BINDIR" ]; then
       mkdir "$DEFAULT_BINDIR"
     fi
-    LBINDIR="$DEFAULT_BINDIR"
+    EFFECTIVE_BINDIR="$DEFAULT_BINDIR"
   fi
-  echo "Installing in $LBINDIR"
+  echo "Installing in $EFFECTIVE_BINDIR"
 }
 
 initArch() {
@@ -67,9 +60,9 @@ initOS() {
 }
 
 initDownloadTool() {
-  if type "curl" >/dev/null; then
+  if command -v "curl" >/dev/null 2>&1; then
     DOWNLOAD_TOOL="curl"
-  elif type "wget" >/dev/null; then
+  elif command -v "wget" >/dev/null 2>&1; then
     DOWNLOAD_TOOL="wget"
   else
     fail "You need curl or wget as download tool. Please install it first before continuing"
@@ -80,130 +73,137 @@ initDownloadTool() {
 checkLatestVersion() {
   # Use the GitHub releases webpage to find the latest version for this project
   # so we don't get rate-limited.
-  local tag
-  local regex="[0-9][A-Za-z0-9\.-]*"
-  local latest_url="https://github.com/arduino/arduino-cli/releases/latest"
+  CHECKLATESTVERSION_REGEX="[0-9][A-Za-z0-9\.-]*"
+  CHECKLATESTVERSION_LATEST_URL="https://github.com/${PROJECT_OWNER}/${PROJECT_NAME}/releases/latest"
   if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-    tag=$(curl -SsL $latest_url | grep -o "<title>Release $regex · arduino/arduino-cli" | grep -o "$regex")
+    CHECKLATESTVERSION_TAG=$(curl -SsL $CHECKLATESTVERSION_LATEST_URL | grep -o "<title>Release $CHECKLATESTVERSION_REGEX · ${PROJECT_OWNER}/${PROJECT_NAME}" | grep -o "$CHECKLATESTVERSION_REGEX")
   elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-    tag=$(wget -q -O - $latest_url | grep -o "<title>Release $regex · arduino/arduino-cli" | grep -o "$regex")
+    CHECKLATESTVERSION_TAG=$(wget -q -O - $CHECKLATESTVERSION_LATEST_URL | grep -o "<title>Release $CHECKLATESTVERSION_REGEX · ${PROJECT_OWNER}/${PROJECT_NAME}" | grep -o "$CHECKLATESTVERSION_REGEX")
   fi
-  if [ "x$tag" = "x" ]; then
+  if [ "$CHECKLATESTVERSION_TAG" = "" ]; then
     echo "Cannot determine latest tag."
     exit 1
   fi
-  eval "$1='$tag'"
+  eval "$1='$CHECKLATESTVERSION_TAG'"
 }
 
 get() {
-  local url="$2"
-  local body
-  local httpStatusCode
-  echo "Getting $url"
+  GET_URL="$2"
+  echo "Getting $GET_URL"
   if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-    httpResponse=$(curl -sL --write-out HTTPSTATUS:%{http_code} "$url")
-    httpStatusCode=$(echo $httpResponse | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
-    body=$(echo "$httpResponse" | sed -e 's/HTTPSTATUS\:.*//g')
+    GET_HTTP_RESPONSE=$(curl -sL --write-out 'HTTPSTATUS:%{http_code}' "$GET_URL")
+    GET_HTTP_STATUS_CODE=$(echo "$GET_HTTP_RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+    GET_BODY=$(echo "$GET_HTTP_RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')
   elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-    tmpFile=$(mktemp)
-    body=$(wget --server-response --content-on-error -q -O - "$url" 2>$tmpFile || true)
-    httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
+    TMP_FILE=$(mktemp)
+    GET_BODY=$(wget --server-response --content-on-error -q -O - "$GET_URL" 2>"$TMP_FILE" || true)
+    GET_HTTP_STATUS_CODE=$(awk '/^  HTTP/{print $2}' "$TMP_FILE")
   fi
-  if [ "$httpStatusCode" != 200 ]; then
-    echo "Request failed with HTTP status code $httpStatusCode"
-    fail "Body: $body"
+  if [ "$GET_HTTP_STATUS_CODE" != 200 ]; then
+    echo "Request failed with HTTP status code $GET_HTTP_STATUS_CODE"
+    fail "Body: $GET_BODY"
   fi
-  eval "$1='$body'"
+  eval "$1='$GET_BODY'"
 }
 
 getFile() {
-  local url="$1"
-  local filePath="$2"
+  GETFILE_URL="$1"
+  GETFILE_FILE_PATH="$2"
   if [ "$DOWNLOAD_TOOL" = "curl" ]; then
-    httpStatusCode=$(curl -s -w '%{http_code}' -L "$url" -o "$filePath")
+    GETFILE_HTTP_STATUS_CODE=$(curl -s -w '%{http_code}' -L "$GETFILE_URL" -o "$GETFILE_FILE_PATH")
   elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
-    tmpFile=$(mktemp)
-    body=$(wget --server-response --content-on-error -q -O "$filePath" "$url" 2>$tmpFile || true)
-    httpStatusCode=$(cat $tmpFile | awk '/^  HTTP/{print $2}')
+    wget --server-response --content-on-error -q -O "$GETFILE_FILE_PATH" "$GETFILE_URL"
+    GETFILE_HTTP_STATUS_CODE=$(awk '/^  HTTP/{print $2}' "$TMP_FILE")
   fi
-  echo "$httpStatusCode"
+  echo "$GETFILE_HTTP_STATUS_CODE"
 }
 
 downloadFile() {
-  if [ -z $1 ]; then
+  if [ -z "$1" ]; then
     checkLatestVersion TAG
   else
     TAG=$1
   fi
-  echo "TAG=$TAG"
-  #  arduino-cli_0.4.0-rc1_Linux_64bit.[tar.gz, zip]
+  #  arduino-lint_0.4.0-rc1_Linux_64bit.[tar.gz, zip]
   if [ "$OS" = "Windows" ]; then
-    CLI_DIST="arduino-cli_${TAG}_${OS}_${ARCH}.zip"
+    APPLICATION_DIST="${PROJECT_NAME}_${TAG}_${OS}_${ARCH}.zip"
   else
-    CLI_DIST="arduino-cli_${TAG}_${OS}_${ARCH}.tar.gz"
+    APPLICATION_DIST="${PROJECT_NAME}_${TAG}_${OS}_${ARCH}.tar.gz"
   fi
-  echo "CLI_DIST=$CLI_DIST"
-  DOWNLOAD_URL="https://downloads.arduino.cc/arduino-cli/$CLI_DIST"
-  CLI_TMP_FILE="/tmp/$CLI_DIST"
+
+  # Support specifying nightly build versions (e.g., "nightly-latest") via the script argument.
+  case "$TAG" in
+  nightly*)
+    DOWNLOAD_URL="https://downloads.arduino.cc/${PROJECT_NAME}/nightly/${APPLICATION_DIST}"
+    ;;
+  *)
+    DOWNLOAD_URL="https://downloads.arduino.cc/${PROJECT_NAME}/${APPLICATION_DIST}"
+    ;;
+  esac
+
+  INSTALLATION_TMP_FILE="/tmp/$APPLICATION_DIST"
   echo "Downloading $DOWNLOAD_URL"
-  httpStatusCode=$(getFile "$DOWNLOAD_URL" "$CLI_TMP_FILE")
+  httpStatusCode=$(getFile "$DOWNLOAD_URL" "$INSTALLATION_TMP_FILE")
   if [ "$httpStatusCode" -ne 200 ]; then
     echo "Did not find a release for your system: $OS $ARCH"
     echo "Trying to find a release using the GitHub API."
-    LATEST_RELEASE_URL="https://api.github.com/repos/arduino/$PROJECT_NAME/releases/tags/$TAG"
+    LATEST_RELEASE_URL="https://api.github.com/repos/${PROJECT_OWNER}/$PROJECT_NAME/releases/tags/$TAG"
     echo "LATEST_RELEASE_URL=$LATEST_RELEASE_URL"
-    get LATEST_RELEASE_JSON $LATEST_RELEASE_URL
+    get LATEST_RELEASE_JSON "$LATEST_RELEASE_URL"
     # || true forces this command to not catch error if grep does not find anything
-    DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | grep 'browser_' | cut -d\" -f4 | grep "$CLI_DIST") || true
+    DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | grep 'browser_' | cut -d\" -f4 | grep "$APPLICATION_DIST") || true
     if [ -z "$DOWNLOAD_URL" ]; then
       echo "Sorry, we dont have a dist for your system: $OS $ARCH"
-      fail "You can request one here: https://github.com/Arduino/$PROJECT_NAME/issues"
+      fail "You can request one here: https://github.com/${PROJECT_OWNER}/$PROJECT_NAME/issues"
     else
       echo "Downloading $DOWNLOAD_URL"
-      getFile "$DOWNLOAD_URL" "$CLI_TMP_FILE"
+      getFile "$DOWNLOAD_URL" "$INSTALLATION_TMP_FILE"
     fi
   fi
 }
 
 installFile() {
-  CLI_TMP="/tmp/$PROJECT_NAME"
-  mkdir -p "$CLI_TMP"
+  INSTALLATION_TMP_DIR="/tmp/$PROJECT_NAME"
+  mkdir -p "$INSTALLATION_TMP_DIR"
   if [ "$OS" = "Windows" ]; then
-    unzip -d "$CLI_TMP" "$CLI_TMP_FILE"
+    unzip -d "$INSTALLATION_TMP_DIR" "$INSTALLATION_TMP_FILE"
   else
-    tar xf "$CLI_TMP_FILE" -C "$CLI_TMP"
+    tar xf "$INSTALLATION_TMP_FILE" -C "$INSTALLATION_TMP_DIR"
   fi
-  CLI_TMP_BIN="$CLI_TMP/$PROJECT_NAME"
-  cp "$CLI_TMP_BIN" "$LBINDIR"
-  rm -rf $CLI_TMP
-  rm -f $CLI_TMP_FILE
+  INSTALLATION_TMP_BIN="$INSTALLATION_TMP_DIR/$PROJECT_NAME"
+  cp "$INSTALLATION_TMP_BIN" "$EFFECTIVE_BINDIR"
+  rm -rf "$INSTALLATION_TMP_DIR"
+  rm -f "$INSTALLATION_TMP_FILE"
 }
 
 bye() {
-  result=$?
-  if [ "$result" != "0" ]; then
+  BYE_RESULT=$?
+  if [ "$BYE_RESULT" != "0" ]; then
     echo "Failed to install $PROJECT_NAME"
   fi
-  exit $result
+  exit $BYE_RESULT
 }
 
 testVersion() {
   set +e
-  CLI="$(which $PROJECT_NAME)"
+  EXECUTABLE_PATH="$(command -v $PROJECT_NAME)"
   if [ "$?" = "1" ]; then
-    echo "$PROJECT_NAME not found. You might want to add "$LBINDIR" to your "'$PATH'
+    # $PATH is intentionally a literal in this message.
+    # shellcheck disable=SC2016
+    echo "$PROJECT_NAME not found. You might want to add \"$EFFECTIVE_BINDIR\" to your "'$PATH'
   else
     # Convert to resolved, absolute paths before comparison
-    CLI_REALPATH="$(cd -- "$(dirname -- "$CLI")" && pwd -P)"
-    LBINDIR_REALPATH="$(cd -- "$LBINDIR" && pwd -P)"
-    if [ "$CLI_REALPATH" != "$LBINDIR_REALPATH" ]; then
-      echo "An existing $PROJECT_NAME was found at $CLI. Please prepend "$LBINDIR" to your "'$PATH'" or remove the existing one."
+    EXECUTABLE_REALPATH="$(cd -- "$(dirname -- "$EXECUTABLE_PATH")" && pwd -P)"
+    EFFECTIVE_BINDIR_REALPATH="$(cd -- "$EFFECTIVE_BINDIR" && pwd -P)"
+    if [ "$EXECUTABLE_REALPATH" != "$EFFECTIVE_BINDIR_REALPATH" ]; then
+      # shellcheck disable=SC2016
+      echo "An existing $PROJECT_NAME was found at $EXECUTABLE_PATH. Please prepend \"$EFFECTIVE_BINDIR\" to your "'$PATH'" or remove the existing one."
     fi
   fi
 
   set -e
-  CLI_VERSION=$($LBINDIR/$PROJECT_NAME version)
-  echo "$CLI_VERSION installed successfully in $LBINDIR"
+  APPLICATION_VERSION="$("$EFFECTIVE_BINDIR/$PROJECT_NAME" version)"
+  echo "$APPLICATION_VERSION installed successfully in $EFFECTIVE_BINDIR"
 }
 
 # Execution
@@ -215,6 +215,6 @@ set -e
 initArch
 initOS
 initDownloadTool
-downloadFile $1
+downloadFile "$1"
 installFile
 testVersion


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure update

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
We have assembled a collection of reusable project assets:
https://github.com/arduino/tooling-project-assets
These assets will be used in the repositories of all Arduino tooling projects.

Some minor improvements and standardizations have been made in the upstream "template" installation script, and those are
introduced to this repository via this pull request.


* **What is the new behavior?**
<!-- if this is a feature change -->

Workflow is synced with the state of the art from upstream.

Notable:

- [ShellCheck ](https://github.com/koalaman/shellcheck)compliance
- Support for specifying nightly build versions (e.g., "nightly-latest") via the script argument
- Remove cryptic output not of interest to the user (likely forgotten debug artifacts from script development)

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

>Does this PR introduce a breaking change

No

>is titled accordingly

Yes

* **Other information**:
<!-- Any additional information that could help the review process -->
Can be tried out before merge by running the copy from this PR's branch:
```
curl -fsSL https://raw.githubusercontent.com/per1234/arduino-cli/install-script/install.sh | sh -s nightly-latest
```
(this particular command demos the new nightly install capability)

The script is already in place in the Arduino Lint repository, which has a CI workflow for testing it:
https://github.com/arduino/arduino-lint/actions/workflows/test-install.yml