### PR TITLE
[skip changelog] Don't require Codecov upload success for test run in fork

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -80,7 +80,7 @@ jobs:
         if: >
           runner.os == 'Linux' &&
           github.event_name == 'push'
-        uses: codecov/codecov-action@v2.0.2
+        uses: codecov/codecov-action@v2
         with:
           file: ./coverage_legacy.txt
           flags: unit

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           file: ./coverage_unit.txt
           flags: unit
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.repository == 'arduino/arduino-cli' }}
 
       - name: Send legacy tests coverage to Codecov
         if: >
@@ -84,3 +84,4 @@ jobs:
         with:
           file: ./coverage_legacy.txt
           flags: unit
+          fail_ci_if_error: ${{ github.repository == 'arduino/arduino-cli' }}


### PR DESCRIPTION
## **Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

### **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The "Test Go" workflow uploads code coverage data to Codecov. There will occasionally be spurious upload failures caused
by transient network outages. These will typically succeed after the workflow is re-run, but the option to re-run is not
offered when the workflow run passes.

Because it's important that the data be complete, the `codecov/codecov-action` action is configured to fail the workflow
run if the upload does not succeed. However, the upload will never be able to succeed for workflow runs in a fork where
the owner has not set up Codecov.

This can cause confusion to contributors who have enabled GitHub Actions in their fork of `arduino/arduino-cli` to get feedback on their development work in preparation for submitting a PR, but who have not set up their Codecov account.

### **What is the new behavior?**
<!-- if this is a feature change -->
The `fail_ci_if_error` input setting is made conditional upon the
repository name.

The result is:

- Coverage data upload success is required for all workflow runs in the `arduino/arduino-cli` repository.
- Uploads are attempted for workflow runs in forks (because the fork owner might have Codecov set up and want the data),
  but they are not required to succeed and will fail silently.

### **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

Not breaking
