### PR TITLE
Better detection of required serial port during upload.

### DIFF
--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -397,7 +397,7 @@ func runTool(recipeID string, props *properties.Map, outStream, errStream io.Wri
 	if strings.TrimSpace(recipe) == "" {
 		return nil // Nothing to run
 	}
-	if props.IsPropertyMissingInExpandPropsInString("serial.port", recipe) {
+	if props.IsPropertyMissingInExpandPropsInString("serial.port", recipe) || props.IsPropertyMissingInExpandPropsInString("serial.port.file", recipe) {
 		return fmt.Errorf(tr("no upload port provided"))
 	}
 	cmdLine := props.ExpandPropsInString(recipe)


### PR DESCRIPTION
Previously we checked the upload recipe for the variable `{serial.port}` to determine if the upload requires a serial port, but this is not sufficient because we must check also for the variable `{serial.port.file}`.
No breaking changes.

Current output:
```
$ arduino-cli upload --dry-run -v -b arduino:samd:adafruit_circuitplayground_m0
Skipping 1200-bps touch reset: no serial port selected!
Waiting for upload port...
No upload port found, using  as fallback
"/home/megabug/.arduino15/packages/arduino/tools/bossac/1.7.0-arduino3/bossac" -i -d --port={serial.port.file} -U true -i -e -w -v "/tmp/arduino-sketch-61DECCCDDA68480BC07770DEB6E56DDB/Bare.ino.bin" -R
```

As we can see the `bossac` tool is launched anyway with the unexpanded `{serial.port.file}` variable.

New behavior:
```
$ arduino-cli upload --dry-run -v -b arduino:samd:adafruit_circuitplayground_m0
Skipping 1200-bps touch reset: no serial port selected!
Waiting for upload port...
No upload port found, using  as fallback
Error during Upload: uploading error: no upload port provided
```

The message `No upload port found, using  as fallback` can be still improved, but at least we have a clear indication that the error is caused by `no upload port provided`.