### PR TITLE
[skip changelog] Run relevant workflows on release branch creation

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -38,10 +38,7 @@ jobs:
           # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
           if [[ \
             "${{ github.event_name }}" != "create" || \
-            ( \
-              "${{ github.event_name }}" == "create" && \
-              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
-            ) \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
           ]]; then
             # Run the other jobs.
             RESULT="true"

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/check-go-task.ya?ml"
@@ -25,8 +26,36 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            ( \
+              "${{ github.event_name }}" == "create" && \
+              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+            ) \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   check-errors:
     name: check-errors (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -62,6 +91,8 @@ jobs:
 
   check-outdated:
     name: check-outdated (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -100,6 +131,8 @@ jobs:
 
   check-style:
     name: check-style (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -138,6 +171,8 @@ jobs:
 
   check-formatting:
     name: check-formatting (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -176,6 +211,8 @@ jobs:
 
   check-config:
     name: check-config (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -208,6 +245,8 @@ jobs:
   # Do a simple "smoke test" build for the modules with no other form of validation
   build:
     name: build (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/check-i18n-task.yml
+++ b/.github/workflows/check-i18n-task.yml
@@ -39,10 +39,7 @@ jobs:
           # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
           if [[ \
             "${{ github.event_name }}" != "create" || \
-            ( \
-              "${{ github.event_name }}" == "create" && \
-              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
-            ) \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
           ]]; then
             # Run the other jobs.
             RESULT="true"

--- a/.github/workflows/check-i18n-task.yml
+++ b/.github/workflows/check-i18n-task.yml
@@ -6,6 +6,7 @@ env:
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/check-i18n-task.ya?ml"
@@ -26,7 +27,35 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            ( \
+              "${{ github.event_name }}" == "create" && \
+              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+            ) \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   check:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-protobuf-task.yml
+++ b/.github/workflows/check-protobuf-task.yml
@@ -33,10 +33,7 @@ jobs:
           # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
           if [[ \
             "${{ github.event_name }}" != "create" || \
-            ( \
-              "${{ github.event_name }}" == "create" && \
-              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
-            ) \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
           ]]; then
             # Run the other jobs.
             RESULT="true"

--- a/.github/workflows/check-protobuf-task.yml
+++ b/.github/workflows/check-protobuf-task.yml
@@ -6,6 +6,7 @@ env:
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/check-protobuf-task.ya?ml"
@@ -20,7 +21,35 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            ( \
+              "${{ github.event_name }}" == "create" && \
+              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+            ) \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   build:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -54,6 +83,8 @@ jobs:
         run: task protoc:compile
 
   check:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -81,6 +112,8 @@ jobs:
         run: task protoc:check
 
   check-formatting:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -3,6 +3,7 @@ name: Publish Tester Build
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/publish-go-tester-task.ya?ml"
@@ -28,7 +29,35 @@ env:
   BUILDS_ARTIFACT: build-artifacts
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            ( \
+              "${{ github.event_name }}" == "create" && \
+              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+            ) \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   build:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -41,10 +41,7 @@ jobs:
           # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
           if [[ \
             "${{ github.event_name }}" != "create" || \
-            ( \
-              "${{ github.event_name }}" == "create" && \
-              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
-            ) \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
           ]]; then
             # Run the other jobs.
             RESULT="true"

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -46,10 +46,7 @@ jobs:
           # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
           if [[ \
             "${{ github.event_name }}" != "create" || \
-            ( \
-              "${{ github.event_name }}" == "create" && \
-              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
-            ) \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
           ]]; then
             # Run the other jobs.
             RESULT="true"

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -9,6 +9,7 @@ env:
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/test-go-integration-task.ya?ml"
@@ -33,7 +34,36 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            ( \
+              "${{ github.event_name }}" == "create" && \
+              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+            ) \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   test:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+
     strategy:
       matrix:
         operating-system:

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
@@ -29,7 +30,36 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            ( \
+              "${{ github.event_name }}" == "create" && \
+              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+            ) \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   test:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+
     strategy:
       matrix:
         operating-system:

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -42,10 +42,7 @@ jobs:
           # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
           if [[ \
             "${{ github.event_name }}" != "create" || \
-            ( \
-              "${{ github.event_name }}" == "create" && \
-              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
-            ) \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
           ]]; then
             # Run the other jobs.
             RESULT="true"


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, ... -->
Infrastructure enhancement

## What is the current behavior?
<!-- You can also link to an open issue here -->
The [trunk-based development](https://trunkbaseddevelopment.com/) strategy is employed by this repository. This means that the release branch may contain a subset of the history of the default branch.

The status of the GitHub Actions workflows should be evaluated before making a release. However, this is not so simple as checking the status of the commit at the tip of the release branch. The reason is that, for the sake of efficiency, the [workflows are configured](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on) to run only when the processes are relevant to the trigger event (e.g., no need to run the Go unit tests for a change to the readme).

In the case of the default branch, you can simply [set the workflow runs filter to that branch](https://github.com/arduino/arduino-cli/actions?query=branch%3Amaster) and then check the result of the latest run of each workflow of interest. However, that is not possible to do with the release branch since it might be that the workflow was never run in that branch. The status of the latest run of the workflow in the default branch might not match the status for the release branch if the release branch does not contain the full history.

## What is the new behavior?
<!-- if this is a feature change -->
For the reason explained above, it will be helpful to trigger all relevant workflows on the creation of a release branch. This will ensure that each of those workflows will always have at least one run in the release branch. Subsequent commits pushed to the branch can run based on their usual trigger filters and the status of the latest run of each workflow in the branch will provide an accurate indication of the state of that branch.

Branches are created for purposes other than releases, most notably feature branches to stage work for a pull request. Because the workflows are very comprehensive, it would not be convenient or efficient to run them on the creation of every feature branch.

Unfortunately, GitHub Actions does not support filters on [the `create` event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#create) of branch creation like it does for the `push` and `pull_request` events. There is support for a [`branches` filter](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags) of the `push` event, but that filter is an AND to the `paths` filter and this application requires an OR. For this reason, the workflows must be triggered by the creation of any branch. The unwanted job runs are prevented by adding a `run-determination` job with the branch filter handled by Bash commands. The other jobs of the workflow use this `run-determination` [job as a dependency](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds), only running when it indicates they should via a [job output](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idoutputs). Because this minimal `run-determination` job runs very quickly, it is roughly equivalent to the workflow having been skipped entirely for non-release branch creations. This approach has been in use for some time already in the website deployment workflow (https://github.com/arduino/arduino-cli/pull/1028).


## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No breaking change
## Other information:
<!-- Any additional information that could help the review process -->

Demo of workflow runs on release branch creation: https://github.com/per1234/arduino-cli/actions?query=branch%3A0.0.x
(note that the workflows were triggered and all jobs ran)

Demo of workflow runs on feature branch creation: https://github.com/per1234/arduino-cli/actions?query=branch%3Asome-feature
(note that the workflows were triggered but all jobs other than `run-determination` were skipped)