### PR TITLE
[skip changelog] Use major version ref for `actions/github-script` action

### DIFF
--- a/.github/workflows/github-stats.yaml
+++ b/.github/workflows/github-stats.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Fetch downloads count
         id: fetch
-        uses: actions/github-script@v4.0.2
+        uses: actions/github-script@v4
         with:
           github-token: ${{github.token}}
           script: |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure enhancement
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The `actions/github-script` GitHub Actions action dependency of the "github-stats" workflow is pinned to the patch version. This means it must be updated every time a release of the action is made.
* **What is the new behavior?**
<!-- if this is a feature change -->
Use of the major version ref will cause the workflow to automatically benefit from ongoing development to its `actions/github-script` GitHub Actions action dependency at each patch or minor release without any intervention from a maintainer, up until such time as a new major release is made. Dependabot will submit a PR at that time, which will serve as the notification that a newer version is available. At that time, the maintainer should evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before manually updating the major ref (i.e., `uses: actions/github-script@v5`).


- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
Not breaking.
* **Other information**:
<!-- Any additional information that could help the review process -->
Alternative to https://github.com/arduino/arduino-cli/pull/1403

Information about the major version ref approach:
https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions