### PR TITLE
[WIP] Add completion for PowerShell

### DIFF
--- a/cli/completion/completion.go
+++ b/cli/completion/completion.go
@@ -32,8 +32,8 @@ var (
 // NewCommand created a new `completion` command
 func NewCommand() *cobra.Command {
 	command := &cobra.Command{
-		Use:       "completion [bash|zsh|fish] [--no-descriptions]",
-		ValidArgs: []string{"bash", "zsh", "fish"},
+		Use:       "completion [bash|zsh|fish|powershell] [--no-descriptions]",
+		ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
 		Args:      cobra.ExactArgs(1),
 		Short:     tr("Generates completion scripts"),
 		Long:      tr("Generates completion scripts for various shells"),
@@ -64,6 +64,9 @@ func run(cmd *cobra.Command, args []string) {
 		break
 	case "fish":
 		cmd.Root().GenFishCompletion(os.Stdout, !completionNoDesc)
+		break
+	case "powershell":
+		cmd.Root().GenPowerShellCompletion(os.Stdout)
 		break
 	}
 }


### PR DESCRIPTION
Add support to generate PowerShell completions for `arduino-cli` in PowerShell 5.0+

This PR:

  * Add PowerShell to completion code generation

While waiting for documentation, please, you can test it following the instructions at [Autocomplete in PowerShell](https://techcommunity.microsoft.com/t5/itops-talk-blog/autocomplete-in-powershell/ba-p/2604524). 
