### PR TITLE
[skip changelog] Fix platform specification docs

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -857,11 +857,11 @@ tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} -p{
 If necessary the same property can be defined multiple times for different protocols:
 
 ```
-leonardo.upload.serial.maximum_size=28672
-leonardo.upload.network.maximum_size=256
+leonardo.upload.serial.speed=57600
+leonardo.upload.network.speed=19200
 ```
 
-The two above properties will be available as **{upload.serial.maximum_size}** and **{upload.network.maximum_size}**.
+The two above properties will be available as **{upload.serial.speed}** and **{upload.network.speed}**.
 
 #### Properties from pluggable discovery
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes a documentation error.

- **What is the current behavior?**

A platform specification documentation example uses a compile time property to show how to set the same upload property for different protocols.

* **What is the new behavior?**

The platform documentation example now uses a property that is only used at upload time to show how to set the same upload property for different protocols.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
