### PR TITLE
Fix compile --build-path not working with relative paths

### DIFF
--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -144,7 +144,7 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 	if req.GetBuildPath() == "" {
 		builderCtx.BuildPath = sk.BuildPath
 	} else {
-		builderCtx.BuildPath = paths.New(req.GetBuildPath())
+		builderCtx.BuildPath = paths.New(req.GetBuildPath()).Canonical()
 	}
 	if err = builderCtx.BuildPath.MkdirAll(); err != nil {
 		return nil, &commands.PermissionDeniedError{Message: tr("Cannot create build directory"), Cause: err}

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1155,3 +1155,33 @@ def test_compile_sketch_with_ipp_file_include(run_command, copy_sketch):
     fqbn = "arduino:avr:uno"
 
     assert run_command(f"compile -b {fqbn} {sketch_path} --verbose")
+
+
+def test_compile_with_relative_build_path(run_command, data_dir, copy_sketch):
+    assert run_command("update")
+
+    run_command("core install arduino:avr@1.8.3")
+
+    sketch_name = "sketch_simple"
+    sketch_path = copy_sketch(sketch_name)
+    fqbn = "arduino:avr:uno"
+
+    build_path = Path("..", "build_path")
+    working_dir = Path(data_dir, "working_dir")
+    working_dir.mkdir()
+    assert run_command(f"compile -b {fqbn} --build-path {build_path} {sketch_path} -v", custom_working_dir=working_dir)
+
+    absolute_build_path = Path(data_dir, "build_path")
+    built_files = [f.name for f in absolute_build_path.glob("*")]
+    assert f"{sketch_name}.ino.eep" in built_files
+    assert f"{sketch_name}.ino.elf" in built_files
+    assert f"{sketch_name}.ino.hex" in built_files
+    assert f"{sketch_name}.ino.with_bootloader.bin" in built_files
+    assert f"{sketch_name}.ino.with_bootloader.hex" in built_files
+    assert "build.options.json" in built_files
+    assert "compile_commands.json" in built_files
+    assert "core" in built_files
+    assert "includes.cache" in built_files
+    assert "libraries" in built_files
+    assert "preproc" in built_files
+    assert "sketch" in built_files


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fix a bug in a command and relative gRPC interface.

- **What is the current behavior?**

Calling `arduino-cli compile --build-path ../build-path -b arduino:avr:uno ~/Arduino/Blink` fails with an unclear error cause of the relative build path:
```
Couldn't deeply cache core build: Rel: can't make ../build-path relative to /tmp/arduino-core-cache                                                
Running normal build of the core...                                                                                                                
                                                                                                                                                   
Error during build: Rel: can't make /home/alien/workspace/build-path/core/core.a relative to ../build-path
```

The related gRPC function has the same behaviour.

* **What is the new behavior?**

Using a relative build path doesn't cause issues anymore and it's handled without problems:

```
~/workspace/arduino-cli
$ ./arduino-cli compile --build-path ../build-path -b arduino:avr:uno ~/Arduino/Blink
Sketch uses 924 bytes (2%) of program storage space. Maximum is 32256 bytes.
Global variables use 9 bytes (0%) of dynamic memory, leaving 2039 bytes for local variables. Maximum is 2048 bytes.

~/workspace/arduino-cli
$ ls ../build-path 
Blink.ino.eep  Blink.ino.hex                  Blink.ino.with_bootloader.hex  compile_commands.json  includes.cache  preproc
Blink.ino.elf  Blink.ino.with_bootloader.bin  build.options.json             core                   libraries       sketch
```

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

Fixes #630.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
