### PR TITLE
[skip changelog] Fix integration tests on OS X

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -204,7 +204,9 @@ def detected_boards(run_command):
     detected_boards = []
     for port in json.loads(result.stdout):
         for board in port.get("boards", []):
-            fqbn = board.get("fqbn")
+            fqbn = board.get("FQBN")
+            if not fqbn:
+                continue
             package, architecture, _id = fqbn.split(":")
             detected_boards.append(
                 Board(

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1066,7 +1066,7 @@ def test_compile_with_esp32_bundled_libraries(run_command, data_dir, copy_sketch
     assert run_command("update")
 
     # Update index with esp32 core and install it
-    url = "https://dl.espressif.com/dl/package_esp32_index.json"
+    url = "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json"
     core_version = "1.0.6"
     assert run_command(f"core update-index --additional-urls={url}")
     assert run_command(f"core install esp32:esp32@{core_version} --additional-urls={url}")

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -210,10 +210,10 @@ def test_core_install_without_updateindex(run_command):
 )
 def test_core_install_esp32(run_command, data_dir):
     # update index
-    url = "https://dl.espressif.com/dl/package_esp32_index.json"
+    url = "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json"
     assert run_command(f"core update-index --additional-urls={url}")
     # install 3rd-party core
-    assert run_command(f"core install esp32:esp32@1.0.4 --additional-urls={url}")
+    assert run_command(f"core install esp32:esp32@2.0.0 --additional-urls={url}")
     # create a sketch and compile to double check the core was successfully installed
     sketch_name = "test_core_install_esp32"
     sketch_path = os.path.join(data_dir, sketch_name)

--- a/test/test_upload_mock.py
+++ b/test/test_upload_mock.py
@@ -29,7 +29,7 @@ def generate_build_dir(sketch_path):
 
 indexes = [
     "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json",
-    "https://dl.espressif.com/dl/package_esp32_index.json",
+    "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json",
     "http://arduino.esp8266.com/stable/package_esp8266com_index.json",
     "https://github.com/sonydevworld/spresense-arduino-compatible/releases/download/generic/package_spresense_index.json",
 ]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes some integration tests.

- **What is the current behavior?**

Upload integration tests are failing on OS X because `board list` command returns also bluetooth devices.

Also some tests are failing cause they're using too old versions of `esp32` platform.

* **What is the new behavior?**

Boards without an FQBN are now skipped in integration tests.

We also updated the package index URL for `esp32` and some platform version used for testing.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
