### PR TITLE
[skip changelog] Fix Windows integration tests

### DIFF
--- a/test/test_board.py
+++ b/test/test_board.py
@@ -394,8 +394,8 @@ gold_board = """
 
 @pytest.mark.skipif(running_on_ci(), reason="VMs have no serial ports")
 def test_board_list(run_command):
-    run_command("core update-index")
-    result = run_command("board list --format json")
+    run_command(["core", "update-index"])
+    result = run_command(["board", "list", "--format", "json"])
     assert result.ok
     # check is a valid json and contains a list of ports
     ports = json.loads(result.stdout)
@@ -406,9 +406,9 @@ def test_board_list(run_command):
 
 
 def test_board_listall(run_command):
-    assert run_command("update")
-    assert run_command("core install arduino:avr@1.8.3")
-    res = run_command("board listall --format json")
+    assert run_command(["update"])
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
+    res = run_command(["board", "listall", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     boards = {b["fqbn"]: b for b in data["boards"]}
@@ -431,14 +431,14 @@ def test_board_listall(run_command):
 
 
 def test_board_listall_with_manually_installed_platform(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Manually installs a core in sketchbooks hardware folder
     git_url = "https://github.com/arduino/ArduinoCore-samd.git"
     repo_dir = Path(data_dir, "hardware", "arduino-beta-development", "samd")
     assert Repo.clone_from(git_url, repo_dir, multi_options=["-b 1.8.11"])
 
-    res = run_command("board listall --format json")
+    res = run_command(["board", "listall", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     boards = {b["fqbn"]: b for b in data["boards"]}
@@ -461,21 +461,21 @@ def test_board_listall_with_manually_installed_platform(run_command, data_dir):
 
 
 def test_board_details(run_command):
-    run_command("core update-index")
+    run_command(["core", "update-index"])
     # Download samd core pinned to 1.8.6
-    run_command("core install arduino:samd@1.8.6")
+    run_command(["core", "install", "arduino:samd@1.8.6"])
 
     # Test board listall with and without showing hidden elements
-    result = run_command("board listall MIPS --format json")
+    result = run_command(["board", "listall", "MIPS", "--format", "json"])
     assert result.ok
     assert result.stdout == "{}\n"
 
-    result = run_command("board listall MIPS -a --format json")
+    result = run_command(["board", "listall", "MIPS", "-a", "--format", "json"])
     assert result.ok
     result = json.loads(result.stdout)
     assert result["boards"][0]["name"] == "Arduino Tian (MIPS Console port)"
 
-    result = run_command("board details -b arduino:samd:nano_33_iot --format json")
+    result = run_command(["board", "details", "-b", "arduino:samd:nano_33_iot", "--format", "json"])
     assert result.ok
     # Sort everything before compare
     result = json.loads(result.stdout)
@@ -494,9 +494,9 @@ def test_board_details(run_command):
         assert programmer in result["programmers"]
 
     # Download samd core pinned to 1.8.8
-    run_command("core install arduino:samd@1.8.8")
+    run_command(["core", "install", "arduino:samd@1.8.8"])
 
-    result = run_command("board details -b arduino:samd:nano_33_iot --format json")
+    result = run_command(["board", "details", "-b", "arduino:samd:nano_33_iot", "--format", "json"])
     assert result.ok
     result = json.loads(result.stdout)
     assert result["debugging_supported"] is True
@@ -504,10 +504,10 @@ def test_board_details(run_command):
 
 # old `arduino-cli board details` did not need -b <fqbn> flag to work
 def test_board_details_old(run_command):
-    run_command("core update-index")
+    run_command(["core", "update-index"])
     # Download samd core pinned to 1.8.6
-    run_command("core install arduino:samd@1.8.6")
-    result = run_command("board details arduino:samd:nano_33_iot --format json")
+    run_command(["core", "install", "arduino:samd@1.8.6"])
+    result = run_command(["board", "details", "arduino:samd:nano_33_iot", "--format", "json"])
     assert result.ok
     # Sort everything before compare
     result = json.loads(result.stdout)
@@ -527,20 +527,20 @@ def test_board_details_old(run_command):
 
 
 def test_board_details_no_flags(run_command):
-    run_command("core update-index")
+    run_command(["core", "update-index"])
     # Download samd core pinned to 1.8.6
-    run_command("core install arduino:samd@1.8.6")
-    result = run_command("board details")
+    run_command(["core", "install", "arduino:samd@1.8.6"])
+    result = run_command(["board", "details"])
     assert not result.ok
     assert "Error getting board details: Invalid FQBN:" in result.stderr
     assert result.stdout == ""
 
 
 def test_board_details_list_programmers_without_flag(run_command):
-    run_command("core update-index")
+    run_command(["core", "update-index"])
     # Download samd core pinned to 1.8.6
-    run_command("core install arduino:samd@1.8.6")
-    result = run_command("board details -b arduino:samd:nano_33_iot")
+    run_command(["core", "install", "arduino:samd@1.8.6"])
+    result = run_command(["board", "details", "-b", "arduino:samd:nano_33_iot"])
     assert result.ok
     lines = [l.strip().split() for l in result.stdout.splitlines()]
     assert ["Programmers:", "Id", "Name"] in lines
@@ -550,10 +550,10 @@ def test_board_details_list_programmers_without_flag(run_command):
 
 
 def test_board_details_list_programmers_flag(run_command):
-    run_command("core update-index")
+    run_command(["core", "update-index"])
     # Download samd core pinned to 1.8.6
-    run_command("core install arduino:samd@1.8.6")
-    result = run_command("board details -b arduino:samd:nano_33_iot --list-programmers")
+    run_command(["core", "install", "arduino:samd@1.8.6"])
+    result = run_command(["board", "details", "-b", "arduino:samd:nano_33_iot", "--list-programmers"])
     assert result.ok
 
     lines = [l.strip() for l in result.stdout.splitlines()]
@@ -564,9 +564,9 @@ def test_board_details_list_programmers_flag(run_command):
 
 
 def test_board_search(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    res = run_command("board search --format json")
+    res = run_command(["board", "search", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     # Verifies boards are returned
@@ -581,7 +581,7 @@ def test_board_search(run_command, data_dir):
     assert "Arduino Portenta H7" in names
 
     # Search in non installed boards
-    res = run_command("board search --format json nano 33")
+    res = run_command(["board", "search", "--format", "json", "nano", "33"])
     assert res.ok
     data = json.loads(res.stdout)
     # Verifies boards are returned
@@ -593,9 +593,9 @@ def test_board_search(run_command, data_dir):
     assert "Arduino Nano 33 IoT" in names
 
     # Install a platform from index
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
-    res = run_command("board search --format json")
+    res = run_command(["board", "search", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) > 0
@@ -607,7 +607,7 @@ def test_board_search(run_command, data_dir):
     assert "arduino:avr:yun" in installed_boards
     assert "Arduino Yún" == installed_boards["arduino:avr:yun"]["name"]
 
-    res = run_command("board search --format json arduino yun")
+    res = run_command(["board", "search", "--format", "json", "arduino", "yun"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) > 0
@@ -620,7 +620,7 @@ def test_board_search(run_command, data_dir):
     repo_dir = Path(data_dir, "hardware", "arduino-beta-development", "samd")
     assert Repo.clone_from(git_url, repo_dir, multi_options=["-b 1.8.11"])
 
-    res = run_command("board search --format json")
+    res = run_command(["board", "search", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) > 0
@@ -641,7 +641,7 @@ def test_board_search(run_command, data_dir):
     assert "Arduino NANO 33 IoT" == installed_boards["arduino-beta-development:samd:nano_33_iot"]["name"]
     assert "arduino-beta-development:samd:arduino_zero_native" in installed_boards
 
-    res = run_command("board search --format json mkr1000")
+    res = run_command(["board", "search", "--format", "json", "mkr1000"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) > 0
@@ -652,25 +652,25 @@ def test_board_search(run_command, data_dir):
 
 
 def test_board_attach_without_sketch_json(run_command, data_dir):
-    run_command("update")
+    run_command(["update"])
 
     sketch_name = "BoardAttachWithoutSketchJson"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
-    assert run_command(f"board attach {fqbn} {sketch_path}")
+    assert run_command(["board", "attach", fqbn, sketch_path])
 
 
 def test_board_search_with_outdated_core(run_command):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install an old core version
-    assert run_command("core install arduino:samd@1.8.6")
+    assert run_command(["core", "install", "arduino:samd@1.8.6"])
 
-    res = run_command("board search arduino:samd:mkrwifi1010 --format json")
+    res = run_command(["board", "search", "arduino:samd:mkrwifi1010", "--format", "json"])
 
     data = json.loads(res.stdout)
     assert len(data) == 1

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -20,14 +20,14 @@ def test_cache_clean(run_command, data_dir):
     Clean the cache under arduino caching file directory which is
     "<Arduino configure file path>/staging"
     """
-    result = run_command("cache clean")
+    result = run_command(["cache", "clean"])
     assert result.ok
 
     # Generate /staging directory
-    result = run_command("lib list")
+    result = run_command(["lib", "list"])
     assert result.ok
 
-    result = run_command("cache clean")
+    result = run_command(["cache", "clean"])
     assert result.ok
 
     assert not os.path.isdir(os.path.join(data_dir, "staging"))

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -28,38 +28,38 @@ from .common import running_on_ci
 
 def test_compile_without_fqbn(run_command):
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # Install Arduino AVR Boards
-    run_command("core install arduino:avr@1.8.3")
+    run_command(["core", "install", "arduino:avr@1.8.3"])
 
     # Build sketch without FQBN
-    result = run_command("compile")
+    result = run_command(["compile"])
     assert result.failed
 
 
 def test_compile_with_simple_sketch(run_command, data_dir, working_dir):
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # Download latest AVR
-    run_command("core install arduino:avr")
+    run_command(["core", "install", "arduino:avr"])
 
     sketch_name = "CompileIntegrationTest"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    result = run_command(f"sketch new {sketch_path}")
+    result = run_command(["sketch", "new", sketch_path])
     assert result.ok
     assert f"Sketch created in: {sketch_path}" in result.stdout
 
     # Build sketch for arduino:avr:uno
-    result = run_command(f"compile -b {fqbn} {sketch_path}")
+    result = run_command(["compile", "-b", fqbn, sketch_path])
     assert result.ok
 
     # Build sketch for arduino:avr:uno with json output
-    result = run_command(f"compile -b {fqbn} {sketch_path} --format json")
+    result = run_command(["compile", "-b", fqbn, sketch_path, "--format", "json"])
     assert result.ok
     # check is a valid json and contains requested data
     compile_output = json.loads(result.stdout)
@@ -90,19 +90,19 @@ def test_compile_with_simple_sketch(run_command, data_dir, working_dir):
 )
 def test_output_flag_default_path(run_command, data_dir, working_dir):
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # Install Arduino AVR Boards
-    run_command("core install arduino:avr@1.8.3")
+    run_command(["core", "install", "arduino:avr@1.8.3"])
 
     # Create a test sketch
     sketch_path = os.path.join(data_dir, "test_output_flag_default_path")
     fqbn = "arduino:avr:uno"
-    result = run_command("sketch new {}".format(sketch_path))
+    result = run_command(["sketch", "new", sketch_path])
     assert result.ok
 
     # Test the --output-dir flag defaulting to current working dir
-    result = run_command("compile -b {fqbn} {sketch_path} --output-dir test".format(fqbn=fqbn, sketch_path=sketch_path))
+    result = run_command(["compile", "-b", fqbn, sketch_path, "--output-dir", "test"])
     assert result.ok
     target = os.path.join(working_dir, "test")
     assert os.path.exists(target) and os.path.isdir(target)
@@ -110,17 +110,17 @@ def test_output_flag_default_path(run_command, data_dir, working_dir):
 
 def test_compile_with_sketch_with_symlink_selfloop(run_command, data_dir):
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # Install Arduino AVR Boards
-    run_command("core install arduino:avr@1.8.3")
+    run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "CompileIntegrationTestSymlinkSelfLoop"
     sketch_path = os.path.join(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    result = run_command("sketch new {}".format(sketch_path))
+    result = run_command(["sketch", "new", sketch_path])
     assert result.ok
     assert "Sketch created in: {}".format(sketch_path) in result.stdout
 
@@ -129,7 +129,7 @@ def test_compile_with_sketch_with_symlink_selfloop(run_command, data_dir):
     os.symlink(loop_file_path, loop_file_path)
 
     # Build sketch for arduino:avr:uno
-    result = run_command("compile -b {fqbn} {sketch_path}".format(fqbn=fqbn, sketch_path=sketch_path))
+    result = run_command(["compile", "-b", fqbn, sketch_path])
     # The assertion is a bit relaxed in this case because win behaves differently from macOs and linux
     # returning a different error detailed message
     assert "Error during build: Can't open sketch:" in result.stderr
@@ -140,7 +140,7 @@ def test_compile_with_sketch_with_symlink_selfloop(run_command, data_dir):
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    result = run_command("sketch new {}".format(sketch_path))
+    result = run_command(["sketch", "new", sketch_path])
     assert result.ok
     assert "Sketch created in: {}".format(sketch_path) in result.stdout
 
@@ -151,7 +151,7 @@ def test_compile_with_sketch_with_symlink_selfloop(run_command, data_dir):
     os.symlink(loop_dir_path, loop_dir_symlink_path)
 
     # Build sketch for arduino:avr:uno
-    result = run_command("compile -b {fqbn} {sketch_path}".format(fqbn=fqbn, sketch_path=sketch_path))
+    result = run_command(["compile", "-b", fqbn, sketch_path])
     # The assertion is a bit relaxed in this case because win behaves differently from macOs and linux
     # returning a different error detailed message
     assert "Error during build: Can't open sketch:" in result.stderr
@@ -164,84 +164,96 @@ def test_compile_blacklisted_sketchname(run_command, data_dir):
     it should be ok for a sketch to be named like RCS.ino
     """
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # Install Arduino AVR Boards
-    run_command("core install arduino:avr@1.8.3")
+    run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "RCS"
     sketch_path = os.path.join(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    result = run_command("sketch new {}".format(sketch_path))
+    result = run_command(["sketch", "new", sketch_path])
     assert result.ok
     assert "Sketch created in: {}".format(sketch_path) in result.stdout
 
     # Build sketch for arduino:avr:uno
-    result = run_command("compile -b {fqbn} {sketch_path}".format(fqbn=fqbn, sketch_path=sketch_path))
+    result = run_command(["compile", "-b", fqbn, sketch_path])
     assert result.ok
 
 
 def test_compile_without_precompiled_libraries(run_command, data_dir):
     # Init the environment explicitly
     url = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json"
-    assert run_command(f"core update-index --additional-urls={url}")
-    assert run_command(f"core install arduino:mbed@1.3.1 --additional-urls={url}")
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
+    assert run_command(["core", "install", "arduino:mbed@1.3.1", f"--additional-urls={url}"])
 
     # Precompiled version of Arduino_TensorflowLite
-    assert run_command("lib install Arduino_LSM9DS1")
-    assert run_command("lib install Arduino_TensorflowLite@2.1.1-ALPHA-precompiled")
+    assert run_command(["lib", "install", "Arduino_LSM9DS1"])
+    assert run_command(["lib", "install", "Arduino_TensorflowLite@2.1.1-ALPHA-precompiled"])
 
     sketch_path = Path(data_dir, "libraries", "Arduino_TensorFlowLite", "examples", "hello_world")
-    assert run_command(f"compile -b arduino:mbed:nano33ble {sketch_path}")
+    assert run_command(["compile", "-b", "arduino:mbed:nano33ble", sketch_path])
 
-    assert run_command(f"core install arduino:samd@1.8.7 --additional-urls={url}")
-    assert run_command(f"core install adafruit:samd@1.6.4 --additional-urls={url}")
+    assert run_command(["core", "install", "arduino:samd@1.8.7", f"--additional-urls={url}"])
+    assert run_command(["core", "install", "adafruit:samd@1.6.4", f"--additional-urls={url}"])
     # should work on adafruit too after https://github.com/arduino/arduino-cli/pull/1134
-    assert run_command(f"compile -b adafruit:samd:adafruit_feather_m4 {sketch_path}")
+    assert run_command(["compile", "-b", "adafruit:samd:adafruit_feather_m4", sketch_path])
 
     # Non-precompiled version of Arduino_TensorflowLite
-    assert run_command("lib install Arduino_TensorflowLite@2.1.0-ALPHA")
-    assert run_command(f"compile -b arduino:mbed:nano33ble {sketch_path}")
-    assert run_command(f"compile -b adafruit:samd:adafruit_feather_m4 {sketch_path}")
+    assert run_command(["lib", "install", "Arduino_TensorflowLite@2.1.0-ALPHA"])
+    assert run_command(["compile", "-b", "arduino:mbed:nano33ble", sketch_path])
+    assert run_command(["compile", "-b", "adafruit:samd:adafruit_feather_m4", sketch_path])
 
     # Bosch sensor library
-    assert run_command('lib install "BSEC Software Library@1.5.1474"')
+    assert run_command(["lib", "install", "BSEC Software Library@1.5.1474"])
     sketch_path = Path(data_dir, "libraries", "BSEC_Software_Library", "examples", "basic")
-    assert run_command(f"compile -b arduino:samd:mkr1000 {sketch_path}")
-    assert run_command(f"compile -b arduino:mbed:nano33ble {sketch_path}")
+    assert run_command(["compile", "-b", "arduino:samd:mkr1000", sketch_path])
+    assert run_command(["compile", "-b", "arduino:mbed:nano33ble", sketch_path])
 
     # USBBlaster library
-    assert run_command('lib install "USBBlaster@1.0.0"')
+    assert run_command(["lib", "install", "USBBlaster@1.0.0"])
     sketch_path = Path(data_dir, "libraries", "USBBlaster", "examples", "USB_Blaster")
-    assert run_command(f"compile -b arduino:samd:mkrvidor4000 {sketch_path}")
+    assert run_command(["compile", "-b", "arduino:samd:mkrvidor4000", sketch_path])
 
 
 def test_compile_with_build_properties_flag(run_command, data_dir, copy_sketch):
     # Init the environment explicitly
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Install Arduino AVR Boards
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_path = copy_sketch("sketch_with_single_string_define")
     fqbn = "arduino:avr:uno"
 
     # Compile using a build property with quotes
     res = run_command(
-        f"compile -b {fqbn} "
-        + '--build-properties="build.extra_flags=\\"-DMY_DEFINE=\\"hello world\\"\\"" '
-        + f"{sketch_path} --verbose --clean"
+        [
+            "compile",
+            "-b",
+            fqbn,
+            '--build-properties="build.extra_flags=\\"-DMY_DEFINE=\\"hello world\\"\\""',
+            sketch_path,
+            "--verbose",
+            "--clean",
+        ]
     )
     assert res.failed
     assert "Flag --build-properties has been deprecated, please use --build-property instead." not in res.stderr
 
     # Try again with quotes
     res = run_command(
-        f"compile -b {fqbn} "
-        + '--build-properties="build.extra_flags=-DMY_DEFINE=\\"hello\\"" '
-        + f"{sketch_path} --verbose --clean"
+        [
+            "compile",
+            "-b",
+            fqbn,
+            '--build-properties="build.extra_flags=-DMY_DEFINE=\\"hello\\""',
+            sketch_path,
+            "--verbose",
+            "--clean",
+        ]
     )
     assert res.failed
     assert "Flag --build-properties has been deprecated, please use --build-property instead." not in res.stderr
@@ -249,9 +261,15 @@ def test_compile_with_build_properties_flag(run_command, data_dir, copy_sketch):
     # Try without quotes
     sketch_path = copy_sketch("sketch_with_single_int_define")
     res = run_command(
-        f"compile -b {fqbn} "
-        + '--build-properties="build.extra_flags=-DMY_DEFINE=1" '
-        + f"{sketch_path} --verbose --clean"
+        [
+            "compile",
+            "-b",
+            fqbn,
+            '--build-properties="build.extra_flags=-DMY_DEFINE=1"',
+            sketch_path,
+            "--verbose",
+            "--clean",
+        ]
     )
     assert res.ok
     assert "Flag --build-properties has been deprecated, please use --build-property instead." in res.stderr
@@ -259,9 +277,15 @@ def test_compile_with_build_properties_flag(run_command, data_dir, copy_sketch):
 
     sketch_path = copy_sketch("sketch_with_multiple_int_defines")
     res = run_command(
-        f"compile -b {fqbn} "
-        + '--build-properties="build.extra_flags=-DFIRST_PIN=1,compiler.cpp.extra_flags=-DSECOND_PIN=2" '
-        + f"{sketch_path} --verbose --clean"
+        [
+            "compile",
+            "-b",
+            fqbn,
+            '--build-properties="build.extra_flags=-DFIRST_PIN=1,compiler.cpp.extra_flags=-DSECOND_PIN=2"',
+            sketch_path,
+            "--verbose",
+            "--clean",
+        ]
     )
     assert res.ok
     assert "Flag --build-properties has been deprecated, please use --build-property instead." in res.stderr
@@ -271,19 +295,24 @@ def test_compile_with_build_properties_flag(run_command, data_dir, copy_sketch):
 
 def test_compile_with_build_property_containing_quotes(run_command, data_dir, copy_sketch):
     # Init the environment explicitly
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Install Arduino AVR Boards
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_path = copy_sketch("sketch_with_single_string_define")
     fqbn = "arduino:avr:uno"
 
     # Compile using a build property with quotes
     res = run_command(
-        f"compile -b {fqbn} "
-        + '--build-property="build.extra_flags=\\"-DMY_DEFINE=\\"hello world\\"\\"" '
-        + f"{sketch_path} --verbose"
+        [
+            "compile",
+            "-b",
+            fqbn,
+            '--build-property=build.extra_flags=\\"-DMY_DEFINE=\\"hello world\\"\\"',
+            sketch_path,
+            "--verbose",
+        ]
     )
     assert res.ok
     assert '-DMY_DEFINE=\\"hello world\\"' in res.stdout
@@ -291,54 +320,84 @@ def test_compile_with_build_property_containing_quotes(run_command, data_dir, co
 
 def test_compile_with_multiple_build_property_flags(run_command, data_dir, copy_sketch, working_dir):
     # Init the environment explicitly
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Install Arduino AVR Boards
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_path = copy_sketch("sketch_with_multiple_defines")
     fqbn = "arduino:avr:uno"
 
     # Compile using multiple build properties separated by a space
     res = run_command(
-        f"compile -b {fqbn} "
-        + '--build-property="compiler.cpp.extra_flags=\\"-DPIN=2 -DSSID=\\"This is a String\\"\\"" '
-        + f"{sketch_path} --verbose --clean"
+        [
+            "compile",
+            "-b",
+            fqbn,
+            '--build-property=compiler.cpp.extra_flags=\\"-DPIN=2 -DSSID=\\"This is a String\\"\\"',
+            sketch_path,
+            "--verbose",
+            "--clean",
+        ]
     )
     assert res.failed
 
     # Compile using multiple build properties separated by a space and properly quoted
     res = run_command(
-        f"compile -b {fqbn} "
-        + '--build-property="compiler.cpp.extra_flags=-DPIN=2 \\"-DSSID=\\"This is a String\\"\\"" '
-        + f"{sketch_path} --verbose --clean"
+        [
+            "compile",
+            "-b",
+            fqbn,
+            '--build-property=compiler.cpp.extra_flags=-DPIN=2 \\"-DSSID=\\"This is a String\\"\\"',
+            sketch_path,
+            "--verbose",
+            "--clean",
+        ]
     )
     assert res.ok
     assert '-DPIN=2 "-DSSID=\\"This is a String\\""' in res.stdout
 
     # Tries compilation using multiple build properties separated by a comma
     res = run_command(
-        f"compile -b {fqbn} "
-        + '--build-property="compiler.cpp.extra_flags=\\"-DPIN=2,-DSSID=\\"This is a String\\"\\"\\" '
-        + f"{sketch_path} --verbose --clean"
+        [
+            "compile",
+            "-b",
+            fqbn,
+            '--build-property=compiler.cpp.extra_flags=\\"-DPIN=2,-DSSID=\\"This is a String\\"\\"',
+            sketch_path,
+            "--verbose",
+            "--clean",
+        ]
     )
     assert res.failed
 
     res = run_command(
-        f"compile -b {fqbn} "
-        + '--build-property="compiler.cpp.extra_flags=\\"-DPIN=2\\"" '
-        + '--build-property="compiler.cpp.extra_flags=\\"-DSSID=\\"This is a String\\"\\"" '
-        + f"{sketch_path} --verbose --clean"
+        [
+            "compile",
+            "-b",
+            fqbn,
+            '--build-property=compiler.cpp.extra_flags=\\"-DPIN=2\\"',
+            '--build-property=compiler.cpp.extra_flags=\\"-DSSID=\\"This is a String\\"\\"',
+            sketch_path,
+            "--verbose",
+            "--clean",
+        ]
     )
     assert res.failed
     assert "-DPIN=2" not in res.stdout
     assert '-DSSID=\\"This is a String\\"' in res.stdout
 
     res = run_command(
-        f"compile -b {fqbn} "
-        + '--build-property="compiler.cpp.extra_flags=\\"-DPIN=2\\"" '
-        + '--build-property="build.extra_flags=\\"-DSSID=\\"hello world\\"\\"" '
-        + f"{sketch_path} --verbose --clean"
+        [
+            "compile",
+            "-b",
+            fqbn,
+            '--build-property=compiler.cpp.extra_flags=\\"-DPIN=2\\"',
+            '--build-property=build.extra_flags=\\"-DSSID=\\"hello world\\"\\"',
+            sketch_path,
+            "--verbose",
+            "--clean",
+        ]
     )
     assert res.ok
     assert "-DPIN=2" in res.stdout
@@ -347,23 +406,23 @@ def test_compile_with_multiple_build_property_flags(run_command, data_dir, copy_
 
 def test_compile_with_output_dir_flag(run_command, data_dir):
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # Download latest AVR
-    run_command("core install arduino:avr")
+    run_command(["core", "install", "arduino:avr"])
 
     sketch_name = "CompileWithOutputDir"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    result = run_command(f"sketch new {sketch_path}")
+    result = run_command(["sketch", "new", sketch_path])
     assert result.ok
     assert f"Sketch created in: {sketch_path}" in result.stdout
 
     # Test the --output-dir flag with absolute path
     output_dir = Path(data_dir, "test_dir", "output_dir")
-    result = run_command(f"compile -b {fqbn} {sketch_path} --output-dir {output_dir}")
+    result = run_command(["compile", "-b", fqbn, sketch_path, "--output-dir", output_dir])
     assert result.ok
 
     # Verifies expected binaries have been built
@@ -387,20 +446,20 @@ def test_compile_with_output_dir_flag(run_command, data_dir):
 
 def test_compile_with_export_binaries_flag(run_command, data_dir):
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # Download latest AVR
-    run_command("core install arduino:avr")
+    run_command(["core", "install", "arduino:avr"])
 
     sketch_name = "CompileWithExportBinariesFlag"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    assert run_command("sketch new {}".format(sketch_path))
+    assert run_command(["sketch", "new", sketch_path])
 
     # Test the --output-dir flag with absolute path
-    result = run_command(f"compile -b {fqbn} {sketch_path} --export-binaries")
+    result = run_command(["compile", "-b", fqbn, sketch_path, "--export-binaries"])
     assert result.ok
     assert Path(sketch_path, "build").exists()
     assert Path(sketch_path, "build").is_dir()
@@ -415,23 +474,23 @@ def test_compile_with_export_binaries_flag(run_command, data_dir):
 
 def test_compile_with_custom_build_path(run_command, data_dir):
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # Download latest AVR
-    run_command("core install arduino:avr")
+    run_command(["core", "install", "arduino:avr"])
 
     sketch_name = "CompileWithBuildPath"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    result = run_command(f"sketch new {sketch_path}")
+    result = run_command(["sketch", "new", sketch_path])
     assert result.ok
     assert f"Sketch created in: {sketch_path}" in result.stdout
 
     # Test the --build-path flag with absolute path
     build_path = Path(data_dir, "test_dir", "build_dir")
-    result = run_command(f"compile -b {fqbn} {sketch_path} --build-path {build_path}")
+    result = run_command(["compile", "-b", fqbn, sketch_path, "--build-path", build_path])
     print(result.stderr)
     assert result.ok
 
@@ -456,17 +515,17 @@ def test_compile_with_custom_build_path(run_command, data_dir):
 
 def test_compile_with_export_binaries_env_var(run_command, data_dir, downloads_dir):
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # Download latest AVR
-    run_command("core install arduino:avr")
+    run_command(["core", "install", "arduino:avr"])
 
     sketch_name = "CompileWithExportBinariesEnvVar"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    assert run_command("sketch new {}".format(sketch_path))
+    assert run_command(["sketch", "new", sketch_path])
 
     env = {
         "ARDUINO_DATA_DIR": data_dir,
@@ -475,7 +534,7 @@ def test_compile_with_export_binaries_env_var(run_command, data_dir, downloads_d
         "ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES": "true",
     }
     # Test compilation with export binaries env var set
-    result = run_command(f"compile -b {fqbn} {sketch_path}", custom_env=env)
+    result = run_command(["compile", "-b", fqbn, sketch_path], custom_env=env)
     assert result.ok
     assert Path(sketch_path, "build").exists()
     assert Path(sketch_path, "build").is_dir()
@@ -490,17 +549,17 @@ def test_compile_with_export_binaries_env_var(run_command, data_dir, downloads_d
 
 def test_compile_with_export_binaries_config(run_command, data_dir, downloads_dir):
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # Download latest AVR
-    run_command("core install arduino:avr")
+    run_command(["core", "install", "arduino:avr"])
 
     sketch_name = "CompileWithExportBinariesConfig"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    assert run_command("sketch new {}".format(sketch_path))
+    assert run_command(["sketch", "new", sketch_path])
 
     # Create settings with export binaries set to true
     env = {
@@ -509,10 +568,10 @@ def test_compile_with_export_binaries_config(run_command, data_dir, downloads_di
         "ARDUINO_SKETCHBOOK_DIR": data_dir,
         "ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES": "true",
     }
-    assert run_command("config init --dest-dir .", custom_env=env)
+    assert run_command(["config", "init", "--dest-dir", "."], custom_env=env)
 
     # Test compilation with export binaries env var set
-    result = run_command(f"compile -b {fqbn} {sketch_path}")
+    result = run_command(["compile", "-b", fqbn, sketch_path])
     assert result.ok
     assert Path(sketch_path, "build").exists()
     assert Path(sketch_path, "build").is_dir()
@@ -527,23 +586,25 @@ def test_compile_with_export_binaries_config(run_command, data_dir, downloads_di
 
 def test_compile_with_invalid_url(run_command, data_dir):
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # Download latest AVR
-    run_command("core install arduino:avr")
+    run_command(["core", "install", "arduino:avr"])
 
     sketch_name = "CompileWithInvalidURL"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    assert run_command(f'sketch new "{sketch_path}"')
+    assert run_command(["sketch", "new", sketch_path])
 
     # Create settings with custom invalid URL
-    assert run_command("config init --dest-dir . --additional-urls https://example.com/package_example_index.json")
+    assert run_command(
+        ["config", "init", "--dest-dir", ".", "--additional-urls", "https://example.com/package_example_index.json"]
+    )
 
     # Verifies compilation fails cause of missing local index file
-    res = run_command(f'compile -b {fqbn} "{sketch_path}"')
+    res = run_command(["compile", "-b", fqbn, sketch_path])
     assert res.ok
     lines = [l.strip() for l in res.stderr.splitlines()]
     assert "Error initializing instance: Loading index file: loading json index file" in lines[0]
@@ -554,13 +615,13 @@ def test_compile_with_invalid_url(run_command, data_dir):
 def test_compile_with_custom_libraries(run_command, copy_sketch):
     # Creates config with additional URL to install necessary core
     url = "http://arduino.esp8266.com/stable/package_esp8266com_index.json"
-    assert run_command(f"config init --dest-dir . --additional-urls {url}")
+    assert run_command(["config", "init", "--dest-dir", ".", "--additional-urls", url])
 
     # Init the environment explicitly
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install core to compile
-    assert run_command("core install esp8266:esp8266")
+    assert run_command(["core", "install", "esp8266:esp8266"])
 
     sketch_path = copy_sketch("sketch_with_multiple_custom_libraries")
     fqbn = "esp8266:esp8266:nodemcu:xtal=80,vt=heap,eesz=4M1M,wipe=none,baud=115200"
@@ -569,95 +630,95 @@ def test_compile_with_custom_libraries(run_command, copy_sketch):
     second_lib = Path(sketch_path, "libraries2")
     # This compile command has been taken from this issue:
     # https://github.com/arduino/arduino-cli/issues/973
-    assert run_command(f"compile --libraries {first_lib},{second_lib} -b {fqbn} {sketch_path}")
+    assert run_command(["compile", "--libraries", first_lib, "--libraries", second_lib, "-b", fqbn, sketch_path])
 
 
 def test_compile_with_archives_and_long_paths(run_command):
     # Creates config with additional URL to install necessary core
     url = "http://arduino.esp8266.com/stable/package_esp8266com_index.json"
-    assert run_command(f"config init --dest-dir . --additional-urls {url}")
+    assert run_command(["config", "init", "--dest-dir", ".", "--additional-urls", url])
 
     # Init the environment explicitly
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install core to compile
-    assert run_command("core install esp8266:esp8266@2.7.4")
+    assert run_command(["core", "install", "esp8266:esp8266@2.7.4"])
 
     # Install test library
-    assert run_command("lib install ArduinoIoTCloud")
+    assert run_command(["lib", "install", "ArduinoIoTCloud"])
 
-    result = run_command("lib examples ArduinoIoTCloud --format json")
+    result = run_command(["lib", "examples", "ArduinoIoTCloud", "--format", "json"])
     assert result.ok
     lib_output = json.loads(result.stdout)
     sketch_path = Path(lib_output[0]["library"]["install_dir"], "examples", "ArduinoIoTCloud-Advanced")
 
-    assert run_command(f"compile -b esp8266:esp8266:huzzah {sketch_path}")
+    assert run_command(["compile", "-b", "esp8266:esp8266:huzzah", sketch_path])
 
 
 def test_compile_with_precompiled_library(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("core install arduino:samd@1.8.11")
+    assert run_command(["core", "install", "arduino:samd@1.8.11"])
     fqbn = "arduino:samd:mkrzero"
 
     # Install precompiled library
     # For more information see:
     # https://arduino.github.io/arduino-cli/latest/library-specification/#precompiled-binaries
-    assert run_command('lib install "BSEC Software Library@1.5.1474"')
+    assert run_command(["lib", "install", "BSEC Software Library@1.5.1474"])
     sketch_folder = Path(data_dir, "libraries", "BSEC_Software_Library", "examples", "basic")
 
     # Compile and verify dependencies detection for fully precompiled library is not skipped
-    result = run_command(f"compile -b {fqbn} {sketch_folder} -v")
+    result = run_command(["compile", "-b", fqbn, sketch_folder, "-v"])
     assert result.ok
     assert "Skipping dependencies detection for precompiled library BSEC Software Library" not in result.stdout
 
 
 def test_compile_with_fully_precompiled_library(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("core install arduino:mbed@1.3.1")
+    assert run_command(["core", "install", "arduino:mbed@1.3.1"])
     fqbn = "arduino:mbed:nano33ble"
 
     # Install fully precompiled library
     # For more information see:
     # https://arduino.github.io/arduino-cli/latest/library-specification/#precompiled-binaries
-    assert run_command("lib install Arduino_TensorFlowLite@2.1.1-ALPHA-precompiled")
+    assert run_command(["lib", "install", "Arduino_TensorFlowLite@2.1.1-ALPHA-precompiled"])
     sketch_folder = Path(data_dir, "libraries", "Arduino_TensorFlowLite", "examples", "hello_world")
 
     # Install example dependency
     # assert run_command("lib install Arduino_LSM9DS1")
 
     # Compile and verify dependencies detection for fully precompiled library is skipped
-    result = run_command(f"compile -b {fqbn} {sketch_folder} -v")
+    result = run_command(["compile", "-b", fqbn, sketch_folder, "-v"])
     assert result.ok
     assert "Skipping dependencies detection for precompiled library Arduino_TensorFlowLite" in result.stdout
 
 
 def test_compile_sketch_with_pde_extension(run_command, data_dir):
     # Init the environment explicitly
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install core to compile
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "CompilePdeSketch"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Renames sketch file to pde
     sketch_file = Path(sketch_path, f"{sketch_name}.ino").rename(sketch_path / f"{sketch_name}.pde")
 
     # Build sketch from folder
-    res = run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    res = run_command(["compile", "--clean", "-b", fqbn, sketch_path])
     assert res.ok
     assert "Sketches with .pde extension are deprecated, please rename the following files to .ino:" in res.stderr
     assert str(sketch_file) in res.stderr
 
     # Build sketch from file
-    res = run_command(f"compile --clean -b {fqbn} {sketch_file}")
+    res = run_command(["compile", "--clean", "-b", fqbn, sketch_file])
     assert res.ok
     assert "Sketches with .pde extension are deprecated, please rename the following files to .ino" in res.stderr
     assert str(sketch_file) in res.stderr
@@ -665,17 +726,17 @@ def test_compile_sketch_with_pde_extension(run_command, data_dir):
 
 def test_compile_sketch_with_multiple_main_files(run_command, data_dir):
     # Init the environment explicitly
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install core to compile
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "CompileSketchMultipleMainFiles"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Copy .ino sketch file to .pde
     sketch_ino_file = Path(sketch_path, f"{sketch_name}.ino")
@@ -683,69 +744,71 @@ def test_compile_sketch_with_multiple_main_files(run_command, data_dir):
     shutil.copyfile(sketch_ino_file, sketch_pde_file)
 
     # Build sketch from folder
-    res = run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    res = run_command(["compile", "--clean", "-b", fqbn, sketch_path])
     assert res.failed
     assert "Error during build: Can't open sketch: multiple main sketch files found" in res.stderr
 
     # Build sketch from .ino file
-    res = run_command(f"compile --clean -b {fqbn} {sketch_ino_file}")
+    res = run_command(["compile", "--clean", "-b", fqbn, sketch_ino_file])
     assert res.failed
     assert "Error during build: Can't open sketch: multiple main sketch files found" in res.stderr
 
     # Build sketch from .pde file
-    res = run_command(f"compile --clean -b {fqbn} {sketch_pde_file}")
+    res = run_command(["compile", "--clean", "-b", fqbn, sketch_pde_file])
     assert res.failed
     assert "Error during build: Can't open sketch: multiple main sketch files found" in res.stderr
 
 
 def test_compile_sketch_case_mismatch_fails(run_command, data_dir):
     # Init the environment explicitly
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install core to compile
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "CompileSketchCaseMismatch"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Rename main .ino file so casing is different from sketch name
     sketch_main_file = Path(sketch_path, f"{sketch_name}.ino").rename(sketch_path / f"{sketch_name.lower()}.ino")
 
     # Verifies compilation fails when:
     # * Compiling with sketch path
-    res = run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    res = run_command(["compile", "--clean", "-b", fqbn, sketch_path])
     assert res.failed
     assert "Error during build: Can't open sketch: no valid sketch found" in res.stderr
     # * Compiling with sketch main file
-    res = run_command(f"compile --clean -b {fqbn} {sketch_main_file}")
+    res = run_command(["compile", "--clean", "-b", fqbn, sketch_main_file])
     assert res.failed
     assert "Error during build: Can't open sketch: no valid sketch found" in res.stderr
     # * Compiling in sketch path
-    res = run_command(f"compile --clean -b {fqbn}", custom_working_dir=sketch_path)
+    res = run_command(["compile", "--clean", "-b", fqbn], custom_working_dir=sketch_path)
     assert res.failed
     assert "Error during build: Can't open sketch: no valid sketch found" in res.stderr
 
 
 def test_compile_with_only_compilation_database_flag(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "CompileSketchOnlyCompilationDatabaseFlag"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Verifies no binaries exist
     build_path = Path(sketch_path, "build")
     assert not build_path.exists()
 
     # Compile with both --export-binaries and --only-compilation-database flags
-    assert run_command(f"compile --export-binaries --only-compilation-database --clean -b {fqbn} {sketch_path}")
+    assert run_command(
+        ["compile", "--export-binaries", "--only-compilation-database", "--clean", "-b", fqbn, sketch_path]
+    )
 
     # Verifies no binaries are exported
     assert not build_path.exists()
@@ -755,50 +818,52 @@ def test_compile_with_only_compilation_database_flag(run_command, data_dir):
     assert not build_path.exists()
 
     # Compile by setting the --output-dir flag and --only-compilation-database flags
-    assert run_command(f"compile --output-dir {build_path} --only-compilation-database --clean -b {fqbn} {sketch_path}")
+    assert run_command(
+        ["compile", "--output-dir", build_path, "--only-compilation-database", "--clean", "-b", fqbn, sketch_path]
+    )
 
     # Verifies no binaries are exported
     assert not build_path.exists()
 
 
 def test_compile_using_platform_local_txt(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "CompileSketchUsingPlatformLocalTxt"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Verifies compilation works without issues
-    assert run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    assert run_command(["compile", "--clean", "-b", fqbn, sketch_path])
 
     # Overrides default platform compiler with an unexisting one
     platform_local_txt = Path(data_dir, "packages", "arduino", "hardware", "avr", "1.8.3", "platform.local.txt")
     platform_local_txt.write_text("compiler.c.cmd=my-compiler-that-does-not-exist")
 
     # Verifies compilation now fails because compiler is not found
-    res = run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    res = run_command(["compile", "--clean", "-b", fqbn, sketch_path])
     assert res.failed
     assert "my-compiler-that-does-not-exist" in res.stderr
 
 
 def test_compile_using_boards_local_txt(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "CompileSketchUsingBoardsLocalTxt"
     sketch_path = Path(data_dir, sketch_name)
     # Use a made up board
     fqbn = "arduino:avr:nessuno"
 
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Verifies compilation fails because board doesn't exist
-    res = run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    res = run_command(["compile", "--clean", "-b", fqbn, sketch_path])
     assert res.failed
     assert "Error during build: Error resolving FQBN: board arduino:avr@1.8.3:nessuno not found" in res.stderr
 
@@ -806,16 +871,16 @@ def test_compile_using_boards_local_txt(run_command, data_dir):
     boards_local_txt = Path(data_dir, "packages", "arduino", "hardware", "avr", "1.8.3", "boards.local.txt")
     shutil.copyfile(Path(__file__).parent / "testdata" / "boards.local.txt", boards_local_txt)
 
-    assert run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    assert run_command(["compile", "--clean", "-b", fqbn, sketch_path])
 
 
 def test_compile_manually_installed_platform(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     sketch_name = "CompileSketchManuallyInstalledPlatformUsingPlatformLocalTxt"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino-beta-development:avr:uno"
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Manually installs a core in sketchbooks hardware folder
     git_url = "https://github.com/arduino/ArduinoCore-avr.git"
@@ -823,19 +888,19 @@ def test_compile_manually_installed_platform(run_command, data_dir):
     assert Repo.clone_from(git_url, repo_dir, multi_options=["-b 1.8.3"])
 
     # Installs also the same core via CLI so all the necessary tools are installed
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     # Verifies compilation works without issues
-    assert run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    assert run_command(["compile", "--clean", "-b", fqbn, sketch_path])
 
 
 def test_compile_manually_installed_platform_using_platform_local_txt(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     sketch_name = "CompileSketchManuallyInstalledPlatformUsingPlatformLocalTxt"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino-beta-development:avr:uno"
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Manually installs a core in sketchbooks hardware folder
     git_url = "https://github.com/arduino/ArduinoCore-avr.git"
@@ -843,28 +908,28 @@ def test_compile_manually_installed_platform_using_platform_local_txt(run_comman
     assert Repo.clone_from(git_url, repo_dir, multi_options=["-b 1.8.3"])
 
     # Installs also the same core via CLI so all the necessary tools are installed
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     # Verifies compilation works without issues
-    assert run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    assert run_command(["compile", "--clean", "-b", fqbn, sketch_path])
 
     # Overrides default platform compiler with an unexisting one
     platform_local_txt = Path(repo_dir, "platform.local.txt")
     platform_local_txt.write_text("compiler.c.cmd=my-compiler-that-does-not-exist")
 
     # Verifies compilation now fails because compiler is not found
-    res = run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    res = run_command(["compile", "--clean", "-b", fqbn, sketch_path])
     assert res.failed
     assert "my-compiler-that-does-not-exist" in res.stderr
 
 
 def test_compile_manually_installed_platform_using_boards_local_txt(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     sketch_name = "CompileSketchManuallyInstalledPlatformUsingBoardsLocalTxt"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino-beta-development:avr:nessuno"
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Manually installs a core in sketchbooks hardware folder
     git_url = "https://github.com/arduino/ArduinoCore-avr.git"
@@ -872,10 +937,10 @@ def test_compile_manually_installed_platform_using_boards_local_txt(run_command,
     assert Repo.clone_from(git_url, repo_dir, multi_options=["-b 1.8.3"])
 
     # Installs also the same core via CLI so all the necessary tools are installed
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     # Verifies compilation fails because board doesn't exist
-    res = run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    res = run_command(["compile", "--clean", "-b", fqbn, sketch_path])
     assert res.failed
     assert (
         "Error during build: Error resolving FQBN: board arduino-beta-development:avr@1.8.3:nessuno not found"
@@ -886,19 +951,19 @@ def test_compile_manually_installed_platform_using_boards_local_txt(run_command,
     boards_local_txt = Path(repo_dir, "boards.local.txt")
     shutil.copyfile(Path(__file__).parent / "testdata" / "boards.local.txt", boards_local_txt)
 
-    assert run_command(f"compile --clean -b {fqbn} {sketch_path}")
+    assert run_command(["compile", "--clean", "-b", fqbn, sketch_path])
 
 
 def test_compile_with_library(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "CompileSketchWithWiFi101Dependency"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
     # Create new sketch and add library include
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
     sketch_file = sketch_path / f"{sketch_name}.ino"
     lines = []
     with open(sketch_file, "r") as f:
@@ -912,15 +977,15 @@ def test_compile_with_library(run_command, data_dir):
     lib_path = Path(data_dir, "my-libraries", "WiFi101")
     assert Repo.clone_from(git_url, lib_path, multi_options=["-b 0.16.1"])
 
-    res = run_command(f"compile -b {fqbn} {sketch_path} --library {lib_path} -v")
+    res = run_command(["compile", "-b", fqbn, sketch_path, "--library", lib_path, "-v"])
     assert res.ok
     assert "WiFi101" in res.stdout
 
 
 def test_compile_with_library_priority(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "CompileSketchWithLibraryPriority"
     sketch_path = Path(data_dir, sketch_name)
@@ -932,10 +997,10 @@ def test_compile_with_library_priority(run_command, data_dir):
     assert Repo.clone_from(git_url, manually_install_lib_path, multi_options=["-b 0.16.1"])
 
     # Install the same library we installed manually
-    assert run_command("lib install WiFi101")
+    assert run_command(["lib", "install", "WiFi101"])
 
     # Create new sketch and add library include
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
     sketch_file = sketch_path / f"{sketch_name}.ino"
     lines = []
     with open(sketch_file, "r") as f:
@@ -944,7 +1009,7 @@ def test_compile_with_library_priority(run_command, data_dir):
     with open(sketch_file, "w") as f:
         f.writelines(lines)
 
-    res = run_command(f"compile -b {fqbn} {sketch_path} --library {manually_install_lib_path} -v")
+    res = run_command(["compile", "-b", fqbn, sketch_path, "--library", manually_install_lib_path, "-v"])
     assert res.ok
     cli_installed_lib_path = Path(data_dir, "libraries", "WiFi101")
     expected_output = [
@@ -956,16 +1021,16 @@ def test_compile_with_library_priority(run_command, data_dir):
 
 
 def test_recompile_with_different_library(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "RecompileCompileSketchWithDifferentLibrary"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Install library
-    assert run_command("lib install WiFi101")
+    assert run_command(["lib", "install", "WiFi101"])
 
     # Manually installs the same library already installed
     git_url = "https://github.com/arduino-libraries/WiFi101.git"
@@ -973,7 +1038,7 @@ def test_recompile_with_different_library(run_command, data_dir):
     assert Repo.clone_from(git_url, manually_install_lib_path, multi_options=["-b 0.16.1"])
 
     # Create new sketch and add library include
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
     sketch_file = sketch_path / f"{sketch_name}.ino"
     lines = []
     with open(sketch_file, "r") as f:
@@ -986,22 +1051,22 @@ def test_recompile_with_different_library(run_command, data_dir):
     build_dir = Path(tempfile.gettempdir(), f"arduino-sketch-{sketch_path_md5}")
 
     # Compile sketch using library not managed by CLI
-    res = run_command(f"compile -b {fqbn} --library {manually_install_lib_path} {sketch_path} -v")
+    res = run_command(["compile", "-b", fqbn, "--library", manually_install_lib_path, sketch_path, "-v"])
     assert res.ok
     obj_path = build_dir / "libraries" / "WiFi101" / "WiFi.cpp.o"
     assert f"Using previously compiled file: {obj_path}" not in res.stdout
 
     # Compile again using library installed from CLI
-    res = run_command(f"compile -b {fqbn} {sketch_path} -v")
+    res = run_command(["compile", "-b", fqbn, sketch_path, "-v"])
     assert res.ok
     obj_path = build_dir / "libraries" / "WiFi101" / "WiFi.cpp.o"
     assert f"Using previously compiled file: {obj_path}" not in res.stdout
 
 
 def test_compile_with_conflicting_libraries_include(run_command, data_dir, copy_sketch):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     # Install conflicting libraries
     git_url = "https://github.com/pstolarz/OneWireNg.git"
@@ -1015,7 +1080,7 @@ def test_compile_with_conflicting_libraries_include(run_command, data_dir, copy_
     sketch_path = copy_sketch("sketch_with_conflicting_libraries_include")
     fqbn = "arduino:avr:uno"
 
-    res = run_command(f"compile -b {fqbn} {sketch_path} --verbose")
+    res = run_command(["compile", "-b", fqbn, sketch_path, "--verbose"])
     assert res.ok
     expected_output = [
         'Multiple libraries were found for "OneWire.h"',
@@ -1026,29 +1091,29 @@ def test_compile_with_conflicting_libraries_include(run_command, data_dir, copy_
 
 
 def test_compile_with_invalid_build_options_json(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "CompileInvalidBuildOptionsJson"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:avr:uno"
 
     # Create a test sketch
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Get the build directory
     sketch_path_md5 = hashlib.md5(bytes(sketch_path)).hexdigest().upper()
     build_dir = Path(tempfile.gettempdir(), f"arduino-sketch-{sketch_path_md5}")
 
-    assert run_command(f"compile -b {fqbn} {sketch_path} --verbose")
+    assert run_command(["compile", "-b", fqbn, sketch_path, "--verbose"])
 
     # Breaks the build.options.json file
     build_options_json = build_dir / "build.options.json"
     with open(build_options_json, "w") as f:
         f.write("invalid json")
 
-    assert run_command(f"compile -b {fqbn} {sketch_path} --verbose")
+    assert run_command(["compile", "-b", fqbn, sketch_path, "--verbose"])
 
 
 def test_compile_with_esp32_bundled_libraries(run_command, data_dir, copy_sketch):
@@ -1063,21 +1128,21 @@ def test_compile_with_esp32_bundled_libraries(run_command, data_dir, copy_sketch
     # The reason those libraries have these suffixes is to avoid an annoying bug in the Java IDE
     # that would have caused the libraries that are both bundled with the core and the Java IDE to be
     # always marked as updatable. For more info see: https://github.com/arduino/Arduino/issues/4189
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Update index with esp32 core and install it
     url = "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json"
     core_version = "1.0.6"
-    assert run_command(f"core update-index --additional-urls={url}")
-    assert run_command(f"core install esp32:esp32@{core_version} --additional-urls={url}")
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
+    assert run_command(["core", "install", f"esp32:esp32@{core_version}", f"--additional-urls={url}"])
 
     # Install a library with the same name as one bundled with the core
-    assert run_command("lib install SD")
+    assert run_command(["lib", "install", "SD"])
 
     sketch_path = copy_sketch("sketch_with_sd_library")
     fqbn = "esp32:esp32:esp32"
 
-    res = run_command(f"compile -b {fqbn} {sketch_path} --verbose")
+    res = run_command(["compile", "-b", fqbn, sketch_path, "--verbose"])
     assert res.failed
 
     core_bundled_lib_path = Path(data_dir, "packages", "esp32", "hardware", "esp32", core_version, "libraries", "SD")
@@ -1102,21 +1167,21 @@ def test_compile_with_esp8266_bundled_libraries(run_command, data_dir, copy_sket
     # The reason those libraries have these suffixes is to avoid an annoying bug in the Java IDE
     # that would have caused the libraries that are both bundled with the core and the Java IDE to be
     # always marked as updatable. For more info see: https://github.com/arduino/Arduino/issues/4189
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Update index with esp8266 core and install it
     url = "http://arduino.esp8266.com/stable/package_esp8266com_index.json"
     core_version = "2.7.4"
-    assert run_command(f"core update-index --additional-urls={url}")
-    assert run_command(f"core install esp8266:esp8266@{core_version} --additional-urls={url}")
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
+    assert run_command(["core", "install", f"esp8266:esp8266@{core_version}", f"--additional-urls={url}"])
 
     # Install a library with the same name as one bundled with the core
-    assert run_command("lib install SD")
+    assert run_command(["lib", "install", "SD"])
 
     sketch_path = copy_sketch("sketch_with_sd_library")
     fqbn = "esp8266:esp8266:generic"
 
-    res = run_command(f"compile -b {fqbn} {sketch_path} --verbose")
+    res = run_command(["compile", "-b", fqbn, sketch_path, "--verbose"])
     assert res.failed
 
     core_bundled_lib_path = Path(
@@ -1132,35 +1197,35 @@ def test_compile_with_esp8266_bundled_libraries(run_command, data_dir, copy_sket
 
 
 def test_compile_sketch_with_tpp_file_include(run_command, copy_sketch):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Download latest AVR
-    run_command("core install arduino:avr")
+    run_command(["core", "install", "arduino:avr"])
 
     sketch_name = "sketch_with_tpp_file_include"
     sketch_path = copy_sketch(sketch_name)
     fqbn = "arduino:avr:uno"
 
-    assert run_command(f"compile -b {fqbn} {sketch_path} --verbose")
+    assert run_command(["compile", "-b", fqbn, sketch_path, "--verbose"])
 
 
 def test_compile_sketch_with_ipp_file_include(run_command, copy_sketch):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Download latest AVR
-    run_command("core install arduino:avr")
+    run_command(["core", "install", "arduino:avr"])
 
     sketch_name = "sketch_with_ipp_file_include"
     sketch_path = copy_sketch(sketch_name)
     fqbn = "arduino:avr:uno"
 
-    assert run_command(f"compile -b {fqbn} {sketch_path} --verbose")
+    assert run_command(["compile", "-b", fqbn, sketch_path, "--verbose"])
 
 
 def test_compile_with_relative_build_path(run_command, data_dir, copy_sketch):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    run_command("core install arduino:avr@1.8.3")
+    run_command(["core", "install", "arduino:avr@1.8.3"])
 
     sketch_name = "sketch_simple"
     sketch_path = copy_sketch(sketch_name)
@@ -1169,7 +1234,10 @@ def test_compile_with_relative_build_path(run_command, data_dir, copy_sketch):
     build_path = Path("..", "build_path")
     working_dir = Path(data_dir, "working_dir")
     working_dir.mkdir()
-    assert run_command(f"compile -b {fqbn} --build-path {build_path} {sketch_path} -v", custom_working_dir=working_dir)
+    assert run_command(
+        ["compile", "-b", fqbn, "--build-path", build_path, sketch_path, "-v"],
+        custom_working_dir=working_dir,
+    )
 
     absolute_build_path = Path(data_dir, "build_path")
     built_files = [f.name for f in absolute_build_path.glob("*")]

--- a/test/test_completion.py
+++ b/test/test_completion.py
@@ -15,14 +15,14 @@
 
 
 def test_completion_no_args(run_command):
-    result = run_command("completion")
+    result = run_command(["completion"])
     assert not result.ok
     assert "Error: accepts 1 arg(s), received 0" in result.stderr
     assert result.stdout == ""
 
 
 def test_completion_bash(run_command):
-    result = run_command("completion bash")
+    result = run_command(["completion", "bash"])
     assert result.ok
     assert result.stderr == ""
     assert "_arduino-cli_root_command()" in result.stdout
@@ -30,7 +30,7 @@ def test_completion_bash(run_command):
 
 
 def test_completion_zsh(run_command):
-    result = run_command("completion zsh")
+    result = run_command(["completion", "zsh"])
     assert result.ok
     assert result.stderr == ""
     assert "#compdef _arduino-cli arduino-cli" in result.stdout
@@ -38,7 +38,7 @@ def test_completion_zsh(run_command):
 
 
 def test_completion_fish(run_command):
-    result = run_command("completion fish")
+    result = run_command(["completion", "fish"])
     assert result.ok
     assert result.stderr == ""
     assert "# fish completion for arduino-cli" in result.stdout
@@ -46,7 +46,7 @@ def test_completion_fish(run_command):
 
 
 def test_completion_powershell(run_command):
-    result = run_command("completion powershell")
+    result = run_command(["completion", "powershell"])
     assert result.ok
     assert result.stderr == ""
     assert "# powershell completion for arduino-cli" in result.stdout
@@ -54,14 +54,14 @@ def test_completion_powershell(run_command):
 
 
 def test_completion_bash_no_desc(run_command):
-    result = run_command("completion bash --no-descriptions")
+    result = run_command(["completion", "bash", "--no-descriptions"])
     assert not result.ok
     assert result.stdout == ""
     assert "Error: command description is not supported by bash" in result.stderr
 
 
 def test_completion_zsh_no_desc(run_command):
-    result = run_command("completion zsh --no-descriptions")
+    result = run_command(["completion", "zsh", "--no-descriptions"])
     assert result.ok
     assert result.stderr == ""
     assert "#compdef _arduino-cli arduino-cli" in result.stdout
@@ -70,7 +70,7 @@ def test_completion_zsh_no_desc(run_command):
 
 
 def test_completion_fish_no_desc(run_command):
-    result = run_command("completion fish --no-descriptions")
+    result = run_command(["completion", "fish", "--no-descriptions"])
     assert result.ok
     assert result.stderr == ""
     assert "# fish completion for arduino-cli" in result.stdout
@@ -79,7 +79,7 @@ def test_completion_fish_no_desc(run_command):
 
 
 def test_completion_powershell_no_desc(run_command):
-    result = run_command("completion powershell --no-descriptions")
+    result = run_command(["completion", "powershell", "--no-descriptions"])
     assert not result.ok
     assert result.stdout == ""
     assert "Error: command description is not supported by powershell" in result.stderr

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -18,14 +18,14 @@ import yaml
 
 
 def test_init(run_command, data_dir, working_dir):
-    result = run_command("config init")
+    result = run_command(["config", "init"])
     assert "" == result.stderr
     assert result.ok
     assert data_dir in result.stdout
 
 
 def test_init_with_existing_custom_config(run_command, data_dir, working_dir, downloads_dir):
-    result = run_command("config init --additional-urls https://example.com")
+    result = run_command(["config", "init", "--additional-urls", "https://example.com"])
     assert result.ok
     assert data_dir in result.stdout
 
@@ -45,7 +45,7 @@ def test_init_with_existing_custom_config(run_command, data_dir, working_dir, do
 
     config_file_path = Path(working_dir) / "config" / "test" / "config.yaml"
     assert not config_file_path.exists()
-    result = run_command(f'config init --dest-file "{config_file_path}"')
+    result = run_command(["config", "init", "--dest-file", config_file_path])
     assert result.ok
     assert str(config_file_path) in result.stdout
 
@@ -65,7 +65,7 @@ def test_init_with_existing_custom_config(run_command, data_dir, working_dir, do
 
 
 def test_init_overwrite_existing_custom_file(run_command, data_dir, working_dir, downloads_dir):
-    result = run_command("config init --additional-urls https://example.com")
+    result = run_command(["config", "init", "--additional-urls", "https://example.com"])
     assert result.ok
     assert data_dir in result.stdout
 
@@ -83,7 +83,7 @@ def test_init_overwrite_existing_custom_file(run_command, data_dir, working_dir,
     assert ":9090" == configs["metrics"]["addr"]
     assert configs["metrics"]["enabled"]
 
-    result = run_command("config init --overwrite")
+    result = run_command(["config", "init", "--overwrite"])
     assert result.ok
     assert data_dir in result.stdout
 
@@ -106,7 +106,7 @@ def test_init_dest_absolute_path(run_command, working_dir):
     dest = Path(working_dir) / "config" / "test"
     expected_config_file = dest / "arduino-cli.yaml"
     assert not expected_config_file.exists()
-    result = run_command(f'config init --dest-dir "{dest}"')
+    result = run_command(["config", "init", "--dest-dir", dest])
     assert result.ok
     assert str(expected_config_file) in result.stdout
     assert expected_config_file.exists()
@@ -116,7 +116,7 @@ def test_init_dest_relative_path(run_command, working_dir):
     dest = Path(working_dir) / "config" / "test"
     expected_config_file = dest / "arduino-cli.yaml"
     assert not expected_config_file.exists()
-    result = run_command('config init --dest-dir "config/test"')
+    result = run_command(["config", "init", "--dest-dir", "config/test"])
     assert result.ok
     assert str(expected_config_file) in result.stdout
     assert expected_config_file.exists()
@@ -128,21 +128,21 @@ def test_init_dest_flag_with_overwrite_flag(run_command, working_dir):
     expected_config_file = dest / "arduino-cli.yaml"
     assert not expected_config_file.exists()
 
-    result = run_command(f'config init --dest-dir "{dest}"')
+    result = run_command(["config", "init", "--dest-dir", dest])
     assert result.ok
     assert expected_config_file.exists()
 
-    result = run_command(f'config init --dest-dir "{dest}"')
+    result = run_command(["config", "init", "--dest-dir", dest])
     assert result.failed
     assert "Config file already exists, use --overwrite to discard the existing one." in result.stderr
 
-    result = run_command(f'config init --dest-dir "{dest}" --overwrite')
+    result = run_command(["config", "init", "--dest-dir", dest, "--overwrite"])
     assert result.ok
     assert str(expected_config_file) in result.stdout
 
 
 def test_init_dest_and_config_file_flags(run_command, working_dir):
-    result = run_command('config init --dest-file "some_other_path" --dest-dir "some_path"')
+    result = run_command(["config", "init", "--dest-file", "some_other_path", "--dest-dir", "some_path"])
     assert result.failed
     assert "Can't use both --dest-file and --dest-dir flags at the same time." in result.stderr
 
@@ -150,7 +150,7 @@ def test_init_dest_and_config_file_flags(run_command, working_dir):
 def test_init_config_file_flag_absolute_path(run_command, working_dir):
     config_file = Path(working_dir) / "config" / "test" / "config.yaml"
     assert not config_file.exists()
-    result = run_command(f'config init --dest-file "{config_file}"')
+    result = run_command(["config", "init", "--dest-file", config_file])
     assert result.ok
     assert str(config_file) in result.stdout
     assert config_file.exists()
@@ -159,7 +159,7 @@ def test_init_config_file_flag_absolute_path(run_command, working_dir):
 def test_init_config_file_flag_relative_path(run_command, working_dir):
     config_file = Path(working_dir) / "config.yaml"
     assert not config_file.exists()
-    result = run_command('config init --dest-file "config.yaml"')
+    result = run_command(["config", "init", "--dest-file", "config.yaml"])
     assert result.ok
     assert str(config_file) in result.stdout
     assert config_file.exists()
@@ -169,15 +169,15 @@ def test_init_config_file_flag_with_overwrite_flag(run_command, working_dir):
     config_file = Path(working_dir) / "config" / "test" / "config.yaml"
     assert not config_file.exists()
 
-    result = run_command(f'config init --dest-file "{config_file}"')
+    result = run_command(["config", "init", "--dest-file", config_file])
     assert result.ok
     assert config_file.exists()
 
-    result = run_command(f'config init --dest-file "{config_file}"')
+    result = run_command(["config", "init", "--dest-file", config_file])
     assert result.failed
     assert "Config file already exists, use --overwrite to discard the existing one." in result.stderr
 
-    result = run_command(f'config init --dest-file "{config_file}" --overwrite')
+    result = run_command(["config", "init", "--dest-file", config_file, "--overwrite"])
     assert result.ok
     assert str(config_file) in result.stdout
 
@@ -186,22 +186,22 @@ def test_dump(run_command, data_dir, working_dir):
     # Create a config file first
     config_file = Path(working_dir) / "config" / "test" / "config.yaml"
     assert not config_file.exists()
-    result = run_command(f'config init --dest-file "{config_file}"')
+    result = run_command(["config", "init", "--dest-file", config_file])
     assert result.ok
     assert config_file.exists()
 
-    result = run_command(f'config dump --config-file "{config_file}" --format json')
+    result = run_command(["config", "dump", "--config-file", config_file, "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert [] == settings_json["board_manager"]["additional_urls"]
 
-    result = run_command('config init --additional-urls "https://example.com"')
+    result = run_command(["config", "init", "--additional-urls", "https://example.com"])
     assert result.ok
     config_file = Path(data_dir) / "arduino-cli.yaml"
     assert str(config_file) in result.stdout
     assert config_file.exists()
 
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert ["https://example.com"] == settings_json["board_manager"]["additional_urls"]
@@ -211,17 +211,25 @@ def test_dump_with_config_file_flag(run_command, working_dir):
     # Create a config file first
     config_file = Path(working_dir) / "config" / "test" / "config.yaml"
     assert not config_file.exists()
-    result = run_command(f'config init --dest-file "{config_file}" --additional-urls=https://example.com')
+    result = run_command(["config", "init", "--dest-file", config_file, "--additional-urls=https://example.com"])
     assert result.ok
     assert config_file.exists()
 
-    result = run_command(f'config dump --config-file "{config_file}" --format json')
+    result = run_command(["config", "dump", "--config-file", config_file, "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert ["https://example.com"] == settings_json["board_manager"]["additional_urls"]
 
     result = run_command(
-        f'config dump --config-file "{config_file}" --additional-urls=https://another-url.com --format json'
+        [
+            "config",
+            "dump",
+            "--config-file",
+            config_file,
+            "--additional-urls=https://another-url.com",
+            "--format",
+            "json",
+        ]
     )
     assert result.ok
     settings_json = json.loads(result.stdout)
@@ -230,41 +238,41 @@ def test_dump_with_config_file_flag(run_command, working_dir):
 
 def test_add_remove_set_delete_on_unexisting_key(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
-    res = run_command("config add some.key some_value")
+    res = run_command(["config", "add", "some.key", "some_value"])
     assert res.failed
     assert "Settings key doesn't exist" in res.stderr
 
-    res = run_command("config remove some.key some_value")
+    res = run_command(["config", "remove", "some.key", "some_value"])
     assert res.failed
     assert "Settings key doesn't exist" in res.stderr
 
-    res = run_command("config set some.key some_value")
+    res = run_command(["config", "set", "some.key", "some_value"])
     assert res.failed
     assert "Settings key doesn't exist" in res.stderr
 
-    res = run_command("config delete some.key")
+    res = run_command(["config", "delete", "some.key"])
     assert res.failed
     assert "Settings key doesn't exist" in res.stderr
 
 
 def test_add_single_argument(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Verifies no additional urls are present
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert [] == settings_json["board_manager"]["additional_urls"]
 
     # Adds one URL
     url = "https://example.com"
-    assert run_command(f"config add board_manager.additional_urls {url}")
+    assert run_command(["config", "add", "board_manager.additional_urls", url])
 
     # Verifies URL has been saved
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert ["https://example.com"] == settings_json["board_manager"]["additional_urls"]
@@ -272,10 +280,10 @@ def test_add_single_argument(run_command):
 
 def test_add_multiple_arguments(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Verifies no additional urls are present
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert [] == settings_json["board_manager"]["additional_urls"]
@@ -285,10 +293,10 @@ def test_add_multiple_arguments(run_command):
         "https://example.com/package_example_index.json",
         "https://example.com/yet_another_package_example_index.json",
     ]
-    assert run_command(f"config add board_manager.additional_urls {' '.join(urls)}")
+    assert run_command(["config", "add", "board_manager.additional_urls"] + urls)
 
     # Verifies URL has been saved
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert 2 == len(settings_json["board_manager"]["additional_urls"])
@@ -298,21 +306,21 @@ def test_add_multiple_arguments(run_command):
 
 def test_add_on_unsupported_key(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Verifies default value
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert "50051" == settings_json["daemon"]["port"]
 
     # Tries and fails to add a new item
-    result = run_command("config add daemon.port 50000")
+    result = run_command(["config", "add", "daemon.port", "50000"])
     assert result.failed
     assert "The key 'daemon.port' is not a list of items, can't add to it.\nMaybe use 'config set'?" in result.stderr
 
     # Verifies value is not changed
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert "50051" == settings_json["daemon"]["port"]
@@ -320,17 +328,17 @@ def test_add_on_unsupported_key(run_command):
 
 def test_remove_single_argument(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Adds URLs
     urls = [
         "https://example.com/package_example_index.json",
         "https://example.com/yet_another_package_example_index.json",
     ]
-    assert run_command(f"config add board_manager.additional_urls {' '.join(urls)}")
+    assert run_command(["config", "add", "board_manager.additional_urls"] + urls)
 
     # Verifies default state
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert 2 == len(settings_json["board_manager"]["additional_urls"])
@@ -338,10 +346,10 @@ def test_remove_single_argument(run_command):
     assert urls[1] in settings_json["board_manager"]["additional_urls"]
 
     # Remove first URL
-    assert run_command(f"config remove board_manager.additional_urls {urls[0]}")
+    assert run_command(["config", "remove", "board_manager.additional_urls", urls[0]])
 
     # Verifies URLs has been removed
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert ["https://example.com/yet_another_package_example_index.json"] == settings_json["board_manager"][
@@ -351,17 +359,17 @@ def test_remove_single_argument(run_command):
 
 def test_remove_multiple_arguments(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Adds URLs
     urls = [
         "https://example.com/package_example_index.json",
         "https://example.com/yet_another_package_example_index.json",
     ]
-    assert run_command(f"config add board_manager.additional_urls {' '.join(urls)}")
+    assert run_command(["config", "add", "board_manager.additional_urls"] + urls)
 
     # Verifies default state
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert 2 == len(settings_json["board_manager"]["additional_urls"])
@@ -369,10 +377,10 @@ def test_remove_multiple_arguments(run_command):
     assert urls[1] in settings_json["board_manager"]["additional_urls"]
 
     # Remove all URLs
-    assert run_command(f"config remove board_manager.additional_urls {' '.join(urls)}")
+    assert run_command(["config", "remove", "board_manager.additional_urls"] + urls)
 
     # Verifies all URLs have been removed
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert [] == settings_json["board_manager"]["additional_urls"]
@@ -380,16 +388,16 @@ def test_remove_multiple_arguments(run_command):
 
 def test_remove_on_unsupported_key(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Verifies default value
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert "50051" == settings_json["daemon"]["port"]
 
     # Tries and fails to add a new item
-    result = run_command("config remove daemon.port 50051")
+    result = run_command(["config", "remove", "daemon.port", "50051"])
     assert result.failed
     assert (
         "The key 'daemon.port' is not a list of items, can't remove from it.\nMaybe use 'config delete'?"
@@ -397,7 +405,7 @@ def test_remove_on_unsupported_key(run_command):
     )
 
     # Verifies value is not changed
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert "50051" == settings_json["daemon"]["port"]
@@ -405,30 +413,30 @@ def test_remove_on_unsupported_key(run_command):
 
 def test_set_slice_with_single_argument(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Verifies default state
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert [] == settings_json["board_manager"]["additional_urls"]
 
     # Set an URL in the list
     url = "https://example.com/package_example_index.json"
-    assert run_command(f"config set board_manager.additional_urls {url}")
+    assert run_command(["config", "set", "board_manager.additional_urls", url])
 
     # Verifies value is changed
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert [url] == settings_json["board_manager"]["additional_urls"]
 
     # Sets another URL
     url = "https://example.com/yet_another_package_example_index.json"
-    assert run_command(f"config set board_manager.additional_urls {url}")
+    assert run_command(["config", "set", "board_manager.additional_urls", url])
 
     # Verifies previous value is overwritten
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert [url] == settings_json["board_manager"]["additional_urls"]
@@ -436,10 +444,10 @@ def test_set_slice_with_single_argument(run_command):
 
 def test_set_slice_with_multiple_arguments(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Verifies default state
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert [] == settings_json["board_manager"]["additional_urls"]
@@ -449,10 +457,10 @@ def test_set_slice_with_multiple_arguments(run_command):
         "https://example.com/first_package_index.json",
         "https://example.com/second_package_index.json",
     ]
-    assert run_command(f"config set board_manager.additional_urls {' '.join(urls)}")
+    assert run_command(["config", "set", "board_manager.additional_urls"] + urls)
 
     # Verifies value is changed
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert 2 == len(settings_json["board_manager"]["additional_urls"])
@@ -464,10 +472,10 @@ def test_set_slice_with_multiple_arguments(run_command):
         "https://example.com/third_package_index.json",
         "https://example.com/fourth_package_index.json",
     ]
-    assert run_command(f"config set board_manager.additional_urls {' '.join(urls)}")
+    assert run_command(["config", "set", "board_manager.additional_urls"] + urls)
 
     # Verifies previous value is overwritten
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert 2 == len(settings_json["board_manager"]["additional_urls"])
@@ -477,19 +485,19 @@ def test_set_slice_with_multiple_arguments(run_command):
 
 def test_set_string_with_single_argument(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Verifies default state
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert "info" == settings_json["logging"]["level"]
 
     # Changes value
-    assert run_command("" "config set logging.level trace")
+    assert run_command(["config", "set", "logging.level", "trace"])
 
     # Verifies value is changed
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert "trace" == settings_json["logging"]["level"]
@@ -497,35 +505,35 @@ def test_set_string_with_single_argument(run_command):
 
 def test_set_string_with_multiple_arguments(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Verifies default state
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert "info" == settings_json["logging"]["level"]
 
     # Tries to change value
-    res = run_command("config set logging.level trace debug")
+    res = run_command(["config", "set", "logging.level", "trace", "debug"])
     assert res.failed
     assert "Can't set multiple values in key logging.level" in res.stderr
 
 
 def test_set_bool_with_single_argument(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Verifies default state
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert not settings_json["library"]["enable_unsafe_install"]
 
     # Changes value
-    assert run_command("config set library.enable_unsafe_install true")
+    assert run_command(["config", "set", "library.enable_unsafe_install", "true"])
 
     # Verifies value is changed
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert settings_json["library"]["enable_unsafe_install"]
@@ -533,32 +541,32 @@ def test_set_bool_with_single_argument(run_command):
 
 def test_set_bool_with_multiple_arguments(run_command):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Verifies default state
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert not settings_json["library"]["enable_unsafe_install"]
 
     # Changes value'
-    res = run_command("config set library.enable_unsafe_install true foo")
+    res = run_command(["config", "set", "library.enable_unsafe_install", "true", "foo"])
     assert res.failed
     assert "Can't set multiple values in key library.enable_unsafe_install" in res.stderr
 
 
 def test_delete(run_command, working_dir):
     # Create a config file
-    assert run_command("config init --dest-dir .")
+    assert run_command(["config", "init", "--dest-dir", "."])
 
     # Verifies default state
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert not settings_json["library"]["enable_unsafe_install"]
 
     # Delete config key
-    assert run_command("config delete library.enable_unsafe_install")
+    assert run_command(["config", "delete", "library.enable_unsafe_install"])
 
     # Verifies value is not found, we read directly from file instead of using
     # the dump command since that would still print the deleted value if it has
@@ -568,13 +576,13 @@ def test_delete(run_command, working_dir):
     assert "enable_unsafe_install" not in config_lines
 
     # Verifies default state
-    result = run_command("config dump --format json")
+    result = run_command(["config", "dump", "--format", "json"])
     assert result.ok
     settings_json = json.loads(result.stdout)
     assert [] == settings_json["board_manager"]["additional_urls"]
 
     # Delete config key and sub keys
-    assert run_command("config delete board_manager")
+    assert run_command(["config", "delete", "board_manager"])
 
     # Verifies value is not found, we read directly from file instead of using
     # the dump command since that would still print the deleted value if it has

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -32,22 +32,22 @@ def test_core_search(run_command, httpserver):
     httpserver.expect_request("/test_index.json").respond_with_data(test_index.read_text())
 
     url = httpserver.url_for("/test_index.json")
-    assert run_command(f"core update-index --additional-urls={url}")
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
     # search a specific core
-    result = run_command("core search avr")
+    result = run_command(["core", "search", "avr"])
     assert result.ok
     assert 2 < len(result.stdout.splitlines())
-    result = run_command("core search avr --format json")
+    result = run_command(["core", "search", "avr", "--format", "json"])
     assert result.ok
     data = json.loads(result.stdout)
     assert 0 < len(data)
     # additional URL
-    result = run_command("core search test_core --format json --additional-urls={}".format(url))
+    result = run_command(["core", "search", "test_core", "--format", "json", f"--additional-urls={url}"])
     assert result.ok
     data = json.loads(result.stdout)
     assert 1 == len(data)
     # show all versions
-    result = run_command("core search test_core --all --format json --additional-urls={}".format(url))
+    result = run_command(["core", "search", "test_core", "--all", "--format", "json", f"--additional-urls={url}"])
     assert result.ok
     data = json.loads(result.stdout)
     assert 2 == len(data)
@@ -60,34 +60,34 @@ def test_core_search(run_command, httpserver):
         return platforms
 
     # Search all Retrokit platforms
-    result = run_command(f"core search retrokit --all --additional-urls={url} --format json")
+    result = run_command(["core", "search", "retrokit", "--all", f"--additional-urls={url}", "--format", "json"])
     assert result.ok
     platforms = get_platforms(result.stdout)
     assert "1.0.5" in platforms["Retrokits-RK002:arm"]
     assert "1.0.6" in platforms["Retrokits-RK002:arm"]
 
     # Search using Retrokit Package Maintainer
-    result = run_command(f"core search Retrokits-RK002 --all --additional-urls={url} --format json")
+    result = run_command(["core", "search", "Retrokits-RK002", "--all", f"--additional-urls={url}", "--format", "json"])
     assert result.ok
     platforms = get_platforms(result.stdout)
     assert "1.0.5" in platforms["Retrokits-RK002:arm"]
     assert "1.0.6" in platforms["Retrokits-RK002:arm"]
 
     # Search using the Retrokit Platform name
-    result = run_command(f"core search rk002 --all --additional-urls={url} --format json")
+    result = run_command(["core", "search", "rk002", "--all", f"--additional-urls={url}", "--format", "json"])
     assert result.ok
     platforms = get_platforms(result.stdout)
     assert "1.0.5" in platforms["Retrokits-RK002:arm"]
     assert "1.0.6" in platforms["Retrokits-RK002:arm"]
 
     # Search using board names
-    result = run_command(f"core search myboard --all --additional-urls={url} --format json")
+    result = run_command(["core", "search", "myboard", "--all", f"--additional-urls={url}", "--format", "json"])
     assert result.ok
     platforms = get_platforms(result.stdout)
     assert "1.2.3" in platforms["Package:x86"]
 
     def run_search(search_args, expected_ids):
-        res = run_command(f"core search --format json {search_args}")
+        res = run_command(["core", "search", "--format", "json"] + search_args.split(" "))
         assert res.ok
         data = json.loads(res.stdout)
         platform_ids = [p["id"] for p in data]
@@ -119,11 +119,11 @@ def test_core_search_no_args(run_command, httpserver):
 
     # update custom index and install test core (installed cores affect `core search`)
     url = httpserver.url_for("/test_index.json")
-    assert run_command(f"core update-index --additional-urls={url}")
-    assert run_command(f"core install test:x86 --additional-urls={url}")
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
+    assert run_command(["core", "install", "test:x86", f"--additional-urls={url}"])
 
     # list all with no additional urls, ensure the test core won't show up
-    result = run_command("core search")
+    result = run_command(["core", "search"])
     assert result.ok
     num_platforms = 0
     lines = [l.strip().split() for l in result.stdout.strip().splitlines()]
@@ -138,14 +138,14 @@ def test_core_search_no_args(run_command, httpserver):
     num_platforms = len(lines[header_index + 1 :])  # noqa: E203
 
     # same thing in JSON format, also check the number of platforms found is the same
-    result = run_command("core search --format json")
+    result = run_command(["core", "search", "--format", "json"])
     assert result.ok
     platforms = json.loads(result.stdout)
     assert 1 == len([e for e in platforms if e.get("name") == "test_core"])
     assert len(platforms) == num_platforms
 
     # list all with additional urls, check the test core is there
-    result = run_command(f"core search --additional-urls={url}")
+    result = run_command(["core", "search", f"--additional-urls={url}"])
     assert result.ok
     num_platforms = 0
     lines = [l.strip().split() for l in result.stdout.strip().splitlines()]
@@ -160,7 +160,7 @@ def test_core_search_no_args(run_command, httpserver):
     num_platforms = len(lines[header_index + 1 :])  # noqa: E203
 
     # same thing in JSON format, also check the number of platforms found is the same
-    result = run_command(f"core search --format json --additional-urls={url}")
+    result = run_command(["core", "search", "--format", "json", f"--additional-urls={url}"])
     assert result.ok
     platforms = json.loads(result.stdout)
     assert 1 == len([e for e in platforms if e.get("name") == "test_core"])
@@ -168,26 +168,26 @@ def test_core_search_no_args(run_command, httpserver):
 
 
 def test_core_updateindex_url_not_found(run_command, httpserver):
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Brings up a local server to fake a failure
     httpserver.expect_request("/test_index.json").respond_with_data(status=404)
     url = httpserver.url_for("/test_index.json")
 
-    result = run_command(f"core update-index --additional-urls={url}")
+    result = run_command(["core", "update-index", f"--additional-urls={url}"])
     assert result.failed
     lines = [l.strip() for l in result.stderr.splitlines()]
     assert f"Error updating index: Error downloading index '{url}': Server responded with: 404 NOT FOUND" in lines
 
 
 def test_core_updateindex_internal_server_error(run_command, httpserver):
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Brings up a local server to fake a failure
     httpserver.expect_request("/test_index.json").respond_with_data(status=500)
     url = httpserver.url_for("/test_index.json")
 
-    result = run_command(f"core update-index --additional-urls={url}")
+    result = run_command(["core", "update-index", f"--additional-urls={url}"])
     assert result.failed
     lines = [l.strip() for l in result.stderr.splitlines()]
     assert (
@@ -199,7 +199,7 @@ def test_core_updateindex_internal_server_error(run_command, httpserver):
 def test_core_install_without_updateindex(run_command):
     # Missing "core update-index"
     # Download samd core pinned to 1.8.6
-    result = run_command("core install arduino:samd@1.8.6")
+    result = run_command(["core", "install", "arduino:samd@1.8.6"])
     assert result.ok
     assert "Updating index: package_index.json downloaded" in result.stdout
 
@@ -211,14 +211,14 @@ def test_core_install_without_updateindex(run_command):
 def test_core_install_esp32(run_command, data_dir):
     # update index
     url = "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json"
-    assert run_command(f"core update-index --additional-urls={url}")
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
     # install 3rd-party core
-    assert run_command(f"core install esp32:esp32@2.0.0 --additional-urls={url}")
+    assert run_command(["core", "install", "esp32:esp32@2.0.0", f"--additional-urls={url}"])
     # create a sketch and compile to double check the core was successfully installed
     sketch_name = "test_core_install_esp32"
     sketch_path = os.path.join(data_dir, sketch_name)
-    assert run_command(f"sketch new {sketch_path}")
-    assert run_command(f"compile -b esp32:esp32:esp32 {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
+    assert run_command(["compile", "-b", "esp32:esp32:esp32", sketch_path])
     # prevent regressions for https://github.com/arduino/arduino-cli/issues/163
     sketch_path_md5 = hashlib.md5(sketch_path.encode()).hexdigest().upper()
     build_dir = Path(tempfile.gettempdir(), f"arduino-sketch-{sketch_path_md5}")
@@ -226,18 +226,18 @@ def test_core_install_esp32(run_command, data_dir):
 
 
 def test_core_download(run_command, downloads_dir):
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Download a specific core version
-    assert run_command("core download arduino:avr@1.6.16")
+    assert run_command(["core", "download", "arduino:avr@1.6.16"])
     assert os.path.exists(os.path.join(downloads_dir, "packages", "avr-1.6.16.tar.bz2"))
 
     # Wrong core version
-    result = run_command("core download arduino:avr@69.42.0")
+    result = run_command(["core", "download", "arduino:avr@69.42.0"])
     assert result.failed
 
     # Wrong core
-    result = run_command("core download bananas:avr")
+    result = run_command(["core", "download", "bananas:avr"])
     assert result.failed
 
 
@@ -253,44 +253,44 @@ def _in(jsondata, name, version=None):
 
 
 def test_core_install(run_command):
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Install a specific core version
-    assert run_command("core install arduino:avr@1.6.16")
-    result = run_command("core list --format json")
+    assert run_command(["core", "install", "arduino:avr@1.6.16"])
+    result = run_command(["core", "list", "--format", "json"])
     assert result.ok
     assert _in(result.stdout, "arduino:avr", "1.6.16")
 
     # Replace it with a more recent one
-    assert run_command("core install arduino:avr@1.6.17")
-    result = run_command("core list --format json")
+    assert run_command(["core", "install", "arduino:avr@1.6.17"])
+    result = run_command(["core", "list", "--format", "json"])
     assert result.ok
     assert _in(result.stdout, "arduino:avr", "1.6.17")
 
     # Confirm core is listed as "updatable"
-    result = run_command("core list --updatable --format json")
+    result = run_command(["core", "list", "--updatable", "--format", "json"])
     assert result.ok
     assert _in(result.stdout, "arduino:avr", "1.6.17")
 
     # Upgrade the core to latest version
-    assert run_command("core upgrade arduino:avr")
-    result = run_command("core list --format json")
+    assert run_command(["core", "upgrade", "arduino:avr"])
+    result = run_command(["core", "list", "--format", "json"])
     assert result.ok
     assert not _in(result.stdout, "arduino:avr", "1.6.17")
     # double check the code isn't updatable anymore
-    result = run_command("core list --updatable --format json")
+    result = run_command(["core", "list", "--updatable", "--format", "json"])
     assert result.ok
     assert not _in(result.stdout, "arduino:avr")
 
 
 def test_core_uninstall(run_command):
-    assert run_command("core update-index")
-    assert run_command("core install arduino:avr")
-    result = run_command("core list --format json")
+    assert run_command(["core", "update-index"])
+    assert run_command(["core", "install", "arduino:avr"])
+    result = run_command(["core", "list", "--format", "json"])
     assert result.ok
     assert _in(result.stdout, "arduino:avr")
-    assert run_command("core uninstall arduino:avr")
-    result = run_command("core list --format json")
+    assert run_command(["core", "uninstall", "arduino:avr"])
+    result = run_command(["core", "list", "--format", "json"])
     assert result.ok
     assert not _in(result.stdout, "arduino:avr")
 
@@ -298,10 +298,10 @@ def test_core_uninstall(run_command):
 def test_core_uninstall_tool_dependency_removal(run_command, data_dir):
     # These platforms both have a dependency on the arduino:avr-gcc@7.3.0-atmel3.6.1-arduino5 tool
     # arduino:avr@1.8.2 has a dependency on arduino:avrdude@6.3.0-arduino17
-    assert run_command("core install arduino:avr@1.8.2")
+    assert run_command(["core", "install", "arduino:avr@1.8.2"])
     # arduino:megaavr@1.8.4 has a dependency on arduino:avrdude@6.3.0-arduino16
-    assert run_command("core install arduino:megaavr@1.8.4")
-    assert run_command("core uninstall arduino:avr")
+    assert run_command(["core", "install", "arduino:megaavr@1.8.4"])
+    assert run_command(["core", "uninstall", "arduino:avr"])
 
     arduino_tools_path = Path(data_dir, "packages", "arduino", "tools")
 
@@ -318,22 +318,22 @@ def test_core_uninstall_tool_dependency_removal(run_command, data_dir):
 
 def test_core_zipslip(run_command):
     url = "https://raw.githubusercontent.com/arduino/arduino-cli/master/test/testdata/test_index.json"
-    assert run_command("core update-index --additional-urls={}".format(url))
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
 
     # Install a core and check if malicious content has been extracted.
-    run_command("core install zipslip:x86 --additional-urls={}".format(url))
+    run_command(["core", "install", "zipslip:x86", f"--additional-urls={url}"])
     assert os.path.exists("/tmp/evil.txt") is False
 
 
 def test_core_broken_install(run_command):
     url = "https://raw.githubusercontent.com/arduino/arduino-cli/master/test/testdata/test_index.json"
-    assert run_command("core update-index --additional-urls={}".format(url))
-    assert not run_command("core install brokenchecksum:x86 --additional-urls={}".format(url))
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
+    assert not run_command(["core", "install", "brokenchecksum:x86", "--additional-urls={url}"])
 
 
 def test_core_install_creates_installed_json(run_command, data_dir):
-    assert run_command("core update-index")
-    assert run_command("core install arduino:avr@1.6.23")
+    assert run_command(["core", "update-index"])
+    assert run_command(["core", "install", "arduino:avr@1.6.23"])
 
     installed_json_file = Path(data_dir, "packages", "arduino", "hardware", "avr", "1.6.23", "installed.json")
     assert installed_json_file.exists()
@@ -357,16 +357,16 @@ def test_core_update_with_local_url(run_command):
     if platform.system() == "Windows":
         test_index = f"/{test_index}".replace("\\", "/")
 
-    res = run_command(f'core update-index --additional-urls="file://{test_index}"')
+    res = run_command(["core", "update-index", f'--additional-urls="file://{test_index}"'])
     assert res.ok
     assert "Updating index: test_index.json downloaded" in res.stdout
 
 
 def test_core_search_manually_installed_cores_not_printed(run_command, data_dir):
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Verifies only cores in board manager are shown
-    res = run_command("core search --format json")
+    res = run_command(["core", "search", "--format", "json"])
     assert res.ok
     cores = json.loads(res.stdout)
     num_cores = len(cores)
@@ -378,7 +378,7 @@ def test_core_search_manually_installed_cores_not_printed(run_command, data_dir)
     assert Repo.clone_from(git_url, repo_dir, multi_options=["-b 1.8.3"])
 
     # Verifies manually installed core is not shown
-    res = run_command("core search --format json")
+    res = run_command(["core", "search", "--format", "json"])
     assert res.ok
     cores = json.loads(res.stdout)
     assert num_cores == len(cores)
@@ -388,10 +388,10 @@ def test_core_search_manually_installed_cores_not_printed(run_command, data_dir)
 
 
 def test_core_list_all_manually_installed_core(run_command, data_dir):
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Verifies only cores in board manager are shown
-    res = run_command("core list --all --format json")
+    res = run_command(["core", "list", "--all", "--format", "json"])
     assert res.ok
     cores = json.loads(res.stdout)
     num_cores = len(cores)
@@ -403,7 +403,7 @@ def test_core_list_all_manually_installed_core(run_command, data_dir):
     assert Repo.clone_from(git_url, repo_dir, multi_options=["-b 1.8.3"])
 
     # Verifies manually installed core is shown
-    res = run_command("core list --all --format json")
+    res = run_command(["core", "list", "--all", "--format", "json"])
     assert res.ok
     cores = json.loads(res.stdout)
     assert num_cores + 1 == len(cores)
@@ -415,10 +415,10 @@ def test_core_list_all_manually_installed_core(run_command, data_dir):
 
 
 def test_core_list_updatable_all_flags(run_command, data_dir):
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Verifies only cores in board manager are shown
-    res = run_command("core list --all --updatable --format json")
+    res = run_command(["core", "list", "--all", "--updatable", "--format", "json"])
     assert res.ok
     cores = json.loads(res.stdout)
     num_cores = len(cores)
@@ -430,7 +430,7 @@ def test_core_list_updatable_all_flags(run_command, data_dir):
     assert Repo.clone_from(git_url, repo_dir, multi_options=["-b 1.8.3"])
 
     # Verifies using both --updatable and --all flags --all takes precedence
-    res = run_command("core list --all --updatable --format json")
+    res = run_command(["core", "list", "--all", "--updatable", "--format", "json"])
     assert res.ok
     cores = json.loads(res.stdout)
     assert num_cores + 1 == len(cores)
@@ -442,49 +442,49 @@ def test_core_list_updatable_all_flags(run_command, data_dir):
 
 
 def test_core_upgrade_removes_unused_tools(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Installs a core
-    assert run_command("core install arduino:avr@1.8.2")
+    assert run_command(["core", "install", "arduino:avr@1.8.2"])
 
     # Verifies expected tool is installed
     tool_path = Path(data_dir, "packages", "arduino", "tools", "avr-gcc", "7.3.0-atmel3.6.1-arduino5")
     assert tool_path.exists()
 
     # Upgrades core
-    assert run_command("core upgrade arduino:avr")
+    assert run_command(["core", "upgrade", "arduino:avr"])
 
     # Verifies tool is uninstalled since it's not used by newer core version
     assert not tool_path.exists()
 
 
 def test_core_install_removes_unused_tools(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Installs a core
-    assert run_command("core install arduino:avr@1.8.2")
+    assert run_command(["core", "install", "arduino:avr@1.8.2"])
 
     # Verifies expected tool is installed
     tool_path = Path(data_dir, "packages", "arduino", "tools", "avr-gcc", "7.3.0-atmel3.6.1-arduino5")
     assert tool_path.exists()
 
     # Installs newer version of already installed core
-    assert run_command("core install arduino:avr@1.8.3")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
 
     # Verifies tool is uninstalled since it's not used by newer core version
     assert not tool_path.exists()
 
 
 def test_core_list_with_installed_json(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install core
     url = "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json"
-    assert run_command(f"core update-index --additional-urls={url}")
-    assert run_command(f"core install adafruit:avr@1.4.13 --additional-urls={url}")
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
+    assert run_command(["core", "install", "adafruit:avr@1.4.13", f"--additional-urls={url}"])
 
     # Verifies installed core is correctly found and name is set
-    res = run_command("core list --format json")
+    res = run_command(["core", "list", "--format", "json"])
     assert res.ok
     cores = json.loads(res.stdout)
     mapped = {core["id"]: core for core in cores}
@@ -501,7 +501,7 @@ def test_core_list_with_installed_json(run_command, data_dir):
     installed_json.unlink()
 
     # Verifies installed core is still found and name is set
-    res = run_command("core list --format json")
+    res = run_command(["core", "list", "--format", "json"])
     assert res.ok
     cores = json.loads(res.stdout)
     mapped = {core["id"]: core for core in cores}
@@ -514,10 +514,10 @@ def test_core_list_with_installed_json(run_command, data_dir):
 
 
 def test_core_search_update_index_delay(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Verifies index update is not run
-    res = run_command("core search")
+    res = run_command(["core", "search"])
     assert res.ok
     assert "Updating index" not in res.stdout
 
@@ -528,12 +528,12 @@ def test_core_search_update_index_delay(run_command, data_dir):
     os.utime(index_file, (mod_time, mod_time))
 
     # Verifies index update is run
-    res = run_command("core search")
+    res = run_command(["core", "search"])
     assert res.ok
     assert "Updating index" in res.stdout
 
     # Verifies index update is not run again
-    res = run_command("core search")
+    res = run_command(["core", "search"])
     assert res.ok
     assert "Updating index" not in res.stdout
 
@@ -545,15 +545,15 @@ def test_core_search_sorted_results(run_command, httpserver):
 
     # update custom index
     url = httpserver.url_for("/test_index.json")
-    assert run_command(f"core update-index --additional-urls={url}")
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
 
     # This is done only to avoid index update output when calling core search
     # since it automatically updates them if they're outdated and it makes it
     # harder to parse the list of cores
-    assert run_command("core search")
+    assert run_command(["core", "search"])
 
     # list all with additional url specified
-    result = run_command(f"core search --additional-urls={url}")
+    result = run_command(["core", "search", f"--additional-urls={url}"])
     assert result.ok
 
     lines = [l.strip().split(maxsplit=2) for l in result.stdout.strip().splitlines()][1:]
@@ -568,7 +568,7 @@ def test_core_search_sorted_results(run_command, httpserver):
     assert lines == not_deprecated + deprecated
 
     # test same behaviour with json output
-    result = run_command(f"core search --additional-urls={url} --format=json")
+    result = run_command(["core", "search", f"--additional-urls={url}", "--format=json"])
     assert result.ok
 
     platforms = json.loads(result.stdout)
@@ -589,13 +589,15 @@ def test_core_list_sorted_results(run_command, httpserver):
 
     # update custom index
     url = httpserver.url_for("/test_index.json")
-    assert run_command(f"core update-index --additional-urls={url}")
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
 
     # install some core for testing
-    assert run_command(f"core install test:x86 Retrokits-RK002:arm Package:x86 --additional-urls={url}")
+    assert run_command(
+        ["core", "install", "test:x86", "Retrokits-RK002:arm", "Package:x86", f"--additional-urls={url}"]
+    )
 
     # list all with additional url specified
-    result = run_command(f"core list --additional-urls={url}")
+    result = run_command(["core", "list", f"--additional-urls={url}"])
     assert result.ok
 
     lines = [l.strip().split(maxsplit=3) for l in result.stdout.strip().splitlines()][1:]
@@ -611,7 +613,7 @@ def test_core_list_sorted_results(run_command, httpserver):
     assert lines == not_deprecated + deprecated
 
     # test same behaviour with json output
-    result = run_command(f"core list --additional-urls={url} --format=json")
+    result = run_command(["core", "list", f"--additional-urls={url}", "--format=json"])
     assert result.ok
 
     platforms = json.loads(result.stdout)
@@ -633,10 +635,10 @@ def test_core_list_deprecated_platform_with_installed_json(run_command, httpserv
 
     # update custom index
     url = httpserver.url_for("/test_index.json")
-    assert run_command(f"core update-index --additional-urls={url}")
+    assert run_command(["core", "update-index", f"--additional-urls={url}"])
 
     # install some core for testing
-    assert run_command(f"core install Package:x86 --additional-urls={url}")
+    assert run_command(["core", "install", "Package:x86", f"--additional-urls={url}"])
 
     installed_json_file = Path(data_dir, "packages", "Package", "hardware", "x86", "1.2.3", "installed.json")
     assert installed_json_file.exists()
@@ -648,7 +650,7 @@ def test_core_list_deprecated_platform_with_installed_json(run_command, httpserv
         json.dump(installed_json, f)
 
     # test same behaviour with json output
-    result = run_command(f"core list --additional-urls={url} --format=json")
+    result = run_command(["core", "list", f"--additional-urls={url}", "--format=json"])
     assert result.ok
 
     platforms = json.loads(result.stdout)
@@ -657,10 +659,10 @@ def test_core_list_deprecated_platform_with_installed_json(run_command, httpserv
 
 
 def test_core_list_platform_without_platform_txt(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Verifies no core is installed
-    res = run_command("core list --format json")
+    res = run_command(["core", "list", "--format", "json"])
     assert res.ok
     cores = json.loads(res.stdout)
     assert len(cores) == 0
@@ -674,7 +676,7 @@ def test_core_list_platform_without_platform_txt(run_command, data_dir):
     boards_txt.write_bytes(test_boards_txt.read_bytes())
 
     # Verifies no core is installed
-    res = run_command("core list --format json")
+    res = run_command(["core", "list", "--format", "json"])
     assert res.ok
     cores = json.loads(res.stdout)
     assert len(cores) == 1
@@ -695,9 +697,9 @@ def test_core_with_wrong_custom_board_options_is_loaded(run_command, data_dir):
         dirs_exist_ok=True,
     )
 
-    assert run_command("update")
+    assert run_command(["update"])
 
-    res = run_command("core list --format json")
+    res = run_command(["core", "list", "--format", "json"])
     assert res.ok
 
     cores = json.loads(res.stdout)
@@ -733,9 +735,9 @@ def test_core_with_missing_custom_board_options_is_loaded(run_command, data_dir)
         dirs_exist_ok=True,
     )
 
-    assert run_command("update")
+    assert run_command(["update"])
 
-    res = run_command("core list --format json")
+    res = run_command(["core", "list", "--format", "json"])
     assert res.ok
 
     cores = json.loads(res.stdout)
@@ -760,12 +762,12 @@ def test_core_with_missing_custom_board_options_is_loaded(run_command, data_dir)
 
 
 def test_core_list_outdated_core(run_command):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install an old core version
-    assert run_command("core install arduino:samd@1.8.6")
+    assert run_command(["core", "install", "arduino:samd@1.8.6"])
 
-    res = run_command("core list --format json")
+    res = run_command(["core", "list", "--format", "json"])
 
     data = json.loads(res.stdout)
     assert len(data) == 1

--- a/test/test_debug.py
+++ b/test/test_debug.py
@@ -19,45 +19,45 @@ from pathlib import Path
 
 def test_debugger_starts(run_command, data_dir):
     # Init the environment explicitly
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Install cores
-    assert run_command("core install arduino:samd")
+    assert run_command(["core", "install", "arduino:samd"])
 
     # Create sketch for testing
     sketch_name = "DebuggerStartTest"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:samd:mkr1000"
 
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Build sketch
-    assert run_command(f"compile -b {fqbn} {sketch_path}")
+    assert run_command(["compile", "-b", fqbn, sketch_path])
 
     programmer = "atmel_ice"
     # Starts debugger
-    assert run_command(f"debug -b {fqbn} -P {programmer} {sketch_path} --info")
+    assert run_command(["debug", "-b", fqbn, "-P", programmer, sketch_path, "--info"])
 
 
 def test_debugger_with_pde_sketch_starts(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install core
-    assert run_command("core install arduino:samd")
+    assert run_command(["core", "install", "arduino:samd"])
 
     # Create sketch for testing
     sketch_name = "DebuggerPdeSketchStartTest"
     sketch_path = Path(data_dir, sketch_name)
     fqbn = "arduino:samd:mkr1000"
 
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Renames sketch file to pde
     Path(sketch_path, f"{sketch_name}.ino").rename(sketch_path / f"{sketch_name}.pde")
 
     # Build sketch
-    assert run_command(f"compile -b {fqbn} {sketch_path}")
+    assert run_command(["compile", "-b", fqbn, sketch_path])
 
     programmer = "atmel_ice"
     # Starts debugger
-    assert run_command(f"debug -b {fqbn} -P {programmer} {sketch_path} --info")
+    assert run_command(["debug", "-b", fqbn, "-P", programmer, sketch_path, "--info"])

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -50,24 +50,24 @@ def download_lib(url, download_dir):
 
 def test_list(run_command):
     # Init the environment explicitly
-    run_command("core update-index")
+    run_command(["core", "update-index"])
 
     # When output is empty, nothing is printed out, no matter the output format
-    result = run_command("lib list")
+    result = run_command(["lib", "list"])
     assert result.ok
     assert "" == result.stderr
     assert "No libraries installed." in result.stdout.strip()
-    result = run_command("lib list --format json")
+    result = run_command(["lib", "list", "--format", "json"])
     assert result.ok
     assert "" == result.stderr
     assert 0 == len(json.loads(result.stdout))
 
     # Install something we can list at a version older than latest
-    result = run_command("lib install ArduinoJson@6.11.0")
+    result = run_command(["lib", "install", "ArduinoJson@6.11.0"])
     assert result.ok
 
     # Look at the plain text output
-    result = run_command("lib list")
+    result = run_command(["lib", "list"])
     assert result.ok
     assert "" == result.stderr
     lines = result.stdout.strip().splitlines()
@@ -82,7 +82,7 @@ def test_list(run_command):
     assert "An efficient and elegant JSON library..." == toks[4]
 
     # Look at the JSON output
-    result = run_command("lib list --format json")
+    result = run_command(["lib", "list", "--format", "json"])
     assert result.ok
     assert "" == result.stderr
     data = json.loads(result.stdout)
@@ -91,10 +91,10 @@ def test_list(run_command):
     assert "" != data[0]["release"]["version"]
 
     # Install something we can list without provides_includes field given in library.properties
-    result = run_command("lib install Arduino_APDS9960@1.0.3")
+    result = run_command(["lib", "install", "Arduino_APDS9960@1.0.3"])
     assert result.ok
     # Look at the JSON output
-    result = run_command("lib list Arduino_APDS9960 --format json")
+    result = run_command(["lib", "list", "Arduino_APDS9960", "--format", "json"])
     assert result.ok
     assert "" == result.stderr
     data = json.loads(result.stdout)
@@ -105,48 +105,48 @@ def test_list(run_command):
 
 def test_list_exit_code(run_command):
     # Init the environment explicitly
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
-    assert run_command("core list")
+    assert run_command(["core", "list"])
 
     # Verifies lib list doesn't fail when platform is not specified
-    result = run_command("lib list")
+    result = run_command(["lib", "list"])
     assert result.ok
     assert result.stderr.strip() == ""
 
     # Verify lib list command fails because specified platform is not installed
-    result = run_command("lib list -b arduino:samd:mkr1000")
+    result = run_command(["lib", "list", "-b", "arduino:samd:mkr1000"])
     assert result.failed
     assert result.stderr.strip() == "Error listing Libraries: Unknown FQBN: platform arduino:samd is not installed"
 
-    assert run_command('lib install "AllThingsTalk LoRaWAN SDK"')
+    assert run_command(["lib", "install", "AllThingsTalk LoRaWAN SDK"])
 
     # Verifies lib list command keeps failing
-    result = run_command("lib list -b arduino:samd:mkr1000")
+    result = run_command(["lib", "list", "-b", "arduino:samd:mkr1000"])
     assert result.failed
     assert result.stderr.strip() == "Error listing Libraries: Unknown FQBN: platform arduino:samd is not installed"
 
-    assert run_command("core install arduino:samd")
+    assert run_command(["core", "install", "arduino:samd"])
 
     # Verifies lib list command now works since platform has been installed
-    result = run_command("lib list -b arduino:samd:mkr1000")
+    result = run_command(["lib", "list", "-b", "arduino:samd:mkr1000"])
     assert result.ok
     assert result.stderr.strip() == ""
 
 
 def test_list_with_fqbn(run_command):
     # Init the environment explicitly
-    assert run_command("core update-index")
+    assert run_command(["core", "update-index"])
 
     # Install core
-    assert run_command("core install arduino:avr")
+    assert run_command(["core", "install", "arduino:avr"])
 
     # Install some library
-    assert run_command("lib install ArduinoJson")
-    assert run_command("lib install wm8978-esp32")
+    assert run_command(["lib", "install", "ArduinoJson"])
+    assert run_command(["lib", "install", "wm8978-esp32"])
 
     # Look at the plain text output
-    result = run_command("lib list -b arduino:avr:uno")
+    result = run_command(["lib", "list", "-b", "arduino:avr:uno"])
     assert result.ok
     assert "" == result.stderr
     lines = result.stdout.strip().splitlines()
@@ -158,7 +158,7 @@ def test_list_with_fqbn(run_command):
     assert "ArduinoJson" == toks[0]
 
     # Look at the JSON output
-    result = run_command("lib list -b arduino:avr:uno --format json")
+    result = run_command(["lib", "list", "-b", "arduino:avr:uno", "--format", "json"])
     assert result.ok
     assert "" == result.stderr
     data = json.loads(result.stdout)
@@ -172,14 +172,14 @@ def test_list_with_fqbn(run_command):
 def test_list_provides_includes_fallback(run_command):
     # Verifies "provides_includes" field is returned even if libraries don't declare
     # the "includes" property in their "library.properties" file
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install core
-    assert run_command("core install arduino:avr@1.8.3")
-    assert run_command("lib install ArduinoJson@6.17.2")
+    assert run_command(["core", "install", "arduino:avr@1.8.3"])
+    assert run_command(["lib", "install", "ArduinoJson@6.17.2"])
 
     # List all libraries, even the ones installed with the above core
-    result = run_command("lib list --all --fqbn arduino:avr:uno --format json")
+    result = run_command(["lib", "list", "--all", "--fqbn", "arduino:avr:uno", "--format", "json"])
     assert result.ok
     assert "" == result.stderr
 
@@ -198,36 +198,36 @@ def test_list_provides_includes_fallback(run_command):
 def test_lib_download(run_command, downloads_dir):
 
     # Download a specific lib version
-    assert run_command("lib download AudioZero@1.0.0")
+    assert run_command(["lib", "download", "AudioZero@1.0.0"])
     assert Path(downloads_dir, "libraries", "AudioZero-1.0.0.zip").exists()
 
     # Wrong lib version
-    result = run_command("lib download AudioZero@69.42.0")
+    result = run_command(["lib", "download", "AudioZero@69.42.0"])
     assert result.failed
 
     # Wrong lib
-    result = run_command("lib download AudioZ")
+    result = run_command(["lib", "download", "AudioZ"])
     assert result.failed
 
 
 def test_install(run_command):
-    libs = ['"AzureIoTProtocol_MQTT"', '"CMMC MQTT Connector"', '"WiFiNINA"']
+    libs = ["AzureIoTProtocol_MQTT", "CMMC MQTT Connector", "WiFiNINA"]
     # Should be safe to run install multiple times
-    assert run_command("lib install {}".format(" ".join(libs)))
-    assert run_command("lib install {}".format(" ".join(libs)))
+    assert run_command(["lib", "install"] + libs)
+    assert run_command(["lib", "install"] + libs)
 
     # Test failing-install of library with wrong dependency
     # (https://github.com/arduino/arduino-cli/issues/534)
-    res = run_command("lib install MD_Parola@3.2.0")
+    res = run_command(["lib", "install", "MD_Parola@3.2.0"])
     assert res.failed
     assert "No valid dependencies solution found: dependency 'MD_MAX72xx' is not available" in res.stderr
 
 
 def test_install_library_with_dependencies(run_command):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Verifies libraries are not installed
-    res = run_command("lib list --format json")
+    res = run_command(["lib", "list", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     installed_libraries = [l["library"]["name"] for l in data]
@@ -235,10 +235,10 @@ def test_install_library_with_dependencies(run_command):
     assert "MD_MAX72XX" not in installed_libraries
 
     # Install library
-    assert run_command("lib install MD_Parola@3.5.5")
+    assert run_command(["lib", "install", "MD_Parola@3.5.5"])
 
     # Verifies library's dependencies are correctly installed
-    res = run_command("lib list --format json")
+    res = run_command(["lib", "list", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     installed_libraries = [l["library"]["name"] for l in data]
@@ -247,10 +247,10 @@ def test_install_library_with_dependencies(run_command):
 
 
 def test_install_no_deps(run_command):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Verifies libraries are not installed
-    res = run_command("lib list --format json")
+    res = run_command(["lib", "list", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     installed_libraries = [l["library"]["name"] for l in data]
@@ -258,10 +258,10 @@ def test_install_no_deps(run_command):
     assert "MD_MAX72XX" not in installed_libraries
 
     # Install library skipping dependencies installation
-    assert run_command("lib install MD_Parola@3.5.5 --no-deps")
+    assert run_command(["lib", "install", "MD_Parola@3.5.5", "--no-deps"])
 
     # Verifies library's dependencies are not installed
-    res = run_command("lib list --format json")
+    res = run_command(["lib", "list", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     installed_libraries = [l["library"]["name"] for l in data]
@@ -272,7 +272,7 @@ def test_install_no_deps(run_command):
 def test_install_git_url_and_zip_path_flags_visibility(run_command, data_dir, downloads_dir):
     # Verifies installation fail because flags are not found
     git_url = "https://github.com/arduino-libraries/WiFi101.git"
-    res = run_command(f"lib install --git-url {git_url}")
+    res = run_command(["lib", "install", "--git-url", git_url])
     assert res.failed
     assert "--git-url and --zip-path are disabled by default, for more information see:" in res.stderr
 
@@ -282,7 +282,7 @@ def test_install_git_url_and_zip_path_flags_visibility(run_command, data_dir, do
     zip_path.parent.mkdir(parents=True, exist_ok=True)
     download_lib(url, zip_path)
 
-    res = run_command(f"lib install --zip-path {zip_path}")
+    res = run_command(["lib", "install", "--zip-path", zip_path])
     assert res.failed
     assert "--git-url and --zip-path are disabled by default, for more information see:" in res.stderr
 
@@ -293,25 +293,25 @@ def test_install_git_url_and_zip_path_flags_visibility(run_command, data_dir, do
         "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL": "true",
     }
     # Verifies installation is successful when flags are enabled with env var
-    res = run_command(f"lib install --git-url {git_url}", custom_env=env)
+    res = run_command(["lib", "install", "--git-url", git_url], custom_env=env)
     assert res.ok
     assert "--git-url and --zip-path flags allow installing untrusted files, use it at your own risk." in res.stdout
 
-    res = run_command(f"lib install --zip-path {zip_path}", custom_env=env)
+    res = run_command(["lib", "install", "--zip-path", zip_path], custom_env=env)
     assert res.ok
     assert "--git-url and --zip-path flags allow installing untrusted files, use it at your own risk." in res.stdout
 
     # Uninstall libraries to install them again
-    assert run_command("lib uninstall WiFi101 AudioZero")
+    assert run_command(["lib", "uninstall", "WiFi101", "AudioZero"])
 
     # Verifies installation is successful when flags are enabled with settings file
-    assert run_command("config init --dest-dir .", custom_env=env)
+    assert run_command(["config", "init", "--dest-dir", "."], custom_env=env)
 
-    res = run_command(f"lib install --git-url {git_url}")
+    res = run_command(["lib", "install", "--git-url", git_url])
     assert res.ok
     assert "--git-url and --zip-path flags allow installing untrusted files, use it at your own risk." in res.stdout
 
-    res = run_command(f"lib install --zip-path {zip_path}")
+    res = run_command(["lib", "install", "--zip-path", zip_path])
     assert res.ok
     assert "--git-url and --zip-path flags allow installing untrusted files, use it at your own risk." in res.stdout
 
@@ -324,7 +324,7 @@ def test_install_with_git_url(run_command, data_dir, downloads_dir):
         "ARDUINO_SKETCHBOOK_DIR": data_dir,
         "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL": "true",
     }
-    assert run_command("config init --dest-dir .", custom_env=env)
+    assert run_command(["config", "init", "--dest-dir", "."], custom_env=env)
 
     lib_install_dir = Path(data_dir, "libraries", "WiFi101")
     # Verifies library is not already installed
@@ -333,7 +333,7 @@ def test_install_with_git_url(run_command, data_dir, downloads_dir):
     git_url = "https://github.com/arduino-libraries/WiFi101.git"
 
     # Test git-url library install
-    res = run_command(f"lib install --git-url {git_url}")
+    res = run_command(["lib", "install", "--git-url", git_url])
     assert res.ok
     assert "--git-url and --zip-path flags allow installing untrusted files, use it at your own risk." in res.stdout
 
@@ -341,7 +341,7 @@ def test_install_with_git_url(run_command, data_dir, downloads_dir):
     assert lib_install_dir.exists()
 
     # Reinstall library
-    assert run_command(f"lib install --git-url {git_url}")
+    assert run_command(["lib", "install", "--git-url", git_url])
 
     # Verifies library remains installed
     assert lib_install_dir.exists()
@@ -355,7 +355,7 @@ def test_install_with_zip_path(run_command, data_dir, downloads_dir):
         "ARDUINO_SKETCHBOOK_DIR": data_dir,
         "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL": "true",
     }
-    assert run_command("config init --dest-dir .", custom_env=env)
+    assert run_command(["config", "init", "--dest-dir", "."], custom_env=env)
 
     # Download a specific lib version
     # Download library
@@ -369,7 +369,7 @@ def test_install_with_zip_path(run_command, data_dir, downloads_dir):
     assert not lib_install_dir.exists()
 
     # Test zip-path install
-    res = run_command(f"lib install --zip-path {zip_path}")
+    res = run_command(["lib", "install", "--zip-path", zip_path])
     assert res.ok
     assert "--git-url and --zip-path flags allow installing untrusted files, use it at your own risk." in res.stdout
 
@@ -384,7 +384,7 @@ def test_install_with_zip_path(run_command, data_dir, downloads_dir):
     assert lib_install_dir / "README.adoc" in files
 
     # Reinstall library
-    assert run_command(f"lib install --zip-path {zip_path}")
+    assert run_command(["lib", "install", "--zip-path", zip_path])
 
     # Verifies library remains installed
     assert lib_install_dir.exists()
@@ -398,7 +398,7 @@ def test_install_with_zip_path(run_command, data_dir, downloads_dir):
 
 
 def test_update_index(run_command):
-    result = run_command("lib update-index")
+    result = run_command(["lib", "update-index"])
     assert result.ok
     lines = [l.strip() for l in result.stdout.splitlines()]
     assert "Updating index: library_index.json.gz downloaded" in lines
@@ -406,18 +406,18 @@ def test_update_index(run_command):
 
 
 def test_uninstall(run_command):
-    libs = ['"AzureIoTProtocol_MQTT"', '"WiFiNINA"']
-    assert run_command("lib install {}".format(" ".join(libs)))
+    libs = ["AzureIoTProtocol_MQTT", "WiFiNINA"]
+    assert run_command(["lib", "install"] + libs)
 
-    result = run_command("lib uninstall {}".format(" ".join(libs)))
+    result = run_command(["lib", "uninstall"] + libs)
     assert result.ok
 
 
 def test_uninstall_spaces(run_command):
-    key = '"LiquidCrystal I2C"'
-    assert run_command("lib install {}".format(key))
-    assert run_command("lib uninstall {}".format(key))
-    result = run_command("lib list --format json")
+    key = "LiquidCrystal I2C"
+    assert run_command(["lib", "install", key])
+    assert run_command(["lib", "uninstall", key])
+    result = run_command(["lib", "list", "--format", "json"])
     assert result.ok
     assert len(json.loads(result.stdout)) == 0
 
@@ -439,17 +439,17 @@ def test_lib_ops_caseinsensitive(run_command):
       Versions: [1.0.0]
     """
     key = "pcm"
-    assert run_command("lib install {}".format(key))
-    assert run_command("lib uninstall {}".format(key))
-    result = run_command("lib list --format json")
+    assert run_command(["lib", "install", key])
+    assert run_command(["lib", "uninstall", key])
+    result = run_command(["lib", "list", "--format", "json"])
     assert result.ok
     assert len(json.loads(result.stdout)) == 0
 
 
 def test_search(run_command):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    result = run_command("lib search --names")
+    result = run_command(["lib", "search", "--names"])
     assert result.ok
     lines = [l.strip() for l in result.stdout.strip().splitlines()]
     assert "Updating index: library_index.json.gz downloaded" in lines
@@ -459,16 +459,16 @@ def test_search(run_command):
     expected = {"WiFi101", "WiFi101OTA", "Firebase Arduino based on WiFi101"}
     assert expected == {lib for lib in libs if "WiFi101" in lib}
 
-    result = run_command("lib search --names --format json")
+    result = run_command(["lib", "search", "--names", "--format", "json"])
     assert result.ok
     libs_json = json.loads(result.stdout)
     assert len(libs) == len(libs_json.get("libraries"))
 
-    result = run_command("lib search --names")
+    result = run_command(["lib", "search", "--names"])
     assert result.ok
 
     def run_search(search_args, expected_libraries):
-        res = run_command(f"lib search --names --format json {search_args}")
+        res = run_command(["lib", "search", "--names", "--format", "json"] + search_args.split(" "))
         assert res.ok
         data = json.loads(res.stdout)
         libraries = [l["name"] for l in data["libraries"]]
@@ -500,8 +500,8 @@ def test_search_paragraph(run_command):
     Search for a string that's only present in the `paragraph` field
     within the index file.
     """
-    assert run_command("lib update-index")
-    result = run_command('lib search "A simple and efficient JSON library" --names --format json')
+    assert run_command(["lib", "update-index"])
+    result = run_command(["lib", "search", "A simple and efficient JSON library", "--names", "--format", "json"])
     assert result.ok
     data = json.loads(result.stdout)
     libraries = [l["name"] for l in data["libraries"]]
@@ -510,25 +510,25 @@ def test_search_paragraph(run_command):
 
 def test_lib_list_with_updatable_flag(run_command):
     # Init the environment explicitly
-    run_command("lib update-index")
+    run_command(["lib", "update-index"])
 
     # No libraries to update
-    result = run_command("lib list --updatable")
+    result = run_command(["lib", "list", "--updatable"])
     assert result.ok
     assert "" == result.stderr
     assert "No updates available." in result.stdout.strip()
     # No library to update in json
-    result = run_command("lib list --updatable --format json")
+    result = run_command(["lib", "list", "--updatable", "--format", "json"])
     assert result.ok
     assert "" == result.stderr
     assert 0 == len(json.loads(result.stdout))
 
     # Install outdated library
-    assert run_command("lib install ArduinoJson@6.11.0")
+    assert run_command(["lib", "install", "ArduinoJson@6.11.0"])
     # Install latest version of library
-    assert run_command("lib install WiFi101")
+    assert run_command(["lib", "install", "WiFi101"])
 
-    res = run_command("lib list --updatable")
+    res = run_command(["lib", "list", "--updatable"])
     assert res.ok
     assert "" == res.stderr
     # lines = res.stdout.strip().splitlines()
@@ -544,7 +544,7 @@ def test_lib_list_with_updatable_flag(run_command):
     assert "An efficient and elegant JSON library..." == line[4]
 
     # Look at the JSON output
-    res = run_command("lib list --updatable --format json")
+    res = run_command(["lib", "list", "--updatable", "--format", "json"])
     assert res.ok
     assert "" == res.stderr
     data = json.loads(res.stdout)
@@ -556,7 +556,7 @@ def test_lib_list_with_updatable_flag(run_command):
 
 
 def test_install_with_git_url_from_current_directory(run_command, downloads_dir, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     env = {
         "ARDUINO_DATA_DIR": data_dir,
@@ -574,7 +574,7 @@ def test_install_with_git_url_from_current_directory(run_command, downloads_dir,
     repo_dir = Path(data_dir, "WiFi101")
     assert Repo.clone_from(git_url, repo_dir)
 
-    assert run_command("lib install --git-url .", custom_working_dir=repo_dir, custom_env=env)
+    assert run_command(["lib", "install", "--git-url", "."], custom_working_dir=repo_dir, custom_env=env)
 
     # Verifies library is installed to correct folder
     assert lib_install_dir.exists()
@@ -586,7 +586,7 @@ def test_install_with_git_url_from_current_directory(run_command, downloads_dir,
     + "this must be removed when this issue is fixed: https://github.com/go-git/go-git/issues/247",
 )
 def test_install_with_git_url_local_file_uri(run_command, downloads_dir, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     env = {
         "ARDUINO_DATA_DIR": data_dir,
@@ -604,14 +604,14 @@ def test_install_with_git_url_local_file_uri(run_command, downloads_dir, data_di
     repo_dir = Path(data_dir, "WiFi101")
     assert Repo.clone_from(git_url, repo_dir)
 
-    assert run_command(f"lib install --git-url {repo_dir.as_uri()}", custom_env=env)
+    assert run_command(["lib", "install", "--git-url", repo_dir.as_uri()], custom_env=env)
 
     # Verifies library is installed
     assert lib_install_dir.exists()
 
 
 def test_install_with_git_local_url(run_command, downloads_dir, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     env = {
         "ARDUINO_DATA_DIR": data_dir,
@@ -629,14 +629,14 @@ def test_install_with_git_local_url(run_command, downloads_dir, data_dir):
     repo_dir = Path(data_dir, "WiFi101")
     assert Repo.clone_from(git_url, repo_dir)
 
-    assert run_command(f"lib install --git-url {repo_dir}", custom_env=env)
+    assert run_command(["lib", "install", "--git-url", repo_dir], custom_env=env)
 
     # Verifies library is installed
     assert lib_install_dir.exists()
 
 
 def test_install_with_git_url_relative_path(run_command, downloads_dir, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     env = {
         "ARDUINO_DATA_DIR": data_dir,
@@ -654,14 +654,14 @@ def test_install_with_git_url_relative_path(run_command, downloads_dir, data_dir
     repo_dir = Path(data_dir, "WiFi101")
     assert Repo.clone_from(git_url, repo_dir)
 
-    assert run_command("lib install --git-url ./WiFi101", custom_working_dir=data_dir, custom_env=env)
+    assert run_command(["lib", "install", "--git-url", "./WiFi101"], custom_working_dir=data_dir, custom_env=env)
 
     # Verifies library is installed
     assert lib_install_dir.exists()
 
 
 def test_install_with_git_url_does_not_create_git_repo(run_command, downloads_dir, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     env = {
         "ARDUINO_DATA_DIR": data_dir,
@@ -679,14 +679,14 @@ def test_install_with_git_url_does_not_create_git_repo(run_command, downloads_di
     repo_dir = Path(data_dir, "WiFi101")
     assert Repo.clone_from(git_url, repo_dir)
 
-    assert run_command(f"lib install --git-url {repo_dir}", custom_env=env)
+    assert run_command(["lib", "install", "--git-url", repo_dir], custom_env=env)
 
     # Verifies installed library is not a git repository
     assert not Path(lib_install_dir, ".git").exists()
 
 
 def test_install_with_git_url_multiple_libraries(run_command, downloads_dir, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     env = {
         "ARDUINO_DATA_DIR": data_dir,
@@ -704,7 +704,7 @@ def test_install_with_git_url_multiple_libraries(run_command, downloads_dir, dat
     wifi_url = "https://github.com/arduino-libraries/WiFi101.git"
     ble_url = "https://github.com/arduino-libraries/ArduinoBLE.git"
 
-    assert run_command(f"lib install --git-url {wifi_url} {ble_url}", custom_env=env)
+    assert run_command(["lib", "install", "--git-url", wifi_url, ble_url], custom_env=env)
 
     # Verifies library are installed
     assert wifi_install_dir.exists()
@@ -712,7 +712,7 @@ def test_install_with_git_url_multiple_libraries(run_command, downloads_dir, dat
 
 
 def test_install_with_zip_path_multiple_libraries(run_command, downloads_dir, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     env = {
         "ARDUINO_DATA_DIR": data_dir,
@@ -734,7 +734,7 @@ def test_install_with_zip_path_multiple_libraries(run_command, downloads_dir, da
     assert not wifi_install_dir.exists()
     assert not ble_install_dir.exists()
 
-    assert run_command(f"lib install --zip-path {wifi_zip_path} {ble_zip_path}", custom_env=env)
+    assert run_command(["lib", "install", "--zip-path", wifi_zip_path, ble_zip_path], custom_env=env)
 
     # Verifies library are installed
     assert wifi_install_dir.exists()
@@ -742,11 +742,11 @@ def test_install_with_zip_path_multiple_libraries(run_command, downloads_dir, da
 
 
 def test_lib_examples(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("lib install Arduino_JSON@0.1.0")
+    assert run_command(["lib", "install", "Arduino_JSON@0.1.0"])
 
-    res = run_command("lib examples Arduino_JSON --format json")
+    res = run_command(["lib", "examples", "Arduino_JSON", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) == 1
@@ -758,11 +758,11 @@ def test_lib_examples(run_command, data_dir):
 
 
 def test_lib_examples_with_pde_file(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("lib install Encoder@1.4.1")
+    assert run_command(["lib", "install", "Encoder@1.4.1"])
 
-    res = run_command("lib examples Encoder --format json")
+    res = run_command(["lib", "examples", "Encoder", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) == 1
@@ -775,11 +775,11 @@ def test_lib_examples_with_pde_file(run_command, data_dir):
 
 
 def test_lib_examples_with_case_mismatch(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
-    assert run_command("lib install WiFiManager@2.0.3-alpha")
+    assert run_command(["lib", "install", "WiFiManager@2.0.3-alpha"])
 
-    res = run_command("lib examples WiFiManager --format json")
+    res = run_command(["lib", "examples", "WiFiManager", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) == 1
@@ -810,13 +810,13 @@ def test_lib_examples_with_case_mismatch(run_command, data_dir):
 
 
 def test_lib_list_using_library_with_invalid_version(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install a library
-    assert run_command("lib install WiFi101@0.16.1")
+    assert run_command(["lib", "install", "WiFi101@0.16.1"])
 
     # Verifies library is correctly returned
-    res = run_command("lib list --format json")
+    res = run_command(["lib", "list", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) == 1
@@ -828,7 +828,7 @@ def test_lib_list_using_library_with_invalid_version(run_command, data_dir):
     Path(lib_path, "library.properties").write_text("version=1.0001")
 
     # Verifies version is now empty
-    res = run_command("lib list --format json")
+    res = run_command(["lib", "list", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) == 1
@@ -836,13 +836,13 @@ def test_lib_list_using_library_with_invalid_version(run_command, data_dir):
 
 
 def test_lib_upgrade_using_library_with_invalid_version(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install a library
-    assert run_command("lib install WiFi101@0.16.1")
+    assert run_command(["lib", "install", "WiFi101@0.16.1"])
 
     # Verifies library is correctly returned
-    res = run_command("lib list --format json")
+    res = run_command(["lib", "list", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) == 1
@@ -854,17 +854,17 @@ def test_lib_upgrade_using_library_with_invalid_version(run_command, data_dir):
     Path(lib_path, "library.properties").write_text("version=1.0001")
 
     # Verifies version is now empty
-    res = run_command("lib list --format json")
+    res = run_command(["lib", "list", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) == 1
     assert "version" not in data[0]["library"]
 
     # Upgrade library
-    assert run_command("lib upgrade WiFi101")
+    assert run_command(["lib", "upgrade", "WiFi101"])
 
     # Verifies library has been updated
-    res = run_command("lib list --format json")
+    res = run_command(["lib", "list", "--format", "json"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) == 1
@@ -879,7 +879,7 @@ def test_install_zip_lib_with_macos_metadata(run_command, data_dir, downloads_di
         "ARDUINO_SKETCHBOOK_DIR": data_dir,
         "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL": "true",
     }
-    assert run_command("config init --dest-dir .", custom_env=env)
+    assert run_command(["config", "init", "--dest-dir", "."], custom_env=env)
 
     lib_install_dir = Path(data_dir, "libraries", "fake-lib")
     # Verifies library is not already installed
@@ -887,7 +887,7 @@ def test_install_zip_lib_with_macos_metadata(run_command, data_dir, downloads_di
 
     zip_path = Path(__file__).parent / "testdata" / "fake-lib.zip"
     # Test zip-path install
-    res = run_command(f"lib install --zip-path {zip_path}")
+    res = run_command(["lib", "install", "--zip-path", zip_path])
     assert res.ok
     assert "--git-url and --zip-path flags allow installing untrusted files, use it at your own risk." in res.stdout
 
@@ -898,7 +898,7 @@ def test_install_zip_lib_with_macos_metadata(run_command, data_dir, downloads_di
     assert lib_install_dir / "src" / "fake-lib.h" in files
 
     # Reinstall library
-    assert run_command(f"lib install --zip-path {zip_path}")
+    assert run_command(["lib", "install", "--zip-path", zip_path])
 
     # Verifies library remains installed
     assert lib_install_dir.exists()
@@ -915,7 +915,7 @@ def test_install_zip_invalid_library(run_command, data_dir, downloads_dir):
         "ARDUINO_SKETCHBOOK_DIR": data_dir,
         "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL": "true",
     }
-    assert run_command("config init --dest-dir .", custom_env=env)
+    assert run_command(["config", "init", "--dest-dir", "."], custom_env=env)
 
     lib_install_dir = Path(data_dir, "libraries", "lib-without-header")
     # Verifies library is not already installed
@@ -923,7 +923,7 @@ def test_install_zip_invalid_library(run_command, data_dir, downloads_dir):
 
     zip_path = Path(__file__).parent / "testdata" / "lib-without-header.zip"
     # Test zip-path install
-    res = run_command(f"lib install --zip-path {zip_path}")
+    res = run_command(["lib", "install", "--zip-path", zip_path])
     assert res.failed
     assert 'library is not valid: missing header file "lib-without-header.h"' in res.stderr
 
@@ -933,7 +933,7 @@ def test_install_zip_invalid_library(run_command, data_dir, downloads_dir):
 
     zip_path = Path(__file__).parent / "testdata" / "lib-without-properties.zip"
     # Test zip-path install
-    res = run_command(f"lib install --zip-path {zip_path}")
+    res = run_command(["lib", "install", "--zip-path", zip_path])
     assert res.failed
     assert 'library is not valid: missing file "library.properties"' in res.stderr
 
@@ -946,7 +946,7 @@ def test_install_git_invalid_library(run_command, data_dir, downloads_dir):
         "ARDUINO_SKETCHBOOK_DIR": data_dir,
         "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL": "true",
     }
-    assert run_command("config init --dest-dir .", custom_env=env)
+    assert run_command(["config", "init", "--dest-dir", "."], custom_env=env)
 
     # Create fake library repository
     repo_dir = Path(data_dir, "lib-without-header")
@@ -960,7 +960,7 @@ def test_install_git_invalid_library(run_command, data_dir, downloads_dir):
     # Verifies library is not already installed
     assert not lib_install_dir.exists()
 
-    res = run_command(f"lib install --git-url {repo_dir}", custom_env=env)
+    res = run_command(["lib", "install", "--git-url", repo_dir], custom_env=env)
     assert res.failed
     assert 'library is not valid: missing header file "lib-without-header.h"' in res.stderr
     assert not lib_install_dir.exists()
@@ -978,7 +978,7 @@ def test_install_git_invalid_library(run_command, data_dir, downloads_dir):
     # Verifies library is not already installed
     assert not lib_install_dir.exists()
 
-    res = run_command(f"lib install --git-url {repo_dir}", custom_env=env)
+    res = run_command(["lib", "install", "--git-url", repo_dir], custom_env=env)
     assert res.failed
     assert 'library is not valid: missing file "library.properties"' in res.stderr
     assert not lib_install_dir.exists()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -20,20 +20,20 @@ import yaml
 
 
 def test_help(run_command):
-    result = run_command("help")
+    result = run_command(["help"])
     assert result.ok
     assert result.stderr == ""
     assert "Usage" in result.stdout
 
 
 def test_version(run_command):
-    result = run_command("version")
+    result = run_command(["version"])
     assert result.ok
     assert "Version:" in result.stdout
     assert "Commit:" in result.stdout
     assert "" == result.stderr
 
-    result = run_command("version --format json")
+    result = run_command(["version", "--format", "json"])
     assert result.ok
     parsed_out = json.loads(result.stdout)
     assert parsed_out.get("Application", False) == "arduino-cli"
@@ -48,29 +48,29 @@ def test_log_options(run_command, data_dir):
     """
 
     # no logs
-    out_lines = run_command("version").stdout.strip().split("\n")
+    out_lines = run_command(["version"]).stdout.strip().split("\n")
     assert len(out_lines) == 1
 
     # plain text logs on stdoud
-    out_lines = run_command("version -v").stdout.strip().split("\n")
+    out_lines = run_command(["version", "-v"]).stdout.strip().split("\n")
     assert len(out_lines) > 1
     assert out_lines[0].startswith("\x1b[36mINFO\x1b[0m")  # account for the colors
 
     # plain text logs on file
     log_file = os.path.join(data_dir, "log.txt")
-    run_command("version --log-file " + log_file)
+    run_command(["version", "--log-file", log_file])
     with open(log_file) as f:
         lines = f.readlines()
         assert lines[0].startswith('time="')  # file format is different from console
 
     # json on stdout
-    out_lines = run_command("version -v --log-format JSON").stdout.strip().split("\n")
+    out_lines = run_command(["version", "-v", "--log-format", "JSON"]).stdout.strip().split("\n")
     lg = json.loads(out_lines[0])
     assert "level" in lg
 
     # json on file
     log_file = os.path.join(data_dir, "log.json")
-    run_command("version --log-format json --log-file " + log_file)
+    run_command(["version", "--log-format", "json", "--log-file", log_file])
     with open(log_file) as f:
         for line in f.readlines():
             json.loads(line)
@@ -82,7 +82,7 @@ def test_inventory_creation(run_command, data_dir):
     """
 
     # no logs
-    out_lines = run_command("version").stdout.strip().split("\n")
+    out_lines = run_command(["version"]).stdout.strip().split("\n")
     assert len(out_lines) == 1
 
     # parse inventory file

--- a/test/test_outdated.py
+++ b/test/test_outdated.py
@@ -18,19 +18,19 @@ from pathlib import Path
 
 def test_outdated(run_command):
     # Updates index for cores and libraries
-    run_command("core update-index")
-    run_command("lib update-index")
+    run_command(["core", "update-index"])
+    run_command(["lib", "update-index"])
 
     # Installs an outdated core and library
-    run_command("core install arduino:avr@1.6.3")
-    assert run_command("lib install USBHost@1.0.0")
+    run_command(["core", "install", "arduino:avr@1.6.3"])
+    assert run_command(["lib", "install", "USBHost@1.0.0"])
 
     # Installs latest version of a core and a library
-    run_command("core install arduino:samd")
-    assert run_command("lib install ArduinoJson")
+    run_command(["core", "install", "arduino:samd"])
+    assert run_command(["lib", "install", "ArduinoJson"])
 
     # Verifies only outdated cores and libraries are returned
-    result = run_command("outdated")
+    result = run_command(["outdated"])
     assert result.ok
     lines = [l.strip() for l in result.stdout.splitlines()]
     assert "Arduino AVR Boards" in lines[1]
@@ -38,13 +38,13 @@ def test_outdated(run_command):
 
 
 def test_outdated_using_library_with_invalid_version(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install latest version of a library library
-    assert run_command("lib install WiFi101")
+    assert run_command(["lib", "install", "WiFi101"])
 
     # Verifies library is correctly returned
-    res = run_command("outdated")
+    res = run_command(["outdated"])
     assert res.ok
     assert "WiFi101" not in res.stdout
 
@@ -54,7 +54,7 @@ def test_outdated_using_library_with_invalid_version(run_command, data_dir):
     Path(lib_path, "library.properties").write_text("version=1.0001")
 
     # Verifies library is correctly returned
-    res = run_command("outdated")
+    res = run_command(["outdated"])
     assert res.ok
     lines = [l.strip().split() for l in res.stdout.splitlines()]
     assert "WiFi101" == lines[1][0]

--- a/test/test_sketch.py
+++ b/test/test_sketch.py
@@ -241,7 +241,7 @@ def test_sketch_archive_relative_sketch_path_with_absolute_zip_path(run_command,
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(["sketch", "archive", "./sketch_simple", f"{archives_folder}"])
+    result = run_command(["sketch", "archive", "./sketch_simple", archives_folder])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{archives_folder}/sketch_simple.zip")

--- a/test/test_sketch.py
+++ b/test/test_sketch.py
@@ -21,7 +21,7 @@ def test_sketch_new(run_command, working_dir):
     current_path = working_dir
     sketch_name = "SketchNewIntegrationTest"
     current_sketch_path = Path(current_path, sketch_name)
-    result = run_command(f"sketch new {sketch_name}")
+    result = run_command(["sketch", "new", sketch_name])
     assert result.ok
     assert f"Sketch created in: {current_sketch_path}" in result.stdout
     assert Path(current_sketch_path, f"{sketch_name}.ino").is_file()
@@ -29,7 +29,7 @@ def test_sketch_new(run_command, working_dir):
     # Create a test sketch in current directory but using an absolute path
     sketch_name = "SketchNewIntegrationTestAbsolute"
     current_sketch_path = Path(current_path, sketch_name)
-    result = run_command(f'sketch new "{current_sketch_path}"')
+    result = run_command(["sketch", "new", current_sketch_path])
     assert result.ok
     assert f"Sketch created in: {current_sketch_path}" in result.stdout
     assert Path(current_sketch_path, f"{sketch_name}.ino").is_file()
@@ -38,7 +38,7 @@ def test_sketch_new(run_command, working_dir):
     sketch_name = "SketchNewIntegrationTestSubpath"
     sketch_subpath = Path("subpath", sketch_name)
     current_sketch_path = Path(current_path, sketch_subpath)
-    result = run_command(f"sketch new {sketch_subpath}")
+    result = run_command(["sketch", "new", sketch_subpath])
     assert result.ok
     assert f"Sketch created in: {current_sketch_path}" in result.stdout
     assert Path(current_sketch_path, f"{sketch_name}.ino").is_file()
@@ -46,7 +46,7 @@ def test_sketch_new(run_command, working_dir):
     # Create a test sketch in current directory using .ino extension
     sketch_name = "SketchNewIntegrationTestDotIno"
     current_sketch_path = Path(current_path, sketch_name)
-    result = run_command(f"sketch new {sketch_name}.ino")
+    result = run_command(["sketch", "new", f"{sketch_name}.ino"])
     assert result.ok
     assert f"Sketch created in: {current_sketch_path}" in result.stdout
     assert Path(current_sketch_path, f"{sketch_name}.ino").is_file()
@@ -85,7 +85,7 @@ def verify_zip_contains_sketch_including_build_dir(files):
 
 
 def test_sketch_archive_no_args(run_command, copy_sketch, working_dir):
-    result = run_command("sketch archive", copy_sketch("sketch_simple"))
+    result = run_command(["sketch", "archive"], copy_sketch("sketch_simple"))
     print(result.stderr)
     assert result.ok
 
@@ -98,7 +98,7 @@ def test_sketch_archive_no_args(run_command, copy_sketch, working_dir):
 
 
 def test_sketch_archive_dot_arg(run_command, copy_sketch, working_dir):
-    result = run_command("sketch archive .", copy_sketch("sketch_simple"))
+    result = run_command(["sketch", "archive", "."], copy_sketch("sketch_simple"))
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/sketch_simple.zip")
@@ -114,7 +114,7 @@ def test_sketch_archive_dot_arg_relative_zip_path(run_command, copy_sketch, work
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command("sketch archive . ../my_archives", copy_sketch("sketch_simple"))
+    result = run_command(["sketch", "archive", ".", "../my_archives"], copy_sketch("sketch_simple"))
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/sketch_simple.zip")
@@ -130,7 +130,7 @@ def test_sketch_archive_dot_arg_absolute_zip_path(run_command, copy_sketch, work
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive . "{archives_folder}"', copy_sketch("sketch_simple"))
+    result = run_command(["sketch", "archive", ".", archives_folder], copy_sketch("sketch_simple"))
     assert result.ok
 
     archive = zipfile.ZipFile(f"{archives_folder}/sketch_simple.zip")
@@ -146,7 +146,7 @@ def test_sketch_archive_dot_arg_relative_zip_path_and_name_without_extension(run
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command("sketch archive . ../my_archives/my_custom_sketch", copy_sketch("sketch_simple"))
+    result = run_command(["sketch", "archive", ".", "../my_archives/my_custom_sketch"], copy_sketch("sketch_simple"))
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/my_custom_sketch.zip")
@@ -162,7 +162,9 @@ def test_sketch_archive_dot_arg_absolute_zip_path_and_name_without_extension(run
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive . "{archives_folder}/my_custom_sketch"', copy_sketch("sketch_simple"))
+    result = run_command(
+        ["sketch", "archive", ".", f"{archives_folder}/my_custom_sketch"], copy_sketch("sketch_simple")
+    )
     assert result.ok
 
     archive = zipfile.ZipFile(f"{archives_folder}/my_custom_sketch.zip")
@@ -178,7 +180,9 @@ def test_sketch_archive_dot_arg_custom_zip_path_and_name_with_extension(run_comm
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive . "{archives_folder}/my_custom_sketch.zip"', copy_sketch("sketch_simple"))
+    result = run_command(
+        ["sketch", "archive", ".", f"{archives_folder}/my_custom_sketch.zip"], copy_sketch("sketch_simple")
+    )
     assert result.ok
 
     archive = zipfile.ZipFile(f"{archives_folder}/my_custom_sketch.zip")
@@ -191,7 +195,7 @@ def test_sketch_archive_dot_arg_custom_zip_path_and_name_with_extension(run_comm
 
 def test_sketch_archive_relative_sketch_path(run_command, copy_sketch, working_dir):
     copy_sketch("sketch_simple")
-    result = run_command("sketch archive ./sketch_simple")
+    result = run_command(["sketch", "archive", "./sketch_simple"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/sketch_simple.zip")
@@ -203,7 +207,7 @@ def test_sketch_archive_relative_sketch_path(run_command, copy_sketch, working_d
 
 
 def test_sketch_archive_absolute_sketch_path(run_command, copy_sketch, working_dir):
-    result = run_command(f'sketch archive "{working_dir}/sketch_simple"', copy_sketch("sketch_simple"))
+    result = run_command(["sketch", "archive", f"{working_dir}/sketch_simple"], copy_sketch("sketch_simple"))
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/sketch_simple.zip")
@@ -220,7 +224,7 @@ def test_sketch_archive_relative_sketch_path_with_relative_zip_path(run_command,
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command("sketch archive ./sketch_simple ./my_archives")
+    result = run_command(["sketch", "archive", "./sketch_simple", "./my_archives"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/sketch_simple.zip")
@@ -237,7 +241,7 @@ def test_sketch_archive_relative_sketch_path_with_absolute_zip_path(run_command,
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive ./sketch_simple "{archives_folder}"')
+    result = run_command(["sketch", "archive", "./sketch_simple", f"{archives_folder}"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{archives_folder}/sketch_simple.zip")
@@ -256,7 +260,7 @@ def test_sketch_archive_relative_sketch_path_with_relative_zip_path_and_name_wit
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command("sketch archive ./sketch_simple ./my_archives/my_custom_sketch")
+    result = run_command(["sketch", "archive", "./sketch_simple", "./my_archives/my_custom_sketch"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/my_custom_sketch.zip")
@@ -275,7 +279,7 @@ def test_sketch_archive_relative_sketch_path_with_relative_zip_path_and_name_wit
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command("sketch archive ./sketch_simple ./my_archives/my_custom_sketch.zip")
+    result = run_command(["sketch", "archive", "./sketch_simple", "./my_archives/my_custom_sketch.zip"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/my_custom_sketch.zip")
@@ -294,7 +298,7 @@ def test_sketch_archive_relative_sketch_path_with_absolute_zip_path_and_name_wit
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive ./sketch_simple "{archives_folder}/my_custom_sketch"')
+    result = run_command(["sketch", "archive", "./sketch_simple", f"{archives_folder}/my_custom_sketch"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{archives_folder}/my_custom_sketch.zip")
@@ -313,7 +317,7 @@ def test_sketch_archive_relative_sketch_path_with_absolute_zip_path_and_name_wit
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive ./sketch_simple "{archives_folder}/my_custom_sketch.zip"')
+    result = run_command(["sketch", "archive", "./sketch_simple", f"{archives_folder}/my_custom_sketch.zip"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{archives_folder}/my_custom_sketch.zip")
@@ -330,7 +334,7 @@ def test_sketch_archive_absolute_sketch_path_with_relative_zip_path(run_command,
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive "{working_dir}/sketch_simple" ./my_archives')
+    result = run_command(["sketch", "archive", f"{working_dir}/sketch_simple", "./my_archives"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/sketch_simple.zip")
@@ -347,7 +351,7 @@ def test_sketch_archive_absolute_sketch_path_with_absolute_zip_path(run_command,
     Path(archives_folder).mkdir()
 
     result = run_command(
-        f'sketch archive "{working_dir}/sketch_simple" "{archives_folder}"', copy_sketch("sketch_simple")
+        ["sketch", "archive", f"{working_dir}/sketch_simple", archives_folder], copy_sketch("sketch_simple")
     )
     assert result.ok
 
@@ -367,7 +371,7 @@ def test_sketch_archive_absolute_sketch_path_with_relative_zip_path_and_name_wit
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive "{working_dir}/sketch_simple" ./my_archives/my_custom_sketch')
+    result = run_command(["sketch", "archive", f"{working_dir}/sketch_simple", "./my_archives/my_custom_sketch"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/my_custom_sketch.zip")
@@ -386,7 +390,7 @@ def test_sketch_archive_absolute_sketch_path_with_relative_zip_path_and_name_wit
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive "{working_dir}/sketch_simple" ./my_archives/my_custom_sketch.zip')
+    result = run_command(["sketch", "archive", f"{working_dir}/sketch_simple", "./my_archives/my_custom_sketch.zip"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/my_custom_sketch.zip")
@@ -405,7 +409,7 @@ def test_sketch_archive_absolute_sketch_path_with_absolute_zip_path_and_name_wit
     Path(archives_folder).mkdir()
 
     result = run_command(
-        f'sketch archive "{working_dir}/sketch_simple" "{archives_folder}/my_custom_sketch"',
+        ["sketch", "archive", f"{working_dir}/sketch_simple", f"{archives_folder}/my_custom_sketch"],
         copy_sketch("sketch_simple"),
     )
     assert result.ok
@@ -426,7 +430,7 @@ def test_sketch_archive_absolute_sketch_path_with_absolute_zip_path_and_name_wit
     Path(archives_folder).mkdir()
 
     result = run_command(
-        f'sketch archive "{working_dir}/sketch_simple" "{archives_folder}/my_custom_sketch.zip"',
+        ["sketch", "archive", f"{working_dir}/sketch_simple", f"{archives_folder}/my_custom_sketch.zip"],
         copy_sketch("sketch_simple"),
     )
     assert result.ok
@@ -440,7 +444,7 @@ def test_sketch_archive_absolute_sketch_path_with_absolute_zip_path_and_name_wit
 
 
 def test_sketch_archive_no_args_with_include_build_dir_flag(run_command, copy_sketch, working_dir):
-    result = run_command("sketch archive --include-build-dir", copy_sketch("sketch_simple"))
+    result = run_command(["sketch", "archive", "--include-build-dir"], copy_sketch("sketch_simple"))
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/sketch_simple.zip")
@@ -452,7 +456,7 @@ def test_sketch_archive_no_args_with_include_build_dir_flag(run_command, copy_sk
 
 
 def test_sketch_archive_dot_arg_with_include_build_dir_flag(run_command, copy_sketch, working_dir):
-    result = run_command("sketch archive . --include-build-dir", copy_sketch("sketch_simple"))
+    result = run_command(["sketch", "archive", ".", "--include-build-dir"], copy_sketch("sketch_simple"))
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/sketch_simple.zip")
@@ -468,7 +472,9 @@ def test_sketch_archive_dot_arg_relative_zip_path_with_include_build_dir_flag(ru
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command("sketch archive . ../my_archives --include-build-dir", copy_sketch("sketch_simple"))
+    result = run_command(
+        ["sketch", "archive", ".", "../my_archives", "--include-build-dir"], copy_sketch("sketch_simple")
+    )
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/sketch_simple.zip")
@@ -484,7 +490,9 @@ def test_sketch_archive_dot_arg_absolute_zip_path_with_include_build_dir_flag(ru
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive . "{archives_folder}" --include-build-dir', copy_sketch("sketch_simple"))
+    result = run_command(
+        ["sketch", "archive", ".", archives_folder, "--include-build-dir"], copy_sketch("sketch_simple")
+    )
     assert result.ok
 
     archive = zipfile.ZipFile(f"{archives_folder}/sketch_simple.zip")
@@ -503,7 +511,8 @@ def test_sketch_archive_dot_arg_relative_zip_path_and_name_without_extension_wit
     Path(archives_folder).mkdir()
 
     result = run_command(
-        "sketch archive . ../my_archives/my_custom_sketch --include-build-dir", copy_sketch("sketch_simple")
+        ["sketch", "archive", ".", "../my_archives/my_custom_sketch", "--include-build-dir"],
+        copy_sketch("sketch_simple"),
     )
     assert result.ok
 
@@ -523,7 +532,8 @@ def test_sketch_archive_dot_arg_absolute_zip_path_and_name_without_extension_wit
     Path(archives_folder).mkdir()
 
     result = run_command(
-        f'sketch archive . "{archives_folder}/my_custom_sketch" --include-build-dir', copy_sketch("sketch_simple")
+        ["sketch", "archive", ".", f"{archives_folder}/my_custom_sketch", "--include-build-dir"],
+        copy_sketch("sketch_simple"),
     )
     assert result.ok
 
@@ -543,7 +553,8 @@ def test_sketch_archive_dot_arg_custom_zip_path_and_name_with_extension_with_inc
     Path(archives_folder).mkdir()
 
     result = run_command(
-        f'sketch archive . "{archives_folder}/my_custom_sketch.zip" --include-build-dir', copy_sketch("sketch_simple")
+        ["sketch", "archive", ".", f"{archives_folder}/my_custom_sketch.zip", "--include-build-dir"],
+        copy_sketch("sketch_simple"),
     )
     assert result.ok
 
@@ -557,7 +568,7 @@ def test_sketch_archive_dot_arg_custom_zip_path_and_name_with_extension_with_inc
 
 def test_sketch_archive_relative_sketch_path_with_include_build_dir_flag(run_command, copy_sketch, working_dir):
     copy_sketch("sketch_simple")
-    result = run_command("sketch archive ./sketch_simple --include-build-dir")
+    result = run_command(["sketch", "archive", "./sketch_simple", "--include-build-dir"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/sketch_simple.zip")
@@ -570,7 +581,7 @@ def test_sketch_archive_relative_sketch_path_with_include_build_dir_flag(run_com
 
 def test_sketch_archive_absolute_sketch_path_with_include_build_dir_flag(run_command, copy_sketch, working_dir):
     result = run_command(
-        f'sketch archive "{working_dir}/sketch_simple" --include-build-dir', copy_sketch("sketch_simple")
+        ["sketch", "archive", f"{working_dir}/sketch_simple", "--include-build-dir"], copy_sketch("sketch_simple")
     )
     assert result.ok
 
@@ -590,7 +601,7 @@ def test_sketch_archive_relative_sketch_path_with_relative_zip_path_with_include
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command("sketch archive ./sketch_simple ./my_archives --include-build-dir")
+    result = run_command(["sketch", "archive", "./sketch_simple", "./my_archives", "--include-build-dir"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/sketch_simple.zip")
@@ -609,7 +620,7 @@ def test_sketch_archive_relative_sketch_path_with_absolute_zip_path_with_include
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive ./sketch_simple "{archives_folder}" --include-build-dir')
+    result = run_command(["sketch", "archive", "./sketch_simple", archives_folder, "--include-build-dir"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{archives_folder}/sketch_simple.zip")
@@ -628,7 +639,9 @@ def test_sketch_archive_relative_sketch_path_with_relative_zip_path_and_name_wit
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command("sketch archive ./sketch_simple ./my_archives/my_custom_sketch --include-build-dir")
+    result = run_command(
+        ["sketch", "archive", "./sketch_simple", "./my_archives/my_custom_sketch", "--include-build-dir"]
+    )
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/my_custom_sketch.zip")
@@ -647,7 +660,9 @@ def test_sketch_archive_relative_sketch_path_with_relative_zip_path_and_name_wit
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command("sketch archive ./sketch_simple ./my_archives/my_custom_sketch.zip --include-build-dir")
+    result = run_command(
+        ["sketch", "archive", "./sketch_simple", "./my_archives/my_custom_sketch.zip", "--include-build-dir"]
+    )
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/my_custom_sketch.zip")
@@ -666,7 +681,9 @@ def test_sketch_archive_relative_sketch_path_with_absolute_zip_path_and_name_wit
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive ./sketch_simple "{archives_folder}/my_custom_sketch" --include-build-dir')
+    result = run_command(
+        ["sketch", "archive", "./sketch_simple", f"{archives_folder}/my_custom_sketch", "--include-build-dir"]
+    )
     assert result.ok
 
     archive = zipfile.ZipFile(f"{archives_folder}/my_custom_sketch.zip")
@@ -685,7 +702,9 @@ def test_sketch_archive_relative_sketch_path_with_absolute_zip_path_and_name_wit
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive ./sketch_simple "{archives_folder}/my_custom_sketch.zip" --include-build-dir')
+    result = run_command(
+        ["sketch", "archive", "./sketch_simple", f"{archives_folder}/my_custom_sketch.zip", "--include-build-dir"]
+    )
     assert result.ok
 
     archive = zipfile.ZipFile(f"{archives_folder}/my_custom_sketch.zip")
@@ -704,7 +723,7 @@ def test_sketch_archive_absolute_sketch_path_with_relative_zip_path_with_include
     archives_folder = f"{working_dir}/my_archives/"
     Path(archives_folder).mkdir()
 
-    result = run_command(f'sketch archive "{working_dir}/sketch_simple" ./my_archives --include-build-dir')
+    result = run_command(["sketch", "archive", f"{working_dir}/sketch_simple", "./my_archives", "--include-build-dir"])
     assert result.ok
 
     archive = zipfile.ZipFile(f"{working_dir}/my_archives/sketch_simple.zip")
@@ -723,7 +742,7 @@ def test_sketch_archive_absolute_sketch_path_with_absolute_zip_path_with_include
     Path(archives_folder).mkdir()
 
     result = run_command(
-        f'sketch archive "{working_dir}/sketch_simple" "{archives_folder}" --include-build-dir',
+        ["sketch", "archive", f"{working_dir}/sketch_simple", archives_folder, "--include-build-dir"],
         copy_sketch("sketch_simple"),
     )
     assert result.ok
@@ -745,7 +764,7 @@ def test_sketch_archive_absolute_sketch_path_with_relative_zip_path_and_name_wit
     Path(archives_folder).mkdir()
 
     result = run_command(
-        f'sketch archive "{working_dir}/sketch_simple" ./my_archives/my_custom_sketch --include-build-dir'
+        ["sketch", "archive", f"{working_dir}/sketch_simple", "./my_archives/my_custom_sketch", "--include-build-dir"]
     )
     assert result.ok
 
@@ -766,7 +785,13 @@ def test_sketch_archive_absolute_sketch_path_with_relative_zip_path_and_name_wit
     Path(archives_folder).mkdir()
 
     result = run_command(
-        f'sketch archive "{working_dir}/sketch_simple" ./my_archives/my_custom_sketch.zip --include-build-dir'
+        [
+            "sketch",
+            "archive",
+            f"{working_dir}/sketch_simple",
+            "./my_archives/my_custom_sketch.zip",
+            "--include-build-dir",
+        ]
     )
     assert result.ok
 
@@ -786,7 +811,13 @@ def test_sketch_archive_absolute_sketch_path_with_absolute_zip_path_and_name_wit
     Path(archives_folder).mkdir()
 
     result = run_command(
-        f'sketch archive "{working_dir}/sketch_simple" "{archives_folder}/my_custom_sketch" --include-build-dir',
+        [
+            "sketch",
+            "archive",
+            f"{working_dir}/sketch_simple",
+            f"{archives_folder}/my_custom_sketch",
+            "--include-build-dir",
+        ],
         copy_sketch("sketch_simple"),
     )
     assert result.ok
@@ -807,7 +838,13 @@ def test_sketch_archive_absolute_sketch_path_with_absolute_zip_path_and_name_wit
     Path(archives_folder).mkdir()
 
     result = run_command(
-        f'sketch archive "{working_dir}/sketch_simple" "{archives_folder}/my_custom_sketch.zip" --include-build-dir',
+        [
+            "sketch",
+            "archive",
+            f"{working_dir}/sketch_simple",
+            f"{archives_folder}/my_custom_sketch.zip",
+            "--include-build-dir",
+        ],
         copy_sketch("sketch_simple"),
     )
     assert result.ok
@@ -824,7 +861,7 @@ def test_sketch_archive_with_pde_main_file(run_command, copy_sketch, working_dir
     sketch_name = "sketch_pde_main_file"
     sketch_dir = copy_sketch(sketch_name)
     sketch_file = Path(sketch_dir, f"{sketch_name}.pde")
-    res = run_command("sketch archive", sketch_dir)
+    res = run_command(["sketch", "archive"], sketch_dir)
     assert res.ok
     assert "Sketches with .pde extension are deprecated, please rename the following files to .ino" in res.stderr
     assert str(sketch_file.relative_to(sketch_dir)) in res.stderr
@@ -841,7 +878,7 @@ def test_sketch_archive_with_multiple_main_files(run_command, copy_sketch, worki
     sketch_name = "sketch_multiple_main_files"
     sketch_dir = copy_sketch(sketch_name)
     sketch_file = Path(sketch_dir, f"{sketch_name}.pde")
-    res = run_command("sketch archive", sketch_dir)
+    res = run_command(["sketch", "archive"], sketch_dir)
     assert res.failed
     assert "Sketches with .pde extension are deprecated, please rename the following files to .ino" in res.stderr
     assert str(sketch_file.relative_to(sketch_dir)) in res.stderr
@@ -852,11 +889,11 @@ def test_sketch_archive_case_mismatch_fails(run_command, data_dir):
     sketch_name = "ArchiveSketchCaseMismatch"
     sketch_path = Path(data_dir, sketch_name)
 
-    assert run_command(f"sketch new {sketch_path}")
+    assert run_command(["sketch", "new", sketch_path])
 
     # Rename main .ino file so casing is different from sketch name
     Path(sketch_path, f"{sketch_name}.ino").rename(sketch_path / f"{sketch_name.lower()}.ino")
 
-    res = run_command(f'sketch archive "{sketch_path}"')
+    res = run_command(["sketch", "archive", sketch_path])
     assert res.failed
     assert "Error archiving: Can't open sketch: no valid sketch found" in res.stderr

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 
 def test_update(run_command):
-    res = run_command("update")
+    res = run_command(["update"])
     assert res.ok
     lines = [l.strip() for l in res.stdout.splitlines()]
 
@@ -29,19 +29,19 @@ def test_update(run_command):
 
 def test_update_showing_outdated(run_command):
     # Updates index for cores and libraries
-    run_command("core update-index")
-    run_command("lib update-index")
+    run_command(["core", "update-index"])
+    run_command(["lib", "update-index"])
 
     # Installs an outdated core and library
-    run_command("core install arduino:avr@1.6.3")
-    assert run_command("lib install USBHost@1.0.0")
+    run_command(["core", "install", "arduino:avr@1.6.3"])
+    assert run_command(["lib", "install", "USBHost@1.0.0"])
 
     # Installs latest version of a core and a library
-    run_command("core install arduino:samd")
-    assert run_command("lib install ArduinoJson")
+    run_command(["core", "install", "arduino:samd"])
+    assert run_command(["lib", "install", "ArduinoJson"])
 
     # Verifies outdated cores and libraries are printed after updating indexes
-    result = run_command("update --show-outdated")
+    result = run_command(["update", "--show-outdated"])
     assert result.ok
     lines = [l.strip() for l in result.stdout.splitlines()]
 
@@ -54,13 +54,13 @@ def test_update_showing_outdated(run_command):
 
 
 def test_update_with_url_not_found(run_command, httpserver):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Brings up a local server to fake a failure
     httpserver.expect_request("/test_index.json").respond_with_data(status=404)
     url = httpserver.url_for("/test_index.json")
 
-    res = run_command(f"update --additional-urls={url}")
+    res = run_command(["update", f"--additional-urls={url}"])
     assert res.failed
     lines = [l.strip() for l in res.stderr.splitlines()]
     assert (
@@ -70,13 +70,13 @@ def test_update_with_url_not_found(run_command, httpserver):
 
 
 def test_update_with_url_internal_server_error(run_command, httpserver):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Brings up a local server to fake a failure
     httpserver.expect_request("/test_index.json").respond_with_data(status=500)
     url = httpserver.url_for("/test_index.json")
 
-    res = run_command(f"update --additional-urls={url}")
+    res = run_command(["update", f"--additional-urls={url}"])
     assert res.failed
     lines = [l.strip() for l in res.stderr.splitlines()]
     assert (
@@ -86,13 +86,13 @@ def test_update_with_url_internal_server_error(run_command, httpserver):
 
 
 def test_update_showing_outdated_using_library_with_invalid_version(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install latest version of a library
-    assert run_command("lib install WiFi101")
+    assert run_command(["lib", "install", "WiFi101"])
 
     # Verifies library doesn't get updated
-    res = run_command("update --show-outdated")
+    res = run_command(["update", "--show-outdated"])
     assert res.ok
     assert "WiFi101" not in res.stdout
 
@@ -102,6 +102,6 @@ def test_update_showing_outdated_using_library_with_invalid_version(run_command,
     Path(lib_path, "library.properties").write_text("version=1.0001")
 
     # Verifies library gets updated
-    res = run_command("update --show-outdated")
+    res = run_command(["update", "--show-outdated"])
     assert res.ok
     assert "WiFi101" in res.stdout

--- a/test/test_upgrade.py
+++ b/test/test_upgrade.py
@@ -18,41 +18,41 @@ from pathlib import Path
 
 def test_upgrade(run_command):
     # Updates index for cores and libraries
-    run_command("core update-index")
-    run_command("lib update-index")
+    run_command(["core", "update-index"])
+    run_command(["lib", "update-index"])
 
     # Installs an outdated core and library
-    run_command("core install arduino:avr@1.6.3")
-    assert run_command("lib install USBHost@1.0.0")
+    run_command(["core", "install", "arduino:avr@1.6.3"])
+    assert run_command(["lib", "install", "USBHost@1.0.0"])
 
     # Installs latest version of a core and a library
-    run_command("core install arduino:samd")
-    assert run_command("lib install ArduinoJson")
+    run_command(["core", "install", "arduino:samd"])
+    assert run_command(["lib", "install", "ArduinoJson"])
 
     # Verifies outdated core and libraries are shown
-    result = run_command("outdated")
+    result = run_command(["outdated"])
     assert result.ok
     lines = result.stdout.splitlines()
     assert "Arduino AVR Boards" in lines[1]
     assert "USBHost" in lines[4]
 
-    result = run_command("upgrade")
+    result = run_command(["upgrade"])
     assert result.ok
 
     # Verifies cores and libraries have been updated
-    result = run_command("outdated")
+    result = run_command(["outdated"])
     assert result.ok
     assert result.stdout == ""
 
 
 def test_upgrade_using_library_with_invalid_version(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Install latest version of a library
-    assert run_command("lib install WiFi101")
+    assert run_command(["lib", "install", "WiFi101"])
 
     # Verifies library is not shown
-    res = run_command("outdated")
+    res = run_command(["outdated"])
     assert res.ok
     assert "WiFi101" not in res.stdout
 
@@ -62,23 +62,23 @@ def test_upgrade_using_library_with_invalid_version(run_command, data_dir):
     Path(lib_path, "library.properties").write_text("version=1.0001")
 
     # Verifies library gets upgraded
-    res = run_command("upgrade")
+    res = run_command(["upgrade"])
     assert res.ok
     assert "WiFi101" in res.stdout
 
 
 def test_upgrade_unused_core_tools_are_removed(run_command, data_dir):
-    assert run_command("update")
+    assert run_command(["update"])
 
     # Installs a core
-    assert run_command("core install arduino:avr@1.8.2")
+    assert run_command(["core", "install", "arduino:avr@1.8.2"])
 
     # Verifies expected tool is installed
     tool_path = Path(data_dir, "packages", "arduino", "tools", "avr-gcc", "7.3.0-atmel3.6.1-arduino5")
     assert tool_path.exists()
 
     # Upgrades everything
-    assert run_command("upgrade")
+    assert run_command(["upgrade"])
 
     # Verifies tool is uninstalled since it's not used by newer core version
     assert not tool_path.exists()

--- a/test/test_upload_mock.py
+++ b/test/test_upload_mock.py
@@ -1185,24 +1185,26 @@ def test_upload_sketch(
 
     # Install everything just once
     if not Path(session_data_dir, "packages").is_dir():
-        assert run_command("config init --overwrite", custom_env=env)
+        assert run_command(["config", "init", "--overwrite"], custom_env=env)
         for package_index in indexes:
-            assert run_command(f"config add board_manager.additional_urls {package_index}", custom_env=env)
-        assert run_command("update", custom_env=env)
+            assert run_command(["config", "add", "board_manager.additional_urls", package_index], custom_env=env)
+        assert run_command(["update"], custom_env=env)
 
         for d in cores_to_install:
-            assert run_command(f"core install {d}", custom_env=env)
+            assert run_command(["core", "install", d], custom_env=env)
 
     # Create a sketch
     sketch_name = "TestSketchForUpload"
     sketch_path = Path(session_data_dir, sketch_name)
-    assert run_command(f'sketch new "{sketch_path}"', custom_env=env)
+    assert run_command(["sketch", "new", sketch_path], custom_env=env)
 
     # Fake compilation, we just need the folder to exist
     build_dir = generate_build_dir(sketch_path)
-    programmer_arg = f"-P {programmer}" if programmer else ""
-    port_arg = f"-p {upload_port}" if upload_port else ""
-    res = run_command(f'upload {port_arg} {programmer_arg} -b {fqbn} "{sketch_path}" --dry-run -v', custom_env=env)
+    programmer_arg = ["-P", programmer] if programmer else []
+    port_arg = ["-p", upload_port] if upload_port else []
+    res = run_command(
+        ["upload"] + port_arg + programmer_arg + ["-b", fqbn, sketch_path, "--dry-run", "-v"], custom_env=env
+    )
     assert res.ok
 
     if isinstance(output, str):


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Enhances the integration tests for Windows to make them work with path that contain spaces.

- **What is the current behavior?**

Integration test can't run on Windows if the user has a space in its name, thus having paths with spaces.

* **What is the new behavior?**

Integration test can now run on Windows correctly also if the user has a path in its name.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

None.

* **Other information**:

This brings it in line with `arduino-lint` integration tests: 
https://github.com/arduino/arduino-lint/blob/cafb51656543665766930a77a698c8b72ae829a9/tests/test_all.py#L262-L303

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
