### PR TITLE
simplified `Tool.LatestRelease()` and some code makeup

### DIFF
--- a/arduino/cores/packagemanager/package_manager_test.go
+++ b/arduino/cores/packagemanager/package_manager_test.go
@@ -346,34 +346,48 @@ func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 
 	pm := packagemanager.NewPackageManager(fakePath, fakePath, fakePath, fakePath)
 	pack := pm.Packages.GetOrCreatePackage("arduino")
-	// some tool
-	tool := pack.GetOrCreateTool("some-tool")
-	toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("4.2.0"))
-	// We set this to fake the tool is installed
-	toolRelease.InstallDir = fakePath
-	// some tool
-	tool = pack.GetOrCreateTool("some-tool")
-	toolRelease = tool.GetOrCreateRelease(semver.ParseRelaxed("5.6.7"))
-	// We set this to fake the tool is installed
-	toolRelease.InstallDir = fakePath
-	// some other tool
-	tool = pack.GetOrCreateTool("some-other-tool")
-	toolRelease = tool.GetOrCreateRelease(semver.ParseRelaxed("6.6.6"))
-	// We set this to fake the tool is installed
-	toolRelease.InstallDir = fakePath
-	// ble-discovery tool
-	tool = pack.GetOrCreateTool("ble-discovery")
-	toolRelease = tool.GetOrCreateRelease(semver.ParseRelaxed("1.0.0"))
-	// We set this to fake the tool is installed
-	toolRelease.InstallDir = fakePath
-	tool.GetOrCreateRelease(semver.ParseRelaxed("0.1.0"))
 
-	// serial-discovery tool
-	tool = pack.GetOrCreateTool("serial-discovery")
-	tool.GetOrCreateRelease(semver.ParseRelaxed("1.0.0"))
-	toolRelease = tool.GetOrCreateRelease(semver.ParseRelaxed("0.1.0"))
-	// We set this to fake the tool is installed
-	toolRelease.InstallDir = fakePath
+	{
+		// some tool
+		tool := pack.GetOrCreateTool("some-tool")
+		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("4.2.0"))
+		// We set this to fake the tool is installed
+		toolRelease.InstallDir = fakePath
+	}
+
+	{
+		// some tool
+		tool := pack.GetOrCreateTool("some-tool")
+		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("5.6.7"))
+		// We set this to fake the tool is installed
+		toolRelease.InstallDir = fakePath
+	}
+
+	{
+		// some other tool
+		tool := pack.GetOrCreateTool("some-other-tool")
+		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("6.6.6"))
+		// We set this to fake the tool is installed
+		toolRelease.InstallDir = fakePath
+	}
+
+	{
+		// ble-discovery tool
+		tool := pack.GetOrCreateTool("ble-discovery")
+		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("1.0.0"))
+		// We set this to fake the tool is installed
+		toolRelease.InstallDir = fakePath
+		tool.GetOrCreateRelease(semver.ParseRelaxed("0.1.0"))
+	}
+
+	{
+		// serial-discovery tool
+		tool := pack.GetOrCreateTool("serial-discovery")
+		tool.GetOrCreateRelease(semver.ParseRelaxed("1.0.0"))
+		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("0.1.0"))
+		// We set this to fake the tool is installed
+		toolRelease.InstallDir = fakePath
+	}
 
 	platform := pack.GetOrCreatePlatform("avr")
 	release := platform.GetOrCreateRelease(semver.MustParse("1.0.0"))

--- a/arduino/cores/tools.go
+++ b/arduino/cores/tools.go
@@ -68,9 +68,8 @@ func (tool *Tool) FindReleaseWithRelaxedVersion(version *semver.RelaxedVersion) 
 
 // GetAllReleasesVersions returns all the version numbers in this Core Package.
 func (tool *Tool) GetAllReleasesVersions() []*semver.RelaxedVersion {
-	releases := tool.Releases
 	versions := []*semver.RelaxedVersion{}
-	for _, release := range releases {
+	for _, release := range tool.Releases {
 		versions = append(versions, release.Version)
 	}
 
@@ -79,27 +78,13 @@ func (tool *Tool) GetAllReleasesVersions() []*semver.RelaxedVersion {
 
 // LatestRelease obtains latest version of a core package.
 func (tool *Tool) LatestRelease() *ToolRelease {
-	latest := tool.latestReleaseVersion()
-	if latest == nil {
-		return nil
-	}
-
-	return tool.FindReleaseWithRelaxedVersion(latest)
-}
-
-// latestReleaseVersion obtains latest version number.
-func (tool *Tool) latestReleaseVersion() *semver.RelaxedVersion {
-	versions := tool.GetAllReleasesVersions()
-	if len(versions) == 0 {
-		return nil
-	}
-	max := versions[0]
-	for i := 1; i < len(versions); i++ {
-		if versions[i].GreaterThan(max) {
-			max = versions[i]
+	var latest *ToolRelease
+	for _, release := range tool.Releases {
+		if latest == nil || release.Version.GreaterThan(latest.Version) {
+			latest = release
 		}
 	}
-	return max
+	return latest
 }
 
 // GetLatestInstalled returns the latest installed ToolRelease for the Tool, or nil if no releases are installed.
@@ -107,9 +92,7 @@ func (tool *Tool) GetLatestInstalled() *ToolRelease {
 	var latest *ToolRelease
 	for _, release := range tool.Releases {
 		if release.IsInstalled() {
-			if latest == nil {
-				latest = release
-			} else if latest.Version.LessThan(release.Version) {
+			if latest == nil || latest.Version.LessThan(release.Version) {
 				latest = release
 			}
 		}


### PR DESCRIPTION
- some code makeup
- simplified `Tool.LatestRelease()` (now it doesn't depend on `tool.FindReleaseWithRelaxedVersion` anymore, this fact will help with another refactoring later)
