### PR TITLE
[skip changelog] Temporarily full pin Python in integration test CI workflow

### DIFF
--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
   GO_VERSION: "1.16"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.9.6"
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Infrastructure fix

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
A bug introduced in the 3.9.7 release of Python causes [a spurious failure](https://github.com/arduino/arduino-cli/pull/1440/checks?check_run_id=3561952128#step:8:916) of the `test\test_lib.py::test_install_git_invalid_library` integration test:
https://bugs.python.org/issue45121


* **What is the new behavior?**
<!-- if this is a feature change -->
As a workaround, the Python version used by the "Test Integration" CI workflow that runs the integration tests is pinned to the last working version: 3.9.6.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

No breaking change.
* **Other information**:
<!-- Any additional information that could help the review process -->
Since it is convenient to get automatic updates for Python patch releases, this full pin should be reverted back to the "3.9" minor version pin once a new version of Python is released with the bug fixed and added to versions available for installation via [the `actions/setup-python` GitHub Actions action](https://github.com/actions/setup-python).
