### PR TITLE
Correct typo in mdns-discovery archive checksum

### DIFF
--- a/commands/bundled_tools_mdns_discovery.go
+++ b/commands/bundled_tools_mdns_discovery.go
@@ -83,7 +83,7 @@ var (
 				ArchiveFileName: fmt.Sprintf("mdns-discovery_%s_Linux_ARMv6.tar.bz2", mdnsDiscoveryVersion),
 				URL:             fmt.Sprintf("https://downloads.arduino.cc/discovery/mdns-discovery/mdns-discovery_%s_Linux_ARMv6.tar.gz", mdnsDiscoveryVersion),
 				Size:            2321304,
-				Checksum:        "SHA-256cc1096936abddb21af23fa10c435e8e9e37ec9df2c3d2c41d265d466b03de0af",
+				Checksum:        "SHA-256:cc1096936abddb21af23fa10c435e8e9e37ec9df2c3d2c41d265d466b03de0af",
 				CachePath:       "tools",
 			},
 		},


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
A typo in the checksum definition for the `arm-linux-gnueabihf ` host version of the mdns-discovery tool caused installation to fail on that target:
```
Installing builtin:mdns-discovery@0.9.2...
Error initializing instance: installing builtin:mdns-discovery@0.9.2 tool: Cannot install tool builtin:mdns-discovery@0.9.2: testing local archive integrity: testing archive checksum: invalid checksum format: SHA-256cc1096936abddb21af23fa10c435e8e9e37ec9df2c3d2c41d265d466b03de0af
```
* **What is the new behavior?**
<!-- if this is a feature change -->
The tool should install successfully on the `arm-linux-gnueabihf ` host.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No breaking change.
* **Other information**:
<!-- Any additional information that could help the review process -->
Fixes https://github.com/arduino/arduino-cli/issues/1446
CC: @tuononh 