### PR TITLE
Fix an issue with arduino-cli lib install stripping too many characters from library names in git URLs

### DIFF
--- a/arduino/libraries/librariesmanager/install.go
+++ b/arduino/libraries/librariesmanager/install.go
@@ -245,12 +245,12 @@ func parseGitURL(gitURL string) (string, error) {
 	if strings.HasPrefix(gitURL, "git@") {
 		// We can't parse these as URLs
 		i := strings.LastIndex(gitURL, "/")
-		res = strings.TrimRight(gitURL[i+1:], ".git")
+		res = strings.TrimSuffix(gitURL[i+1:], ".git")
 	} else if path := paths.New(gitURL); path.Exist() {
 		res = path.Base()
 	} else if parsed, err := url.Parse(gitURL); err == nil {
 		i := strings.LastIndex(parsed.Path, "/")
-		res = strings.TrimRight(parsed.Path[i+1:], ".git")
+		res = strings.TrimSuffix(parsed.Path[i+1:], ".git")
 	} else {
 		return "", fmt.Errorf(tr("invalid git url"))
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fixes an issue with handling of git URLs when installing libraries using `--git-url`.

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
When using `arduino-cli lib install` with the `--git-url` flag too many characters may be stripped from the end of the library name. Internally the librarymanagers [`parseGitURL`](https://github.com/arduino/arduino-cli/blob/master/arduino/libraries/librariesmanager/install.go#L243) function is incorrectly using `strings.TrimRight` instead of `strings.TrimSuffix`.

Example:
```
strings.TrimRight("NTPClient.git", ".git") => "NTPClien"
strings.TrimSuffix("NTPClient.git", ".git") => "NTPClient"
```

* **What is the new behavior?**
<!-- if this is a feature change -->
`parseGitURL` now correctly strips the `.git` suffix from git URLs.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
This PR contains no breaking changes

* **Other information**:
<!-- Any additional information that could help the review process -->
There are not currently any test cases for `arduino/libraries/librariesmanager/install.go`, given the size of the change, and how much time I currently have available I'm not sure if unit tests for this are strictly necessary.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
