### PR TITLE
[skip changelog] Add workflow and repo dispatch triggers to stats collection workflows

### DIFF
--- a/.github/workflows/arduino-stats.yaml
+++ b/.github/workflows/arduino-stats.yaml
@@ -4,6 +4,8 @@ on:
   schedule:
     # run every day at 12:30:00
     - cron: "30 12 * * *"
+  workflow_dispatch:
+  repository_dispatch:
 
 jobs:
   push-stats:

--- a/.github/workflows/github-stats.yaml
+++ b/.github/workflows/github-stats.yaml
@@ -4,6 +4,8 @@ on:
   schedule:
     # run every 30 minutes
     - cron: "*/30 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
 
 jobs:
   push-stats:


### PR DESCRIPTION


**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Changes two workflows.

- **What is the current behavior?**

`arduino-stats.yaml` and `github-stats.yaml` workflows can't be triggered manually.

* **What is the new behavior?**

`arduino-stats.yaml` and `github-stats.yaml` workflows can be triggered manually.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
