### PR TITLE
[skip changelog] Add partition load query before fetching metrics and schedule extraction 3 times a day

### DIFF
--- a/.github/workflows/arduino-stats.yaml
+++ b/.github/workflows/arduino-stats.yaml
@@ -2,8 +2,8 @@ name: arduino-stats
 
 on:
   schedule:
-    # run every day at 12:30:00
-    - cron: "30 12 * * *"
+    # run every day at 07:00 AM, 03:00 PM and 11:00 PM
+    - cron: "0 7,15,23 * * *"
   workflow_dispatch:
   repository_dispatch:
 


### PR DESCRIPTION
Add partition load query before fetching metrics and schedule extraction 3 times a day, in order to get more granular datapoints

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

- **What is the current behavior?**
<!-- You can also link to an open issue here -->

* **What is the new behavior?**
<!-- if this is a feature change -->

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
