### PR TITLE
[skip changelog] Add missing partitioning query in Athena script

### DIFF
--- a/.github/tools/fetch_athena_stats.py
+++ b/.github/tools/fetch_athena_stats.py
@@ -18,7 +18,6 @@ def execute(client, statement, dest_s3_output_location):
     result = client.start_query_execution(
         QueryString=statement,
         ClientRequestToken=str(uuid.uuid4()),
-        QueryExecutionContext={"Database": "etl_kpi_prod_hwfw"},
         ResultConfiguration={
             "OutputLocation": dest_s3_output_location,
         },
@@ -112,6 +111,9 @@ if __name__ == "__main__":
 
     session = boto3.session.Session(region_name="us-east-1")
     athena_client = session.client("athena")
+
+    # Load all partitions before querying downloads
+    execute(athena_client, f"MSCK REPAIR TABLE {AWS_ATHENA_SOURCE_TABLE};", DEST_S3_OUTPUT)
 
     query = f"""SELECT replace(json_extract_scalar(url_decode(url_decode(querystring)),
 '$.data.url'), 'https://downloads.arduino.cc/arduino-cli/arduino-cli_', '')


### PR DESCRIPTION

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes Python script that fetches downloads data from Athena.

- **What is the current behavior?**

Athena partitions are not loaded before the query byt the script that fetches download data, this may lead to potential losses of downloads count.

* **What is the new behavior?**

Athena partitions are now loaded before the query byt the script that fetches download data.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
