### PR TITLE
[skip changelog] Temporarily full pin Python in all GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-mkdocs-task.yml
+++ b/.github/workflows/check-mkdocs-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
   GO_VERSION: "1.16"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.9.6"
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -3,7 +3,7 @@ name: Check Python
 
 env:
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.9.6"
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
   GO_VERSION: "1.16"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.9.6"
 
 on:
   push:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
A bug introduced in the 3.9.7 release of Python causes a spurious failure of the
`test\test_lib.py::test_install_git_invalid_library` integration test:
https://bugs.python.org/issue45121

As a workaround, the last working version of Python must be used: 3.9.6. In order to ensure this is done when running the
integration tests locally, this version is specified in the Poetry configuration (https://github.com/arduino/arduino-cli/pull/1470). Even though only the integration tests
require this version limitation, the Poetry configuration change affects all processes that use Poetry. Since only the
integration test workflow was adjusted accordingly (https://github.com/arduino/arduino-cli/pull/1470), the other workflows using Poetry continued to explicitely install
a version of Python that did not fulfill the version constraints specified in the Poetry configuration. It seems it was
possible for Poetry to find a compatible version on the runner:

https://github.com/per1234/arduino-cli/runs/3718711989?check_suite_focus=true#step:11:19 (visible due to debug output having been enabled in my fork)
> The currently activated Python version 3.9.7 is not supported by the project (>=3.8, <3.9.7).
> Trying to find and use a compatible version.
> Using python3.8 (3.8.10)

but this additional output caused a failure of the "Deploy Website" workflow due to expecting only valid JSON as the
output from the siteversion.py script:

https://github.com/arduino/arduino-cli/runs/3701954217?check_suite_focus=true#step:12:1
```
Error: The template is not valid. Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: T. Path '', line 0, position 0.
```

* **What is the new behavior?**
<!-- if this is a feature change -->
Even though the other workflows were able to continue to work with the discovered Python 3.8.10, it seems safest avoid
reliance on whatever Python the runner happens to have installed and instead explicitly install the Python version we
want to be used. So the full pin of Python is done in all workflows that use Poetry.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No breaking change
* **Other information**:
<!-- Any additional information that could help the review process -->
Since it is convenient to get automatic updates for Python patch releases, this full pin should be reverted back to the
"3.9" minor version pin once a new version of Python is released with the bug fixed and added to versions available for
installation via the `actions/setup-python` GitHub Actions action.
