### PR TITLE
Fix bad error message when board ID part of FQBN is wrong

### DIFF
--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -186,7 +186,7 @@ func (pm *PackageManager) ResolveFQBN(fqbn *cores.FQBN) (
 	board := platformRelease.Boards[fqbn.BoardID]
 	if board == nil {
 		return targetPackage, platformRelease, nil, nil, nil,
-			fmt.Errorf(tr("board %s:%s not found"), platformRelease, fqbn.BoardID)
+			fmt.Errorf(tr("board %s not found"), fqbn.StringWithoutConfig())
 	}
 
 	buildProperties, err := board.GetBuildProperties(fqbn.Configs)

--- a/i18n/data/en.po
+++ b/i18n/data/en.po
@@ -2444,8 +2444,8 @@ msgid "binary file not found in %s"
 msgstr "binary file not found in %s"
 
 #: arduino/cores/packagemanager/package_manager.go:189
-msgid "board %s:%s not found"
-msgstr "board %s:%s not found"
+msgid "board %s not found"
+msgstr "board %s not found"
 
 #: commands/board/list.go:41
 msgid "board not found"

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -865,7 +865,7 @@ def test_compile_using_boards_local_txt(run_command, data_dir):
     # Verifies compilation fails because board doesn't exist
     res = run_command(["compile", "--clean", "-b", fqbn, sketch_path])
     assert res.failed
-    assert "Error during build: Error resolving FQBN: board arduino:avr@1.8.3:nessuno not found" in res.stderr
+    assert "Error during build: Error resolving FQBN: board arduino:avr:nessuno not found" in res.stderr
 
     # Use custom boards.local.txt with made arduino:avr:nessuno board
     boards_local_txt = Path(data_dir, "packages", "arduino", "hardware", "avr", "1.8.3", "boards.local.txt")
@@ -943,8 +943,7 @@ def test_compile_manually_installed_platform_using_boards_local_txt(run_command,
     res = run_command(["compile", "--clean", "-b", fqbn, sketch_path])
     assert res.failed
     assert (
-        "Error during build: Error resolving FQBN: board arduino-beta-development:avr@1.8.3:nessuno not found"
-        in res.stderr
+        "Error during build: Error resolving FQBN: board arduino-beta-development:avr:nessuno not found" in res.stderr
     )
 
     # Use custom boards.local.txt with made arduino:avr:nessuno board


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Enhances an existing error message.

- **What is the current behavior?**

Calling a command that expects an FQBN with one that contains a board ID that doesn't exist returns this error message:

```
Error resolving FQBN: board arduino:samd@1.8.11:mkr1010 not found
```

* **What is the new behavior?**

Calling a command that expects an FQBN with one that contains a board ID that doesn't exist now returns this error message:

```
Error resolving FQBN: board arduino:samd:mkr1010 not found
```

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
