### PR TITLE
[skip changelog] Document `packages[*].platforms[*].deprecated` package index field

### DIFF
--- a/docs/package_index_json-specification.md
+++ b/docs/package_index_json-specification.md
@@ -234,6 +234,9 @@ Each PLATFORM describes a core for a specific architecture. The fields needed ar
 - `architecture`: is the architecture of the platform (avr, sam, etc...). It must match the architecture of the core as
   explained in the [Arduino platform specification](platform-specification.md#hardware-folders-structure)
 - `version`: the version of the platform.
+- `deprecated`: (optional) setting to `true` causes the platform to be moved to the bottom of all Boards Manager and
+  [`arduino-cli core`](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_core/) listings and marked
+  "DEPRECATED".
 - `category`: this field is reserved, a 3rd party core must set it to `Contributed`
 - `help`/`online`: is a URL that is displayed on the Arduino IDE's Boards Manager as an "Online Help" link
 - `url`, `archiveFileName`, `size` and `checksum`: metadata of the core archive file. The meaning is the same as for the


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
In the event an Arduino boards platform is deprecated by the maintainer, it will be useful to clearly communicate this
fact to the user and ensure they will easily find a preferred alternative platform. In order to facilitate this, a
`packages[*].platforms[*].deprecated` field was added to the Arduino package index format (https://github.com/arduino/arduino-cli/pull/1278) and this information is used to
enhance the user interfaces of the official Arduino development software.

This field is undocumented, meaning platform developers will be unlikely be aware of its existence.

* **What is the new behavior?**
<!-- if this is a feature change -->
This useful feature is now documented in the Arduino package index specification.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
Not breaking
