### PR TITLE
libdefs: a way for user to configure libraries

### DIFF
--- a/i18n/data/en.po
+++ b/i18n/data/en.po
@@ -395,7 +395,7 @@ msgstr "Compiling core..."
 msgid "Compiling libraries..."
 msgstr "Compiling libraries..."
 
-#: legacy/builder/phases/libraries_builder.go:135
+#: legacy/builder/phases/libraries_builder.go:136
 msgid "Compiling library \"{0}\""
 msgstr "Compiling library \"{0}\""
 
@@ -1358,7 +1358,7 @@ msgstr "Library installed"
 msgid "Library name"
 msgstr "Library name"
 
-#: legacy/builder/phases/libraries_builder.go:91
+#: legacy/builder/phases/libraries_builder.go:92
 msgid "Library {0} has been declared precompiled:"
 msgstr "Library {0} has been declared precompiled:"
 
@@ -1745,8 +1745,8 @@ msgstr "Port closed:"
 msgid "Port monitor error"
 msgstr "Port monitor error"
 
-#: legacy/builder/phases/libraries_builder.go:101
-#: legacy/builder/phases/libraries_builder.go:109
+#: legacy/builder/phases/libraries_builder.go:102
+#: legacy/builder/phases/libraries_builder.go:110
 msgid "Precompiled library in \"{0}\" not found"
 msgstr "Precompiled library in \"{0}\" not found"
 
@@ -2069,7 +2069,7 @@ msgstr "The key '%[1]v' is not a list of items, can't remove from it.\n"
 msgid "The output format for the logs, can be: %s"
 msgstr "The output format for the logs, can be: %s"
 
-#: legacy/builder/phases/libraries_builder.go:151
+#: legacy/builder/phases/libraries_builder.go:152
 msgid "The platform does not support '{0}' for precompiled libraries."
 msgstr "The platform does not support '{0}' for precompiled libraries."
 
@@ -2333,8 +2333,8 @@ msgstr "Using library {0} in folder: {1} {2}"
 msgid "Using precompiled core: {0}"
 msgstr "Using precompiled core: {0}"
 
-#: legacy/builder/phases/libraries_builder.go:98
-#: legacy/builder/phases/libraries_builder.go:106
+#: legacy/builder/phases/libraries_builder.go:99
+#: legacy/builder/phases/libraries_builder.go:107
 msgid "Using precompiled library in {0}"
 msgstr "Using precompiled library in {0}"
 

--- a/legacy/builder/phases/libraries_builder.go
+++ b/legacy/builder/phases/libraries_builder.go
@@ -37,7 +37,8 @@ type LibrariesBuilder struct{}
 func (s *LibrariesBuilder) Run(ctx *types.Context) error {
 	librariesBuildPath := ctx.LibrariesBuildPath
 	buildProperties := ctx.BuildProperties
-	includes := utils.Map(ctx.IncludeFolders.AsStrings(), utils.WrapWithHyphenI)
+    libFolders := append(ctx.IncludeFolders.AsStrings(), ctx.BuildPath.Join("sketch").Join("libdefs").String()) // user definitions for library include files
+    includes := utils.Map(libFolders, utils.WrapWithHyphenI)
 	libs := ctx.ImportedLibraries
 
 	if err := librariesBuildPath.MkdirAll(); err != nil {

--- a/legacy/builder/phases/sketch_builder.go
+++ b/legacy/builder/phases/sketch_builder.go
@@ -27,7 +27,8 @@ type SketchBuilder struct{}
 func (s *SketchBuilder) Run(ctx *types.Context) error {
 	sketchBuildPath := ctx.SketchBuildPath
 	buildProperties := ctx.BuildProperties
-	includes := utils.Map(ctx.IncludeFolders.AsStrings(), utils.WrapWithHyphenI)
+    libFolders := append(ctx.IncludeFolders.AsStrings(), ctx.BuildPath.Join("sketch").Join("libdefs").String()) // user definitions for library include files
+    includes := utils.Map(libFolders, utils.WrapWithHyphenI)
 
 	if err := sketchBuildPath.MkdirAll(); err != nil {
 		return errors.WithStack(err)

--- a/test/testdata/sketch_with_multiple_custom_libraries/libdefs/lib2_user_config.h
+++ b/test/testdata/sketch_with_multiple_custom_libraries/libdefs/lib2_user_config.h
@@ -1,0 +1,8 @@
+
+// This user file is in 'sketchDir/libdefs/' so it can be included by libraries.
+//
+// Its name and what to include is specified by the library documentation.
+
+#pragma once
+
+#define LIB2_SOME_CONFIG 1

--- a/test/testdata/sketch_with_multiple_custom_libraries/libraries2/Lib/lib2.h
+++ b/test/testdata/sketch_with_multiple_custom_libraries/libraries2/Lib/lib2.h
@@ -1,0 +1,14 @@
+
+#if defined __has_include
+#  if __has_include (<lib2_user_config.h>)
+#    pragma message "Including local project config file <lib2_user_config.h>"
+#    include <lib2_user_config.h>
+#    define DEFAULT_VALUES_ARE_GIVEN 1
+#  endif
+#endif
+
+#ifndef LIB2_SOME_CONFIG
+#define LIB2_SOME_CONFIG 0
+#endif
+
+#define LIB2_SOME_SIZE ((LIB2_SOME_CONFIG) * 42)

--- a/test/testdata/sketch_with_multiple_custom_libraries/sketch_with_multiple_custom_libraries.ino
+++ b/test/testdata/sketch_with_multiple_custom_libraries/sketch_with_multiple_custom_libraries.ino
@@ -1,6 +1,10 @@
 #include "lib1.h"
 #include "lib2.h"
 
+#if LIB2_SOME_SIZE == 42
+#pragma message "this was expected"
+#endif
+
 void setup() {
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [X] Not a breaking change

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This proposal gives the ability for any sketch to use additional configuration files for libraries that are aware of this feature.

- **What is the current behavior?**
<!-- You can also link to an open issue here -->

This is yet another proposal for #846 and https://github.com/arduino/Arduino/issues/421: Compiler flags are not addressed, global defines for sketch *and* libraries is the target.
It would additionally replace and close #1117.

* **What is the new behavior?**
<!-- if this is a feature change -->

A library source file (header or code) could optionally use this kind of snippet:

`CoolLibrary/CoolLibrary.h`
-----
```cpp
#if defined __has_include
#  if __has_include (<CoolLibrary_user_config.h>)
#    pragma message "CoolLibrary: Including local project config file <CoolLibrary_user_config.h>"
#    include <CoolLibrary_user_config.h>
#  endif
#endif

#ifndef COOLLIBRARY_BUFFER_SIZE
#define COOLLIBRARY_BUFFER_SIZE 42  // default value if sketch did not redefined it in its local config file
#endif 
```

`CoolLibrary/CoolLibrary.cpp`
-----
```cpp
#include "CoolLibrary.h"

// COOLLIBRARY_BUFFER_SIZE is 42 by default per header file
// but it can also be overridden by configuration file from sketch directory and taken into account in cpp file
static const unsigned char libbuf [COOLLIBRARY_BUFFER_SIZE];
...
```

A sketch using this library can create a local subdirectory called `libdefs/` and store, in this specific case, a file named `CoolLibrary_user_config.h`. Name and content of this file need to match the specific library requirements.

The goal for the library maintainer is to willingly allow users to change default values, or provide some specific configuration (like `#define COOLLIBRARY_DEBUG_MODE`) ***without*** having to force users to modify the library files (header or code). #1117 may give more details on the same subject with additional examples.

For security, files added in `libdefs/` are accessible during the compilation phases of libraries and sketch, but not when core source files are involved.
