### PR TITLE
fix `GetPlatform` function ignoring the `All` field

### DIFF
--- a/commands/core/list.go
+++ b/commands/core/list.go
@@ -45,13 +45,13 @@ func GetPlatforms(req *rpc.PlatformListRequest) ([]*rpc.Platform, error) {
 				} else {
 					installedVersion = platformRelease.Version.String()
 				}
-				rpcPlatform := commands.PlatformReleaseToRPC(platform.GetLatestRelease())
+				rpcPlatform := commands.PlatformReleaseToRPC(platformRelease)
 				rpcPlatform.Installed = installedVersion
 				res = append(res, rpcPlatform)
-				continue
-			}
 
-			if platformRelease != nil {
+			} else if platform.ManuallyInstalled {
+				continue
+			} else if platformRelease != nil {
 				latest := platform.GetLatestRelease()
 				if latest == nil {
 					return nil, &commands.PlatformNotFound{Platform: platform.String(), Cause: errors.New(tr("the platform has no releases"))}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
#1520 
* **What is the new behavior?**
<!-- if this is a feature change -->
The all field inside the `PlatformListRequest` works correctly now
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
