### PR TITLE
Fix compile error message not printed to correct writer on error

### DIFF
--- a/legacy/builder/container_find_includes.go
+++ b/legacy/builder/container_find_includes.go
@@ -95,7 +95,6 @@ package builder
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"time"
 
@@ -378,7 +377,7 @@ func findIncludesUntilDone(ctx *types.Context, cache *includeCache, sourceFile t
 					return errors.New(tr("Internal error in cache"))
 				}
 			}
-			os.Stderr.Write(preproc_stderr)
+			ctx.ExecStderr.Write(preproc_stderr)
 			return errors.WithStack(preproc_err)
 		}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)x
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes an issue with `compile` command and related gRPC function.

- **What is the current behavior?**

If the user tries to compile a Sketch that includes a library that's not installed an error is printed to stderr.

The gRPC interface doesn't show the error at all.

```
$ arduino-cli compile -b arduino:avr:uno /home/alien/Arduino/Blink/Blink.ino --format json
/home/alien/Arduino/Blink/Blink.ino:1:10: fatal error: SD: No such file or directory
 #include <SD>
          ^~~~
compilation terminated.
{
  "compiler_out": "",
  "compiler_err": "",
  "builder_result": {
    "build_path": "/tmp/arduino-sketch-302F70E5AC1B118F7324375770CFA163"
  },
  "success": false
}
```

* **What is the new behavior?**

Compilation of a Sketch that includes a library not installed now correctly prints the error to the expected error stream.
This also fixes the gRPC function.

```
$ arduino-cli compile -b arduino:avr:uno /home/alien/Arduino/Blink/Blink.ino --format json
{
  "compiler_out": "",
  "compiler_err": "/home/alien/Arduino/Blink/Blink.ino:1:10: fatal error: SD: No such file or directory\n #include \u003cSD\u003e\n          ^~~~\ncompilation terminated.\n",
  "builder_result": {
    "build_path": "/tmp/arduino-sketch-302F70E5AC1B118F7324375770CFA163"
  },
  "success": false
}
```

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
