### PR TITLE
[skip changelog] Mention interfaces in documentation introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![cli-logo](./docs/img/CLI_Logo_small.png)
 
 Arduino CLI is an all-in-one solution that provides Boards/Library Managers, sketch builder, board detection, uploader,
-and many other tools needed to use any Arduino compatible board and platform.
+and many other tools needed to use any Arduino compatible board and platform from command line or machine interfaces.
 
 [![Test Go status](https://github.com/arduino/arduino-cli/actions/workflows/test-go-task.yml/badge.svg)](https://github.com/arduino/arduino-cli/actions/workflows/test-go-task.yml)
 [![Test Integration status](https://github.com/arduino/arduino-cli/actions/workflows/test-go-integration-task.yml/badge.svg)](https://github.com/arduino/arduino-cli/actions/workflows/test-go-integration-task.yml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 Arduino CLI is an all-in-one solution that provides Boards/Library Managers, sketch builder, board detection, uploader,
-and many other tools needed to use any Arduino compatible board and platform.
+and many other tools needed to use any Arduino compatible board and platform from command line or machine interfaces.
 
 In addition to being a standalone tool, Arduino CLI is the heart of all official Arduino development software (Arduino
 IDE, Arduino Web Editor). Parts of this documentation apply to those tools as well.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation enhancement
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Unlike the IDE and Web Editor, Arduino CLI is intended to be used directly only by advanced users. However, all types of
users are likely to visit the repository and documentation website. Some of these readers will not be familiar with the
meaning of the acronym "CLI".

The previous documentation introduces Arduino CLI as:

> an all-in-one solution that provides [wonderful things] to use any Arduino compatible board and platform

Which sounds like something every Arduino user would be interested in.

Those readers might therefore get the impression this is some sort of GUI application like the IDE and be frustrated and confused after spending time to install and run the program, only to find that it doesn't apparently do anything when they run the executable (because they did it from a file browser or shortcut).

* **What is the new behavior?**
<!-- if this is a feature change -->
The introduction in the repository readme and documentation website home page mentions that Arduino CLI's capabilities are provided via command line and machine interfaces.

It is a bit difficult to describe Arduino CLI's interface in a short introduction because, despite the "CLI" in the name,
command line is only one of the interfaces provided by Arduino CLI (the others being the gRPC and Go API). I added the
term "machine" to cover the others.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No breaking change.