### PR TITLE
Do not give-up on `compile --only-compilation-database` if prototypes generation fails

### DIFF
--- a/legacy/builder/container_find_includes.go
+++ b/legacy/builder/container_find_includes.go
@@ -110,6 +110,15 @@ import (
 type ContainerFindIncludes struct{}
 
 func (s *ContainerFindIncludes) Run(ctx *types.Context) error {
+	err := s.findIncludes(ctx)
+	if err != nil && ctx.OnlyUpdateCompilationDatabase {
+		ctx.GetLogger().Println("info", "%s: %s", tr("An error occurred detecting libraries"), tr("the compilation database may be incomplete or inaccurate"))
+		return nil
+	}
+	return err
+}
+
+func (s *ContainerFindIncludes) findIncludes(ctx *types.Context) error {
 	cachePath := ctx.BuildPath.Join("includes.cache")
 	cache := readCache(cachePath)
 

--- a/test/test_compile_part_4.py
+++ b/test/test_compile_part_4.py
@@ -292,16 +292,19 @@ def test_compile_with_esp8266_bundled_libraries(run_command, data_dir, copy_sket
     assert "\n".join(expected_output) not in res.stdout
 
 
-def test_generate_compile_commands_json_with_esp32(run_command, data_dir, copy_sketch):
-    # https://github.com/arduino/arduino-cli/issues/1547
+def test_generate_compile_commands_json_resilience(run_command, data_dir, copy_sketch):
     assert run_command(["update"])
 
-    # Update index with esp32 core and install it
+    # check it didn't fail with esp32@2.0.1 that has a prebuild hook that must run:
+    # https://github.com/arduino/arduino-cli/issues/1547
     url = "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json"
     assert run_command(["core", "update-index", f"--additional-urls={url}"])
     assert run_command(["core", "install", "esp32:esp32@2.0.1", f"--additional-urls={url}"])
-
     sketch_path = copy_sketch("sketch_simple")
+    assert run_command(["compile", "-b", "esp32:esp32:featheresp32", "--only-compilation-database", sketch_path])
+
+    # check it didn't fail on a sketch with a missing include
+    sketch_path = copy_sketch("sketch_with_missing_include")
     assert run_command(["compile", "-b", "esp32:esp32:featheresp32", "--only-compilation-database", sketch_path])
 
 

--- a/test/testdata/sketch_with_missing_include/sketch_with_missing_include.ino
+++ b/test/testdata/sketch_with_missing_include/sketch_with_missing_include.ino
@@ -1,0 +1,1 @@
+#include "akdshfgdfkgweriuweriyuiqwuegdhsgfsdkfgyuawetrkdshfdsufg.h"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
Makes the generation of the "compilation database" more resilient.

- **What is the current behavior?**
the database generation fails if the sketch cannot compile.

* **What is the new behavior?**
The database is generated anyway unless there are critical components missing or the platform is misconfigured.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No