### PR TITLE
Locale is now refreshed on Init

### DIFF
--- a/commands/instances.go
+++ b/commands/instances.go
@@ -334,6 +334,11 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 		})
 	}
 
+	// Refreshes the locale used, this will change the
+	// language of the CLI if the locale is different
+	// after started.
+	i18n.Init(configuration.Settings.GetString("locale"))
+
 	return nil
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Adds a way for gRPC consumers to refresh the CLI locale without restarting the daemon process.

- **What is the current behavior?**

gRPC consumers have no way of changing the language of the CLI without restarting the daemon process.

* **What is the new behavior?**

gRPC consumers can now call the `Init` function to refresh the locale in use. 

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
