### PR TITLE
fix a regression introduced in #be5022e. `--input` flags were ignored

### DIFF
--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/arduino/arduino-cli/arduino/sketch"
 	"github.com/arduino/arduino-cli/cli/arguments"
 	"github.com/arduino/arduino-cli/cli/errorcodes"
 	"github.com/arduino/arduino-cli/cli/feedback"
@@ -76,10 +77,27 @@ func runUploadCommand(command *cobra.Command, args []string) {
 	if len(args) > 0 {
 		path = args[0]
 	}
-
 	sketchPath := arguments.InitSketchPath(path)
-	sk := arguments.NewSketch(sketchPath)
-	discoveryPort := port.GetDiscoveryPort(instance, sk)
+
+	// .pde files are still supported but deprecated, this warning urges the user to rename them
+	if files := sketch.CheckForPdeFiles(sketchPath); len(files) > 0 && importDir == "" && importFile == "" {
+		feedback.Error(tr("Sketches with .pde extension are deprecated, please rename the following files to .ino:"))
+		for _, f := range files {
+			feedback.Error(f)
+		}
+	}
+
+	sk, err := sketch.New(sketchPath)
+	if err != nil && importDir == "" && importFile == "" {
+		feedback.Errorf(tr("Error during Upload: %v"), err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
+
+	discoveryPort, err := port.GetPort(instance, sk)
+	if err != nil {
+		feedback.Errorf(tr("Error during Upload: %v"), err)
+		os.Exit(errorcodes.ErrGeneric)
+	}
 
 	if fqbn.String() == "" && sk != nil && sk.Metadata != nil {
 		// If the user didn't specify an FQBN and a sketch.json file is present

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -79,12 +79,8 @@ func runUploadCommand(command *cobra.Command, args []string) {
 	}
 	sketchPath := arguments.InitSketchPath(path)
 
-	// .pde files are still supported but deprecated, this warning urges the user to rename them
-	if files := sketch.CheckForPdeFiles(sketchPath); len(files) > 0 && importDir == "" && importFile == "" {
-		feedback.Error(tr("Sketches with .pde extension are deprecated, please rename the following files to .ino:"))
-		for _, f := range files {
-			feedback.Error(f)
-		}
+	if importDir == "" && importFile == "" {
+		arguments.WarnDeprecatedFiles(sketchPath)
 	}
 
 	sk, err := sketch.New(sketchPath)

--- a/test/test_upload.py
+++ b/test/test_upload.py
@@ -111,7 +111,7 @@ def test_upload_after_attach(run_command, data_dir, detected_boards):
         # Create a sketch
         sketch_path = os.path.join(data_dir, "foo")
         assert run_command(["sketch", "new", sketch_path])
-        assert run_command(["board", "attach", f"serial://{board.address}", sketch_path])
+        assert run_command(["board", "attach", "-p", board.address, sketch_path])
         # Build sketch
         assert run_command(["compile", sketch_path])
         # Upload


### PR DESCRIPTION
partially revert "refactor sketch path calculation" in `upload.go`

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
fix regression
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The test `test/test_upload.py::test_upload_with_input_dir_flag` was failing
* **What is the new behavior?**
<!-- if this is a feature change -->
fixed the regression introduced by reverting a change made in #1542 
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
