### PR TITLE
Bump go version to go 1.17.8

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -3,7 +3,7 @@ name: Check Go Dependencies
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -3,7 +3,7 @@ name: Check Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -3,7 +3,7 @@ name: Check Markdown
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-mkdocs-task.yml
+++ b/.github/workflows/check-mkdocs-task.yml
@@ -3,7 +3,7 @@ name: Check Website
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
   PYTHON_VERSION: "3.9"
 

--- a/.github/workflows/check-protobuf-task.yml
+++ b/.github/workflows/check-protobuf-task.yml
@@ -2,7 +2,7 @@ name: Check Protocol Buffers
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -3,7 +3,7 @@ name: Deploy Website
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
   PYTHON_VERSION: "3.9"
 

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -3,7 +3,7 @@ name: Test Integration
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
   PYTHON_VERSION: "3.9.6"
 

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -3,7 +3,7 @@ name: Test Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -19,7 +19,7 @@ version: "3"
 
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
-  GO_VERSION: "1.16.4"
+  GO_VERSION: "1.17.8"
   CHECKSUM_FILE: "{{.VERSION}}-checksums.txt"
 
 tasks:

--- a/arduino/discovery/discovery_client/go.mod
+++ b/arduino/discovery/discovery_client/go.mod
@@ -1,10 +1,29 @@
 module github.com/arduino/arduino-cli/arduino/discovery/discovery_client
 
-go 1.14
+go 1.17
 
 replace github.com/arduino/arduino-cli => ../../..
 
 require (
 	github.com/arduino/arduino-cli v0.0.0-00010101000000-000000000000
 	github.com/gizak/termui/v3 v3.1.0
+)
+
+require (
+	github.com/arduino/go-paths-helper v1.7.0 // indirect
+	github.com/arduino/go-properties-orderedmap v1.6.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/leonelquinteros/gotext v1.4.0 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/sirupsen/logrus v1.4.2 // indirect
+	golang.org/x/net v0.0.0-20210505024714-0287a6fb4125 // indirect
+	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/arduino/discovery/discovery_client/go.sum
+++ b/arduino/discovery/discovery_client/go.sum
@@ -215,7 +215,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leonelquinteros/gotext v1.4.0 h1:2NHPCto5IoMXbrT0bldPrxj0qM5asOCwtb1aUQZ1tys=
 github.com/leonelquinteros/gotext v1.4.0/go.mod h1:yZGXREmoGTtBvZHNcc+Yfug49G/2spuF/i/Qlsvz1Us=
@@ -247,7 +246,6 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d h1:x3S6kxmy49zXVVyhcnrFqxvNVCBPb2KZ9hV2RBdS840=
 github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
@@ -658,7 +656,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20160105164936-4f90aeace3a2/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/client_example/go.mod
+++ b/client_example/go.mod
@@ -1,10 +1,19 @@
 module github.com/arduino/arduino-cli/client_example
 
-go 1.14
+go 1.17
 
 replace github.com/arduino/arduino-cli => ../
 
 require (
 	github.com/arduino/arduino-cli v0.0.0-20200109150215-ffa84fdaab21
 	google.golang.org/grpc v1.38.0
+)
+
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
+	golang.org/x/net v0.0.0-20210505024714-0287a6fb4125 // indirect
+	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -70,7 +70,7 @@ submitting a PR:
 
 To build the Arduino CLI from sources you need the following tools to be available in your local environment:
 
-- [Go][1] version 1.14 or later
+- [Go][1] version 1.17 or later
 - [Taskfile][2] to help you run the most common tasks from the command line
 
 If you want to run integration tests you will also need:
@@ -272,7 +272,7 @@ If you want to check out how the documentation would look after some local chang
 happens in the CI, generating the full documentation website from your personal computer. To run the docs toolchain
 locally, you need to have a few dependencies and tools installed:
 
-- [Go][1] version 1.14 or later
+- [Go][1] version 1.17 or later
 - [Taskfile][2] to help you run the most common tasks from the command line
 - A working [Python][3] environment, see [this paragraph](#integration-tests) if you need to setup one
 

--- a/docsgen/go.mod
+++ b/docsgen/go.mod
@@ -1,11 +1,84 @@
 // Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/cobra/docsgen/go.mod
 module github.com/arduino/arduino-cli/docsgen
 
-go 1.16
+go 1.17
 
 replace github.com/arduino/arduino-cli => ../
 
 require (
 	github.com/arduino/arduino-cli v0.0.0
 	github.com/spf13/cobra v1.2.1
+)
+
+require (
+	github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c // indirect
+	github.com/arduino/go-paths-helper v1.7.0 // indirect
+	github.com/arduino/go-properties-orderedmap v1.6.0 // indirect
+	github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b // indirect
+	github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b // indirect
+	github.com/cmaglie/pb v1.0.27 // indirect
+	github.com/codeclysm/cc v1.2.2 // indirect
+	github.com/codeclysm/extract/v3 v3.0.2 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/creack/goselect v0.1.2 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/fluxio/iohelpers v0.0.0-20160419043813-3a4dd67a94d2 // indirect
+	github.com/fluxio/multierror v0.0.0-20160419044231-9c68d39025e5 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/gofrs/uuid v3.2.0+incompatible // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/h2non/filetype v1.0.8 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/leonelquinteros/gotext v1.4.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/marcinbor85/gohex v0.0.0-20210308104911-55fb1c624d84 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/miekg/dns v1.1.43 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/oleksandr/bonjour v0.0.0-20160508152359-5dcf00d8b228 // indirect
+	github.com/pelletier/go-toml v1.9.3 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmylund/sortutil v0.0.0-20120526081524-abeda66eb583 // indirect
+	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/schollz/closestmatch v2.1.0+incompatible // indirect
+	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e // indirect
+	github.com/segmentio/stats/v4 v4.5.3 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.4.2 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/viper v1.8.1 // indirect
+	github.com/src-d/gcfg v1.4.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/xanzy/ssh-agent v0.2.1 // indirect
+	go.bug.st/cleanup v1.0.0 // indirect
+	go.bug.st/downloader/v2 v2.1.1 // indirect
+	go.bug.st/relaxed-semver v0.0.0-20190922224835-391e10178d18 // indirect
+	go.bug.st/serial v1.3.2 // indirect
+	go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/net v0.0.0-20210505024714-0287a6fb4125 // indirect
+	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/ini.v1 v1.62.0 // indirect
+	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
+	gopkg.in/src-d/go-git.v4 v4.13.1 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/arduino-cli
 
-go 1.16
+go 1.17
 
 require (
 	github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c
@@ -50,4 +50,38 @@ require (
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/creack/goselect v0.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/pelletier/go-toml v1.9.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/src-d/gcfg v1.4.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/xanzy/ssh-agent v0.2.1 // indirect
+	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
+	gopkg.in/ini.v1 v1.62.0 // indirect
+	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Update go version used
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
We currently use go 1.16.4
* **What is the new behavior?**
<!-- if this is a feature change -->
We currently use go 1.17.8
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
nope
* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
