### PR TITLE
Fix panic when discovery doesn't send an ok message after a command

### DIFF
--- a/arduino/discovery/discovery.go
+++ b/arduino/discovery/discovery.go
@@ -162,6 +162,7 @@ func (disc *PluggableDiscovery) jsonDecodeLoop(in io.Reader, outChan chan<- *dis
 			// This is fine, we exit gracefully
 			disc.statusMutex.Lock()
 			disc.state = Dead
+			disc.incomingMessagesError = err
 			disc.statusMutex.Unlock()
 			close(outChan)
 			return


### PR DESCRIPTION
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Bug fixing.

- **What is the current behavior?**

If the user has installed a core that comes with a pluggable discovery that doesn't send an `ok` message after a discovery command is received the `arduino-cli` might panic when running some commands.

* **What is the new behavior?**

The `arduino-cli` doesn't panic anymore but just logs the error if a discovery doesn't send an `ok` message after receiving a discovery command.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
