### PR TITLE
[skip changelog] Fix link in tests README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -3,4 +3,4 @@
 This dir contains integration tests, aimed to test the Command Line Interface and its output from a pure user point of
 view.
 
-For instructions, see the [contributing guide](../docs/CONTRIBUTING.md/#integration-tests).
+For instructions, see the [contributing guide](../docs/CONTRIBUTING.md#integration-tests).


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fix a link in a markdown file.

- **What is the current behavior?**

`tests/README.md` contains a malformed link: `../docs/CONTRIBUTING.md/#integration-tests`

* **What is the new behavior?**

`tests/README.md` link is now correct: `../docs/CONTRIBUTING.md#integration-tests`

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

The check is now failing cause the new recent release of `markdown-link-check` correctly indentifies the link as broken.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
