### PR TITLE
Pin task version to 3.9.0 because of the PATH on win bug

### DIFF
--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -109,7 +109,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 3.9.0
 
       - name: Build Arduino CLI
         run: task go:build

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -83,7 +83,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 3.9.0
 
       - name: Run tests
         run: task go:test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure fix

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The **Test Go** workflow on Windows is broken after the newest release of Task (3.9.1) and was working fine with 3.9.0
The problem should be linked to the upgrade in `mvdan/sh` they did in 3.9.1.
The bug is present only on Windows, apparently the PATH env variable is not expanded correctly under subcommands. Log attached for further details
* **What is the new behavior?**
<!-- if this is a feature change -->
To mitigate the problem, we decided to pin the task version used to 3.9.0 in the workflows

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
[logs_46403.zip](https://github.com/arduino/arduino-cli/files/7626724/logs_46403.zip)

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
