### PR TITLE
Add minified json output format

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -111,14 +111,15 @@ func createCliCommandTree(cmd *cobra.Command) {
 		return validLogLevels, cobra.ShellCompDirectiveDefault
 	})
 	cmd.PersistentFlags().String("log-file", "", tr("Path to the file where logs will be written."))
-	validFormats := []string{"text", "json"}
-	cmd.PersistentFlags().String("log-format", "", tr("The output format for the logs, can be: %s", strings.Join(validFormats, ", ")))
+	validLogFormats := []string{"text", "json"}
+	cmd.PersistentFlags().String("log-format", "", tr("The output format for the logs, can be: %s", strings.Join(validLogFormats, ", ")))
 	cmd.RegisterFlagCompletionFunc("log-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return validFormats, cobra.ShellCompDirectiveDefault
+		return validLogFormats, cobra.ShellCompDirectiveDefault
 	})
-	cmd.PersistentFlags().StringVar(&outputFormat, "format", "text", tr("The output format for the logs, can be: %s", strings.Join(validFormats, ", ")))
+	validOutputFormats := []string{"text", "json", "jsonmini"}
+	cmd.PersistentFlags().StringVar(&outputFormat, "format", "text", tr("The output format for the logs, can be: %s", strings.Join(validOutputFormats, ", ")))
 	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return validFormats, cobra.ShellCompDirectiveDefault
+		return validOutputFormats, cobra.ShellCompDirectiveDefault
 	})
 	cmd.PersistentFlags().StringVar(&configFile, "config-file", "", tr("The custom config file (if not specified the default will be used)."))
 	cmd.PersistentFlags().StringSlice("additional-urls", []string{}, tr("Comma-separated list of additional URLs for the Boards Manager."))
@@ -144,9 +145,10 @@ func toLogLevel(s string) (t logrus.Level, found bool) {
 
 func parseFormatString(arg string) (feedback.OutputFormat, bool) {
 	f, found := map[string]feedback.OutputFormat{
-		"json": feedback.JSON,
-		"text": feedback.Text,
-	}[arg]
+		"json":     feedback.JSON,
+		"jsonmini": feedback.JSONMini,
+		"text":     feedback.Text,
+	}[strings.ToLower(arg)]
 
 	return f, found
 }

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -61,7 +61,7 @@ func runVersionCommand(cmd *cobra.Command, args []string) {
 	latestVersion := updater.ForceCheckForUpdate(currentVersion)
 
 	versionInfo := globals.VersionInfo
-	if feedback.GetFormat() == feedback.JSON && latestVersion != nil {
+	if f := feedback.GetFormat(); (f == feedback.JSON || f == feedback.JSONMini) && latestVersion != nil {
 		// Set this only we managed to get the latest version
 		versionInfo.LatestVersion = latestVersion.String()
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Adds a new output format.

- **What is the current behavior?**

The `arduino-cli` supports two output formats as of now: `text` (default) and `json`.
`json` is always pretty printed, this might make it difficult for some to parse it correctly, it also make the output much more longer than necessary with lots of empty space.

* **What is the new behavior?**

The `arduino-cli` now supports three output formats as of now: `text` (default), `json` and `jsonmini`.

Example output:

```
$ arduino-cli board list
Port         Protocol Type              Board Name                FQBN             Core
/dev/ttyACM0 serial   Unknown
/dev/ttyACM1 serial   Serial Port (USB) Arduino Mega or Mega 2560 arduino:avr:mega arduino:avr


$ arduino-cli board list --format json
[
  {
    "port": {
      "address": "/dev/ttyACM0",
      "label": "/dev/ttyACM0",
      "protocol": "serial",
      "protocol_label": "Serial Port (USB)",
      "properties": {
        "pid": "0x5385",
        "serialNumber": "HTK32",
        "vid": "0x27c6"
      }
    }
  },
  {
    "matching_boards": [
      {
        "name": "Arduino Mega or Mega 2560",
        "fqbn": "arduino:avr:mega"
      }
    ],
    "port": {
      "address": "/dev/ttyACM1",
      "label": "/dev/ttyACM1",
      "protocol": "serial",
      "protocol_label": "Serial Port (USB)",
      "properties": {
        "pid": "0x0242",
        "serialNumber": "85438303133351C080B1",
        "vid": "0x2341"
      }
    }
  }
]

$ arduino-cli board list --format jsonmini
[{"port":{"address":"/dev/ttyACM0","label":"/dev/ttyACM0","protocol":"serial","protocol_label":"Serial Port (USB)","properties":{"pid":"0x5385","serialNumber":"HTK32","vid":"0x27c6"}}},{"matching_boards":[{"name":"Arduino Mega or Mega 2560","fqbn":"arduino:avr:mega"}],"port":{"address":"/dev/ttyACM1","label":"/dev/ttyACM1","protocol":"serial","protocol_label":"Serial Port (USB)","properties":{"pid":"0x0242","serialNumber":"85438303133351C080B1","vid":"0x2341"}}}]
```


- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

Fixes #1584.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
