### PR TITLE
Add YAML to feedback formats

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -116,7 +116,7 @@ func createCliCommandTree(cmd *cobra.Command) {
 	cmd.RegisterFlagCompletionFunc("log-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return validLogFormats, cobra.ShellCompDirectiveDefault
 	})
-	validOutputFormats := []string{"text", "json", "jsonmini"}
+	validOutputFormats := []string{"text", "json", "jsonmini", "yaml"}
 	cmd.PersistentFlags().StringVar(&outputFormat, "format", "text", tr("The output format for the logs, can be: %s", strings.Join(validOutputFormats, ", ")))
 	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return validOutputFormats, cobra.ShellCompDirectiveDefault
@@ -148,6 +148,7 @@ func parseFormatString(arg string) (feedback.OutputFormat, bool) {
 		"json":     feedback.JSON,
 		"jsonmini": feedback.JSONMini,
 		"text":     feedback.Text,
+		"yaml":     feedback.YAML,
 	}[strings.ToLower(arg)]
 
 	return f, found

--- a/cli/feedback/feedback.go
+++ b/cli/feedback/feedback.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/arduino/arduino-cli/i18n"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/status"
@@ -37,6 +39,8 @@ const (
 	JSON
 	// JSONMini is identical to JSON but without whitespaces
 	JSONMini
+	// YAML means YAML format
+	YAML
 )
 
 // Result is anything more complex than a sentence that needs to be printed
@@ -156,13 +160,27 @@ func (fb *Feedback) printJSON(v interface{}) {
 	}
 }
 
+// printYAML is a convenient wrapper to provide feedback by printing the
+// desired output in YAML format. It adds a newline to the output.
+func (fb *Feedback) printYAML(v interface{}) {
+	d, err := yaml.Marshal(v)
+	if err != nil {
+		fb.Errorf(tr("Error during YAML encoding of the output: %v"), err)
+		return
+	}
+	fmt.Fprintf(fb.out, "%v\n", string(d))
+}
+
 // PrintResult is a convenient wrapper to provide feedback for complex data,
 // where the contents can't be just serialized to JSON but requires more
 // structure.
 func (fb *Feedback) PrintResult(res Result) {
-	if fb.format == JSON || fb.format == JSONMini {
+	switch fb.format {
+	case JSON, JSONMini:
 		fb.printJSON(res.Data())
-	} else {
+	case YAML:
+		fb.printYAML(res.Data())
+	default:
 		fb.Print(fmt.Sprintf("%s", res))
 	}
 }

--- a/cli/feedback/feedback.go
+++ b/cli/feedback/feedback.go
@@ -113,9 +113,12 @@ func (fb *Feedback) Printf(format string, v ...interface{}) {
 
 // Print behaves like fmt.Print but writes on the out writer and adds a newline.
 func (fb *Feedback) Print(v interface{}) {
-	if fb.format == JSON || fb.format == JSONMini {
+	switch fb.format {
+	case JSON, JSONMini:
 		fb.printJSON(v)
-	} else {
+	case YAML:
+		fb.printYAML(v)
+	default:
 		fmt.Fprintln(fb.out, v)
 	}
 }

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -61,7 +61,7 @@ func runVersionCommand(cmd *cobra.Command, args []string) {
 	latestVersion := updater.ForceCheckForUpdate(currentVersion)
 
 	versionInfo := globals.VersionInfo
-	if f := feedback.GetFormat(); (f == feedback.JSON || f == feedback.JSONMini) && latestVersion != nil {
+	if f := feedback.GetFormat(); (f == feedback.JSON || f == feedback.JSONMini || f == feedback.YAML) && latestVersion != nil {
 		// Set this only we managed to get the latest version
 		versionInfo.LatestVersion = latestVersion.String()
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This pr enhances the `feedback` package by allowing to use also the YAML format.
For the YAML marshal It's been selected a YAML dependency already present in `go.mod`

- **What is the current behavior?**
<!-- You can also link to an open issue here -->

* **What is the new behavior?**
<!-- if this is a feature change -->

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
