### PR TITLE
Fix install script's check for previous installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -186,19 +186,19 @@ bye() {
 
 testVersion() {
   set +e
-  EXECUTABLE_PATH="$(command -v $PROJECT_NAME)"
-  if [ "$?" = "1" ]; then
-    # $PATH is intentionally a literal in this message.
-    # shellcheck disable=SC2016
-    echo "$PROJECT_NAME not found. You might want to add \"$EFFECTIVE_BINDIR\" to your "'$PATH'
-  else
+  if EXECUTABLE_PATH="$(command -v $PROJECT_NAME)"; then
     # Convert to resolved, absolute paths before comparison
     EXECUTABLE_REALPATH="$(cd -- "$(dirname -- "$EXECUTABLE_PATH")" && pwd -P)"
     EFFECTIVE_BINDIR_REALPATH="$(cd -- "$EFFECTIVE_BINDIR" && pwd -P)"
     if [ "$EXECUTABLE_REALPATH" != "$EFFECTIVE_BINDIR_REALPATH" ]; then
+      # $PATH is intentionally a literal in this message.
       # shellcheck disable=SC2016
       echo "An existing $PROJECT_NAME was found at $EXECUTABLE_PATH. Please prepend \"$EFFECTIVE_BINDIR\" to your "'$PATH'" or remove the existing one."
     fi
+  else
+    # $PATH is intentionally a literal in this message.
+    # shellcheck disable=SC2016
+    echo "$PROJECT_NAME not found. You might want to add \"$EFFECTIVE_BINDIR\" to your "'$PATH'
   fi
 
   set -e


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure fix.
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The installation script checks for an existing installation in the PATH in order to provide appropriate advice to the
user about adding the installation to their their PATH environment variable.

This check is done using `command -v`. It turns out that the exit status is shell dependent in the event the command is
not found, so that it might be either 1 or 127 depending on the user's system. The script previously assumed that the
exit status would be 1 when the command was not found in PATH, which resulted in spurious advice under these conditions:

```
An existing arduino-cli was found at . Please prepend "/home/foo/arduino-cli/bin" to your $PATH or remove the existing one.
```
[example](https://github.com/arduino/tooling-project-assets/runs/4556007479?check_suite_focus=true#step:4:13)
* **What is the new behavior?**
<!-- if this is a feature change -->

Previous installation check's logic is inverted so that the advice about an existing installation in PATH is only printed when one was found, making it only dependent on exit status 0.
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No breaking change.
* **Other information**:
<!-- Any additional information that could help the review process -->

---

See upstream commits for more atomic breakdown of changes: https://github.com/arduino/tooling-project-assets/pull/189

Checks for proper behavior of this aspect have been added for the parent: https://github.com/arduino/tooling-project-assets/actions/runs/1601562939

---

Originally reported at https://forum.arduino.cc/t/failing-to-instlal-arduino-cli-on-raspberry/936871