### PR TITLE
Bugfix: apply monitor settings on monitor opening

### DIFF
--- a/commands/monitor/monitor.go
+++ b/commands/monitor/monitor.go
@@ -84,6 +84,10 @@ func Monitor(ctx context.Context, req *rpc.MonitorRequest) (*PortProxy, *pluggab
 		return nil, nil, &arduino.FailedMonitorError{Cause: err}
 	}
 
+	for _, setting := range req.GetPortConfiguration().Settings {
+		m.Configure(setting.SettingId, setting.Value)
+	}
+
 	return &PortProxy{
 		rw:               monIO,
 		changeSettingsCB: m.Configure,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
The `arduino-cli monitor -c ....` flag wasn't working, this PR fix the problem

- **What is the current behavior?**
Port settings are not applied.

* **What is the new behavior?**
Port settings are applied.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No

* **Other information**:
Fix #1562

