### PR TITLE
Do not abort compile if loading errors happens for not compiled platforms

### DIFF
--- a/legacy/builder/hardware_loader.go
+++ b/legacy/builder/hardware_loader.go
@@ -18,7 +18,6 @@ package builder
 import (
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
-	"github.com/pkg/errors"
 )
 
 type HardwareLoader struct{}
@@ -33,7 +32,13 @@ func (s *HardwareLoader) Run(ctx *types.Context) error {
 			// I have no intention right now to start a refactoring of the legacy package too, so
 			// here's this shitty solution for now.
 			// When we're gonna refactor the legacy package this will be gone.
-			return errors.WithStack(errs[0].Err())
+
+			if ctx.Verbose {
+				log := ctx.GetLogger()
+				for _, err := range errs {
+					log.Println("info", "Error loading hardware platform: {0}", err.Message())
+				}
+			}
 		}
 		ctx.PackageManager = pm
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
The change is mainly on the legacy package and influence how the `arduino-builder` behaves.

- **What is the current behavior?**
If an installed platform has errors that prevent its loading, the builder will abort the compilation, even if the platform is not needed for the build and is not compiled at all.

* **What is the new behavior?**
The error is ignored (just printed on the output), and the compile continues.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No
