### PR TITLE
Listen at all network interfaces.

### DIFF
--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -112,7 +112,7 @@ func runDaemonCommand(cmd *cobra.Command, args []string) {
 		}()
 	}
 
-	ip := "127.0.0.1"
+	ip := "0.0.0.0"
 	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%s", ip, port))
 	if err != nil {
 		// Invalid port, such as "Foo"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
This is a minor change: daemon listening on all the network interfaces, not just 127.0.0.1

- **What is the current behavior?**
Listening to 127.0.0.1

* **What is the new behavior?**
Listening to all the network interfaces. This might be needed for virtualization/containerization/back-end use cases.
This does not limit/reduce anything.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No changes required. The `arduino daemon` output will be a bit different: "Listening ... 0.0.0.0" instead of ".. 127.0.0.1" if anyone relies on this.

* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
