### PR TITLE
Allow case-insensitive `ok` or `OK` replies from pluggable discoveries and monitors

### DIFF
--- a/arduino/discovery/discovery.go
+++ b/arduino/discovery/discovery.go
@@ -312,7 +312,7 @@ func (disc *PluggableDiscovery) Run() (err error) {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "HELLO", err)
 	} else if msg.EventType != "hello" {
 		return errors.Errorf(tr("communication out of sync, expected 'hello', received '%s'"), msg.EventType)
-	} else if msg.Message != "OK" || msg.Error {
+	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
 	} else if msg.ProtocolVersion > 1 {
 		return errors.Errorf(tr("protocol version not supported: requested 1, got %d"), msg.ProtocolVersion)
@@ -333,7 +333,7 @@ func (disc *PluggableDiscovery) Start() error {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "START", err)
 	} else if msg.EventType != "start" {
 		return errors.Errorf(tr("communication out of sync, expected 'start', received '%s'"), msg.EventType)
-	} else if msg.Message != "OK" || msg.Error {
+	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
 	}
 	disc.statusMutex.Lock()
@@ -353,7 +353,7 @@ func (disc *PluggableDiscovery) Stop() error {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "STOP", err)
 	} else if msg.EventType != "stop" {
 		return errors.Errorf(tr("communication out of sync, expected 'stop', received '%s'"), msg.EventType)
-	} else if msg.Message != "OK" || msg.Error {
+	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
 	}
 	disc.statusMutex.Lock()
@@ -376,7 +376,7 @@ func (disc *PluggableDiscovery) Quit() error {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "QUIT", err)
 	} else if msg.EventType != "quit" {
 		return errors.Errorf(tr("communication out of sync, expected 'quit', received '%s'"), msg.EventType)
-	} else if msg.Message != "OK" || msg.Error {
+	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
 	}
 	disc.killProcess()
@@ -416,7 +416,7 @@ func (disc *PluggableDiscovery) StartSync(size int) (<-chan *Event, error) {
 		return nil, fmt.Errorf(tr("calling %[1]s: %[2]w"), "START_SYNC", err)
 	} else if msg.EventType != "start_sync" {
 		return nil, errors.Errorf(tr("communication out of sync, expected 'start_sync', received '%s'"), msg.EventType)
-	} else if msg.Message != "OK" || msg.Error {
+	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
 		return nil, errors.Errorf(tr("command failed: %s"), msg.Message)
 	}
 

--- a/arduino/discovery/discovery.go
+++ b/arduino/discovery/discovery.go
@@ -311,7 +311,7 @@ func (disc *PluggableDiscovery) Run() (err error) {
 	if msg, err := disc.waitMessage(time.Second * 10); err != nil {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "HELLO", err)
 	} else if msg.EventType != "hello" {
-		return errors.Errorf(tr("communication out of sync, expected 'hello', received '%s'"), msg.EventType)
+		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "hello", msg.EventType)
 	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
 	} else if msg.ProtocolVersion > 1 {
@@ -332,7 +332,7 @@ func (disc *PluggableDiscovery) Start() error {
 	if msg, err := disc.waitMessage(time.Second * 10); err != nil {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "START", err)
 	} else if msg.EventType != "start" {
-		return errors.Errorf(tr("communication out of sync, expected 'start', received '%s'"), msg.EventType)
+		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "start", msg.EventType)
 	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
 	}
@@ -352,7 +352,7 @@ func (disc *PluggableDiscovery) Stop() error {
 	if msg, err := disc.waitMessage(time.Second * 10); err != nil {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "STOP", err)
 	} else if msg.EventType != "stop" {
-		return errors.Errorf(tr("communication out of sync, expected 'stop', received '%s'"), msg.EventType)
+		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "stop", msg.EventType)
 	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
 	}
@@ -375,7 +375,7 @@ func (disc *PluggableDiscovery) Quit() error {
 	if msg, err := disc.waitMessage(time.Second * 10); err != nil {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "QUIT", err)
 	} else if msg.EventType != "quit" {
-		return errors.Errorf(tr("communication out of sync, expected 'quit', received '%s'"), msg.EventType)
+		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "quit", msg.EventType)
 	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
 	}
@@ -392,7 +392,7 @@ func (disc *PluggableDiscovery) List() ([]*Port, error) {
 	if msg, err := disc.waitMessage(time.Second * 10); err != nil {
 		return nil, fmt.Errorf(tr("calling %[1]s: %[2]w"), "LIST", err)
 	} else if msg.EventType != "list" {
-		return nil, errors.Errorf(tr("communication out of sync, expected 'list', received '%s'"), msg.EventType)
+		return nil, errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "list", msg.EventType)
 	} else if msg.Error {
 		return nil, errors.Errorf(tr("command failed: %s"), msg.Message)
 	} else {
@@ -415,7 +415,7 @@ func (disc *PluggableDiscovery) StartSync(size int) (<-chan *Event, error) {
 	if msg, err := disc.waitMessage(time.Second * 10); err != nil {
 		return nil, fmt.Errorf(tr("calling %[1]s: %[2]w"), "START_SYNC", err)
 	} else if msg.EventType != "start_sync" {
-		return nil, errors.Errorf(tr("communication out of sync, expected 'start_sync', received '%s'"), msg.EventType)
+		return nil, errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "start_sync", msg.EventType)
 	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
 		return nil, errors.Errorf(tr("command failed: %s"), msg.Message)
 	}

--- a/arduino/discovery/discovery.go
+++ b/arduino/discovery/discovery.go
@@ -312,8 +312,10 @@ func (disc *PluggableDiscovery) Run() (err error) {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "HELLO", err)
 	} else if msg.EventType != "hello" {
 		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "hello", msg.EventType)
-	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
+	} else if msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
+	} else if strings.ToUpper(msg.Message) != "OK" {
+		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "OK", msg.Message)
 	} else if msg.ProtocolVersion > 1 {
 		return errors.Errorf(tr("protocol version not supported: requested 1, got %d"), msg.ProtocolVersion)
 	}
@@ -333,8 +335,10 @@ func (disc *PluggableDiscovery) Start() error {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "START", err)
 	} else if msg.EventType != "start" {
 		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "start", msg.EventType)
-	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
+	} else if msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
+	} else if strings.ToUpper(msg.Message) != "OK" {
+		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "OK", msg.Message)
 	}
 	disc.statusMutex.Lock()
 	defer disc.statusMutex.Unlock()
@@ -353,8 +357,10 @@ func (disc *PluggableDiscovery) Stop() error {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "STOP", err)
 	} else if msg.EventType != "stop" {
 		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "stop", msg.EventType)
-	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
+	} else if msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
+	} else if strings.ToUpper(msg.Message) != "OK" {
+		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "OK", msg.Message)
 	}
 	disc.statusMutex.Lock()
 	defer disc.statusMutex.Unlock()
@@ -376,8 +382,10 @@ func (disc *PluggableDiscovery) Quit() error {
 		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "QUIT", err)
 	} else if msg.EventType != "quit" {
 		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "quit", msg.EventType)
-	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
+	} else if msg.Error {
 		return errors.Errorf(tr("command failed: %s"), msg.Message)
+	} else if strings.ToUpper(msg.Message) != "OK" {
+		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "OK", msg.Message)
 	}
 	disc.killProcess()
 	return nil
@@ -416,8 +424,10 @@ func (disc *PluggableDiscovery) StartSync(size int) (<-chan *Event, error) {
 		return nil, fmt.Errorf(tr("calling %[1]s: %[2]w"), "START_SYNC", err)
 	} else if msg.EventType != "start_sync" {
 		return nil, errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "start_sync", msg.EventType)
-	} else if strings.ToUpper(msg.Message) != "OK" || msg.Error {
+	} else if msg.Error {
 		return nil, errors.Errorf(tr("command failed: %s"), msg.Message)
+	} else if strings.ToUpper(msg.Message) != "OK" {
+		return nil, errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "OK", msg.Message)
 	}
 
 	disc.statusMutex.Lock()

--- a/arduino/monitor/monitor.go
+++ b/arduino/monitor/monitor.go
@@ -145,7 +145,7 @@ func (mon *PluggableMonitor) waitMessage(timeout time.Duration, expectedEvt stri
 	if msg.EventType != expectedEvt {
 		return msg, fmt.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), expectedEvt, msg.EventType)
 	}
-	if msg.Message != "OK" || msg.Error {
+	if strings.ToUpper(msg.Message) != "OK" || msg.Error {
 		return msg, fmt.Errorf(tr("command '%[1]s' failed: %[2]s"), expectedEvt, msg.Message)
 	}
 	return msg, nil

--- a/arduino/monitor/monitor.go
+++ b/arduino/monitor/monitor.go
@@ -145,8 +145,11 @@ func (mon *PluggableMonitor) waitMessage(timeout time.Duration, expectedEvt stri
 	if msg.EventType != expectedEvt {
 		return msg, fmt.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), expectedEvt, msg.EventType)
 	}
-	if strings.ToUpper(msg.Message) != "OK" || msg.Error {
+	if msg.Error {
 		return msg, fmt.Errorf(tr("command '%[1]s' failed: %[2]s"), expectedEvt, msg.Message)
+	}
+	if strings.ToUpper(msg.Message) != "OK" {
+		return msg, fmt.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "OK", msg.Message)
 	}
 	return msg, nil
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
Allow case-insensitive `ok` or `OK` replies from pluggable discoveries and monitors.

**What is the current behavior?**
If a discovery or a monitor replies to a command, for example, with:
```
{
  "eventType": "describe",
  "message": "ok",
  "port_description": {
    "protocol": "serial",
    "configuration_parameters": {
    }
  }
}
```

the answer is treated as an error because it requires a **case-sensitive** `"OK"`.
Also. the error message is completely useless:

```
Error getting port settings details: Port monitor error: command 'describe' failed: ok
```

**What is the new behavior?**
The response is accepted for any case-insensitive `ok` / `OK`

**Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No breaking changes
