### PR TITLE
bugfix: Install pluggable monitor dependencies together with a platform

### DIFF
--- a/arduino/cores/packagemanager/download.go
+++ b/arduino/cores/packagemanager/download.go
@@ -96,14 +96,23 @@ func (pm *PackageManager) FindPlatformReleaseDependencies(item *PlatformReferenc
 		return nil, nil, fmt.Errorf(tr("getting tool dependencies for platform %[1]s: %[2]s"), release.String(), err)
 	}
 
-	// discovery dependencies differ from normal tool since we always want to use the latest \
+	// discovery dependencies differ from normal tool since we always want to use the latest
 	// available version for the platform package
 	discoveryDependencies, err := pm.Packages.GetPlatformReleaseDiscoveryDependencies(release)
 	if err != nil {
 		return nil, nil, fmt.Errorf(tr("getting discovery dependencies for platform %[1]s: %[2]s"), release.String(), err)
 	}
+	toolDeps = append(toolDeps, discoveryDependencies...)
 
-	return release, append(toolDeps, discoveryDependencies...), nil
+	// monitor dependencies differ from normal tool since we always want to use the latest
+	// available version for the platform package
+	monitorDependencies, err := pm.Packages.GetPlatformReleaseMonitorDependencies(release)
+	if err != nil {
+		return nil, nil, fmt.Errorf(tr("getting monitor dependencies for platform %[1]s: %[2]s"), release.String(), err)
+	}
+	toolDeps = append(toolDeps, monitorDependencies...)
+
+	return release, toolDeps, nil
 }
 
 // DownloadToolRelease downloads a ToolRelease. If the tool is already downloaded a nil Downloader

--- a/arduino/cores/packagemanager/package_manager_test.go
+++ b/arduino/cores/packagemanager/package_manager_test.go
@@ -443,6 +443,16 @@ func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 	require.Len(t, tools, 6)
 }
 
+func TestFindPlatformReleaseDependencies(t *testing.T) {
+	pm := packagemanager.NewPackageManager(nil, nil, nil, nil)
+	pm.LoadPackageIndexFromFile(paths.New("testdata", "package_tooltest_index.json"))
+	pl, tools, err := pm.FindPlatformReleaseDependencies(&packagemanager.PlatformReference{Package: "test", PlatformArchitecture: "avr"})
+	require.NoError(t, err)
+	require.NotNil(t, pl)
+	require.Len(t, tools, 3)
+	require.Equal(t, "[test:some-tool@0.42.0 test:discovery-tool@0.42.0 test:monitor-tool@0.42.0]", fmt.Sprint(tools))
+}
+
 func TestLegacyPackageConversionToPluggableDiscovery(t *testing.T) {
 	// Pass nil, since these paths are only used for installing
 	pm := packagemanager.NewPackageManager(nil, nil, nil, nil)

--- a/arduino/cores/packagemanager/testdata/package_tooltest_index.json
+++ b/arduino/cores/packagemanager/testdata/package_tooltest_index.json
@@ -1,0 +1,215 @@
+{
+  "packages": [
+    {
+      "name": "test",
+      "maintainer": "foo",
+      "websiteURL": "http://example.com/",
+      "email": "foo@example.com",
+      "help": {
+        "online": "http://example.com"
+      },
+      "platforms": [
+        {
+          "name": "Foo Boards",
+          "architecture": "avr",
+          "version": "1.2.3",
+          "category": "Contributed",
+          "help": {
+            "online": "http://example.com/"
+          },
+          "url": "http://downloads.arduino.cc/cores/avr-1.8.3.tar.bz2",
+          "archiveFileName": "avr-1.8.3.tar.bz2",
+          "checksum": "SHA-256:de8a9b982477762d3d3e52fc2b682cdd8ff194dc3f1d46f4debdea6a01b33c14",
+          "size": "4941548",
+          "boards": [],
+          "toolsDependencies": [
+            {
+              "packager": "test",
+              "name": "some-tool",
+              "version": "0.42.0"
+            }
+          ],
+          "discoveryDependencies": [
+            {
+              "packager": "test",
+              "name": "discovery-tool"
+            }
+          ],
+          "monitorDependencies": [
+            {
+              "packager": "test",
+              "name": "monitor-tool"
+            }
+          ]
+        }
+      ],
+      "tools": [
+        {
+          "name": "some-tool",
+          "version": "0.42.0",
+          "systems": [
+            {
+              "host": "i686-pc-linux-gnu",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_32bit.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_32bit.tar.gz",
+              "size": 1633143,
+              "checksum": "SHA-256:2fb17882018f3eefeaf933673cbc42cea83ce739503880ccc7f9cf521de0e513"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_64bit.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_64bit.tar.gz",
+              "size": 1688362,
+              "checksum": "SHA-256:e0e55ea9c5e05f12af5d89dc3a69d63e12211f54122b4bf45a7cab9f0a6f89e5"
+            },
+            {
+              "host": "i686-mingw32",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Windows_32bit.zip",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Windows_32bit.zip",
+              "size": 1742668,
+              "checksum": "SHA-256:4acfe521d6fc3b29643ab69ced246d7dd20637772fc79fc3e509829c18290d90"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Windows_64bit.zip",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Windows_64bit.zip",
+              "size": 1709333,
+              "checksum": "SHA-256:82b2edea04f7c97b98cbb04de95ec48be95de64fa5f196d730dc824d7558b952"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_macOS_64bit.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_macOS_64bit.tar.gz",
+              "size": 964596,
+              "checksum": "SHA-256:ec4be0f5c1ed6af3f31bb01ed6a5433274a76a1dc7cb68d39813b2b0475d7337"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_ARMv6.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_ARMv6.tar.gz",
+              "size": 1570847,
+              "checksum": "SHA-256:9341e2541ad41ee2cdaad1e8d851254c8bce63c937cdafd57db7d1439d8ced59"
+            },
+            {
+              "host": "arm64-linux-gnueabihf",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_ARM64.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_ARM64.tar.gz",
+              "size": 1580108,
+              "checksum": "SHA-256:1da38f94be8db69bbe26d6a95692b665f6bc9bf89aa62b58d4e4cfb0f7fd8733"
+            }
+          ]
+        },
+        {
+          "name": "discovery-tool",
+          "version": "0.42.0",
+          "systems": [
+            {
+              "host": "i686-pc-linux-gnu",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_32bit.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_32bit.tar.gz",
+              "size": 1633143,
+              "checksum": "SHA-256:2fb17882018f3eefeaf933673cbc42cea83ce739503880ccc7f9cf521de0e513"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_64bit.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_64bit.tar.gz",
+              "size": 1688362,
+              "checksum": "SHA-256:e0e55ea9c5e05f12af5d89dc3a69d63e12211f54122b4bf45a7cab9f0a6f89e5"
+            },
+            {
+              "host": "i686-mingw32",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Windows_32bit.zip",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Windows_32bit.zip",
+              "size": 1742668,
+              "checksum": "SHA-256:4acfe521d6fc3b29643ab69ced246d7dd20637772fc79fc3e509829c18290d90"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Windows_64bit.zip",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Windows_64bit.zip",
+              "size": 1709333,
+              "checksum": "SHA-256:82b2edea04f7c97b98cbb04de95ec48be95de64fa5f196d730dc824d7558b952"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_macOS_64bit.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_macOS_64bit.tar.gz",
+              "size": 964596,
+              "checksum": "SHA-256:ec4be0f5c1ed6af3f31bb01ed6a5433274a76a1dc7cb68d39813b2b0475d7337"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_ARMv6.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_ARMv6.tar.gz",
+              "size": 1570847,
+              "checksum": "SHA-256:9341e2541ad41ee2cdaad1e8d851254c8bce63c937cdafd57db7d1439d8ced59"
+            },
+            {
+              "host": "arm64-linux-gnueabihf",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_ARM64.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_ARM64.tar.gz",
+              "size": 1580108,
+              "checksum": "SHA-256:1da38f94be8db69bbe26d6a95692b665f6bc9bf89aa62b58d4e4cfb0f7fd8733"
+            }
+          ]
+        },
+        {
+          "name": "monitor-tool",
+          "version": "0.42.0",
+          "systems": [
+            {
+              "host": "i686-pc-linux-gnu",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_32bit.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_32bit.tar.gz",
+              "size": 1633143,
+              "checksum": "SHA-256:2fb17882018f3eefeaf933673cbc42cea83ce739503880ccc7f9cf521de0e513"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_64bit.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_64bit.tar.gz",
+              "size": 1688362,
+              "checksum": "SHA-256:e0e55ea9c5e05f12af5d89dc3a69d63e12211f54122b4bf45a7cab9f0a6f89e5"
+            },
+            {
+              "host": "i686-mingw32",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Windows_32bit.zip",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Windows_32bit.zip",
+              "size": 1742668,
+              "checksum": "SHA-256:4acfe521d6fc3b29643ab69ced246d7dd20637772fc79fc3e509829c18290d90"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Windows_64bit.zip",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Windows_64bit.zip",
+              "size": 1709333,
+              "checksum": "SHA-256:82b2edea04f7c97b98cbb04de95ec48be95de64fa5f196d730dc824d7558b952"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_macOS_64bit.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_macOS_64bit.tar.gz",
+              "size": 964596,
+              "checksum": "SHA-256:ec4be0f5c1ed6af3f31bb01ed6a5433274a76a1dc7cb68d39813b2b0475d7337"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_ARMv6.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_ARMv6.tar.gz",
+              "size": 1570847,
+              "checksum": "SHA-256:9341e2541ad41ee2cdaad1e8d851254c8bce63c937cdafd57db7d1439d8ced59"
+            },
+            {
+              "host": "arm64-linux-gnueabihf",
+              "archiveFileName": "serial-discovery_v1.3.0-rc1_Linux_ARM64.tar.bz2",
+              "url": "https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.3.0-rc1_Linux_ARM64.tar.gz",
+              "size": 1580108,
+              "checksum": "SHA-256:1da38f94be8db69bbe26d6a95692b665f6bc9bf89aa62b58d4e4cfb0f7fd8733"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
Fixed a bug that prevented pluggable monitors to be installed

**What is the current behavior?**
non-builtin pluggable monitors are not installed (see https://github.com/arduino/arduino-cli/issues/1564)

**What is the new behavior?**
non-builtin pluggable monitors are now installed

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No breaking changes
