### PR TITLE
Improved error logging for pluggable monitors / Fixed resource leak in some rare conditions

### DIFF
--- a/arduino/monitor/monitor.go
+++ b/arduino/monitor/monitor.go
@@ -111,7 +111,7 @@ func (mon *PluggableMonitor) jsonDecodeLoop(in io.Reader, outChan chan<- *monito
 		if err := decoder.Decode(&msg); err != nil {
 			mon.incomingMessagesError = err
 			close(outChan)
-			mon.log.Errorf("stopped decode loop")
+			mon.log.Errorf("stopped decode loop: %s", err)
 			return
 		}
 		mon.log.

--- a/commands/monitor/monitor.go
+++ b/commands/monitor/monitor.go
@@ -77,11 +77,13 @@ func Monitor(ctx context.Context, req *rpc.MonitorRequest) (*PortProxy, *pluggab
 
 	descriptor, err := m.Describe()
 	if err != nil {
+		m.Quit()
 		return nil, nil, &arduino.FailedMonitorError{Cause: err}
 	}
 
 	monIO, err := m.Open(req.GetPort().GetAddress(), req.GetPort().GetProtocol())
 	if err != nil {
+		m.Quit()
 		return nil, nil, &arduino.FailedMonitorError{Cause: err}
 	}
 

--- a/commands/monitor/monitor.go
+++ b/commands/monitor/monitor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/arduino/arduino-cli/i18n"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-properties-orderedmap"
+	"github.com/sirupsen/logrus"
 )
 
 var tr = i18n.Tr
@@ -85,9 +86,12 @@ func Monitor(ctx context.Context, req *rpc.MonitorRequest) (*PortProxy, *pluggab
 	}
 
 	for _, setting := range req.GetPortConfiguration().Settings {
-		m.Configure(setting.SettingId, setting.Value)
+		if err := m.Configure(setting.SettingId, setting.Value); err != nil {
+			logrus.Errorf("Could not set configuration %s=%s: %s", setting.SettingId, setting.Value, err)
+		}
 	}
 
+	logrus.Infof("Port %s successfully opened", req.GetPort().GetAddress())
 	return &PortProxy{
 		rw:               monIO,
 		changeSettingsCB: m.Configure,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
* Added more logging for pluggable monitor
* Force monitor close if the port cannot be opened (fix resource leak)

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
no breaking change
