### PR TITLE
Fix panic calling compile with wrong FQBN

### DIFF
--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -119,12 +119,10 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 		PlatformArchitecture: fqbn.PlatformArch,
 	})
 	if targetPlatform == nil || pm.GetInstalledPlatformRelease(targetPlatform) == nil {
-		// TODO: Move this error message in `cli` module
-		// errorMessage := fmt.Sprintf(
-		// 	"\"%[1]s:%[2]s\" platform is not installed, please install it by running \""+
-		// 		version.GetAppName()+" core install %[1]s:%[2]s\".", fqbn.Package, fqbn.PlatformArch)
-		// feedback.Error(errorMessage)
-		return nil, &arduino.PlatformNotFoundError{Platform: targetPlatform.String(), Cause: fmt.Errorf(tr("platform not installed"))}
+		return nil, &arduino.PlatformNotFoundError{
+			Platform: fmt.Sprintf("%s:%s", fqbn.Package, fqbn.PlatformArch),
+			Cause:    fmt.Errorf(tr("platform not installed")),
+		}
 	}
 
 	builderCtx := &types.Context{}

--- a/test/test_compile_part_4.py
+++ b/test/test_compile_part_4.py
@@ -378,3 +378,22 @@ def test_compile_without_upload_and_fqbn(run_command, data_dir):
     res = run_command(["compile", sketch_path])
     assert res.failed
     assert "Error during build: Missing FQBN (Fully Qualified Board Name)" in res.stderr
+
+
+def test_compile_non_installed_platform_with_wrong_packager_and_arch(run_command, data_dir):
+    assert run_command(["update"])
+
+    # Create a sketch
+    sketch_name = "SketchSimple"
+    sketch_path = Path(data_dir, sketch_name)
+    assert run_command(["sketch", "new", sketch_path])
+
+    # Compile with wrong packager
+    res = run_command(["compile", "-b", "wrong:avr:uno", sketch_path])
+    assert res.failed
+    assert "Error during build: Platform 'wrong:avr' not found: platform not installed" in res.stderr
+
+    # Compile with wrong arch
+    res = run_command(["compile", "-b", "arduino:wrong:uno", sketch_path])
+    assert res.failed
+    assert "Error during build: Platform 'arduino:wrong' not found: platform not installed" in res.stderr


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Fixes a panic on `compile`.

- **What is the current behavior?**

```
$ arduino-cli compile -b aduino:avr:uno ~/Documents/Arduino/Blink/
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x38 pc=0x10128f424]

goroutine 1 [running]:
github.com/arduino/arduino-cli/arduino/cores.(*Platform).String(...)
	/Users/alien/workspace/arduino-cli/arduino/cores/cores.go:262
github.com/arduino/arduino-cli/commands/compile.Compile(0x1016a14a0, 0x1400003c0c8, 0x140001c5c58, 0x10168e3a8, 0x14000010018, 0x10168e3a8, 0x14000010020, 0x14000412d00, 0x0, 0x0, ...)
	/Users/alien/workspace/arduino-cli/commands/compile/compile.go:127 +0xa44
github.com/arduino/arduino-cli/cli/compile.run(0x140003faf00, 0x140004124e0, 0x1, 0x3)
	/Users/alien/workspace/arduino-cli/cli/compile/compile.go:194 +0x41c
github.com/spf13/cobra.(*Command).execute(0x140003faf00, 0x140004124b0, 0x3, 0x3, 0x140003faf00, 0x140004124b0)
	/Users/alien/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:860 +0x1d0
github.com/spf13/cobra.(*Command).ExecuteC(0x14000301680, 0x1, 0x1, 0x0)
	/Users/alien/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x264
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/alien/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
	/Users/alien/workspace/arduino-cli/main.go:31 +0xd4
```

```
$ arduino-cli compile -b arduino:av:uno ~/Documents/Arduino/Blink/
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x38 pc=0x1032df424]

goroutine 1 [running]:
github.com/arduino/arduino-cli/arduino/cores.(*Platform).String(...)
	/Users/alien/workspace/arduino-cli/arduino/cores/cores.go:262
github.com/arduino/arduino-cli/commands/compile.Compile(0x1036f14a0, 0x140001a4008, 0x1400009bc58, 0x1036de3a8, 0x140001b0008, 0x1036de3a8, 0x140001b0010, 0x1400043cd00, 0x0, 0x0, ...)
	/Users/alien/workspace/arduino-cli/commands/compile/compile.go:127 +0xa44
github.com/arduino/arduino-cli/cli/compile.run(0x14000426f00, 0x1400043c4e0, 0x1, 0x3)
	/Users/alien/workspace/arduino-cli/cli/compile/compile.go:194 +0x41c
github.com/spf13/cobra.(*Command).execute(0x14000426f00, 0x1400043c4b0, 0x3, 0x3, 0x14000426f00, 0x1400043c4b0)
	/Users/alien/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:860 +0x1d0
github.com/spf13/cobra.(*Command).ExecuteC(0x1400032d680, 0x1, 0x1, 0x0)
	/Users/alien/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x264
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/alien/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
	/Users/alien/workspace/arduino-cli/main.go:31 +0xd4
```

* **What is the new behavior?**

```
$ arduino-cli compile -b aduino:avr:uno ~/Documents/Arduino/Blink/

Error during build: Platform 'arduino:vr' not found: platform not installed                                                                        
```

```
$ arduino-cli compile -b arduino:av:uno  ~/Documents/Arduino/Blink/

Error during build: Platform 'arduino:av' not found: platform not installed
```

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

Fixes #1531.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
