### PR TITLE
Sample command to solve compile or upload issue is now shown to CLI users

### DIFF
--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -286,7 +286,7 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 			})
 
 			if platform != nil {
-				feedback.Errorf(tr("Try running `%s core install %s`", globals.VersionInfo.Application, platformErr.Platform))
+				feedback.Errorf(tr("Try running %s", fmt.Sprintf("`%s core install %s`", globals.VersionInfo.Application, platformErr.Platform)))
 			} else {
 				feedback.Errorf(tr("Platform %s is not found in any known index", platformErr.Platform))
 			}

--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -19,12 +19,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
+	"strings"
 
+	"github.com/arduino/arduino-cli/arduino"
+	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/arduino/discovery"
 	"github.com/arduino/arduino-cli/arduino/sketch"
 	"github.com/arduino/arduino-cli/cli/arguments"
 	"github.com/arduino/arduino-cli/cli/feedback"
+	"github.com/arduino/arduino-cli/cli/globals"
 	"github.com/arduino/arduino-cli/cli/output"
 	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/configuration"
@@ -264,6 +269,28 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 	})
 	if compileError != nil && output.OutputFormat != "json" {
 		feedback.Errorf(tr("Error during build: %v"), compileError)
+
+		// Check the error type to give the user better feedback on how
+		// to resolve it
+		var platformErr *arduino.PlatformNotFoundError
+		if errors.As(compileError, &platformErr) {
+			split := strings.Split(platformErr.Platform, ":")
+			if len(split) < 2 {
+				panic(tr("Platform ID is not correct"))
+			}
+
+			pm := commands.GetPackageManager(inst.GetId())
+			platform := pm.FindPlatform(&packagemanager.PlatformReference{
+				Package:              split[0],
+				PlatformArchitecture: split[1],
+			})
+
+			if platform != nil {
+				feedback.Errorf(tr("Try running `%s core install %s`", globals.VersionInfo.Application, platformErr.Platform))
+			} else {
+				feedback.Errorf(tr("Platform %s is not found in any known index", platformErr.Platform))
+			}
+		}
 		os.Exit(errorcodes.ErrGeneric)
 	}
 }

--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -268,7 +268,7 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 		BuilderResult: compileRes,
 		Success:       compileError == nil,
 	})
-	if compileError != nil && output.OutputFormat != "json" {
+	if compileError != nil {
 		feedback.Errorf(tr("Error during build: %v"), compileError)
 
 		// Check the error type to give the user better feedback on how

--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -288,7 +289,7 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 			if platform != nil {
 				feedback.Errorf(tr("Try running %s", fmt.Sprintf("`%s core install %s`", globals.VersionInfo.Application, platformErr.Platform)))
 			} else {
-				feedback.Errorf(tr("Platform %s is not found in any known index", platformErr.Platform))
+				feedback.Errorf(tr("Platform %s is not found in any known index\nMaybe you need to add a 3rd party URL?", platformErr.Platform))
 			}
 		}
 		os.Exit(errorcodes.ErrGeneric)

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -132,7 +132,7 @@ func runUploadCommand(command *cobra.Command, args []string) {
 			})
 
 			if platform != nil {
-				feedback.Errorf(tr("Try running `%s core install %s`", globals.VersionInfo.Application, platformErr.Platform))
+				feedback.Errorf(tr("Try running %s", fmt.Sprintf("`%s core install %s`", globals.VersionInfo.Application, platformErr.Platform)))
 			} else {
 				feedback.Errorf(tr("Platform %s is not found in any known index", platformErr.Platform))
 			}

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -18,6 +18,7 @@ package upload
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -134,7 +135,7 @@ func runUploadCommand(command *cobra.Command, args []string) {
 			if platform != nil {
 				feedback.Errorf(tr("Try running %s", fmt.Sprintf("`%s core install %s`", globals.VersionInfo.Application, platformErr.Platform)))
 			} else {
-				feedback.Errorf(tr("Platform %s is not found in any known index", platformErr.Platform))
+				feedback.Errorf(tr("Platform %s is not found in any known index\nMaybe you need to add a 3rd party URL?", platformErr.Platform))
 			}
 		}
 		os.Exit(errorcodes.ErrGeneric)

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -67,7 +67,12 @@ func SupportedUserFields(ctx context.Context, req *rpc.SupportedUserFieldsReques
 	}
 
 	_, platformRelease, _, boardProperties, _, err := pm.ResolveFQBN(fqbn)
-	if err != nil {
+	if platformRelease == nil {
+		return nil, &arduino.PlatformNotFoundError{
+			Platform: fmt.Sprintf("%s:%s", fqbn.Package, fqbn.PlatformArch),
+			Cause:    err,
+		}
+	} else if err != nil {
 		return nil, &arduino.UnknownFQBNError{Cause: err}
 	}
 
@@ -286,7 +291,12 @@ func runProgramAction(pm *packagemanager.PackageManager,
 
 	// Find target board and board properties
 	_, boardPlatform, board, boardProperties, buildPlatform, err := pm.ResolveFQBN(fqbn)
-	if err != nil {
+	if boardPlatform == nil {
+		return &arduino.PlatformNotFoundError{
+			Platform: fmt.Sprintf("%s:%s", fqbn.Package, fqbn.PlatformArch),
+			Cause:    err,
+		}
+	} else if err != nil {
 		return &arduino.UnknownFQBNError{Cause: err}
 	}
 	logrus.

--- a/test/test_compile_part_4.py
+++ b/test/test_compile_part_4.py
@@ -392,8 +392,26 @@ def test_compile_non_installed_platform_with_wrong_packager_and_arch(run_command
     res = run_command(["compile", "-b", "wrong:avr:uno", sketch_path])
     assert res.failed
     assert "Error during build: Platform 'wrong:avr' not found: platform not installed" in res.stderr
+    assert "Platform wrong:avr is not found in any known index" in res.stderr
 
     # Compile with wrong arch
     res = run_command(["compile", "-b", "arduino:wrong:uno", sketch_path])
     assert res.failed
     assert "Error during build: Platform 'arduino:wrong' not found: platform not installed" in res.stderr
+    assert "Platform arduino:wrong is not found in any known index" in res.stderr
+
+
+def test_compile_with_known_platform_not_installed(run_command, data_dir):
+    assert run_command(["update"])
+
+    # Create a sketch
+    sketch_name = "SketchSimple"
+    sketch_path = Path(data_dir, sketch_name)
+    assert run_command(["sketch", "new", sketch_path])
+
+    # Try to compile using a platform found in the index but not installed
+    res = run_command(["compile", "-b", "arduino:avr:uno", sketch_path])
+    assert res.failed
+    assert "Error during build: Platform 'arduino:avr' not found: platform not installed" in res.stderr
+    # Verifies command to fix error is shown to user
+    assert "Try running `arduino-cli core install arduino:avr`" in res.stderr


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Enhances certain error messages of `compile` and `upload` commands.

- **What is the current behavior?**

```
$ arduino-cli core list


$ arduino-cli compile -b arduino:samd:nano_33_iot ~/Arduino/Blink

Error during build: Platform 'arduino:samd' not found: platform not installed

$ arduino-cli compile -b adafruit:samd:adafruit_feather_m4 ~/Arduino/Blink

Error during build: Platform 'adafruit:samd' not found: platform not installed

$ arduino-cli upload -b arduino:samd:nano_33_iot ~/Arduino/Blink -p /dev/ttyACM1
Error during Upload: Unknown FQBN: platform arduino:samd is not installed

$ arduino-cli upload -b adafruit:samd:adafruit_feather_m4 ~/Arduino/Blink -p /dev/ttyACM1
Error during Upload: Unknown FQBN: unknown package adafruit
```

* **What is the new behavior?**

```
$ arduino-cli core list


$ arduino-cli compile -b arduino:samd:nano_33_iot ~/Arduino/Blink

Error during build: Platform 'arduino:samd' not found: platform not installed
Try running `arduino-cli core install arduino:samd`

$ arduino-cli compile -b adafruit:samd:adafruit_feather_m4 ~/Arduino/Blink

Error during build: Platform 'adafruit:samd' not found: platform not installed
Platform adafruit:samd is not found in any known index

$ arduino-cli upload -b arduino:samd:nano_33_iot ~/Arduino/Blink -p /dev/ttyACM1
Error during Upload: Platform 'arduino:samd' not found: platform arduino:samd is not installed
Try running `arduino-cli core install arduino:samd`

$ arduino-cli upload -b adafruit:samd:adafruit_feather_m4 ~/Arduino/Blink -p /dev/ttyACM1
Error during Upload: Platform 'adafruit:samd' not found: unknown package adafruit
Platform adafruit:samd is not found in any known index
```


- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

Closes #1356.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
