### PR TITLE
Add ip flag to daemon command

### DIFF
--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -44,6 +44,7 @@ import (
 
 var (
 	tr           = i18n.Tr
+	ip           string
 	daemonize    bool
 	debug        bool
 	debugFilters []string
@@ -59,6 +60,7 @@ func NewCommand() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Run:     runDaemonCommand,
 	}
+	daemonCommand.PersistentFlags().StringVar(&ip, "ip", "127.0.0.1", tr("The IP address the daemon will listen to"))
 	daemonCommand.PersistentFlags().String("port", "", tr("The TCP port the daemon will listen to"))
 	configuration.Settings.BindPFlag("daemon.port", daemonCommand.PersistentFlags().Lookup("port"))
 	daemonCommand.Flags().BoolVar(&daemonize, "daemonize", false, tr("Do not terminate daemon process if the parent process dies"))
@@ -112,7 +114,6 @@ func runDaemonCommand(cmd *cobra.Command, args []string) {
 		}()
 	}
 
-	ip := "127.0.0.1"
 	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%s", ip, port))
 	if err != nil {
 		// Invalid port, such as "Foo"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Adds a new flag to an existing command.

- **What is the current behavior?**

A user running `daemon` has no way of setting a custom IP. 

* **What is the new behavior?**

A user can now use the `--ip` flag to use a custom IP to listen for gRPC requests.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

This flag was also introduced in #1622 but it won't be merged into `master` until the whole configs migration is finished.
Since this is small change and has been asked by the community we decided it was worth releasing it before the whole configs migration.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
