### PR TITLE
Discoveries are now closed and unregistered after failure

### DIFF
--- a/arduino/discovery/discovery.go
+++ b/arduino/discovery/discovery.go
@@ -374,21 +374,12 @@ func (disc *PluggableDiscovery) Stop() error {
 }
 
 // Quit terminates the discovery. No more commands can be accepted by the discovery.
-func (disc *PluggableDiscovery) Quit() error {
-	if err := disc.sendCommand("QUIT\n"); err != nil {
-		return err
-	}
-	if msg, err := disc.waitMessage(time.Second * 10); err != nil {
-		return fmt.Errorf(tr("calling %[1]s: %[2]w"), "QUIT", err)
-	} else if msg.EventType != "quit" {
-		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "quit", msg.EventType)
-	} else if msg.Error {
-		return errors.Errorf(tr("command failed: %s"), msg.Message)
-	} else if strings.ToUpper(msg.Message) != "OK" {
-		return errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "OK", msg.Message)
+func (disc *PluggableDiscovery) Quit() {
+	_ = disc.sendCommand("QUIT\n")
+	if _, err := disc.waitMessage(time.Second * 5); err != nil {
+		logrus.Errorf("Quitting discovery %s: %s", disc.id, err)
 	}
 	disc.killProcess()
-	return nil
 }
 
 // List executes an enumeration of the ports and returns a list of the available

--- a/arduino/discovery/discovery_client/main.go
+++ b/arduino/discovery/discovery_client/main.go
@@ -135,9 +135,7 @@ out:
 	}
 
 	for _, disc := range discoveries {
-		if err := disc.Quit(); err != nil {
-			log.Fatal("Error stopping discovery:", err)
-		}
+		disc.Quit()
 		fmt.Println("Discovery QUITed")
 		for disc.State() == discovery.Alive {
 			time.Sleep(time.Millisecond)

--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -296,15 +296,14 @@ func Watch(instanceID int32, interrupt <-chan bool) (<-chan *rpc.BoardListWatchR
 					Error:     boardsError,
 				}
 			case <-interrupt:
-				errs := dm.StopAll()
-				if len(errs) > 0 {
+				for _, err := range dm.StopAll() {
+					// Discoveries that return errors have their process
+					// closed and are removed from the list of discoveries
+					// in the manager
 					outChan <- &rpc.BoardListWatchResponse{
 						EventType: "error",
-						Error:     tr("stopping discoveries: %s", errs),
+						Error:     tr("stopping discoveries: %s", err),
 					}
-					// Don't close the channel if quitting all discoveries
-					// failed, otherwise some processes might be left running.
-					continue
 				}
 				return
 			}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Enhances internal handling of pluggable discoveries.

- **What is the current behavior?**

If sending a command to a discovery returns an error its process is left running, this often causes subsequent commands to fail.

* **What is the new behavior?**

If sending a command to a discovery returns an error now its process is killed and the discovery removed from the list of running discoveries.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Nope.

* **Other information**:

None.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
