### PR TITLE
board list now returns partial results in case of errors

### DIFF
--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -70,7 +70,6 @@ func runListCommand(cmd *cobra.Command, args []string) {
 	})
 	if err != nil {
 		feedback.Errorf(tr("Error detecting boards: %v"), err)
-		os.Exit(errorcodes.ErrNetwork)
 	}
 	feedback.PrintResult(result{ports})
 }

--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -174,7 +174,9 @@ func identify(pm *packagemanager.PackageManager, port *discovery.Port) ([]*rpc.B
 	return boards, nil
 }
 
-// List FIXMEDOC
+// List returns a list of boards found by the loaded discoveries.
+// In case of errors partial results from discoveries that didn't fail
+// are returned.
 func List(req *rpc.BoardListRequest) (r []*rpc.DetectedPort, e error) {
 	tags := map[string]string{}
 	// Use defer func() to evaluate tags map when function returns
@@ -208,9 +210,6 @@ func List(req *rpc.BoardListRequest) (r []*rpc.DetectedPort, e error) {
 
 	retVal := []*rpc.DetectedPort{}
 	ports, errs := pm.DiscoveryManager().List()
-	if len(errs) > 0 {
-		return nil, &arduino.UnavailableError{Message: tr("Error getting board list"), Cause: fmt.Errorf("%v", errs)}
-	}
 	for _, port := range ports {
 		boards, err := identify(pm, port)
 		if err != nil {
@@ -225,7 +224,9 @@ func List(req *rpc.BoardListRequest) (r []*rpc.DetectedPort, e error) {
 		}
 		retVal = append(retVal, b)
 	}
-
+	if len(errs) > 0 {
+		return retVal, &arduino.UnavailableError{Message: tr("Error getting board list"), Cause: fmt.Errorf("%v", errs)}
+	}
 	return retVal, nil
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Makes `arduino-cli` more resilient to errors.

- **What is the current behavior?**

Calling `arduino-cli board list` runs all discoveries installed, by default `builtin:serial-discovery` and `builtin:mdns-discovery` are installed and ran.

If one of those discoveries return an error the whole command fails.

* **What is the new behavior?**

`arduino-cli board list` now prints any error from discoveries and then eventual partial results obtains from other discoveries.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

None.

* **Other information**:

Fixes #1666.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
