### PR TITLE
Fix a couple memory leaks caused by unclosed file handles

### DIFF
--- a/arduino/security/signatures.go
+++ b/arduino/security/signatures.go
@@ -42,6 +42,7 @@ func VerifyArduinoDetachedSignature(targetPath *paths.Path, signaturePath *paths
 	if err != nil {
 		panic("could not find bundled signature keys")
 	}
+	defer arduinoKeyringFile.Close()
 	return VerifySignature(targetPath, signaturePath, arduinoKeyringFile)
 }
 

--- a/i18n/cmd/po/parser.go
+++ b/i18n/cmd/po/parser.go
@@ -31,6 +31,7 @@ func Parse(filename string) MessageCatalog {
 	}
 
 	file, err := os.Open(filename)
+	defer file.Close()
 
 	if err != nil {
 		fmt.Println(err.Error())


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

It's a bug fix.

- **What is the current behavior?**

I have been using arduino-cli as a Go library to run batch operations like installing multiple libraries. I noticed the process was leaking memory quite quickly.

* **What is the new behavior?**

With these two fixes, memory consumption is much more stable. I think there might be still other memory leaks somewhere else, but for now this is what I found.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

No breaking change.

* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
