### PR TITLE
Fix error being printed in index parsing during first start

### DIFF
--- a/cli/instance/instance.go
+++ b/cli/instance/instance.go
@@ -159,7 +159,7 @@ func CreateInstanceAndRunFirstUpdate() *rpc.Instance {
 	// we must use instance.Create instead of instance.CreateAndInit for the
 	// reason stated above.
 	if err := FirstUpdate(inst); err != nil {
-		feedback.Errorf(tr("Error updating indexes: %v"), status)
+		feedback.Errorf(tr("Error updating indexes: %v"), err)
 		os.Exit(errorcodes.ErrGeneric)
 	}
 	return inst


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
If index parsing on first start fails for some reason, the error is not correctly printed.
* **What is the new behavior?**
<!-- if this is a feature change -->
The error gets printed
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->

See https://github.com/arduino/ArduinoCore-samd/runs/5286418366?check_suite_focus=true#step:7:300

---
See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
