### PR TITLE
Fix: add missing value in 'board list' table

### DIFF
--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -157,7 +157,7 @@ func (dr result) String() string {
 			board := tr("Unknown")
 			fqbn := ""
 			coreName := ""
-			t.AddRow(address, protocol, board, fqbn, coreName)
+			t.AddRow(address, protocol, protocolLabel, board, fqbn, coreName)
 		}
 	}
 	return t.Render()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
Fix a missing value in the `board list` table output.

**What is the current behavior?**
```
$ arduino-cli board list
Porta        Protocollo Tipo    Nome scheda FQBN Core
/dev/ttyUSB0 serial     Unknown                 
```

**What is the new behavior?**
```
$ arduino-cli board list
Porta        Protocollo Tipo              Nome scheda FQBN Core
/dev/ttyUSB0 serial     Serial Port (USB) Unknown
```

**Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No
