### PR TITLE
[docs] Make use of 'avr' as example platform more consistent

### DIFF
--- a/docs/sketch-build-process.md
+++ b/docs/sketch-build-process.md
@@ -157,8 +157,8 @@ its cloud-based nature may make the locations of libraries less obvious.
 
 ## Compilation
 
-Sketches are compiled by platform-specific versions of `gcc` and `g++` according to the variables in the boards.txt file of the selected board's
-[platform](platform-specification.md).
+Sketches are compiled by platform-specific versions of `gcc` and `g++` according to the variables in the boards.txt file
+of the selected board's [platform](platform-specification.md).
 
 The sketch is built in a temporary directory in the system-wide temporary directory (e.g. /tmp on Linux).
 
@@ -185,8 +185,9 @@ the build process will be printed in the console.
 
 ## Uploading
 
-Sketches are uploaded by a platform-specific upload tool (e.g., avrdude). The upload process is also controlled by variables in the boards and main preferences
-files. See the [Arduino platform specification](platform-specification.md) page for details.
+Sketches are uploaded by a platform-specific upload tool (e.g., avrdude). The upload process is also controlled by
+variables in the boards and main preferences files. See the [Arduino platform specification](platform-specification.md)
+page for details.
 
-If verbose output during upload is enabled, debugging information will be output to the console, including the upload tool's
-command lines and verbose output.
+If verbose output during upload is enabled, debugging information will be output to the console, including the upload
+tool's command lines and verbose output.

--- a/docs/sketch-build-process.md
+++ b/docs/sketch-build-process.md
@@ -157,8 +157,8 @@ its cloud-based nature may make the locations of libraries less obvious.
 
 ## Compilation
 
-Sketches are compiled by platform-specific versions of `gcc` and `g++` according to the variables in the boards.txt file
-of the selected board's [platform](platform-specification.md).
+Sketches are compiled by architecture-specific versions of `gcc` and `g++` according to the variables in the boards.txt
+file of the selected board's [platform](platform-specification.md).
 
 The sketch is built in a temporary directory in the system-wide temporary directory (e.g. /tmp on Linux).
 

--- a/docs/sketch-build-process.md
+++ b/docs/sketch-build-process.md
@@ -1,12 +1,12 @@
 The process the Arduino development software uses to build a sketch. More useful information can be found in the
 [Arduino platform specification](platform-specification.md). Note that the following refers specifically to the build
-process for AVR targets. Other architectures will have a similar build process.
+process for AVR targets. Other architectures follow a similar build process, but may use other tools and compilers.
 
 ## Overview
 
 A number of things have to happen for your Arduino code to get onto the Arduino board. First, the Arduino development
 software performs some minor pre-processing to turn your sketch into a C++ program. Next, dependencies of the sketch are
-located. It then gets passed to a compiler (avr-gcc), which turns the human readable code into machine readable
+located. It then gets passed to a compiler (e.g, `avr-gcc`), which turns the human readable code into machine readable
 instructions (or object files). Then your code gets combined with (linked against) the standard Arduino libraries that
 provide basic functions like `digitalWrite()` or `Serial.print()`. The result is a single Intel hex file, which contains
 the specific bytes that need to be written to the program memory of the chip on the Arduino board. This file is then
@@ -15,8 +15,8 @@ external programming hardware.
 
 ## Pre-Processing
 
-The Arduino development software performs a few transformations to your sketch before passing it to the avr-gcc
-compiler:
+The Arduino development software performs a few transformations to your sketch before passing it to the 
+compiler (e.g., `avr-gcc`): 
 
 - All .ino and .pde files in the sketch folder (shown in the Arduino IDE as tabs with no extension) are concatenated
   together, starting with the file that matches the folder name followed by the others in alphabetical order. The .cpp
@@ -157,7 +157,7 @@ its cloud-based nature may make the locations of libraries less obvious.
 
 ## Compilation
 
-Sketches are compiled by avr-gcc and avr-g++ according to the variables in the boards.txt file of the selected board's
+Sketches are compiled by platform-specific versions of `gcc` and `g++` according to the variables in the boards.txt file of the selected board's
 [platform](platform-specification.md).
 
 The sketch is built in a temporary directory in the system-wide temporary directory (e.g. /tmp on Linux).
@@ -185,8 +185,8 @@ the build process will be printed in the console.
 
 ## Uploading
 
-Sketches are uploaded by avrdude. The upload process is also controlled by variables in the boards and main preferences
+Sketches are uploaded by a platform-specific upload tool (e.g., avrdude). The upload process is also controlled by variables in the boards and main preferences
 files. See the [Arduino platform specification](platform-specification.md) page for details.
 
-If verbose output during upload is enabled, debugging information will be output to the console, including avrdude
+If verbose output during upload is enabled, debugging information will be output to the console, including the upload tool's
 command lines and verbose output.

--- a/docs/sketch-build-process.md
+++ b/docs/sketch-build-process.md
@@ -15,8 +15,8 @@ external programming hardware.
 
 ## Pre-Processing
 
-The Arduino development software performs a few transformations to your sketch before passing it to the 
-compiler (e.g., `avr-gcc`): 
+The Arduino development software performs a few transformations to your sketch before passing it to the
+compiler (e.g., `avr-gcc`):
 
 - All .ino and .pde files in the sketch folder (shown in the Arduino IDE as tabs with no extension) are concatenated
   together, starting with the file that matches the folder name followed by the others in alphabetical order. The .cpp

--- a/docs/sketch-build-process.md
+++ b/docs/sketch-build-process.md
@@ -15,8 +15,8 @@ external programming hardware.
 
 ## Pre-Processing
 
-The Arduino development software performs a few transformations to your sketch before passing it to the
-compiler (e.g., `avr-gcc`):
+The Arduino development software performs a few transformations to your sketch before passing it to the compiler (e.g.,
+`avr-gcc`):
 
 - All .ino and .pde files in the sketch folder (shown in the Arduino IDE as tabs with no extension) are concatenated
   together, starting with the file that matches the folder name followed by the others in alphabetical order. The .cpp


### PR DESCRIPTION
It's fairly easy to miss the one line early in the doc that says this text uses 'avr' as an example, leading a reader to possibly believe the documentation hasn't been updated since 'avr' was the only platform choice. Within the doc, the text was a little inconsistent as to how it referred to the avr platform and platform specific tools. This change tries to standardize how we refer to the example platform.

**Please check if the PR fulfills these requirements**

- [X ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
docs

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Non-breaking

* **Other information**:

I'm happy to rework this if the intent of the change is desirable, but the exact text needs work.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
