### PR TITLE
De-parallelize and increase verbosity of integration tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -144,7 +144,7 @@ def run_command(pytestconfig, data_dir, downloads_dir, working_dir):
         # It escapes spaces in the path using "\ " but it doesn't always work,
         # wrapping the path in quotation marks is the safest approach
         with run_context.prefix(f'{cd_command} "{custom_working_dir}"'):
-            return run_context.run(cli_full_line, echo=False, hide=True, warn=True, env=custom_env, encoding="utf-8")
+            return run_context.run(cli_full_line, echo=True, hide=False, warn=True, env=custom_env, encoding="utf-8")
 
     return _run
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -144,7 +144,7 @@ def run_command(pytestconfig, data_dir, downloads_dir, working_dir):
         # It escapes spaces in the path using "\ " but it doesn't always work,
         # wrapping the path in quotation marks is the safest approach
         with run_context.prefix(f'{cd_command} "{custom_working_dir}"'):
-            return run_context.run(cli_full_line, echo=True, hide=False, warn=True, env=custom_env, encoding="utf-8")
+            return run_context.run(cli_full_line, echo=True, hide=False, warn=True, env=custom_env, encoding="ascii")
 
     return _run
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -14,4 +14,4 @@ markers =
 # -n=auto sets the numbers of parallel processes to use
 # --dist=loadfile distributes the tests in the parallel processes dividing them per file
 # See https://pypi.org/project/pytest-xdist/#parallelization for more info on parallelization
-addopts = -x -s --verbose --tb=long -n=auto --dist=loadfile
+addopts = -x -s --verbose --tb=long

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -413,9 +413,9 @@ def test_board_listall(run_command):
     data = json.loads(res.stdout)
     boards = {b["fqbn"]: b for b in data["boards"]}
     assert len(boards) == 26
-    assert "arduino:avr:yun" in boards
-    assert "Arduino Yún" == boards["arduino:avr:yun"]["name"]
-    platform = boards["arduino:avr:yun"]["platform"]
+    assert "arduino:avr:bt" in boards
+    assert "Arduino BT" == boards["arduino:avr:bt"]["name"]
+    platform = boards["arduino:avr:bt"]["platform"]
     assert "arduino:avr" == platform["id"]
     assert "1.8.3" == platform["installed"]
     assert "" != platform["latest"]
@@ -551,7 +551,7 @@ def test_board_search(run_command, data_dir):
     assert len([board["fqbn"] for board in data if "fqbn" in board]) == 0
     names = [board["name"] for board in data if "name" in board]
     assert "Arduino Uno" in names
-    assert "Arduino Yún" in names
+    assert "Arduino BT" in names
     assert "Arduino Zero" in names
     assert "Arduino Nano 33 BLE" in names
     assert "Arduino Portenta H7" in names
@@ -580,16 +580,16 @@ def test_board_search(run_command, data_dir):
     installed_boards = {board["fqbn"]: board for board in data if "fqbn" in board}
     assert "arduino:avr:uno" in installed_boards
     assert "Arduino Uno" == installed_boards["arduino:avr:uno"]["name"]
-    assert "arduino:avr:yun" in installed_boards
-    assert "Arduino Yún" == installed_boards["arduino:avr:yun"]["name"]
+    assert "arduino:avr:bt" in installed_boards
+    assert "Arduino BT" == installed_boards["arduino:avr:bt"]["name"]
 
-    res = run_command(["board", "search", "--format", "json", "arduino", "yun"])
+    res = run_command(["board", "search", "--format", "json", "arduino", "bt"])
     assert res.ok
     data = json.loads(res.stdout)
     assert len(data) > 0
     installed_boards = {board["fqbn"]: board for board in data if "fqbn" in board}
-    assert "arduino:avr:yun" in installed_boards
-    assert "Arduino Yún" == installed_boards["arduino:avr:yun"]["name"]
+    assert "arduino:avr:bt" in installed_boards
+    assert "Arduino BT" == installed_boards["arduino:avr:bt"]["name"]
 
     # Manually installs a core in sketchbooks hardware folder
     git_url = "https://github.com/arduino/ArduinoCore-samd.git"
@@ -605,8 +605,8 @@ def test_board_search(run_command, data_dir):
     installed_boards = {board["fqbn"]: board for board in data if "fqbn" in board}
     assert "arduino:avr:uno" in installed_boards
     assert "Arduino Uno" == installed_boards["arduino:avr:uno"]["name"]
-    assert "arduino:avr:yun" in installed_boards
-    assert "Arduino Yún" == installed_boards["arduino:avr:yun"]["name"]
+    assert "arduino:avr:bt" in installed_boards
+    assert "Arduino BT" == installed_boards["arduino:avr:bt"]["name"]
     assert "arduino-beta-development:samd:mkrwifi1010" in installed_boards
     assert "Arduino MKR WiFi 1010" == installed_boards["arduino-beta-development:samd:mkrwifi1010"]["name"]
     assert "arduino-beta-development:samd:mkr1000" in installed_boards


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
Increase verbosity of integration tests.
To see the verbose output the tests must not be parallelized, but this is no more a problem now since we use github actions to spread the work across multiple runners.
