### PR TITLE
update dead documentation links

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -8,7 +8,7 @@ This is the specification for the Arduino library format, to be used with Arduin
 This new library format is intended to be used in tandem with **Library Manager**, available since Arduino IDE 1.6.2.
 The Library Manager allows users to automatically download and install libraries needed in their projects, with an easy
 to use graphical interface in the
-[Arduino IDE](https://www.arduino.cc/en/guide/libraries#toc3)/[Arduino IDE 2.0](https://www.arduino.cc/en/Tutorial/getting-started-with-ide-v2/ide-v2-installing-a-library#installing-a-library)
+[Arduino IDE](https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries#using-the-library-manager)/[Arduino IDE 2.0](https://www.arduino.cc/en/Tutorial/getting-started-with-ide-v2/ide-v2-installing-a-library#installing-a-library)
 and
 [Arduino Web Editor](https://create.arduino.cc/projecthub/Arduino_Genuino/getting-started-with-arduino-web-editor-on-various-platforms-4b3e4a#toc-libraries-and-the-arduino-web-editor-11)
 as well as [`arduino-cli lib`](commands/arduino-cli_lib.md).

--- a/docs/package_index_json-specification.md
+++ b/docs/package_index_json-specification.md
@@ -3,7 +3,7 @@ provide Boards Manager installation support for a platform, a JSON formatted ind
 specification for that file.
 
 Boards Manager functionality is provided by [Arduino CLI](getting-started.md#adding-3rd-party-cores),
-[Arduino IDE](https://www.arduino.cc/en/Guide/Cores), and Arduino Pro IDE.
+[Arduino IDE](https://docs.arduino.cc/learn/starting-guide/cores), and Arduino Pro IDE.
 
 ## Naming of the JSON index file
 

--- a/docs/sketch-specification.md
+++ b/docs/sketch-specification.md
@@ -130,10 +130,11 @@ no requirement to store sketches in the sketchbook folder.
 ## Library/Boards Manager links
 
 A URI in a comment in the form `http://librarymanager#SEARCH_TERM` will open a search for SEARCH_TERM in
-[Library Manager](https://www.arduino.cc/en/guide/libraries#toc3) when clicked in the Arduino IDE.
+[Library Manager](https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries#using-the-library-manager) when
+clicked in the Arduino IDE.
 
 A URI in a comment in the form `http://boardsmanager#SEARCH_TERM` will open a search for SEARCH_TERM in
-[Boards Manager](https://www.arduino.cc/en/Guide/Cores) when clicked in the Arduino IDE.
+[Boards Manager](https://docs.arduino.cc/learn/starting-guide/cores) when clicked in the Arduino IDE.
 
 This can be used to offer the user an easy way to install dependencies of the sketch.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The CI is failing because of broken links
* **What is the new behavior?**
<!-- if this is a feature change -->
The links have been updated
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
nope
* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
