### PR TITLE
[skip changelog] Disable internal anchor checks by link checker tool

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -4,6 +4,9 @@
   "aliveStatusCodes": [200, 206],
   "ignorePatterns": [
     {
+      "pattern": "^#"
+    },
+    {
       "pattern": "https?://localhost:\\d*/"
     },
     {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] ~~Tests for the changes have been added (for bug fixes / features)~~
- [N/A] ~~Docs have been added / updated (for bug fixes / features)~~
- [N/A] ~~`UPGRADING.md` has been updated with a migration guide (for breaking changes)~~

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Infrastructure bug fix.

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Validation of links to internal anchors was recently added to [the "**markdown-link-check**" tool](https://github.com/tcort/markdown-link-check) used to check for broken links in this project's documentation.

Although a much needed feature, unfortunately it does not currently support anchors created by HTML anchor tags.

For example, this is valid and common Markdown:

```markdown
[click here](#some-anchor)
<a name="some-anchor"></a>
```

but will fail the check:

```text
FILE: foo.md
  [✖] #some-anchor

  1 links checked.

  ERROR: 1 dead links found!
  [✖] #some-anchor → Status: 404
```

This type of link markup is used by [the "**protoc-gen-doc**" tool](https://github.com/pseudomuto/protoc-gen-doc) that generates [the gRPC interface documentation](https://arduino.github.io/arduino-cli/dev/rpc/commands/), causing [a spurious failure of the link check](https://github.com/arduino/arduino-cli/actions/runs/2021009405).

* **What is the new behavior?**
<!-- if this is a feature change -->

The solution is to configure "**markdown-link-check**" to skip these links (which was the behavior anyway with versions 3.8.7 and older of that tool). That configuration will be reverted whenever the tool is able to correctly validate internal anchor links (https://github.com/tcort/markdown-link-check/pull/193).

```text
FILE: foo.md
  [/] #some-anchor

  1 links checked.
```

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

No breaking change.
