### PR TITLE
Fixed some weird behaviour in gRPC Monitor command

### DIFF
--- a/arduino/monitor/monitor.go
+++ b/arduino/monitor/monitor.go
@@ -127,13 +127,15 @@ func jsonDecodeLoop(in io.Reader, outChan chan<- *monitorMessage, log *logrus.En
 }
 
 func (mon *PluggableMonitor) waitMessage(timeout time.Duration, expectedEvt string) (*monitorMessage, error) {
+	mon.log.WithField("expected", expectedEvt).Debugf("waiting for event")
 	var msg *monitorMessage
 	select {
-	case msg = <-mon.incomingMessagesChan:
-		if msg == nil {
+	case m, ok := <-mon.incomingMessagesChan:
+		if !ok {
 			// channel has been closed
 			return nil, mon.incomingMessagesError
 		}
+		msg = m
 	case <-time.After(timeout):
 		return nil, fmt.Errorf(tr("timeout waiting for message"))
 	}

--- a/arduino/monitor/monitor.go
+++ b/arduino/monitor/monitor.go
@@ -292,7 +292,7 @@ func (mon *PluggableMonitor) Close() error {
 	if err := mon.sendCommand("CLOSE\n"); err != nil {
 		return err
 	}
-	_, err := mon.waitMessage(time.Second*10, "close")
+	_, err := mon.waitMessage(time.Millisecond*250, "close")
 	return err
 }
 
@@ -303,7 +303,7 @@ func (mon *PluggableMonitor) Quit() error {
 	if err := mon.sendCommand("QUIT\n"); err != nil {
 		return err
 	}
-	if _, err := mon.waitMessage(time.Second*10, "quit"); err != nil {
+	if _, err := mon.waitMessage(time.Millisecond*250, "quit"); err != nil {
 		return err
 	}
 	return nil

--- a/commands/monitor/monitor.go
+++ b/commands/monitor/monitor.go
@@ -86,10 +86,11 @@ func Monitor(ctx context.Context, req *rpc.MonitorRequest) (*PortProxy, *pluggab
 		m.Quit()
 		return nil, nil, &arduino.FailedMonitorError{Cause: err}
 	}
-
-	for _, setting := range req.GetPortConfiguration().Settings {
-		if err := m.Configure(setting.SettingId, setting.Value); err != nil {
-			logrus.Errorf("Could not set configuration %s=%s: %s", setting.SettingId, setting.Value, err)
+	if portConfig := req.GetPortConfiguration(); portConfig != nil {
+		for _, setting := range portConfig.Settings {
+			if err := m.Configure(setting.SettingId, setting.Value); err != nil {
+				logrus.Errorf("Could not set configuration %s=%s: %s", setting.SettingId, setting.Value, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
Here is the list of bugs fixed, they are all related to the pluggable monitor management and gRPC:
- ensure that monitor processes are killed and collected correctly (previously it leaked a zombie process)
- fixed the gRPC `commands.Monitor` streaming call, now the cancel request is handled correctly
- fixed crash if no configuration is provided in the `commands.Monitor` gRPC call
- reduce timeout for monitor close/quit commands to 250ms, this allows termination of the monitor even if the monitor itself lags in freeing up resources

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No breaking changes.
