### PR TITLE
[skip-changelog] fix nav being left out form #1686

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,8 @@ nav:
   - Pluggable discovery specification: pluggable-discovery-specification.md
   - Pluggable monitor specification: pluggable-monitor-specification.md
   - Package index specification: package_index_json-specification.md
+  - Guides:
+      - Secure boot: guides/secure-boot.md
 
 extra:
   version:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
fix doc
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
I forgot to update the nav in #1686 
* **What is the new behavior?**
<!-- if this is a feature change -->
fix nav bar
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
no
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

* **Other information**:
<!-- Any additional information that could help the review process -->
---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
