### PR TITLE
[skip changelog] Detect unused dependency license metadata files

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Check for outdated cache
         id: diff
         run: |
-          git add --intent-to-add .
-          if ! git diff --color --exit-code; then
+          git add .
+          if ! git diff --cached --color --exit-code; then
             echo
             echo "::error::Dependency license metadata out of sync. See: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md#metadata-cache"
             exit 1


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- ~~[N/A] Tests for the changes have been added (for bug fixes / features)~~
- ~~[N/A] Docs have been added / updated (for bug fixes / features)~~
- ~~[N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)~~

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

- **What is the current behavior?**
<!-- You can also link to an open issue here -->

The "**Check Go Dependencies**" GitHub Actions workflow checks for dependencies with incompatible or unapproved license types.

The dependency license metadata consumed by [the "**Licensed**" tool](https://github.com/github/licensed) is cached in the project repository, in a dedicated file for each dependency.

The `check-cache` job of the workflow checks whether that cache is in sync with the project's current dependencies. It does this by using the "Licensed" tool to update the cache and then a [`git diff`](https://git-scm.com/docs/git-diff) command to check whether that resulted in any changes (which would indicate it is out of sync).

Out of sync states could result from any of three distinct conditions:

- Missing metadata file
- Incorrect metadata file contents
- Superfluous metadata file

🐛 An incorrectly configured `git diff` command previously caused the last of these to be missed.

For example, here an unnecessary dependency license metadata file is introduced into the repository:
https://github.com/arduino/arduino-cli/pull/1711/commits/c3b7aa50147ddf6c64637e15612956c6cdfd5106
🐛 However, the `check-cache` job run for that commit passed:
https://github.com/arduino/arduino-cli/runs/6009282571

My first take at this system was simply using `git diff --exit-code` alone. That detects the last two, but misses the first. I added a preceding [`git add --intent-to-add .`](https://git-scm.com/docs/git-add#Documentation/git-add.txt---intent-to-add) command to detect added files, but didn't realize that it also caused the last condition to be missed.

* **What is the new behavior?**
<!-- if this is a feature change -->

Superfluous files in the dependency license metadata cache won't actually interfere with its intended functionality, but it is still important to avoid an accumulation of unused files.

The new commands will catch all three of the possible out of sync conditions by staging all changes that result from the metadata cache update to the repository and then comparing those against the `HEAD` commit.

Demonstration of the superfluous file being caught by the version of the `check-cache` job from this PR:
https://github.com/per1234/arduino-cli/runs/6036878271?check_suite_focus=true

And then passing after the file is removed:
https://github.com/per1234/arduino-cli/runs/6036924036?check_suite_focus=true

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

No breaking change.

* **Other information**:
<!-- Any additional information that could help the review process -->

Related discussion here : https://github.com/arduino/arduino-cli/pull/1711#discussion_r850513635

---

I considered an alternative approach which works just as well as the chosen one (explanation of the two approaches [here](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-Variouswaystocheckyourworkingtree)):

```text
git add .
git diff --exit-code HEAD
```

However, I feel that the `git diff` command with [the `--cached` flag](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-emgitdiffemltoptionsgt--cached--merge-baseltcommitgt--ltpathgt82308203) is more self-explanatory.
