### PR TITLE
[skip changelog] Sync "Check Go Dependencies" workflow with upstream

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -2,11 +2,12 @@
 name: Check Go Dependencies
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"
 
-# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/check-go-dependencies-task.ya?ml"
@@ -27,11 +28,39 @@ on:
       - "**/.gitmodules"
       - "**/go.mod"
       - "**/go.sum"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 8 * * WED"
   workflow_dispatch:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   check-cache:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -80,6 +109,8 @@ jobs:
           path: .licenses/
 
   check-deps:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [N/A] ~~`UPGRADING.md` has been updated with a migration guide (for breaking changes)~~

## What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, ... -->

Enhancement

## What is the current behavior?
<!-- You can also link to an open issue here -->

A "Check Go Dependencies" GitHub Actions workflow is used to check whether all Go package dependencies of the modules in this repository use compatible licenses.

This workflow is hosted and maintained in a repository dedicated to a collection of such reusable Arduino tooling project assets.

Several enhancements have been made to the upstream file, but those have not been pulled into this repository.

- Add schedule event trigger to catch breakage caused by external changes
  https://github.com/arduino/tooling-project-assets/commit/e71e4702279bd165769efd830f276b6b492de92c
- Run workflow on release branch creation
  https://github.com/arduino/tooling-project-assets/commit/22504dc85c1bea37613506016e677cd545a9af1b

## What is the new behavior?
<!-- if this is a feature change -->
The file in this repository is in sync with the upstream file.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No breaking change