### PR TITLE
Fix resolution of library names when checking for upgrades

### DIFF
--- a/arduino/libraries/librariesindex/index.go
+++ b/arduino/libraries/librariesindex/index.go
@@ -125,7 +125,7 @@ func (idx *Index) FindRelease(ref *Reference) *Release {
 // FindIndexedLibrary search an indexed library that matches the provided
 // installed library or nil if not found
 func (idx *Index) FindIndexedLibrary(lib *libraries.Library) *Library {
-	return idx.Libraries[lib.Name]
+	return idx.Libraries[lib.RealName]
 }
 
 // FindLibraryUpdate check if an installed library may be updated using

--- a/arduino/libraries/librariesindex/index_test.go
+++ b/arduino/libraries/librariesindex/index_test.go
@@ -72,22 +72,22 @@ func TestIndexer(t *testing.T) {
 	})
 	require.Nil(t, rtcInexistent)
 
-	rtc := index.FindIndexedLibrary(&libraries.Library{Name: "RTCZero"})
+	rtc := index.FindIndexedLibrary(&libraries.Library{RealName: "RTCZero"})
 	require.NotNil(t, rtc)
 	require.Equal(t, "RTCZero", rtc.Name)
 
-	rtcUpdate := index.FindLibraryUpdate(&libraries.Library{Name: "RTCZero", Version: semver.MustParse("1.0.0")})
+	rtcUpdate := index.FindLibraryUpdate(&libraries.Library{RealName: "RTCZero", Version: semver.MustParse("1.0.0")})
 	require.NotNil(t, rtcUpdate)
 	require.Equal(t, "RTCZero@1.6.0", rtcUpdate.String())
 
-	rtcUpdateNoVersion := index.FindLibraryUpdate(&libraries.Library{Name: "RTCZero", Version: nil})
+	rtcUpdateNoVersion := index.FindLibraryUpdate(&libraries.Library{RealName: "RTCZero", Version: nil})
 	require.NotNil(t, rtcUpdateNoVersion)
 	require.Equal(t, "RTCZero@1.6.0", rtcUpdateNoVersion.String())
 
-	rtcNoUpdate := index.FindLibraryUpdate(&libraries.Library{Name: "RTCZero", Version: semver.MustParse("3.0.0")})
+	rtcNoUpdate := index.FindLibraryUpdate(&libraries.Library{RealName: "RTCZero", Version: semver.MustParse("3.0.0")})
 	require.Nil(t, rtcNoUpdate)
 
-	rtcInexistent2 := index.FindLibraryUpdate(&libraries.Library{Name: "RTCZero-blah", Version: semver.MustParse("1.0.0")})
+	rtcInexistent2 := index.FindLibraryUpdate(&libraries.Library{RealName: "RTCZero-blah", Version: semver.MustParse("1.0.0")})
 	require.Nil(t, rtcInexistent2)
 
 	resolve1 := index.ResolveDependencies(alp.Releases["1.2.1"])

--- a/cli/lib/list.go
+++ b/cli/lib/list.go
@@ -129,7 +129,10 @@ func (ir installedResult) String() string {
 	lastName := ""
 	for _, libMeta := range ir.installedLibs {
 		lib := libMeta.GetLibrary()
-		name := lib.Name
+		name := lib.RealName
+		if name == "" {
+			name = lib.Name
+		}
 		if name == lastName {
 			name = ` "`
 		} else {

--- a/commands/lib/list.go
+++ b/commands/lib/list.go
@@ -47,7 +47,7 @@ func LibraryList(ctx context.Context, req *rpc.LibraryListRequest) (*rpc.Library
 
 	nameFilter := strings.ToLower(req.GetName())
 
-	instaledLibs := []*rpc.InstalledLibrary{}
+	installedLibs := []*rpc.InstalledLibrary{}
 	res := listLibraries(lm, req.GetUpdatable(), req.GetAll())
 	if f := req.GetFqbn(); f != "" {
 		fqbn, err := cores.ParseFQBN(req.GetFqbn())
@@ -106,13 +106,13 @@ func LibraryList(ctx context.Context, req *rpc.LibraryListRequest) (*rpc.Library
 		if err != nil {
 			return nil, &arduino.PermissionDeniedError{Message: tr("Error getting information for library %s", lib.Library.Name), Cause: err}
 		}
-		instaledLibs = append(instaledLibs, &rpc.InstalledLibrary{
+		installedLibs = append(installedLibs, &rpc.InstalledLibrary{
 			Library: rpcLib,
 			Release: release,
 		})
 	}
 
-	return &rpc.LibraryListResponse{InstalledLibraries: instaledLibs}, nil
+	return &rpc.LibraryListResponse{InstalledLibraries: installedLibs}, nil
 }
 
 // listLibraries returns the list of installed libraries. If updatable is true it

--- a/commands/lib/upgrade.go
+++ b/commands/lib/upgrade.go
@@ -82,7 +82,7 @@ func filterByName(libs []*installedLib, names []string) []*installedLib {
 	ret := []*installedLib{}
 	for _, lib := range libs {
 		// skip if library name wasn't in the query
-		if _, found := queryMap[lib.Library.Name]; found {
+		if _, found := queryMap[lib.Library.RealName]; found {
 			ret = append(ret, lib)
 		}
 	}

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -826,7 +826,7 @@ def test_lib_list_using_library_with_invalid_version(run_command, data_dir):
     # Changes the version of the currently installed library so that it's
     # invalid
     lib_path = Path(data_dir, "libraries", "WiFi101")
-    Path(lib_path, "library.properties").write_text("version=1.0001")
+    Path(lib_path, "library.properties").write_text("name=WiFi101\nversion=1.0001")
 
     # Verifies version is now empty
     res = run_command(["lib", "list", "--format", "json"])
@@ -852,7 +852,7 @@ def test_lib_upgrade_using_library_with_invalid_version(run_command, data_dir):
     # Changes the version of the currently installed library so that it's
     # invalid
     lib_path = Path(data_dir, "libraries", "WiFi101")
-    Path(lib_path, "library.properties").write_text("version=1.0001")
+    Path(lib_path, "library.properties").write_text("name=WiFi101\nversion=1.0001")
 
     # Verifies version is now empty
     res = run_command(["lib", "list", "--format", "json"])

--- a/test/test_outdated.py
+++ b/test/test_outdated.py
@@ -51,7 +51,7 @@ def test_outdated_using_library_with_invalid_version(run_command, data_dir):
     # Changes the version of the currently installed library so that it's
     # invalid
     lib_path = Path(data_dir, "libraries", "WiFi101")
-    Path(lib_path, "library.properties").write_text("version=1.0001")
+    Path(lib_path, "library.properties").write_text("name=WiFi101\nversion=1.0001")
 
     # Verifies library is correctly returned
     res = run_command(["outdated"])

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -99,7 +99,7 @@ def test_update_showing_outdated_using_library_with_invalid_version(run_command,
     # Changes the version of the currently installed library so that it's
     # invalid
     lib_path = Path(data_dir, "libraries", "WiFi101")
-    Path(lib_path, "library.properties").write_text("version=1.0001")
+    Path(lib_path, "library.properties").write_text("name=WiFi101\nversion=1.0001")
 
     # Verifies library gets updated
     res = run_command(["update", "--show-outdated"])

--- a/test/test_upgrade.py
+++ b/test/test_upgrade.py
@@ -59,7 +59,7 @@ def test_upgrade_using_library_with_invalid_version(run_command, data_dir):
     # Changes the version of the currently installed library so that it's
     # invalid
     lib_path = Path(data_dir, "libraries", "WiFi101")
-    Path(lib_path, "library.properties").write_text("version=1.0001")
+    Path(lib_path, "library.properties").write_text("name=WiFi101\nversion=1.0001")
 
     # Verifies library gets upgraded
     res = run_command(["upgrade"])


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This change resolves #1041, where packages that have upgrades based on `library_index.json` do not show up as upgradable with using the `arduino-cli lib` commands.

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
When using the `arduino-cli lib` commands to check for or apply updates, packages that have spaces in the name in the index are not shown as upgradable.


* **What is the new behavior?**
<!-- if this is a feature change -->
The overall behavior is unchanged and commands remain as currently implemented and documented. However, the resolution of packages that have spaces in the names now works, so commands such as `arduino-cli lib list --updatable` will now show all upgradable packages.


- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No

* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
