### PR TITLE
Pin `buf` to v1.4.0

### DIFF
--- a/.github/workflows/check-protobuf-task.yml
+++ b/.github/workflows/check-protobuf-task.yml
@@ -95,9 +95,9 @@ jobs:
 
       - name: Install buf (protoc linter)
         run: |
-          go install github.com/bufbuild/buf/cmd/buf@latest
-          go install github.com/bufbuild/buf/cmd/protoc-gen-buf-breaking@latest
-          go install github.com/bufbuild/buf/cmd/protoc-gen-buf-lint@latest
+          go install github.com/bufbuild/buf/cmd/buf@v1.4.0
+          go install github.com/bufbuild/buf/cmd/protoc-gen-buf-breaking@v1.4.0
+          go install github.com/bufbuild/buf/cmd/protoc-gen-buf-lint@v1.4.0
 
       - name: Install Task
         uses: arduino/setup-task@v1


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
Pin `buf` to v1.4.0. The latest 1.5.0 requires go1.18+.
We could put it back to "latest" once we migrate to go1.18.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No
