### PR TITLE
De-parallelize integration test

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -124,7 +124,7 @@ def run_command(pytestconfig, data_dir, downloads_dir, working_dir):
     }
     (Path(data_dir) / "packages").mkdir(exist_ok=True)
 
-    def _run(cmd: list, custom_working_dir=None, custom_env=None):
+    def _run(cmd: list, custom_working_dir=None, custom_env=None, hide=False):
         if cmd is None:
             cmd = []
         quoted_cmd = [f'"{t}"' for t in cmd]
@@ -144,7 +144,7 @@ def run_command(pytestconfig, data_dir, downloads_dir, working_dir):
         # It escapes spaces in the path using "\ " but it doesn't always work,
         # wrapping the path in quotation marks is the safest approach
         with run_context.prefix(f'{cd_command} "{custom_working_dir}"'):
-            return run_context.run(cli_full_line, echo=False, hide=True, warn=True, env=custom_env, encoding="utf-8")
+            return run_context.run(cli_full_line, echo=True, hide=hide, warn=True, env=custom_env, encoding="utf-8")
 
     return _run
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -14,4 +14,4 @@ markers =
 # -n=auto sets the numbers of parallel processes to use
 # --dist=loadfile distributes the tests in the parallel processes dividing them per file
 # See https://pypi.org/project/pytest-xdist/#parallelization for more info on parallelization
-addopts = -x -s --verbose --tb=long -n=auto --dist=loadfile
+addopts = -x -s --verbose --tb=long

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -11,7 +11,5 @@ markers =
 # -s to disable per-test capture
 # --verbose is what is says it is
 # --tb=long sets the length of the traceback in case of failures
-# -n=auto sets the numbers of parallel processes to use
-# --dist=loadfile distributes the tests in the parallel processes dividing them per file
 # See https://pypi.org/project/pytest-xdist/#parallelization for more info on parallelization
 addopts = -x -s --verbose --tb=long

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -516,7 +516,7 @@ def test_board_details_list_programmers_without_flag(run_command):
     run_command(["core", "update-index"])
     # Download samd core pinned to 1.8.6
     run_command(["core", "install", "arduino:samd@1.8.6"])
-    result = run_command(["board", "details", "-b", "arduino:samd:nano_33_iot"])
+    result = run_command(["board", "details", "-b", "arduino:samd:nano_33_iot"], hide=True)
     assert result.ok
     lines = [l.strip().split() for l in result.stdout.splitlines()]
     assert ["Programmers:", "Id", "Name"] in lines
@@ -529,7 +529,7 @@ def test_board_details_list_programmers_flag(run_command):
     run_command(["core", "update-index"])
     # Download samd core pinned to 1.8.6
     run_command(["core", "install", "arduino:samd@1.8.6"])
-    result = run_command(["board", "details", "-b", "arduino:samd:nano_33_iot", "--list-programmers"])
+    result = run_command(["board", "details", "-b", "arduino:samd:nano_33_iot", "--list-programmers"], hide=True)
     assert result.ok
 
     lines = [l.strip() for l in result.stdout.splitlines()]

--- a/test/test_completion.py
+++ b/test/test_completion.py
@@ -135,11 +135,11 @@ def test_config_completion(run_command):
 # here we test if the completions coming from the libs are working
 def test_lib_completion(run_command):
     assert run_command(["lib", "update-index"])
-    result = run_command(["__complete", "lib", "install", ""])
+    result = run_command(["__complete", "lib", "install", ""], hide=True)
     assert "WiFi101" in result.stdout
-    result = run_command(["__complete", "lib", "download", ""])
+    result = run_command(["__complete", "lib", "download", ""], hide=True)
     assert "WiFi101" in result.stdout
-    result = run_command(["__complete", "lib", "uninstall", ""])
+    result = run_command(["__complete", "lib", "uninstall", ""], hide=True)
     assert "WiFi101" not in result.stdout  # not yet installed
 
     assert run_command(["lib", "install", "WiFi101"])

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -58,7 +58,7 @@ def test_list(run_command):
     assert result.ok
     assert "" == result.stderr
     assert "No libraries installed." in result.stdout.strip()
-    result = run_command(["lib", "list", "--format", "json"])
+    result = run_command(["lib", "list", "--format", "json"], hide=True)
     assert result.ok
     assert "" == result.stderr
     assert 0 == len(json.loads(result.stdout))
@@ -83,7 +83,7 @@ def test_list(run_command):
     assert "An efficient and elegant JSON library..." == toks[4]
 
     # Look at the JSON output
-    result = run_command(["lib", "list", "--format", "json"])
+    result = run_command(["lib", "list", "--format", "json"], hide=True)
     assert result.ok
     assert "" == result.stderr
     data = json.loads(result.stdout)
@@ -159,7 +159,7 @@ def test_list_with_fqbn(run_command):
     assert "ArduinoJson" == toks[0]
 
     # Look at the JSON output
-    result = run_command(["lib", "list", "-b", "arduino:avr:uno", "--format", "json"])
+    result = run_command(["lib", "list", "-b", "arduino:avr:uno", "--format", "json"], hide=True)
     assert result.ok
     assert "" == result.stderr
     data = json.loads(result.stdout)
@@ -180,7 +180,7 @@ def test_list_provides_includes_fallback(run_command):
     assert run_command(["lib", "install", "ArduinoJson@6.17.2"])
 
     # List all libraries, even the ones installed with the above core
-    result = run_command(["lib", "list", "--all", "--fqbn", "arduino:avr:uno", "--format", "json"])
+    result = run_command(["lib", "list", "--all", "--fqbn", "arduino:avr:uno", "--format", "json"], hide=True)
     assert result.ok
     assert "" == result.stderr
 
@@ -545,7 +545,7 @@ def test_lib_list_with_updatable_flag(run_command):
     assert "An efficient and elegant JSON library..." == line[4]
 
     # Look at the JSON output
-    res = run_command(["lib", "list", "--updatable", "--format", "json"])
+    res = run_command(["lib", "list", "--updatable", "--format", "json"], hide=True)
     assert res.ok
     assert "" == res.stderr
     data = json.loads(res.stdout)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
Integration tests are no more parallelized and the test output Is displayed for better debugging.
The parallelization is no more needed since they are split using GitHub actions runners.

**What is the current behavior?**
Tests are run in "parallel" (in reality only one test per runner so there is no effective parallelization) and the output is hidden.

**What is the new behavior?**
Tests are run sequentially and the output is visible.

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No

**Other information**:
Some tests are still hidden because their output is UTF-8 and it seems to cause some python exceptions on Windows runners: while waiting for a better solution I've opted for the quick-and-dirty workaround.
