### PR TITLE
fix `arduino-cli outdated --format json` output

### DIFF
--- a/test/test_upgrade.py
+++ b/test/test_upgrade.py
@@ -42,7 +42,7 @@ def test_upgrade(run_command):
     # Verifies cores and libraries have been updated
     result = run_command(["outdated"])
     assert result.ok
-    assert result.stdout == ""
+    assert result.stdout == "\n"
 
 
 def test_upgrade_using_library_with_invalid_version(run_command, data_dir):


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bug fix :bug: 
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
`arduino-cli outdated --format json` command does not print correctly json output
* **What is the new behavior?**
<!-- if this is a feature change -->
fixed
- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
nop
* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
