### PR TITLE
disable CGO on every OS except macOS

### DIFF
--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -41,7 +41,7 @@ tasks:
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=1 \
+        -e CGO_ENABLED=0 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
@@ -63,7 +63,7 @@ tasks:
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=1 \
+        -e CGO_ENABLED=0 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
@@ -85,7 +85,7 @@ tasks:
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=1 \
+        -e CGO_ENABLED=0 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
@@ -107,7 +107,7 @@ tasks:
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=1 \
+        -e CGO_ENABLED=0 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
@@ -129,7 +129,7 @@ tasks:
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=1 \
+        -e CGO_ENABLED=0 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
@@ -151,7 +151,7 @@ tasks:
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=1 \
+        -e CGO_ENABLED=0 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
@@ -201,7 +201,7 @@ tasks:
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=1 \
+        -e CGO_ENABLED=0 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
enhancement
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The Arduino CLI is built with `CGO_ENABLED=1`:
> Cgo enables the creation of Go packages that call C code

This does not allow the cli to be a fully static binary. We have to use CGO because of `go.bug.st/serial.v1/enumerator` used by [`go.bug.st/serial`](https://pkg.go.dev/go.bug.st/serial):
>  This library tries to avoid the use of the "C" package (and consequently the need of cgo) to simplify cross compiling. Unfortunately the USB enumeration package for darwin (MacOSX) requires cgo to access the IOKit framework. This means that if you need USB enumeration on darwin you're forced to use cgo. 

* **What is the new behavior?**
<!-- if this is a feature change -->
CGO is disabled on every OS except macOS. This gives some advantages (for example on Linux amd64):
**new**
```
$ file arduino-cli 
arduino-cli: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
$ ldd arduino-cli 
        not a dynamic executable
$ ls -l arduino-cli
-rwxr-xr-x 1 root root 27278394 giu  8 11:51 arduino-cli*
```
**old**
```
$ file arduino-cli 
arduino-cli: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, not stripped
$ ldd arduino-cli 
        linux-vdso.so.1 (0x00007fffbdd7e000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007faf86ede000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007faf86aed000)
        /lib64/ld-linux-x86-64.so.2 (0x00007faf870fd000)
$ ls -l arduino-cli
-rwxr-xr-x 1 root root 27355615 giu  8 12:22 arduino-cli*
```

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
nop
* **Other information**:
<!-- Any additional information that could help the review process -->

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
