### PR TITLE
adding example usage for command option

### DIFF
--- a/i18n/data/en.po
+++ b/i18n/data/en.po
@@ -413,8 +413,8 @@ msgid "Config file written to: %s"
 msgstr "Config file written to: %s"
 
 #: cli/monitor/monitor.go:63
-msgid "Configuration of the port."
-msgstr "Configuration of the port."
+msgid "Configuration of the port, e.g.: baudrate=1000000"
+msgstr "Configuration of the port, e.g.: baudrate=1000000"
 
 #: cli/debug/debug.go:146
 msgid "Configuration options for %s"


### PR DESCRIPTION
Hello, please take a look at this small documentation change.

Basically I struggled for a while to figure out why the monitor wasn't working, and I had to play with the IDE to understand that I needed to match the baud rates.

I'm adding a really low effort change that might help users work out how to use the `-c` option once they figured out they need to change the baud rate.

Ideally I think the options should be collapsed into command line flags so that the following works:

```text
arduino-cli monitor --baudrate 1000000
```

But for now I think this small change can be pulled, if it can be tested by someone with a working build.

If possible, I would also change the flag usage from

```text
-c, --config strings
```

to 

```text
-c --config ID=Setting
```

in addition to clarifying the syntax, it also points the user towards the `--describe` keywords.

Thank you.
Tom