### PR TITLE
Do library rescan on compile (if no profies are used)

### DIFF
--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/cores/packageindex"
 	"github.com/arduino/arduino-cli/arduino/discovery/discoverymanager"
+	"github.com/arduino/arduino-cli/arduino/sketch"
 	"github.com/arduino/arduino-cli/i18n"
 	paths "github.com/arduino/go-paths-helper"
 	properties "github.com/arduino/go-properties-orderedmap"
@@ -44,6 +45,7 @@ type PackageManager struct {
 	DownloadDir            *paths.Path
 	TempDir                *paths.Path
 	CustomGlobalProperties *properties.Map
+	profile                *sketch.Profile
 	discoveryManager       *discoverymanager.DiscoveryManager
 	userAgent              string
 }
@@ -63,6 +65,11 @@ func NewPackageManager(indexDir, packagesDir, downloadDir, tempDir *paths.Path, 
 		discoveryManager:       discoverymanager.New(),
 		userAgent:              userAgent,
 	}
+}
+
+// GetProfile returns the active profile for this package manager, or nil if no profile is selected.
+func (pm *PackageManager) GetProfile() *sketch.Profile {
+	return pm.profile
 }
 
 // GetEnvVarsForSpawnedProcess produces a set of environment variables that

--- a/arduino/cores/packagemanager/profiles.go
+++ b/arduino/cores/packagemanager/profiles.go
@@ -33,6 +33,8 @@ import (
 // LoadHardwareForProfile load the hardware platforms for the given profile.
 // If installMissing is true then possibly missing tools and platforms will be downloaded and installed.
 func (pm *PackageManager) LoadHardwareForProfile(p *sketch.Profile, installMissing bool, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) []error {
+	pm.profile = p
+
 	// Load required platforms
 	var merr []error
 	var platformReleases []*cores.PlatformRelease

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -111,7 +111,9 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 
 	builderCtx := &types.Context{}
 	builderCtx.PackageManager = pm
-	builderCtx.LibrariesManager = lm
+	if pm.GetProfile() != nil {
+		builderCtx.LibrariesManager = lm
+	}
 	builderCtx.FQBN = fqbn
 	builderCtx.SketchLocation = sk.FullPath
 	builderCtx.ProgressCB = progressCB
@@ -124,9 +126,6 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 	builderCtx.OtherLibrariesDirs = paths.NewPathList(req.GetLibraries()...)
 	builderCtx.OtherLibrariesDirs.Add(configuration.LibrariesDir(configuration.Settings))
 	builderCtx.LibraryDirs = paths.NewPathList(req.Library...)
-	if len(req.GetLibraries()) > 0 || len(req.GetLibrary()) > 0 {
-		builderCtx.LibrariesManager = nil // let the builder rebuild the library manager
-	}
 	if req.GetBuildPath() == "" {
 		builderCtx.BuildPath = sk.BuildPath
 	} else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
The compiler will now detect changes in the filesystem when not using profiles. This fixes a regression described in #1755

**What is the current behavior?**
The daemon caches all the libraries installed in the sketchbook. This provides a quicker compile but it prevents detection of changes in the sketchbook happening outside the daemon process.

**What is the new behavior?**
Libraries are re-scanned at each compile.

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No

**Other Information**:
Fix #1755
Integration-testing requires the implementation of a testing harness to test gRPC and launch the daemon, this will be done in the future.
