### PR TITLE
Rate limit the number of outgoing gRPC messages

### DIFF
--- a/arduino/utils/stream.go
+++ b/arduino/utils/stream.go
@@ -25,7 +25,7 @@ import (
 func FeedStreamTo(writer func(data []byte)) io.Writer {
 	r, w := io.Pipe()
 	go func() {
-		data := make([]byte, 10240)
+		data := make([]byte, 16384)
 		for {
 			if n, err := r.Read(data); err == nil {
 				writer(data[:n])

--- a/arduino/utils/stream.go
+++ b/arduino/utils/stream.go
@@ -15,17 +15,26 @@
 
 package utils
 
-import "io"
+import (
+	"io"
+	"time"
+)
 
 // FeedStreamTo creates a pipe to pass data to the writer function.
 // FeedStreamTo returns the io.Writer side of the pipe, on which the user can write data
 func FeedStreamTo(writer func(data []byte)) io.Writer {
 	r, w := io.Pipe()
 	go func() {
-		data := make([]byte, 1024)
+		data := make([]byte, 10240)
 		for {
 			if n, err := r.Read(data); err == nil {
 				writer(data[:n])
+
+				// Rate limit the number of outgoing gRPC messages
+				// (less messages with biggger data blocks)
+				if n < len(data) {
+					time.Sleep(50 * time.Millisecond)
+				}
 			} else {
 				r.Close()
 				return


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
This change should allow a better buffering of the outgoing gRPC messages (fewer messages with bigger data blocks -> less fragmentation). This should allow the clients (IDE) to better handle incoming data.

**What is the current behavior?**
In particular on Windows, the output of the compile commands may be very fragmented, leading to a lot of small gRPC messages each one transporting just a single o few bytes.

**What is the new behavior?**
Messages are buffered and sent every 50 ms (unless an higher throughput is required).

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No