### PR TITLE
[breaking] `daemon --debug-file` will overwrite the log file instead of appending to it

### DIFF
--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -65,7 +65,7 @@ func NewCommand() *cobra.Command {
 	configuration.Settings.BindPFlag("daemon.port", daemonCommand.PersistentFlags().Lookup("port"))
 	daemonCommand.Flags().BoolVar(&daemonize, "daemonize", false, tr("Do not terminate daemon process if the parent process dies"))
 	daemonCommand.Flags().BoolVar(&debug, "debug", false, tr("Enable debug logging of gRPC calls"))
-	daemonCommand.Flags().StringVar(&debugFile, "debug-file", "", tr("Append debug logging to the specified file"))
+	daemonCommand.Flags().StringVar(&debugFile, "debug-file", "", tr("Log to the specified file, the file will be overwritten"))
 	daemonCommand.Flags().StringSliceVar(&debugFilters, "debug-filter", []string{}, tr("Display only the provided gRPC calls"))
 	return daemonCommand
 }
@@ -84,7 +84,7 @@ func runDaemonCommand(cmd *cobra.Command, args []string) {
 	if debug {
 		if debugFile != "" {
 			outFile := paths.New(debugFile)
-			f, err := outFile.Append()
+			f, err := outFile.Create()
 			if err != nil {
 				feedback.Error(tr("Error opening debug logging file: %s", err))
 				os.Exit(errorcodes.ErrBadCall)

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -2,6 +2,14 @@
 
 Here you can find a list of migration guides to handle breaking changes between releases of the CLI.
 
+## 0.24.0
+
+### The flag `--debug-file path` in `daemon` command now overwrites the file instead of appending.
+
+Previously running the Arduino CLI in deamon mode with the flag `--debug-file log.txt` will append to `log.txt`, now the
+file is overwritten. Since the amount of log produced is very high this will help to keep the log size on a reasonable
+amount if the flag is left enabled.
+
 ## 0.23.0
 
 ### Arduino IDE builtin libraries are now excluded from the build when running `arduino-cli` standalone


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
`daemon --debug-file log.txt` will overwrite `log.txt` instead of appending to it

**What is the current behavior?**
`daemon --debug-file log.txt` will append on `log.txt`

**What is the new behavior?**
`daemon --debug-file log.txt` will overwrite `log.txt`

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
Yes, UPGRADING.md has been updated
