### PR TITLE
Allow using specific revisions in `lib install --git-url` (#1113)

### DIFF
--- a/arduino/libraries/librariesmanager/install_test.go
+++ b/arduino/libraries/librariesmanager/install_test.go
@@ -24,43 +24,57 @@ import (
 
 func TestParseGitURL(t *testing.T) {
 	gitURL := ""
-	libraryName, err := parseGitURL(gitURL)
+	libraryName, ref, err := parseGitURL(gitURL)
 	require.Equal(t, "", libraryName)
+	require.EqualValues(t, "", ref)
 	require.Errorf(t, err, "invalid git url")
 
 	gitURL = "https://github.com/arduino/arduino-lib.git"
-	libraryName, err = parseGitURL(gitURL)
+	libraryName, ref, err = parseGitURL(gitURL)
 	require.Equal(t, "arduino-lib", libraryName)
+	require.EqualValues(t, "", ref)
+	require.NoError(t, err)
+
+	gitURL = "https://github.com/arduino/arduino-lib.git#0.1.2"
+	libraryName, ref, err = parseGitURL(gitURL)
+	require.Equal(t, "arduino-lib", libraryName)
+	require.EqualValues(t, "0.1.2", ref)
 	require.NoError(t, err)
 
 	gitURL = "git@github.com:arduino/arduino-lib.git"
-	libraryName, err = parseGitURL(gitURL)
+	libraryName, ref, err = parseGitURL(gitURL)
 	require.Equal(t, "arduino-lib", libraryName)
+	require.EqualValues(t, "", ref)
 	require.NoError(t, err)
 
 	gitURL = "file:///path/to/arduino-lib"
-	libraryName, err = parseGitURL(gitURL)
+	libraryName, ref, err = parseGitURL(gitURL)
 	require.Equal(t, "arduino-lib", libraryName)
+	require.EqualValues(t, "", ref)
 	require.NoError(t, err)
 
 	gitURL = "file:///path/to/arduino-lib.git"
-	libraryName, err = parseGitURL(gitURL)
+	libraryName, ref, err = parseGitURL(gitURL)
 	require.Equal(t, "arduino-lib", libraryName)
+	require.EqualValues(t, "", ref)
 	require.NoError(t, err)
 
 	gitURL = "/path/to/arduino-lib"
-	libraryName, err = parseGitURL(gitURL)
+	libraryName, ref, err = parseGitURL(gitURL)
 	require.Equal(t, "arduino-lib", libraryName)
+	require.EqualValues(t, "", ref)
 	require.NoError(t, err)
 
 	gitURL = "/path/to/arduino-lib.git"
-	libraryName, err = parseGitURL(gitURL)
+	libraryName, ref, err = parseGitURL(gitURL)
 	require.Equal(t, "arduino-lib", libraryName)
+	require.EqualValues(t, "", ref)
 	require.NoError(t, err)
 
 	gitURL = "file:///path/to/arduino-lib"
-	libraryName, err = parseGitURL(gitURL)
+	libraryName, ref, err = parseGitURL(gitURL)
 	require.Equal(t, "arduino-lib", libraryName)
+	require.EqualValues(t, "", ref)
 	require.NoError(t, err)
 }
 

--- a/cli/lib/install.go
+++ b/cli/lib/install.go
@@ -51,6 +51,7 @@ func initInstallCommand() *cobra.Command {
 			"  " + os.Args[0] + " lib install AudioZero       # " + tr("for the latest version.") + "\n" +
 			"  " + os.Args[0] + " lib install AudioZero@1.0.0 # " + tr("for the specific version.") + "\n" +
 			"  " + os.Args[0] + " lib install --git-url https://github.com/arduino-libraries/WiFi101.git https://github.com/arduino-libraries/ArduinoBLE.git\n" +
+			"  " + os.Args[0] + " lib install --git-url https://github.com/arduino-libraries/WiFi101.git#0.16.0 # " + tr("for the specific version.") + "\n" +
 			"  " + os.Args[0] + " lib install --zip-path /path/to/WiFi101.zip /path/to/ArduinoBLE.zip\n",
 		Args: cobra.MinimumNArgs(1),
 		Run:  runInstallCommand,

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -348,6 +348,39 @@ def test_install_with_git_url(run_command, data_dir, downloads_dir):
     assert lib_install_dir.exists()
 
 
+def test_install_with_git_url_fragment_as_branch(run_command, data_dir, downloads_dir):
+    # Initialize configs to enable --git-url flag
+    env = {
+        "ARDUINO_DATA_DIR": data_dir,
+        "ARDUINO_DOWNLOADS_DIR": downloads_dir,
+        "ARDUINO_SKETCHBOOK_DIR": data_dir,
+        "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL": "true",
+    }
+    assert run_command(["config", "init", "--dest-dir", "."], custom_env=env)
+
+    lib_install_dir = Path(data_dir, "libraries", "WiFi101")
+    # Verifies library is not already installed
+    assert not lib_install_dir.exists()
+
+    git_url = "https://github.com/arduino-libraries/WiFi101.git"
+
+    # Test that a bad ref fails
+    res = run_command(["lib", "install", "--git-url", git_url + "#x-ref-does-not-exist"])
+    assert res.failed
+
+    # Verifies library is installed in expected path
+    res = run_command(["lib", "install", "--git-url", git_url + "#0.16.0"])
+    assert res.ok
+    assert lib_install_dir.exists()
+
+    # Reinstall library at an existing ref
+    assert run_command(["lib", "install", "--git-url", git_url + "#master"])
+    assert res.ok
+
+    # Verifies library remains installed
+    assert lib_install_dir.exists()
+
+
 def test_install_with_zip_path(run_command, data_dir, downloads_dir):
     # Initialize configs to enable --zip-path flag
     env = {


### PR DESCRIPTION
This is done by providing the desired revision in the fragment, e.g.
`…/Library.git#0.1.0`. When set, this disables the clone depth limit so
all remote references will be available.

This is part of what's discussed in arduino/arduino-cli#1113 (i.e. for raw library URLs - not for cores, and not for packaged libraries.)

**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**

Feature.

- **What is the current behavior?**

Installing a library via `--git-url` always installs the default remote branch's HEAD.

* **What is the new behavior?**

A URL fragment may be used to identify a revision per the rules for go-git's `ResolveRevision`, e.g. `https://github.com/arduino-libraries/WiFi101.git#master` or `https://github.com/arduino-libraries/WiFi101.git#0.16.0`. The version currently used by arduino-cli supports branch, tag, and full SHAs; more recent versions would also support short SHAs.

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

Mostly no, unless someone was passing a wrong fragment in their URLs already and expecting to be ignored. If they were, it will now print a message like

```
Error installing Git Library: Library install failed: reference not found
```

* **Other information**:

Other possible syntax would be `@ref` instead of `#ref`. Based on other tools I use `#ref` seems more common with purely URL-based specifications while `@ref` is more common for not-really-URLs like `go get` or package repositories. Since these are really URLs I've gone with `#`.

This is only supported on true URLs, not the `git@` or path variants, as it's not clear what character would be guaranteed to be unambiguous for these formats.

I'm open to reconsidering both of these choices, as well as any additional testing ideas.