### PR TITLE
[skip changelog] Restore globbing of nightly build artifact filename

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -139,7 +139,8 @@ jobs:
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"
-          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_nightly-*${{ matrix.artifact.path }}"
+          # Use of an array here is required for globbing
+          PACKAGE_FILENAME=(${{ env.PROJECT_NAME }}_nightly-*${{ matrix.artifact.path }})
           tar -czvf "$PACKAGE_FILENAME" \
           -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

During a refactoring of the "Publish Nightly Build" workflow (https://github.com/arduino/arduino-cli/pull/1770/commits/f96ce4bef60a9192f954983ee96e3d27f163b81d), [globbing](https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html) of the macOS build artifact filename in the repackaging step was accidentally lost, causing the glob pattern to be treated instead as a string and the updated package saved to a file named by that string instead of to the original filename.

This resulted in the workflow failing with errors like:

https://github.com/arduino/arduino-cli/actions/runs/2546192732

```text
Artifact path is not valid: /arduino-cli_nightly-*macOS_64bit.tar.gz. Contains the following character: Asterisk *
```

## What is the new behavior?

The previous `basename` command was providing the globbing. After the refactoring, `basename` is no longer needed, so an alternative way to achieve globbing is needed. It seems the preferred approach is use of an [array](https://www.gnu.org/software/bash/manual/html_node/Arrays.html). Since the globbing will only expand to a single filename, the array can be referenced as before by the rest of the step, since [it will resolve to the first element in the array](https://www.gnu.org/software/bash/manual/html_node/Arrays.html#:~:text=Referencing%20an%20array%20variable%20without%20a%20subscript) (equivalent to `$PACKAGE_FILENAME[0]`).


## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change

## Other information

Demonstration run of the updated workflow in my fork here: https://github.com/per1234/arduino-cli/actions/runs/2547150008
