### PR TITLE
[skip changelog] Enable Codecov reports on pull requests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,3 @@
-comment: off
-
 ignore:
   - rpc/**
   - i18n/cmd/**

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -11,7 +11,9 @@ on:
   push:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
-      - "codecov.ya?ml"
+      - ".github/.?codecov.ya?ml"
+      - "dev/.?codecov.ya?ml"
+      - ".?codecov.ya?ml"
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
@@ -20,7 +22,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
-      - "codecov.ya?ml"
+      - ".github/.?codecov.ya?ml"
+      - "dev/.?codecov.ya?ml"
+      - ".?codecov.ya?ml"
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

### What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, ... -->

Infrastructure enhancement

###  What is the current behavior?
<!-- You can also link to an open issue here -->

[Code coverage](https://en.wikipedia.org/wiki/Code_coverage) is an important metric of quality, efficiency, and sustainability of the development and maintenance of a software project.

Although it is commendable that an above average coverage level has been achieved in this project, the current level is still not sufficient.

No meaningful attention is given to the overall coverage level and impact of each specific proposal on coverage.

### What is the new behavior?

Codecov will now automatically comment on relevant pull requests to provide a report of the code coverage impact that would result from the proposed changes:

https://docs.codecov.com/docs/pull-request-comments

These comments are valuable for several reasons:

- Brings test deficiencies to the contributor's attention
- Encourages contributors to improve PRs that originally had insufficient test coverage for the added code
- Facilitates the review process for the maintainers
- Increases awareness of code coverage trends in the project ([the Codecov website](https://app.codecov.io/gh/arduino/arduino-cli) is great for this, but likely rarely visited)

### Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.

### Other information

The "Test Go" workflow was updated to support the [alternative Codecov configuration filename](https://docs.codecov.com/docs/codecov-yaml#can-i-name-the-file-codecovyml) used by this project.
