### PR TITLE
[skip changelog] Document library dependency version constraints

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -74,7 +74,9 @@ otherwise below, **all fields are required**. The available fields are:
   install the dependencies during installation of the library.
   [`arduino-cli lib install`](commands/arduino-cli_lib_install.md) will automatically install the dependencies. Since
   spaces are allowed in the `name` of a library, but not commas, you can refer to libraries containing spaces in the
-  name without ambiguity for example:<br> `depends=Very long library name, Another library with long-name`
+  name without ambiguity for example:<br> `depends=Very long library name, Another library with long-name`<br>
+  [Version constraints](#version-constraints) for the dependency may be specified in parentheses after the name:<br>
+  `depends=ArduinoHttpClient (>=1.0.0)`
 - **dot_a_linkage** - **(available from Arduino IDE 1.6.0 / arduino-builder 1.0.0-beta13)** (optional) when set to
   `true`, the library will be compiled using a .a (archive) file. First, all source files are compiled into .o files as
   normal. Then instead of including all .o
@@ -116,6 +118,56 @@ architectures=avr
 includes=WebServer.h
 depends=ArduinoHttpClient
 ```
+
+#### Version constraints
+
+**(available from Arduino IDE 2.0.0-beta.3/Arduino CLI 0.7.0)**
+
+By default, the latest version of a dependency specified in the `depends` field of
+[`library.properties`](#libraryproperties-file-format) is installed along with the library. Specifying an exact version
+or range of versions is also supported.
+
+The following operators are available:
+
+<!-- code tags used below to reconcile mismatch between Prettier and Python-Markdown handling of pipe characters -->
+
+|                   |                               |
+| ----------------- | ----------------------------- |
+| `=`               | equal to                      |
+| `>`               | greater than                  |
+| `>=`              | greater than or equal to      |
+| `<`               | less than                     |
+| `<=`              | less than or equal to         |
+| `!`               | NOT [<sup>1</sup>](#not-note) |
+| `&&`              | AND                           |
+| <code>\|\|</code> | OR                            |
+| `(`, `)`          | constraint group              |
+
+<a id="not-note"></a> <sup>1</sup> Available from Arduino IDE 2.0.0-rc7/Arduino CLI 0.22.0
+
+##### Examples
+
+If the library "ArduinoHttpClient" has the following releases:
+
+- `0.1.0`
+- `1.0.0`
+- `2.0.0`
+- `2.1.0`
+
+The version of it installed as a dependency would be as follows:
+
+| `depends` field value                                           | Installs<br> version |
+| --------------------------------------------------------------- | -------------------- |
+| `ArduinoHttpClient`                                             | `2.1.0`              |
+| `ArduinoHttpClient (=1.0.0)`                                    | `1.0.0`              |
+| `ArduinoHttpClient (>1.0.0)`                                    | `2.1.0`              |
+| `ArduinoHttpClient (>=1.0.0)`                                   | `2.1.0`              |
+| `ArduinoHttpClient (<2.0.0)`                                    | `1.0.0`              |
+| `ArduinoHttpClient (<=2.0.0)`                                   | `2.0.0`              |
+| `ArduinoHttpClient (!=1.0.0)`                                   | `2.1.0`              |
+| `ArduinoHttpClient (>1.0.0 && <2.1.0)`                          | `2.0.0`              |
+| <code>ArduinoHttpClient (<1.0.0 \|\| >2.0.0)</code>             | `2.1.0`              |
+| <code>ArduinoHttpClient ((>0.1.0 && <2.0.0) \|\| >2.1.0)</code> | `1.0.0`              |
 
 ### Layout of folders and files
 


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

### **What kind of change does this PR introduce?**

Documentation update.

### **What is the current behavior?**
<!-- You can also link to an open issue here -->

Arduino libraries may specify dependencies on other libraries in their metadata. The Arduino Library Manager offers the option to install these dependencies when the user installs the library.

By default, the latest version of the dependency is installed. However, libraries may be compatible or tested working only with specific versions of a dependency. In this case, the library developer may wish to specify a particular version or version range of the dependency.

Arduino CLI and [the Arduino Library index system](https://github.com/arduino/libraries-repository-engine) has had support for such dependency version constraints for the last 2.5 years, but it was never documented so has only been used by the few library developers who discovered it via other means.

### **What is the new behavior?**
<!-- if this is a feature change -->

The dependencies version constraint system is fully documented in the [Arduino library specification](https://arduino.github.io/arduino-cli/dev/library-specification/). This will allow meaningful benefit to finally come from the work done to add this valuable capability.

### **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

No breaking changes.

### **Other information**:
<!-- Any additional information that could help the review process -->

I had to resort to some unusual markup in order to produce a syntax table that would be formatted correctly by the Prettier formatter (which expects the escaped pipe `\|` approach supported by the ["GitHub Flavored Markdown"](https://github.github.com/gfm/) dialect) and also rendered correctly in the [MkDocs]/[Python-Markdown](https://python-markdown.github.io/)-produced [website](https://arduino.github.io/arduino-cli/dev/) (which faithfully adheres to the original Markdown specification, and so does not recognize the pipe escaping syntax): https://github.com/mkdocs/mkdocs/issues/2761

---

Version constraints documentation from the `go.bug.st/relaxed-semver` package that provides this capability to Arduino CLI: https://github.com/bugst/relaxed-semver#version-constraints

---

Version constraints are not supported by Arduino IDE 1.x (it always installs the latest version of the dependency after user confirmation), and older versions of Arduino CLI and Arduino IDE 2.x. I have documented the cutoff versions in the specification. The specific points in the development history are:

- Introduction of version constraints support
  - Arduino CLI: https://github.com/arduino/arduino-cli/commit/b544181e20c3410f3125574dc28ec042f28d41f6
  - Arduino IDE: https://github.com/arduino/arduino-ide/commit/057904d38d07b2f7646f4d520c33045f5ca3fa1c
- Introduction of NOT operator support:
  - `go.bug.st/relaxed-semver`: https://github.com/bugst/relaxed-semver/commit/a3a14e567333df796ae4a489c7cce91842859774
  - Arduino CLI: https://github.com/arduino/arduino-cli/commit/8375a6d77aeb0fd2ad1fa9d16ede8820019f9dcb
  - Arduino IDE: https://github.com/arduino/arduino-ide/commit/4c55807392b3b724e2c5912280c621f9ed8db5e6
