### PR TITLE
cli: use cached index with lib search (#1624)

### DIFF
--- a/cli/lib/search.go
+++ b/cli/lib/search.go
@@ -204,7 +204,7 @@ func versionsFromSearchedLibrary(library *rpc.SearchedLibrary) []*semver.Version
 
 // indexNeedsUpdating returns whether library_index.json need updating.
 // A positive duration string must be provided to calculate the time threshold 
-// used to update the index (default: +24 hours).
+// used to update the index.
 // Valid duration units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 // Use a duration of 0 to always update the index.
 func indexNeedsUpdating(duration string) bool {

--- a/cli/lib/search.go
+++ b/cli/lib/search.go
@@ -203,7 +203,7 @@ func versionsFromSearchedLibrary(library *rpc.SearchedLibrary) []*semver.Version
 }
 
 // indexNeedsUpdating returns whether library_index.json need updating.
-// A positive duration string must be provided to calculate the time threshold 
+// A positive duration string must be provided to calculate the time threshold
 // used to update the index.
 // Valid duration units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 // Use a duration of 0 to always update the index.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
Feature

- **What is the current behavior?**
A new copy of `library_index.json` is downloaded every time `lib search` is called (unconditionally).

* **What is the new behavior?**
A new copy of `library_index.json` is downloaded every time `lib search` is called and either one of the following conditions exists: 
  1. The index has never been downloaded
  2. The time since the last index update is greater than one hour

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No

* **Other information**:
  - Fixes: #1624
  - Changes based on: #1063
  - **Need assistance adding test cases and documentation for this change**

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
