### PR TITLE
Fix gRPC `BoardList*` methods concurrency issues

### DIFF
--- a/arduino/cores/packagemanager/package_manager_test.go
+++ b/arduino/cores/packagemanager/package_manager_test.go
@@ -329,16 +329,14 @@ func TestPackageManagerClear(t *testing.T) {
 	packageManager := packagemanager.NewPackageManager(customHardware, customHardware, customHardware, customHardware, "test")
 	packageManager.LoadHardwareFromDirectory(customHardware)
 
-	// Creates another PackageManager but don't load the hardware
-	emptyPackageManager := packagemanager.NewPackageManager(customHardware, customHardware, customHardware, customHardware, "test")
+	// Check that the hardware is loaded
+	require.NotEmpty(t, packageManager.Packages)
 
-	// Verifies they're not equal
-	require.NotEqual(t, packageManager, emptyPackageManager)
-
-	// Clear the first PackageManager that contains loaded hardware
+	// Clear the package manager
 	packageManager.Clear()
-	// Verifies both PackageManagers are now equal
-	require.Equal(t, packageManager, emptyPackageManager)
+
+	// Check that the hardware is cleared
+	require.Empty(t, packageManager.Packages)
 }
 
 func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {

--- a/arduino/discovery/discovery.go
+++ b/arduino/discovery/discovery.go
@@ -371,10 +371,13 @@ func (disc *PluggableDiscovery) Stop() error {
 
 func (disc *PluggableDiscovery) stopSync() {
 	if disc.eventChan != nil {
+		for _, port := range disc.cachedPorts {
+			disc.eventChan <- &Event{"remove", port, disc.GetID()}
+		}
+		disc.cachedPorts = map[string]*Port{}
 		disc.eventChan <- &Event{"stop", nil, disc.GetID()}
 		close(disc.eventChan)
 		disc.eventChan = nil
-		disc.cachedPorts = map[string]*Port{}
 	}
 }
 

--- a/arduino/discovery/discovery.go
+++ b/arduino/discovery/discovery.go
@@ -121,8 +121,9 @@ func (p *Port) String() string {
 
 // Event is a pluggable discovery event
 type Event struct {
-	Type string
-	Port *Port
+	Type        string
+	Port        *Port
+	DiscoveryID string
 }
 
 // New create and connect to the given pluggable discovery
@@ -178,7 +179,7 @@ func (disc *PluggableDiscovery) jsonDecodeLoop(in io.Reader, outChan chan<- *dis
 			disc.statusMutex.Lock()
 			disc.cachedPorts[msg.Port.Address+"|"+msg.Port.Protocol] = msg.Port
 			if disc.eventChan != nil {
-				disc.eventChan <- &Event{"add", msg.Port}
+				disc.eventChan <- &Event{"add", msg.Port, disc.GetID()}
 			}
 			disc.statusMutex.Unlock()
 		} else if msg.EventType == "remove" {
@@ -189,7 +190,7 @@ func (disc *PluggableDiscovery) jsonDecodeLoop(in io.Reader, outChan chan<- *dis
 			disc.statusMutex.Lock()
 			delete(disc.cachedPorts, msg.Port.Address+"|"+msg.Port.Protocol)
 			if disc.eventChan != nil {
-				disc.eventChan <- &Event{"remove", msg.Port}
+				disc.eventChan <- &Event{"remove", msg.Port, disc.GetID()}
 			}
 			disc.statusMutex.Unlock()
 		} else {

--- a/arduino/discovery/discovery.go
+++ b/arduino/discovery/discovery.go
@@ -407,6 +407,9 @@ func (disc *PluggableDiscovery) List() ([]*Port, error) {
 // The event channel must be consumed as quickly as possible since it may block the
 // discovery if it becomes full. The channel size is configurable.
 func (disc *PluggableDiscovery) StartSync(size int) (<-chan *Event, error) {
+	disc.statusMutex.Lock()
+	defer disc.statusMutex.Unlock()
+
 	if err := disc.sendCommand("START_SYNC\n"); err != nil {
 		return nil, err
 	}
@@ -421,8 +424,6 @@ func (disc *PluggableDiscovery) StartSync(size int) (<-chan *Event, error) {
 		return nil, errors.Errorf(tr("communication out of sync, expected '%[1]s', received '%[2]s'"), "OK", msg.Message)
 	}
 
-	disc.statusMutex.Lock()
-	defer disc.statusMutex.Unlock()
 	disc.state = Syncing
 	// In case there is already an existing event channel in use we close it before creating a new one.
 	disc.stopSync()

--- a/arduino/discovery/discovery.go
+++ b/arduino/discovery/discovery.go
@@ -371,6 +371,8 @@ func (disc *PluggableDiscovery) Stop() error {
 
 func (disc *PluggableDiscovery) stopSync() {
 	if disc.eventChan != nil {
+		// When stopping sync send a batch of "remove" events for
+		// all the active ports.
 		for _, port := range disc.cachedPorts {
 			disc.eventChan <- &Event{"remove", port, disc.GetID()}
 		}

--- a/arduino/discovery/discovery_client/go.mod
+++ b/arduino/discovery/discovery_client/go.mod
@@ -7,6 +7,7 @@ replace github.com/arduino/arduino-cli => ../../..
 require (
 	github.com/arduino/arduino-cli v0.0.0-00010101000000-000000000000
 	github.com/gizak/termui/v3 v3.1.0
+	github.com/sirupsen/logrus v1.4.2
 )
 
 require (
@@ -20,7 +21,6 @@ require (
 	github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/sirupsen/logrus v1.4.2 // indirect
 	golang.org/x/net v0.0.0-20210505024714-0287a6fb4125 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.6 // indirect

--- a/arduino/discovery/discovery_client/main.go
+++ b/arduino/discovery/discovery_client/main.go
@@ -41,7 +41,7 @@ func main() {
 	activePorts := map[string]*discovery.Port{}
 	watcher, err := dm.Watch()
 	if err != nil {
-		log.Fatalf("failed to start discvoeries: %v", err)
+		log.Fatalf("failed to start discoveries: %v", err)
 	}
 	if err := ui.Init(); err != nil {
 		log.Fatalf("failed to initialize termui: %v", err)

--- a/arduino/discovery/discovery_client/main.go
+++ b/arduino/discovery/discovery_client/main.go
@@ -21,36 +21,28 @@ import (
 	"log"
 	"os"
 	"sort"
-	"time"
 
 	"github.com/arduino/arduino-cli/arduino/discovery"
+	"github.com/arduino/arduino-cli/arduino/discovery/discoverymanager"
 	ui "github.com/gizak/termui/v3"
 	"github.com/gizak/termui/v3/widgets"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	discoveries := []*discovery.PluggableDiscovery{}
-	discEvent := make(chan *discovery.Event)
+	logrus.SetLevel(logrus.ErrorLevel)
+	dm := discoverymanager.New()
 	for _, discCmd := range os.Args[1:] {
-		disc := discovery.New("", discCmd)
-		if err := disc.Run(); err != nil {
-			log.Fatal("Error starting discovery:", err)
-		}
-		if err := disc.Start(); err != nil {
-			log.Fatal("Error starting discovery:", err)
-		}
-		eventChan, err := disc.StartSync(10)
-		if err != nil {
-			log.Fatal("Error starting discovery:", err)
-		}
-		go func() {
-			for msg := range eventChan {
-				discEvent <- msg
-			}
-		}()
-		discoveries = append(discoveries, disc)
+		disc := discovery.New(discCmd, discCmd)
+		dm.Add(disc)
 	}
+	dm.Start()
 
+	activePorts := map[string]*discovery.Port{}
+	watcher, err := dm.Watch()
+	if err != nil {
+		log.Fatalf("failed to start discvoeries: %v", err)
+	}
 	if err := ui.Init(); err != nil {
 		log.Fatalf("failed to initialize termui: %v", err)
 	}
@@ -66,15 +58,20 @@ func main() {
 	updateList := func() {
 		rows := []string{}
 		rows = append(rows, "Available ports list:")
-		for _, disc := range discoveries {
-			for i, port := range disc.ListCachedPorts() {
-				rows = append(rows, fmt.Sprintf(" [%04d] Address: %s", i, port.AddressLabel))
-				rows = append(rows, fmt.Sprintf("        Protocol: %s", port.ProtocolLabel))
-				keys := port.Properties.Keys()
-				sort.Strings(keys)
-				for _, k := range keys {
-					rows = append(rows, fmt.Sprintf("                  %s=%s", k, port.Properties.Get(k)))
-				}
+
+		ids := sort.StringSlice{}
+		for id := range activePorts {
+			ids = append(ids, id)
+		}
+		ids.Sort()
+		for _, id := range ids {
+			port := activePorts[id]
+			rows = append(rows, fmt.Sprintf("> Address: %s", port.AddressLabel))
+			rows = append(rows, fmt.Sprintf("  Protocol: %s", port.ProtocolLabel))
+			keys := port.Properties.Keys()
+			sort.Strings(keys)
+			for _, k := range keys {
+				rows = append(rows, fmt.Sprintf("                  %s=%s", k, port.Properties.Get(k)))
 			}
 		}
 		l.Rows = rows
@@ -123,20 +120,16 @@ out:
 				previousKey = e.ID
 			}
 
-		case <-discEvent:
+		case ev := <-watcher.Feed():
+			if ev.Type == "add" {
+				activePorts[ev.Port.Address+"|"+ev.Port.Protocol] = ev.Port
+			}
+			if ev.Type == "remove" {
+				delete(activePorts, ev.Port.Address+"|"+ev.Port.Protocol)
+			}
 			updateList()
 		}
 
 		ui.Render(l)
 	}
-
-	for _, disc := range discoveries {
-		disc.Quit()
-		fmt.Println("Discovery QUITed")
-		for disc.State() == discovery.Alive {
-			time.Sleep(time.Millisecond)
-		}
-		fmt.Println("Discovery correctly terminated")
-	}
-
 }

--- a/arduino/discovery/discoverymanager/discoverymanager.go
+++ b/arduino/discovery/discoverymanager/discoverymanager.go
@@ -28,8 +28,12 @@ import (
 // DiscoveryManager is required to handle multiple pluggable-discovery that
 // may be shared across platforms
 type DiscoveryManager struct {
-	discoveriesMutex sync.Mutex
-	discoveries      map[string]*discovery.PluggableDiscovery
+	discoveriesMutex   sync.Mutex
+	discoveries        map[string]*discovery.PluggableDiscovery
+	discoveriesRunning bool
+	feed               chan *discovery.Event
+	watchersMutex      sync.Mutex
+	watchers           map[*PortWatcher]bool
 }
 
 var tr = i18n.Tr
@@ -38,15 +42,20 @@ var tr = i18n.Tr
 func New() *DiscoveryManager {
 	return &DiscoveryManager{
 		discoveries: map[string]*discovery.PluggableDiscovery{},
+		watchers:    map[*PortWatcher]bool{},
+		feed:        make(chan *discovery.Event, 50),
 	}
 }
 
 // Clear resets the DiscoveryManager to its initial state
 func (dm *DiscoveryManager) Clear() {
-	dm.QuitAll()
 	dm.discoveriesMutex.Lock()
-	defer dm.discoveriesMutex.Unlock()
+	for _, d := range dm.discoveries {
+		d.Quit()
+		logrus.Infof("Closed and removed discovery %s", d.GetID())
+	}
 	dm.discoveries = map[string]*discovery.PluggableDiscovery{}
+	dm.discoveriesMutex.Unlock()
 }
 
 // IDs returns the list of discoveries' ids in this DiscoveryManager
@@ -60,233 +69,137 @@ func (dm *DiscoveryManager) IDs() []string {
 	return ids
 }
 
-// Add adds a discovery to the list of managed discoveries
-func (dm *DiscoveryManager) Add(disc *discovery.PluggableDiscovery) error {
-	id := disc.GetID()
+// Start starts all the discoveries in this DiscoveryManager.
+// If the discoveries are already running, this function does nothing.
+func (dm *DiscoveryManager) Start() {
 	dm.discoveriesMutex.Lock()
 	defer dm.discoveriesMutex.Unlock()
+	if dm.discoveriesRunning {
+		return
+	}
+
+	go dm.feeder()
+
+	var wg sync.WaitGroup
+	for _, d := range dm.discoveries {
+		wg.Add(1)
+		go func(d *discovery.PluggableDiscovery) {
+			dm.startDiscovery(d)
+			wg.Done()
+		}(d)
+	}
+	wg.Wait()
+	dm.discoveriesRunning = true
+}
+
+// Add adds a discovery to the list of managed discoveries
+func (dm *DiscoveryManager) Add(d *discovery.PluggableDiscovery) error {
+	dm.discoveriesMutex.Lock()
+	defer dm.discoveriesMutex.Unlock()
+
+	id := d.GetID()
 	if _, has := dm.discoveries[id]; has {
 		return errors.Errorf(tr("pluggable discovery already added: %s"), id)
 	}
-	dm.discoveries[id] = disc
+	dm.discoveries[id] = d
+
+	if dm.discoveriesRunning {
+		dm.startDiscovery(d)
+	}
 	return nil
 }
 
-// remove quits and deletes the discovery with specified id
-// from the discoveries managed by this DiscoveryManager
-func (dm *DiscoveryManager) remove(id string) {
-	dm.discoveriesMutex.Lock()
-	d := dm.discoveries[id]
-	delete(dm.discoveries, id)
-	dm.discoveriesMutex.Unlock()
-	d.Quit()
-	logrus.Infof("Closed and removed discovery %s", id)
+// PortWatcher is a watcher for all discovery events (port connection/disconnection)
+type PortWatcher struct {
+	closeCB func()
+	feed    chan *discovery.Event
 }
 
-// parallelize runs function f concurrently for each discovery.
-// Returns a list of errors returned by each call of f.
-func (dm *DiscoveryManager) parallelize(f func(d *discovery.PluggableDiscovery) error) []error {
-	var wg sync.WaitGroup
-	errChan := make(chan error)
-	dm.discoveriesMutex.Lock()
-	discoveries := []*discovery.PluggableDiscovery{}
-	for _, d := range dm.discoveries {
-		discoveries = append(discoveries, d)
-	}
-	dm.discoveriesMutex.Unlock()
-	for _, d := range discoveries {
-		wg.Add(1)
-		go func(d *discovery.PluggableDiscovery) {
-			defer wg.Done()
-			if err := f(d); err != nil {
-				errChan <- err
-			}
-		}(d)
-	}
+// Feed returns the feed of events coming from the discoveries
+func (pw *PortWatcher) Feed() <-chan *discovery.Event {
+	return pw.feed
+}
 
-	// Wait in a goroutine to collect eventual errors running a discovery.
-	// When all goroutines that are calling discoveries are done close the errors chan.
-	go func() {
-		wg.Wait()
-		close(errChan)
+// Close closes the PortWatcher
+func (pw *PortWatcher) Close() {
+	pw.closeCB()
+}
+
+// Watch starts a watcher for all discovery events (port connection/disconnection).
+// The watcher must be closed when it is no longer needed with the Close method.
+func (dm *DiscoveryManager) Watch() (*PortWatcher, error) {
+	dm.Start()
+
+	watcher := &PortWatcher{
+		feed: make(chan *discovery.Event),
+	}
+	watcher.closeCB = func() {
+		dm.watchersMutex.Lock()
+		delete(dm.watchers, watcher)
+		dm.watchersMutex.Unlock()
+		close(watcher.feed)
+	}
+	dm.watchersMutex.Lock()
+	dm.watchers[watcher] = true
+	dm.watchersMutex.Unlock()
+	return watcher, nil
+}
+
+func (dm *DiscoveryManager) startDiscovery(d *discovery.PluggableDiscovery) (discErr error) {
+	defer func() {
+		if discErr != nil {
+			logrus.Errorf("Discovery %s failed to run: %s", d.GetID(), discErr)
+		}
 	}()
 
-	errs := []error{}
-	for err := range errChan {
-		errs = append(errs, err)
+	if err := d.Run(); err != nil {
+		return fmt.Errorf(tr("discovery %[1]s process not started: %[2]w"), d.GetID(), err)
 	}
-	return errs
-}
-
-// RunAll the discoveries for this DiscoveryManager,
-// returns an error for each discovery failing to run
-func (dm *DiscoveryManager) RunAll() []error {
-	return dm.parallelize(func(d *discovery.PluggableDiscovery) error {
-		if d.State() != discovery.Dead {
-			// This discovery is already alive, nothing to do
-			return nil
-		}
-
-		if err := d.Run(); err != nil {
-			dm.remove(d.GetID())
-			return fmt.Errorf(tr("discovery %[1]s process not started: %[2]w"), d.GetID(), err)
-		}
-		return nil
-	})
-}
-
-// StartAll the discoveries for this DiscoveryManager,
-// returns an error for each discovery failing to start
-func (dm *DiscoveryManager) StartAll() []error {
-	return dm.parallelize(func(d *discovery.PluggableDiscovery) error {
-		state := d.State()
-		if state != discovery.Idling {
-			// Already started
-			return nil
-		}
-		if err := d.Start(); err != nil {
-			dm.remove(d.GetID())
-			return fmt.Errorf(tr("starting discovery %[1]s: %[2]w"), d.GetID(), err)
-		}
-		return nil
-	})
-}
-
-// StartSyncAll the discoveries for this DiscoveryManager,
-// returns an error for each discovery failing to start syncing
-func (dm *DiscoveryManager) StartSyncAll() (<-chan *discovery.Event, []error) {
-	eventSink := make(chan *discovery.Event, 5)
-	var wg sync.WaitGroup
-	errs := dm.parallelize(func(d *discovery.PluggableDiscovery) error {
-		state := d.State()
-		if state != discovery.Idling || state == discovery.Syncing {
-			// Already syncing
-			return nil
-		}
-
-		eventCh, err := d.StartSync(5)
-		if err != nil {
-			dm.remove(d.GetID())
-			return fmt.Errorf(tr("start syncing discovery %[1]s: %[2]w"), d.GetID(), err)
-		}
-
-		wg.Add(1)
-		go func() {
-			for ev := range eventCh {
-				eventSink <- ev
-			}
-			wg.Done()
-		}()
-		return nil
-	})
-	go func() {
-		wg.Wait()
-		eventSink <- &discovery.Event{Type: "quit"}
-		close(eventSink)
-	}()
-	return eventSink, errs
-}
-
-// StopAll the discoveries for this DiscoveryManager,
-// returns an error for each discovery failing to stop
-func (dm *DiscoveryManager) StopAll() []error {
-	return dm.parallelize(func(d *discovery.PluggableDiscovery) error {
-		state := d.State()
-		if state != discovery.Syncing && state != discovery.Running {
-			// Not running nor syncing, nothing to stop
-			return nil
-		}
-
-		if err := d.Stop(); err != nil {
-			dm.remove(d.GetID())
-			return fmt.Errorf(tr("stopping discovery %[1]s: %[2]w"), d.GetID(), err)
-		}
-		return nil
-	})
-}
-
-// QuitAll quits all the discoveries managed by this DiscoveryManager.
-// Returns an error for each discovery that fails quitting
-func (dm *DiscoveryManager) QuitAll() []error {
-	errs := dm.parallelize(func(d *discovery.PluggableDiscovery) error {
-		if d.State() == discovery.Dead {
-			// Stop! Stop! It's already dead!
-			return nil
-		}
-
-		d.Quit()
-		return nil
-	})
-	return errs
-}
-
-// List returns a list of available ports detected from all discoveries
-// and a list of errors for those discoveries that returned one.
-func (dm *DiscoveryManager) List() ([]*discovery.Port, []error) {
-	var wg sync.WaitGroup
-	// Use this struct to avoid the need of two separate
-	// channels for ports and errors.
-	type listMsg struct {
-		Err  error
-		Port *discovery.Port
-	}
-	msgChan := make(chan listMsg)
-	dm.discoveriesMutex.Lock()
-	discoveries := []*discovery.PluggableDiscovery{}
-	for _, d := range dm.discoveries {
-		discoveries = append(discoveries, d)
-	}
-	dm.discoveriesMutex.Unlock()
-	for _, d := range discoveries {
-		wg.Add(1)
-		go func(d *discovery.PluggableDiscovery) {
-			defer wg.Done()
-			if d.State() != discovery.Running {
-				// Discovery is not running, it won't return anything
-				return
-			}
-			ports, err := d.List()
-			if err != nil {
-				msgChan <- listMsg{Err: fmt.Errorf(tr("listing ports from discovery %[1]s: %[2]w"), d.GetID(), err)}
-			}
-			for _, p := range ports {
-				msgChan <- listMsg{Port: p}
-			}
-		}(d)
+	eventCh, err := d.StartSync(5)
+	if err != nil {
+		return fmt.Errorf("%s: %s", tr("starting discovery %s", d.GetID()), err)
 	}
 
 	go func() {
-		// Close the channel only after all goroutines are done
-		wg.Wait()
-		close(msgChan)
-	}()
-
-	ports := []*discovery.Port{}
-	errs := []error{}
-	for msg := range msgChan {
-		if msg.Err != nil {
-			errs = append(errs, msg.Err)
-		} else {
-			ports = append(ports, msg.Port)
+		for ev := range eventCh {
+			dm.feed <- ev
 		}
-	}
-	return ports, errs
+	}()
+	return nil
 }
 
-// ListCachedPorts return the current list of ports detected from all discoveries
-func (dm *DiscoveryManager) ListCachedPorts() []*discovery.Port {
+func (dm *DiscoveryManager) feeder() {
+	// Feed all watchers with data coming from the discoveries
+	for ev := range dm.feed {
+		dm.watchersMutex.Lock()
+		for watcher := range dm.watchers {
+			select {
+			case watcher.feed <- ev:
+				// OK
+			default:
+				// If the watcher is not able to process event fast enough
+				// remove the watcher from the list of watchers
+				go watcher.Close()
+			}
+		}
+		dm.cacheEvent(ev)
+		dm.watchersMutex.Unlock()
+	}
+}
+
+func (dm *DiscoveryManager) cacheEvent(ev *discovery.Event) {
+	// XXX: TODO
+}
+
+// List return the current list of ports detected from all discoveries
+func (dm *DiscoveryManager) List() []*discovery.Port {
+	dm.Start()
+
+	// XXX: Cache ports and return them
+	dm.discoveriesMutex.Lock()
+	defer dm.discoveriesMutex.Unlock()
 	res := []*discovery.Port{}
-	dm.discoveriesMutex.Lock()
-	discoveries := []*discovery.PluggableDiscovery{}
 	for _, d := range dm.discoveries {
-		discoveries = append(discoveries, d)
-	}
-	dm.discoveriesMutex.Unlock()
-	for _, d := range discoveries {
-		if d.State() != discovery.Syncing {
-			// Discovery is not syncing
-			continue
-		}
 		res = append(res, d.ListCachedPorts()...)
 	}
 	return res

--- a/arduino/discovery/discoverymanager/discoverymanager.go
+++ b/arduino/discovery/discoverymanager/discoverymanager.go
@@ -150,9 +150,9 @@ func (dm *DiscoveryManager) Watch() (*PortWatcher, error) {
 	}
 	watcher.closeCB = func() {
 		dm.watchersMutex.Lock()
+		defer dm.watchersMutex.Unlock()
 		delete(dm.watchers, watcher)
 		close(watcher.feed)
-		dm.watchersMutex.Unlock()
 	}
 	go func() {
 		dm.watchersMutex.Lock()

--- a/arduino/discovery/discoverymanager/discoverymanager.go
+++ b/arduino/discovery/discoverymanager/discoverymanager.go
@@ -214,7 +214,22 @@ func (dm *DiscoveryManager) feedEvent(ev *discovery.Event) {
 	}
 
 	if ev.Type == "stop" {
-		// Remove all the cached events for the terminating discovery
+		// Send remove events for all the cached ports of the terminating discovery
+		cache := dm.watchersCache[ev.DiscoveryID]
+		for _, addEv := range cache {
+			removeEv := &discovery.Event{
+				Type: "remove",
+				Port: &discovery.Port{
+					Address:       addEv.Port.Address,
+					AddressLabel:  addEv.Port.AddressLabel,
+					Protocol:      addEv.Port.Protocol,
+					ProtocolLabel: addEv.Port.ProtocolLabel},
+				DiscoveryID: addEv.DiscoveryID,
+			}
+			sendToAllWatchers(removeEv)
+		}
+
+		// Remove the cache for the terminating discovery
 		delete(dm.watchersCache, ev.DiscoveryID)
 		return
 	}

--- a/arduino/discovery/discoverymanager/discoverymanager.go
+++ b/arduino/discovery/discoverymanager/discoverymanager.go
@@ -207,7 +207,7 @@ func (dm *DiscoveryManager) feedEvent(ev *discovery.Event) {
 			case <-time.After(time.Millisecond * 500):
 				// If the watcher is not able to process event fast enough
 				// remove the watcher from the list of watchers
-				logrus.Info("Watcher is not able to process events fast enough, removing it from the list of watchers")
+				logrus.Error("Watcher is not able to process events fast enough, removing it from the list of watchers")
 				delete(dm.watchers, watcher)
 			}
 		}

--- a/cli/arguments/completion.go
+++ b/cli/arguments/completion.go
@@ -178,7 +178,7 @@ func GetInstallableLibs() []string {
 func GetConnectedBoards() []string {
 	inst := instance.CreateAndInit()
 
-	list, _ := board.List(&rpc.BoardListRequest{
+	list, _, _ := board.List(&rpc.BoardListRequest{
 		Instance: inst,
 	})
 	var res []string

--- a/cli/arguments/port.go
+++ b/cli/arguments/port.go
@@ -146,7 +146,7 @@ func (p *Port) GetSearchTimeout() time.Duration {
 // discovered Port object together with the FQBN. If the port does not match
 // exactly 1 board,
 func (p *Port) DetectFQBN(inst *rpc.Instance) (string, *rpc.Port) {
-	detectedPorts, err := board.List(&rpc.BoardListRequest{
+	detectedPorts, _, err := board.List(&rpc.BoardListRequest{
 		Instance: inst,
 		Timeout:  p.timeout.Get().Milliseconds(),
 	})

--- a/cli/arguments/port.go
+++ b/cli/arguments/port.go
@@ -106,31 +106,16 @@ func (p *Port) GetPort(instance *rpc.Instance, sk *sketch.Sketch) (*discovery.Po
 		return nil, errors.New("invalid instance")
 	}
 	dm := pm.DiscoveryManager()
-	if errs := dm.RunAll(); len(errs) == len(dm.IDs()) {
-		// All discoveries failed to run, we can't do anything
-		return nil, fmt.Errorf("%v", errs)
-	} else if len(errs) > 0 {
-		// If only some discoveries failed to run just tell the user and go on
-		for _, err := range errs {
-			feedback.Error(err)
-		}
+	watcher, err := dm.Watch()
+	if err != nil {
+		return nil, err
 	}
-	eventChan, errs := dm.StartSyncAll()
-	if len(errs) > 0 {
-		return nil, fmt.Errorf("%v", errs)
-	}
-
-	defer func() {
-		// Quit all discoveries at the end.
-		if errs := dm.QuitAll(); len(errs) > 0 {
-			logrus.Errorf("quitting discoveries when getting port metadata: %v", errs)
-		}
-	}()
+	defer watcher.Close()
 
 	deadline := time.After(p.timeout.Get())
 	for {
 		select {
-		case portEvent := <-eventChan:
+		case portEvent := <-watcher.Feed():
 			if portEvent.Type != "add" {
 				continue
 			}

--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -75,11 +75,12 @@ func runListCommand(cmd *cobra.Command, args []string) {
 }
 
 func watchList(cmd *cobra.Command, inst *rpc.Instance) {
-	eventsChan, err := board.Watch(inst.Id, nil)
+	eventsChan, closeCB, err := board.Watch(inst.Id)
 	if err != nil {
 		feedback.Errorf(tr("Error detecting boards: %v"), err)
 		os.Exit(errorcodes.ErrNetwork)
 	}
+	defer closeCB()
 
 	// This is done to avoid printing the header each time a new event is received
 	if feedback.GetFormat() == feedback.Text {

--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -64,12 +64,15 @@ func runListCommand(cmd *cobra.Command, args []string) {
 		os.Exit(0)
 	}
 
-	ports, err := board.List(&rpc.BoardListRequest{
+	ports, discvoeryErrors, err := board.List(&rpc.BoardListRequest{
 		Instance: inst,
 		Timeout:  timeoutArg.Get().Milliseconds(),
 	})
 	if err != nil {
 		feedback.Errorf(tr("Error detecting boards: %v"), err)
+	}
+	for _, err := range discvoeryErrors {
+		feedback.Errorf(tr("Error starting discovery: %v"), err)
 	}
 	feedback.PrintResult(result{ports})
 }

--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -16,6 +16,7 @@
 package board
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -183,22 +184,11 @@ func List(req *rpc.BoardListRequest) (r []*rpc.DetectedPort, e error) {
 	}
 
 	dm := pm.DiscoveryManager()
-	if errs := dm.RunAll(); len(errs) > 0 {
-		return nil, &arduino.UnavailableError{Message: tr("Error starting board discoveries"), Cause: fmt.Errorf("%v", errs)}
-	}
-	if errs := dm.StartAll(); len(errs) > 0 {
-		return nil, &arduino.UnavailableError{Message: tr("Error starting board discoveries"), Cause: fmt.Errorf("%v", errs)}
-	}
-	defer func() {
-		if errs := dm.StopAll(); len(errs) > 0 {
-			logrus.Error(errs)
-		}
-	}()
+	dm.Start()
 	time.Sleep(time.Duration(req.GetTimeout()) * time.Millisecond)
 
 	retVal := []*rpc.DetectedPort{}
-	ports, errs := pm.DiscoveryManager().List()
-	for _, port := range ports {
+	for _, port := range dm.List() {
 		boards, err := identify(pm, port)
 		if err != nil {
 			return nil, err
@@ -212,92 +202,49 @@ func List(req *rpc.BoardListRequest) (r []*rpc.DetectedPort, e error) {
 		}
 		retVal = append(retVal, b)
 	}
-	if len(errs) > 0 {
-		return retVal, &arduino.UnavailableError{Message: tr("Error getting board list"), Cause: fmt.Errorf("%v", errs)}
-	}
 	return retVal, nil
 }
 
 // Watch returns a channel that receives boards connection and disconnection events.
-// The discovery process can be interrupted by sending a message to the interrupt channel.
-func Watch(instanceID int32, interrupt <-chan bool) (<-chan *rpc.BoardListWatchResponse, error) {
+// It also returns a callback function that must be used to stop and dispose the watch.
+func Watch(instanceID int32) (<-chan *rpc.BoardListWatchResponse, func(), error) {
 	pm := commands.GetPackageManager(instanceID)
 	dm := pm.DiscoveryManager()
 
-	runErrs := dm.RunAll()
-	if len(runErrs) == len(dm.IDs()) {
-		// All discoveries failed to run, we can't do anything
-		return nil, &arduino.UnavailableError{Message: tr("Error starting board discoveries"), Cause: fmt.Errorf("%v", runErrs)}
+	watcher, err := dm.Watch()
+	if err != nil {
+		return nil, nil, err
 	}
 
-	eventsChan, errs := dm.StartSyncAll()
-	if len(runErrs) > 0 {
-		errs = append(runErrs, errs...)
-	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-ctx.Done()
+		watcher.Close()
+	}()
 
 	outChan := make(chan *rpc.BoardListWatchResponse)
-
 	go func() {
 		defer close(outChan)
-		for _, err := range errs {
-			outChan <- &rpc.BoardListWatchResponse{
-				EventType: "error",
-				Error:     err.Error(),
+		for event := range watcher.Feed() {
+			port := &rpc.DetectedPort{
+				Port: event.Port.ToRPC(),
 			}
-		}
-		for {
-			select {
-			case event := <-eventsChan:
-				if event.Type == "quit" {
-					// The discovery manager has closed its event channel because it's
-					// quitting all the discovery processes that are running, this
-					// means that the events channel we're listening from won't receive any
-					// more events.
-					// Handling this case is necessary when the board watcher is running and
-					// the instance being used is reinitialized since that quits all the
-					// discovery processes and reset the discovery manager. That would leave
-					// this goroutine listening forever on a "dead" channel and might even
-					// cause panics.
-					// This message avoid all this issues.
-					// It will be the client's task restarting the board watcher if necessary,
-					// this host won't attempt restarting it.
-					outChan <- &rpc.BoardListWatchResponse{
-						EventType: event.Type,
-					}
-					return
-				}
 
-				port := &rpc.DetectedPort{
-					Port: event.Port.ToRPC(),
+			boardsError := ""
+			if event.Type == "add" {
+				boards, err := identify(pm, event.Port)
+				if err != nil {
+					boardsError = err.Error()
 				}
-
-				boardsError := ""
-				if event.Type == "add" {
-					boards, err := identify(pm, event.Port)
-					if err != nil {
-						boardsError = err.Error()
-					}
-					port.MatchingBoards = boards
-				}
-				outChan <- &rpc.BoardListWatchResponse{
-					EventType: event.Type,
-					Port:      port,
-					Error:     boardsError,
-				}
-			case <-interrupt:
-				for _, err := range dm.StopAll() {
-					// Discoveries that return errors have their process
-					// closed and are removed from the list of discoveries
-					// in the manager
-					outChan <- &rpc.BoardListWatchResponse{
-						EventType: "error",
-						Error:     tr("stopping discoveries: %s", err),
-					}
-				}
-				return
+				port.MatchingBoards = boards
+			}
+			outChan <- &rpc.BoardListWatchResponse{
+				EventType: event.Type,
+				Port:      port,
+				Error:     boardsError,
 			}
 		}
 	}()
 
-	return outChan, nil
+	return outChan, cancel, nil
 }

--- a/commands/daemon/daemon.go
+++ b/commands/daemon/daemon.go
@@ -67,7 +67,7 @@ func (s *ArduinoCoreServerImpl) BoardDetails(ctx context.Context, req *rpc.Board
 
 // BoardList FIXMEDOC
 func (s *ArduinoCoreServerImpl) BoardList(ctx context.Context, req *rpc.BoardListRequest) (*rpc.BoardListResponse, error) {
-	ports, err := board.List(req)
+	ports, _, err := board.List(req)
 	if err != nil {
 		return nil, convertErrorToRPCStatus(err)
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
Fix the functionality of the discovery manager, making it more robust when `arduino-cli` is running as a daemon with many concurrent calls.

**What is the current behavior?**
The behavior is undefined, the most frequent issues are:
- when a `BoardListWatch` is disconnected and reconnected it will not see new events
- running `BoardList` multiple times on the same instance may cause issues/crashes

**What is the new behavior?**
It should be more resistant to the above cases.

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No breaking changes.

**Other information**:
~This PR adds an experimental testsuite to test gRPC function calls. It's a collection of utilities/scripts, I finally found the time to put together.~
