### PR TITLE
Fix path in error messages on sketch loading

### DIFF
--- a/arduino/sketch/sketch.go
+++ b/arduino/sketch/sketch.go
@@ -64,7 +64,7 @@ func New(path *paths.Path) (*Sketch, error) {
 	}
 
 	path = path.Canonical()
-	if !path.IsDir() {
+	if _, validIno := globals.MainFileValidExtensions[path.Ext()]; validIno && !path.IsDir() {
 		path = path.Parent()
 	}
 
@@ -81,6 +81,9 @@ func New(path *paths.Path) (*Sketch, error) {
 				)
 			}
 		}
+	}
+	if mainFile == nil {
+		return nil, fmt.Errorf(tr("main file missing from sketch: %s", path.Join(path.Base()+globals.MainFileValidExtension)))
 	}
 
 	sketch := &Sketch{
@@ -269,7 +272,6 @@ func (s *Sketch) checkSketchCasing() error {
 		return &InvalidSketchFolderNameError{
 			SketchFolder: s.FullPath,
 			SketchFile:   sketchFile,
-			Sketch:       s,
 		}
 	}
 
@@ -280,7 +282,6 @@ func (s *Sketch) checkSketchCasing() error {
 type InvalidSketchFolderNameError struct {
 	SketchFolder *paths.Path
 	SketchFile   *paths.Path
-	Sketch       *Sketch
 }
 
 func (e *InvalidSketchFolderNameError) Error() string {

--- a/arduino/sketch/sketch.go
+++ b/arduino/sketch/sketch.go
@@ -64,6 +64,11 @@ func New(path *paths.Path) (*Sketch, error) {
 	}
 
 	path = path.Canonical()
+	if exist, err := path.ExistCheck(); err != nil {
+		return nil, fmt.Errorf("%s: %s", tr("sketch path is not valid"), err)
+	} else if !exist {
+		return nil, fmt.Errorf("%s: %s", tr("no such file or directory"), path)
+	}
 	if _, validIno := globals.MainFileValidExtensions[path.Ext()]; validIno && !path.IsDir() {
 		path = path.Parent()
 	}

--- a/arduino/sketch/sketch_test.go
+++ b/arduino/sketch/sketch_test.go
@@ -114,16 +114,39 @@ func TestNewSketchWrongMain(t *testing.T) {
 }
 
 func TestNewSketchCasingWrong(t *testing.T) {
-	sketchPath := paths.New("testdata", "SketchWithWrongMain")
-	sketch, err := New(sketchPath)
-	assert.Nil(t, sketch)
-	assert.Error(t, err)
-	assert.IsType(t, &InvalidSketchFolderNameError{}, err)
-	e := err.(*InvalidSketchFolderNameError)
-	assert.NotNil(t, e.Sketch)
-	sketchPath, _ = sketchPath.Abs()
-	expectedError := fmt.Sprintf("no valid sketch found in %s: missing %s", sketchPath.String(), sketchPath.Join(sketchPath.Base()+".ino"))
-	assert.EqualError(t, err, expectedError)
+	{
+		sketchPath := paths.New("testdata", "SketchWithWrongMain")
+		sketch, err := New(sketchPath)
+		assert.Nil(t, sketch)
+		assert.Error(t, err)
+		_, ok := err.(*InvalidSketchFolderNameError)
+		assert.False(t, ok)
+		sketchPath, _ = sketchPath.Abs()
+		expectedError := fmt.Sprintf("main file missing from sketch: %s", sketchPath.Join(sketchPath.Base()+".ino"))
+		assert.EqualError(t, err, expectedError)
+	}
+	{
+		sketchPath := paths.New("testdata", "SketchWithWrongMain", "main.ino")
+		sketch, err := New(sketchPath)
+		assert.Nil(t, sketch)
+		assert.Error(t, err)
+		_, ok := err.(*InvalidSketchFolderNameError)
+		assert.False(t, ok)
+		sketchPath, _ = sketchPath.Parent().Abs()
+		expectedError := fmt.Sprintf("main file missing from sketch: %s", sketchPath.Join(sketchPath.Base()+".ino"))
+		assert.EqualError(t, err, expectedError)
+	}
+	{
+		sketchPath := paths.New("testdata", "non-existent")
+		sketch, skerr := New(sketchPath)
+		require.Nil(t, sketch)
+		require.Error(t, skerr)
+		_, ok := skerr.(*InvalidSketchFolderNameError)
+		assert.False(t, ok)
+		sketchPath, _ = sketchPath.Abs()
+		expectedError := fmt.Sprintf("main file missing from sketch: %s", sketchPath.Join(sketchPath.Base()+".ino"))
+		require.EqualError(t, skerr, expectedError)
+	}
 }
 
 func TestNewSketchCasingCorrect(t *testing.T) {

--- a/arduino/sketch/sketch_test.go
+++ b/arduino/sketch/sketch_test.go
@@ -108,7 +108,7 @@ func TestNewSketchWrongMain(t *testing.T) {
 	sketch, err = New(mainFilePath)
 	require.Nil(t, sketch)
 	require.Error(t, err)
-	expectedError = fmt.Sprintf("main file missing from sketch: %s", expectedMainFile)
+	expectedError = fmt.Sprintf("no such file or directory: %s", expectedMainFile)
 	require.Contains(t, err.Error(), expectedError)
 }
 
@@ -143,7 +143,7 @@ func TestNewSketchCasingWrong(t *testing.T) {
 		_, ok := skerr.(*InvalidSketchFolderNameError)
 		assert.False(t, ok)
 		sketchPath, _ = sketchPath.Abs()
-		expectedError := fmt.Sprintf("main file missing from sketch: %s", sketchPath.Join(sketchPath.Base()+".ino"))
+		expectedError := fmt.Sprintf("no such file or directory: %s", sketchPath)
 		require.EqualError(t, skerr, expectedError)
 	}
 }

--- a/arduino/sketch/sketch_test.go
+++ b/arduino/sketch/sketch_test.go
@@ -100,7 +100,7 @@ func TestNewSketchWrongMain(t *testing.T) {
 	require.Error(t, err)
 	sketchFolderPath, _ = sketchFolderPath.Abs()
 	expectedMainFile := sketchFolderPath.Join(sketchName)
-	expectedError := fmt.Sprintf("no valid sketch found in %s: missing %s", sketchFolderPath, expectedMainFile)
+	expectedError := fmt.Sprintf("main file missing from sketch: %s", expectedMainFile)
 	require.Contains(t, err.Error(), expectedError)
 
 	sketchFolderPath = paths.New("testdata", sketchName)
@@ -108,8 +108,7 @@ func TestNewSketchWrongMain(t *testing.T) {
 	sketch, err = New(mainFilePath)
 	require.Nil(t, sketch)
 	require.Error(t, err)
-	sketchFolderPath, _ = sketchFolderPath.Abs()
-	expectedError = fmt.Sprintf("no valid sketch found in %s: missing %s", sketchFolderPath, expectedMainFile)
+	expectedError = fmt.Sprintf("main file missing from sketch: %s", expectedMainFile)
 	require.Contains(t, err.Error(), expectedError)
 }
 

--- a/legacy/builder/container_setup.go
+++ b/legacy/builder/container_setup.go
@@ -16,8 +16,6 @@
 package builder
 
 import (
-	"fmt"
-
 	sk "github.com/arduino/arduino-cli/arduino/sketch"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	"github.com/pkg/errors"
@@ -61,16 +59,8 @@ func (s *ContainerSetupHardwareToolsLibsSketchAndProps) Run(ctx *types.Context) 
 
 		// load sketch
 		sketch, err := sk.New(sketchLocation)
-		if e, ok := err.(*sk.InvalidSketchFolderNameError); ctx.IgnoreSketchFolderNameErrors && ok {
-			// ignore error
-			// This is only done by the arduino-builder since the Arduino Java IDE
-			// supports sketches with invalid names
-			sketch = e.Sketch
-		} else if err != nil {
+		if err != nil {
 			return errors.WithStack(err)
-		}
-		if sketch.MainFile == nil {
-			return fmt.Errorf(tr("main file missing from sketch"))
 		}
 		sketch.BuildPath = ctx.BuildPath
 		ctx.SketchLocation = sketch.MainFile

--- a/test/test_compile_part_1.py
+++ b/test/test_compile_part_1.py
@@ -37,6 +37,30 @@ def test_compile_without_fqbn(run_command):
     assert result.failed
 
 
+def test_compile_error_message(run_command, working_dir):
+    # Init the environment explicitly
+    run_command(["core", "update-index"])
+
+    # Download latest AVR
+    run_command(["core", "install", "arduino:avr"])
+
+    # Run a batch of bogus compile in a temp dir to check the error messages
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        res = run_command(["compile", "-b", "arduino:avr:uno", tmp / "ABCDEF"])
+        assert res.failed
+        assert "missing" in res.stderr
+        assert "ABCDEF" in res.stderr
+        res = run_command(["compile", "-b", "arduino:avr:uno", tmp / "ABCDEF" / "ABCDEF.ino"])
+        assert res.failed
+        assert "missing" in res.stderr
+        assert "ABCDEF" in res.stderr
+        res = run_command(["compile", "-b", "arduino:avr:uno", tmp / "ABCDEF" / "QWERTY"])
+        assert res.failed
+        assert "missing" in res.stderr
+        assert "QWERTY" in res.stderr
+
+
 def test_compile_with_simple_sketch(run_command, data_dir, working_dir):
     # Init the environment explicitly
     run_command(["core", "update-index"])

--- a/test/test_compile_part_1.py
+++ b/test/test_compile_part_1.py
@@ -47,18 +47,30 @@ def test_compile_error_message(run_command, working_dir):
     # Run a batch of bogus compile in a temp dir to check the error messages
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp = Path(tmp_dir)
-        res = run_command(["compile", "-b", "arduino:avr:uno", tmp / "ABCDEF"])
+        abcdef = tmp / "ABCDEF"
+        res = run_command(["compile", "-b", "arduino:avr:uno", abcdef])
         assert res.failed
-        assert "missing" in res.stderr
-        assert "ABCDEF" in res.stderr
-        res = run_command(["compile", "-b", "arduino:avr:uno", tmp / "ABCDEF" / "ABCDEF.ino"])
+        assert "no such file or directory:" in res.stderr
+        res = run_command(["compile", "-b", "arduino:avr:uno", abcdef / "ABCDEF.ino"])
         assert res.failed
-        assert "missing" in res.stderr
-        assert "ABCDEF" in res.stderr
-        res = run_command(["compile", "-b", "arduino:avr:uno", tmp / "ABCDEF" / "QWERTY"])
+        assert "no such file or directory:" in res.stderr
+        res = run_command(["compile", "-b", "arduino:avr:uno", abcdef / "QWERTY"])
         assert res.failed
-        assert "missing" in res.stderr
-        assert "QWERTY" in res.stderr
+        assert "no such file or directory:" in res.stderr
+
+        abcdef.mkdir()
+        res = run_command(["compile", "-b", "arduino:avr:uno", abcdef])
+        assert res.failed
+        assert "main file missing from sketch:" in res.stderr
+        res = run_command(["compile", "-b", "arduino:avr:uno", abcdef / "ABCDEF.ino"])
+        assert res.failed
+        assert "no such file or directory:" in res.stderr
+
+        qwerty_ino = abcdef / "QWERTY.ino"
+        qwerty_ino.touch()
+        res = run_command(["compile", "-b", "arduino:avr:uno", qwerty_ino])
+        assert res.failed
+        assert "main file missing from sketch:" in res.stderr
 
 
 def test_compile_with_simple_sketch(run_command, data_dir, working_dir):

--- a/test/test_compile_part_3.py
+++ b/test/test_compile_part_3.py
@@ -124,15 +124,15 @@ def test_compile_sketch_case_mismatch_fails(run_command, data_dir):
     # * Compiling with sketch path
     res = run_command(["compile", "--clean", "-b", fqbn, sketch_path])
     assert res.failed
-    assert "Error opening sketch: no valid sketch found" in res.stderr
+    assert "Error opening sketch:" in res.stderr
     # * Compiling with sketch main file
     res = run_command(["compile", "--clean", "-b", fqbn, sketch_main_file])
     assert res.failed
-    assert "Error opening sketch: no valid sketch found" in res.stderr
+    assert "Error opening sketch:" in res.stderr
     # * Compiling in sketch path
     res = run_command(["compile", "--clean", "-b", fqbn], custom_working_dir=sketch_path)
     assert res.failed
-    assert "Error opening sketch: no valid sketch found" in res.stderr
+    assert "Error opening sketch:" in res.stderr
 
 
 def test_compile_with_only_compilation_database_flag(run_command, data_dir):

--- a/test/test_sketch.py
+++ b/test/test_sketch.py
@@ -896,4 +896,4 @@ def test_sketch_archive_case_mismatch_fails(run_command, data_dir):
 
     res = run_command(["sketch", "archive", sketch_path])
     assert res.failed
-    assert "Error archiving: Can't open sketch: no valid sketch found" in res.stderr
+    assert "Error archiving: Can't open sketch:" in res.stderr

--- a/test/test_upload.py
+++ b/test/test_upload.py
@@ -364,7 +364,7 @@ def test_compile_and_upload_combo_sketch_with_mismatched_casing(run_command, dat
         # Try to compile
         res = run_command(["compile", "--clean", "-b", board.fqbn, "-u", "-p", board.address, sketch_path])
         assert res.failed
-        assert "Error opening sketch: no valid sketch found in" in res.stderr
+        assert "Error opening sketch:" in res.stderr
 
 
 def test_upload_sketch_with_mismatched_casing(run_command, data_dir, detected_boards, wait_for_board):
@@ -387,7 +387,7 @@ def test_upload_sketch_with_mismatched_casing(run_command, data_dir, detected_bo
         # searching for binaries since the sketch is not valid
         res = run_command(["upload", "-b", board.fqbn, "-p", board.address, sketch_path])
         assert res.failed
-        assert "Error during Upload: no valid sketch found in" in res.stderr
+        assert "Error during Upload:" in res.stderr
 
 
 def test_upload_to_port_with_board_autodetect(run_command, data_dir, detected_boards):


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
* Fix #1797
* Removes a compatibility layer for the Arduino IDE 1.x, see https://github.com/arduino/arduino-cli/pull/1187 for details. The proper fix must be made in the Arduino IDE 1.x, not as an exception in the CLI.

**What is the current behavior?**

```
$ arduino-cli version
arduino-cli.exe  Version: git-snapshot Commit: 6ac5f7a3 Date: 2022-07-09T19:16:18Z

$ mkdir /tmp/Arduino

$ arduino-cli compile -b arduino:avr:uno /tmp/Arduino/alma
Error opening sketch: no valid sketch found in C:\Users\per\AppData\Local\Temp\Arduino: missing C:\Users\per\AppData\Local\Temp\Arduino\Arduino.ino

$ arduino-cli compile -b arduino:avr:uno /tmp/Arduino/alma/alma.ino
Error opening sketch: reading files: open C:\Users\per\AppData\Local\Temp\Arduino\alma: The system cannot find the file specified.

$ arduino-cli compile -b arduino:avr:uno /tmp/Arduino/alma/nonexistent
Error opening sketch: reading files: open C:\Users\per\AppData\Local\Temp\Arduino\alma: The system cannot find the file specified.
```

**What is the new behavior?**
```
$ arduino-cli version
arduino-cli.exe  Version: git-snapshot Commit: 6ac5f7a3 Date: 2022-07-09T19:16:18Z

$ mkdir /tmp/Arduino

$ arduino-cli compile -b arduino:avr:uno /tmp/Arduino/alma
Error opening sketch: main file missing from sketch: /tmp/Arduino/alma/alma.ino

$ arduino-cli compile -b arduino:avr:uno /tmp/Arduino/alma/alma.ino
Error opening sketch: main file missing from sketch: /tmp/Arduino/alma/alma.ino

$ arduino-cli compile -b arduino:avr:uno /tmp/Arduino/alma/nonexistent
Error opening sketch: main file missing from sketch: /tmp/Arduino/alma/nonexistent/nonexistent.ino
```

**Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No
