### PR TITLE
Fix bogus "wrong file size" error in some rare cases

### DIFF
--- a/arduino/resources/checksums.go
+++ b/arduino/resources/checksums.go
@@ -94,7 +94,7 @@ func (r *DownloadResource) TestLocalArchiveSize(downloadDir *paths.Path) (bool, 
 		return false, fmt.Errorf(tr("getting archive info: %s"), err)
 	}
 	if info.Size() != r.Size {
-		return false, fmt.Errorf(tr("fetched archive size differs from size specified in index"))
+		return false, fmt.Errorf("%s: %d != %d", tr("fetched archive size differs from size specified in index"), info.Size(), r.Size)
 	}
 
 	return true, nil


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
Package indexes are loaded after the installed platforms.

The reason for this change is that the installed packages keep an extract of the original `package_XXX_index.json`, at the moment of the installation, inside a file named `installed.json`. This extract turns out useful if the original `package_XXX_index.json` is lost or removed to keep the platform functional.

On the other hand, if the original `package_XXX_index.json` is modified the information kept in the
`installed.json` may be outdated and should be replaced by the upstream index: this is the reason why it's loaded after the hardware platforms.

**What is the current behavior?**
In some rare cases, the tool installation may fail due to an inconsistency in checksums and file size stored in the index and in the `installed.json`.

**What is the new behavior?**
The checksums and file size in the index will always take precedence.

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No
