### PR TITLE
[skip changelog] Enable Codecov comments on PRs from forks

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -98,9 +98,7 @@ jobs:
         run: task test-legacy
 
       - name: Send unit tests coverage to Codecov
-        if: >
-          runner.os == 'Linux' &&
-          github.event_name == 'push'
+        if: runner.os == 'Linux'
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage_unit.txt
@@ -108,9 +106,7 @@ jobs:
           fail_ci_if_error: ${{ github.repository == 'arduino/arduino-cli' }}
 
       - name: Send legacy tests coverage to Codecov
-        if: >
-          runner.os == 'Linux' &&
-          github.event_name == 'push'
+        if: runner.os == 'Linux'
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage_legacy.txt


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

### What kind of change does this PR introduce?

Infrastructure enhancement

### What is the current behavior?

Versions of [the `codecov/codecov-action` GitHub Actions action](https://github.com/codecov/codecov-action) prior to 1.0.6 required the use of a token provided by Codecov in order to upload coverage data to Codecov. This token was stored in a [secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) in the Arduino CLI repository and used in the test workflow.

For security reasons, [secrets are not accessible when a workflow is triggered by an event generated by a fork of the repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow). This meant that it was impossible to upload coverage data for the test runs triggered by PRs from forks (https://github.com/codecov/codecov-action/issues/29). A conditional was added to the upload step of the workflow to cause it to only run on `push` event triggers, which effectively prevented its failure for runs on PRs from forks (https://github.com/arduino/arduino-cli/pull/388).

The token requirement was removed in [the 1.0.6 release of `codecov/codecov-action`](https://github.com/codecov/codecov-action/releases/tag/v1.0.6), but the now pointless conditional was never removed from the workflow. This prevented PRs from forks from receiving [the automated code coverage report comments](https://docs.codecov.com/docs/pull-request-comments) that would otherwise encourage those contributors to resolve coverage deficiencies and facilitate the review process.

### What is the new behavior?

The harmful conditional is removed from the coverage data upload steps of the workflow and PRs from forks will now receive coverage report comments, just as PRs from branches do already.

### Does this PR introduce a breaking change

No breaking change.

### Other information

The configuration of the coverage data upload step proposed here is aligned with our standardized "template" workflow:

https://github.com/arduino/tooling-project-assets/blob/d9f73eb4e5b16c0141e184d7f04493cd62221ea4/workflow-templates/test-go-task.yml#L104

That form of the workflow is already in use in several other Arduino tooling projects. For example:

- https://github.com/arduino/arduino-create-agent/blob/main/.github/workflows/test-go-task.yml
- https://github.com/arduino/arduino-fwuploader/blob/main/.github/workflows/test-go-task.yml
- https://github.com/arduino/arduino-lint/blob/main/.github/workflows/test-go-task.yml
- https://github.com/arduino/libraries-repository-engine/blob/main/.github/workflows/test-go-task.yml
