### PR TITLE
[skip-changelog] Fixed integration tests using a library that is no more available

### DIFF
--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -212,7 +212,7 @@ def test_lib_download(run_command, downloads_dir):
 
 
 def test_install(run_command):
-    libs = ["AzureIoTProtocol_MQTT", "CMMC MQTT Connector", "WiFiNINA"]
+    libs = ["Arduino_BQ24195", "CMMC MQTT Connector", "WiFiNINA"]
     # Should be safe to run install multiple times
     assert run_command(["lib", "install"] + libs)
     assert run_command(["lib", "install"] + libs)
@@ -452,7 +452,7 @@ def test_update_index(run_command):
 
 
 def test_uninstall(run_command):
-    libs = ["AzureIoTProtocol_MQTT", "WiFiNINA"]
+    libs = ["Arduino_BQ24195", "WiFiNINA"]
     assert run_command(["lib", "install"] + libs)
 
     result = run_command(["lib", "uninstall"] + libs)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
Fix integration tests using library `AzureIoTProtocol_MQTT` that has been removed from the registry

- **What is the current behavior?**
Integration tests fails

* **What is the new behavior?**
Integration tests succeed

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No
