### PR TITLE
[skip changelog] Remove spurious argument from error message

### DIFF
--- a/arduino/cores/packagemanager/download.go
+++ b/arduino/cores/packagemanager/download.go
@@ -125,7 +125,7 @@ func (pm *PackageManager) DownloadToolRelease(tool *cores.ToolRelease, config *d
 	if resource == nil {
 		return &arduino.FailedDownloadError{
 			Message: tr("Error downloading tool %s", tool),
-			Cause:   errors.New(tr("no versions available for the current OS", tool))}
+			Cause:   errors.New(tr("no versions available for the current OS"))}
 	}
 	if err := resource.Download(pm.DownloadDir, config, tool.String(), progressCB); err != nil {
 		return &arduino.FailedDownloadError{


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, ... -->

Bug fix

## What is the current behavior?
<!-- You can also link to an open issue here -->

[`github.com/arduino/arduino-cli/i18n.Tr`](https://github.com/arduino/arduino-cli/blob/c7163b776f756a0ca25e9bebf872eeb1e7bf404a/i18n/i18n.go#L41-L45) provides [a `fmt.Printf`-style interface](https://pkg.go.dev/fmt#hdr-Printing), where the first argument may serve as a template filled by subsequent arguments according to its format verbs.

The call modified in this PR contains a subsequent argument, but no verb in the format string to use it. This generates some cryptic content in the error message.

For example:

```text
Error during install: Error downloading tool arduino:bossac@1.7.0-arduino3: no versions available for the current OS%!(EXTRA *cores.ToolRelease=arduino:bossac@1.7.0-arduino3)
```

(note the unexpected `%!(EXTRA *cores.ToolRelease=arduino:bossac@1.7.0-arduino3)`)

## What is the new behavior?
<!-- if this is a feature change -->

The cryptic content is not present in the error message:

For example:

```text
Error during install: Error downloading tool arduino:bossac@1.7.0-arduino3: no versions available for the current OS
```

The tool name is already provided in the correctly configured `Message` field of the error, so there is no need to include it in the `Cause` field as well, so the spurious argument can be removed entirely rather than the alternative fix of adjusting the format string argument. I suspect the spurious argument was simply the result of a copy/paste error.

## Does this PR introduce a breaking change?

No breaking change