### PR TITLE
[skip changelog] Update broken or outdated links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/platform-dependent/bug-report.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/platform-dependent/bug-report.yml
 # See: https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
 
 name: Bug report

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/platform-dependent/bug-report.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/platform-dependent/feature-request.yml
 # See: https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
 
 name: Feature request

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -369,12 +369,9 @@ If your PR doesn't need to be included in the changelog, please start the commit
 [1]: https://golang.org/doc/install
 [2]: https://taskfile.dev/#/installation
 [3]: https://www.python.org/downloads/
-[4]: https://docs.python.org/3/tutorial/venv.html
-[5]: https://github.com/ofek/hatch
 [6]: https://github.com/protocolbuffers/protobuf/releases
 [7]: https://pages.github.com/
 [9]: https://www.mkdocs.org/
-[10]: https://github.com/jimporter/mike
 [11]: https://github.com/arduino/arduino-cli/blob/master/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
 [12]:
   https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -366,7 +366,7 @@ If your PR doesn't need to be included in the changelog, please start the commit
 **[skip changelog]**
 
 [0]: https://cla-assistant.io/arduino/arduino-cli
-[1]: https://golang.org/doc/install
+[1]: https://go.dev/doc/install
 [2]: https://taskfile.dev/#/installation
 [3]: https://www.python.org/downloads/
 [6]: https://github.com/protocolbuffers/protobuf/releases

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -31,7 +31,7 @@ If your question wasn't answered, feel free to ask on [Arduino CLI's forum board
 
 [arduino cli board list]: commands/arduino-cli_board_list.md
 [0]: platform-specification.md
-[1]: https://forum.arduino.cc/index.php?board=145.0
+[1]: https://forum.arduino.cc/c/software/arduino-cli/89
 [screen]: https://www.gnu.org/software/screen/manual/screen.html
 [putty]: https://www.chiark.greenend.org.uk/~sgtatham/putty/
 [monitor command]: commands/arduino-cli_monitor.md

--- a/docs/command-line-completion.md
+++ b/docs/command-line-completion.md
@@ -38,9 +38,9 @@ Remember to open a new shell to test the functionality.
 
 Use `arduino-cli completion fish > arduino-cli.fish` to generate the completion file. At this point you can place the
 file in `~/.config/fish/completions` as stated in the
-[official documentation](http://fishshell.com/docs/current/index.html#where-to-put-completions). Remember to create the
-directory if it's not already there `mkdir -p ~/.config/fish/completions/` and then place the completion file in there
-with `mv arduino-cli.fish ~/.config/fish/completions/`
+[official documentation](https://fishshell.com/docs/current/completions.html#where-to-put-completions). Remember to
+create the directory if it's not already there `mkdir -p ~/.config/fish/completions/` and then place the completion file
+in there with `mv arduino-cli.fish ~/.config/fish/completions/`
 
 Remember to open a new shell to test the functionality.
 

--- a/docs/integration-options.md
+++ b/docs/integration-options.md
@@ -87,9 +87,9 @@ contains [example code showing how to implement a gRPC client][grpc client examp
 designed the low level API, have a look at the [commands package] and don’t hesitate to leave feedback on the [issue
 tracker] if you’ve got a use case that doesn’t fit one of the three pillars.
 
-[golang]: https://golang.org/
+[golang]: https://go.dev/
 [arduino pro ide]: https://www.arduino.cc/pro/arduino-pro-ide
-[arduino cloud]: https://create.arduino.cc
+[arduino cloud]: https://cloud.arduino.cc/home
 [continuous integration]: https://en.wikipedia.org/wiki/Continuous_integration
 [continuous deployment]: https://en.wikipedia.org/wiki/Continuous_deployment
 [configuration documentation]: configuration.md

--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -14,7 +14,7 @@ and
 as well as [`arduino-cli lib`](commands/arduino-cli_lib.md).
 
 More information about how Library Manager works is available
-[here](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ).
+[here](https://github.com/arduino/library-registry/blob/main/FAQ.md#readme).
 
 Arduino development software supports multiple microcontroller architectures (e.g. AVR, SAM, etc), meaning that
 libraries may need to work on multiple architectures. The new 1.5 library format doesn’t contain special support for
@@ -23,7 +23,7 @@ code to specific architectures.
 
 ## See also
 
-- [Arduino library style guide](http://docs.arduino.cc/learn/contributions/arduino-library-style-guide)
+- [Arduino library style guide](https://docs.arduino.cc/learn/contributions/arduino-library-style-guide)
 - [Library dependency resolution process documentation](sketch-build-process.md#dependency-resolution)
 
 ## 1.5 library format (rev. 2.2)
@@ -44,9 +44,9 @@ otherwise below, **all fields are required**. The available fields are:
 - **name** - the name of the library. Library names must contain only basic letters (A-Z or a-z) and numbers (0-9),
   spaces ( ), underscores (\_), dots (.) and dashes (-). They must start with a letter or number. They must contain at
   least one letter. Note that libraries with a `name` value starting with `Arduino` will no longer be allowed
-  [addition to the Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ) as these names
-  are now reserved for official Arduino libraries.
-- **version** - version of the library. Version should be [semver](http://semver.org/) compliant. 1.2.0 is correct; 1.2
+  [addition to the Library Manager index](https://github.com/arduino/library-registry/blob/main/README.md#adding-a-library-to-library-manager)
+  as these names are now reserved for official Arduino libraries.
+- **version** - version of the library. Version should be [semver](https://semver.org/) compliant. 1.2.0 is correct; 1.2
   is accepted; r5, 003, 1.1c are invalid
 - **author** - name/nickname of the authors and their email addresses (not mandatory) separated by comma (,)
 - **maintainer** - name and email of the maintainer
@@ -360,8 +360,8 @@ Normally the Arduino IDE treats the contents of the library folder as read-only.
 accidentally modifying example sketches. During the library development process you may want to edit example sketches in
 place using the Arduino IDE. With Arduino IDE 1.6.6 and newer, the read-only behavior can be disabled by adding a file
 named .development to the root of the library folder. A [library.properties](#libraryproperties-file-format) file must
-also be present. The [Library Manager indexer](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ) will not
-pick up releases that contain a .development file so be sure not to push this file to your remote repository.
+also be present. The [Library Manager indexer](https://github.com/arduino/library-registry/blob/main/FAQ.md#readme) will
+not pick up releases that contain a .development file so be sure not to push this file to your remote repository.
 
 ### A complete example
 

--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -276,7 +276,7 @@ Editor.
 More information:
 
 - [Arduino sketch specification](sketch-specification.md)
-- [Style guide for Arduino examples](https://www.arduino.cc/en/Reference/StyleGuide)
+- [Style guide for Arduino examples](https://docs.arduino.cc/learn/contributions/arduino-writing-style-guide)
 
 #### Extra documentation
 

--- a/docs/sketch-specification.md
+++ b/docs/sketch-specification.md
@@ -168,4 +168,4 @@ This feature was added in Arduino IDE 1.6.9.
 ## See also
 
 - [Sketch build process documentation](sketch-build-process.md)
-- [Style guide for example sketches](https://www.arduino.cc/en/Reference/StyleGuide)
+- [Style guide for example sketches](https://docs.arduino.cc/learn/contributions/arduino-writing-style-guide)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, ... -->

Documentation fix

## What is the current behavior?
<!-- You can also link to an open issue here -->

Some of the links in the documentation are broken (in ways or forms that are not covered by the automated link check).

Some of the links in the documentation rely on redirects which could break in the future.

## What is the new behavior?
<!-- if this is a feature change -->

All links in documentation reach their intended target, and reach it directly.

## Does this PR introduce a breaking change
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

No breaking change.

## Other information

Fixes https://github.com/arduino/arduino-cli/issues/1832