### PR TITLE
[skip changelog] Add readme for localization data

### DIFF
--- a/i18n/data/README.md
+++ b/i18n/data/README.md
@@ -1,0 +1,12 @@
+# Localization data
+
+This folder contains the [localization](https://wikipedia.org/wiki/Language_localisation) data for **Arduino CLI**.
+
+❗ These files are automatically generated and so can not be edited directly. If you wish to modify the contents, do it
+at the source:
+
+- **en.po** - edit the string in the source code file indicated by the comment above it <br /> e.g., a comment
+  `#: commands/upload/upload.go:615` indicates the source string is at line 615 of the file
+  [`commands/upload/upload.go`](../../commands/upload/upload.go)
+- **All other files** - the localization is done on **Transifex**: <br />
+  https://explore.transifex.com/arduino-1/arduino-cli/


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

### What kind of change does this PR introduce?

Documentation enhancement

### What is the current behavior?

**Arduino CLI** has been translated to [12 languages](https://explore.transifex.com/arduino-1/arduino-cli/).

The [localization](https://wikipedia.org/wiki/Language_localisation) process follows the following steps:

1. An English language source string is defined in the **Arduino CLI** codebase
2. The source string is [pushed](https://github.com/arduino/arduino-cli/blob/master/.github/workflows/i18n-nightly-push.yaml) to [**Transifex**](https://explore.transifex.com/arduino-1/arduino-cli/).
3. Community translators localize the string
4. The localization data is [pulled](https://github.com/arduino/arduino-cli/blob/master/.github/workflows/i18n-weekly-pull.yaml) into the **Arduino CLI** repository
5. The localization data is incorporated into the **Arduino CLI** distribution

Experience with maintenance of the [Arduino IDE 1.x project](https://github.com/arduino/Arduino) indicates that the data files generated at step (4) can appear to be the appropriate place to make edits for casual contributors not familiar with the project's sophisticated internationalization infrastructure.

Since those files are generated by automated systems, any edits made there would only be overwritten. If a contributor targeting localized data starts from [`CONTRIBUTING.md`](https://github.com/arduino/arduino-cli/blob/master/docs/CONTRIBUTING.md), they will be directed to the appropriate place to do that on **Transifex**. However, they may not use that entry point to their efforts, or they may be targeting the English language source strings instead.

### What is the new behavior?

A readme file located in the same folder as the localization data explains the correct ways to contribute to that content, supplementing the existing information in `CONTRIBUTING.md`.

### Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.

### Other information

The rendered content can be previewed here:

https://github.com/per1234/arduino-cli/tree/l10n-data-docs/i18n/data#readme