### PR TITLE
Added 'label' and 'properties' fields in `board -w` command (json output)

### DIFF
--- a/cli/board/list.go
+++ b/cli/board/list.go
@@ -91,9 +91,11 @@ func watchList(cmd *cobra.Command, inst *rpc.Instance) {
 	for event := range eventsChan {
 		feedback.PrintResult(watchEvent{
 			Type:          event.EventType,
+			Label:         event.Port.Port.Label,
 			Address:       event.Port.Port.Address,
 			Protocol:      event.Port.Port.Protocol,
 			ProtocolLabel: event.Port.Port.ProtocolLabel,
+			Properties:    event.Port.Port.Properties,
 			Boards:        event.Port.MatchingBoards,
 			Error:         event.Error,
 		})
@@ -166,8 +168,10 @@ func (dr result) String() string {
 type watchEvent struct {
 	Type          string               `json:"type"`
 	Address       string               `json:"address,omitempty"`
+	Label         string               `json:"label,omitempty"`
 	Protocol      string               `json:"protocol,omitempty"`
 	ProtocolLabel string               `json:"protocol_label,omitempty"`
+	Properties    map[string]string    `json:"properties"`
 	Boards        []*rpc.BoardListItem `json:"boards,omitempty"`
 	Error         string               `json:"error,omitempty"`
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
Adds all the information available from discoveries to the `board -w --format json` output, in particular the `label` and `properties` fields that are missing from the output.

**What is the current behavior?**
```
$ arduino-cli board -w --format json
{
  "type": "add",
  "address": "/dev/ttyACM0",
  "protocol": "serial",
  "protocol_label": "Serial Port (USB)",
  "boards": [
    {
      "name": "Arduino Uno",
      "fqbn": "arduino:avr:uno"
    }
  ]
}
```

**What is the new behavior?**
```
$ arduino-cli board -w --format json
{
  "type": "add",
  "address": "/dev/ttyACM0",
  "label": "/dev/ttyACM0",
  "protocol": "serial",
  "protocol_label": "Serial Port (USB)",
  "properties": {
    "pid": "0x0043",
    "serialNumber": "754393237353511051D2",
    "vid": "0x2341"
  },
  "boards": [
    {
      "name": "Arduino Uno",
      "fqbn": "arduino:avr:uno"
    }
  ]
}
```

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No