### PR TITLE
Correct key name in `arduino-cli compile --dump-profile` output

### DIFF
--- a/cli/compile/compile.go
+++ b/cli/compile/compile.go
@@ -303,7 +303,7 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 			newProfileName = split[2]
 		}
 		fmt.Println()
-		fmt.Println("profile:")
+		fmt.Println("profiles:")
 		fmt.Println("  " + newProfileName + ":")
 		fmt.Println("    fqbn: " + compileRequest.GetFqbn())
 		fmt.Println("    platforms:")


### PR DESCRIPTION

The key name is hereby corrected.

### Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

The `--dump-profile` flag causes Arduino CLI to print the board and sketch dependencies of that compilation as a YAML document. This could be copied into a ["sketch project file"](https://arduino.github.io/arduino-cli/dev/sketch-project-file/) for later use as a ["build profile"](https://arduino.github.io/arduino-cli/dev/sketch-project-file/#build-profiles) specified via the `--profile` flag.

A typo in the `profiles` key name caused the generated "build profile" entry to not be recognized when added to a "sketch project file":

```text
arduino-cli compile --fqbn arduino:avr:uno --dump-profile
Sketch uses 3720 bytes (11%) of program storage space. Maximum is 32256 bytes.
Global variables use 393 bytes (19%) of dynamic memory, leaving 1655 bytes for local variables. Maximum is 2048 bytes.

profile:
  uno:
    fqbn: arduino:avr:uno
    platforms:
      - platform: arduino:avr (1.8.5)

Used library   Version Path
EEPROM         2.0     C:\Users\per\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.5\libraries\EEPROM
SoftwareSerial 1.0     C:\Users\per\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.5\libraries\SoftwareSerial

Used platform Version Path
arduino:avr   1.8.5   C:\Users\per\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.5
```

### What is the new behavior?

The `arduino-cli compile --dump-profile` output uses the valid key name `profiles`.

```text
arduino-cli compile --fqbn arduino:avr:uno --dump-profile
Sketch uses 3720 bytes (11%) of program storage space. Maximum is 32256 bytes.
Global variables use 393 bytes (19%) of dynamic memory, leaving 1655 bytes for local variables. Maximum is 2048 bytes.

profiles:
  uno:
    fqbn: arduino:avr:uno
    platforms:
      - platform: arduino:avr (1.8.5)

Used library   Version Path
EEPROM         2.0     C:\Users\per\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.5\libraries\EEPROM
SoftwareSerial 1.0     C:\Users\per\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.5\libraries\SoftwareSerial

Used platform Version Path
arduino:avr   1.8.5   C:\Users\per\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.5
```

### Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.

### Other information

Originally reported at https://forum.arduino.cc/t/dump-profile-error/1024698

---

This indicates to me that the existing dedicated infrastructure for printing build profiles should be used instead of duplicating what is already hacky code all over again specifically for use with the `--dump-profile` flag:

https://github.com/arduino/arduino-cli/blob/f43c9ec042d03390767689348922082173d4611f/arduino/sketch/profiles.go#L56