### PR TITLE
Fixed cryptic error messages returned from Compile

### DIFF
--- a/commands/daemon/daemon.go
+++ b/commands/daemon/daemon.go
@@ -278,7 +278,10 @@ func (s *ArduinoCoreServerImpl) Compile(req *rpc.CompileRequest, stream rpc.Ardu
 	errStream.Close()
 	<-outCtx.Done()
 	<-errCtx.Done()
-	compileRespSendErr := stream.Send(compileResp)
+	var compileRespSendErr error
+	if compileResp != nil {
+		compileRespSendErr = stream.Send(compileResp)
+	}
 	if compileErr != nil {
 		return convertErrorToRPCStatus(compileErr)
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
Fix the error messages from `compile`, they were not correctly encoded in the response.

- **What is the current behavior?**
The message `grpc: error while marshaling: proto: Marshal called with nil` appeared instead of the real error message. See #1812 for details.

* **What is the new behavior?**
The correct error message is outputted.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No

* **Other information**:
Fix #1812