### PR TITLE
Extended Pluggable Monitor specification to allow board-specific settings to be applied

### DIFF
--- a/arduino/cores/board.go
+++ b/arduino/cores/board.go
@@ -175,6 +175,7 @@ func (b *Board) IsBoardMatchingIDProperties(query *properties.Map) bool {
 }
 
 // GetMonitorSettings returns the settings for the pluggable monitor of the given protocol
-func (b *Board) GetMonitorSettings(protocol string) *properties.Map {
-	return b.Properties.SubTree("monitor_port." + protocol)
+// and set of board properties.
+func GetMonitorSettings(protocol string, boardProperties *properties.Map) *properties.Map {
+	return boardProperties.SubTree("monitor_port." + protocol)
 }

--- a/arduino/cores/board.go
+++ b/arduino/cores/board.go
@@ -173,3 +173,8 @@ func (b *Board) IsBoardMatchingIDProperties(query *properties.Map) bool {
 	}
 	return false
 }
+
+// GetMonitorSettings returns the settings for the pluggable monitor of the given protocol
+func (b *Board) GetMonitorSettings(protocol string) *properties.Map {
+	return b.Properties.SubTree("monitor_port." + protocol)
+}

--- a/arduino/cores/packagemanager/loader.go
+++ b/arduino/cores/packagemanager/loader.go
@@ -504,6 +504,7 @@ func (pm *Builder) loadBoards(platform *cores.PlatformRelease) error {
 			convertVidPidIdentificationPropertiesToPluggableDiscovery(boardProperties)
 			convertUploadToolsToPluggableDiscovery(boardProperties)
 		}
+		convertLegacySerialPortRTSDTRSettingsToPluggableMonitor(boardProperties)
 
 		// The board's ID must be available in a board's properties since it can
 		// be used in all configuration files for several reasons, like setting compilation
@@ -525,6 +526,24 @@ func (pm *Builder) loadBoards(platform *cores.PlatformRelease) error {
 
 // Converts the old:
 //
+//   - xxx.serial.disableRTS=true
+//   - xxx.serial.disableDTR=true
+//
+// properties into pluggable monitor compatible:
+//
+//   - xxx.monitor_port.serial.rts=off
+//   - xxx.monitor_port.serial.dtr=off
+func convertLegacySerialPortRTSDTRSettingsToPluggableMonitor(boardProperties *properties.Map) {
+	if boardProperties.GetBoolean("serial.disableDTR") {
+		boardProperties.Set("monitor_port.serial.dtr", "off")
+	}
+	if boardProperties.GetBoolean("serial.disableRTS") {
+		boardProperties.Set("monitor_port.serial.rts", "off")
+	}
+}
+
+// Converts the old:
+//
 //   - xxx.vid.N
 //   - xxx.pid.N
 //
@@ -532,7 +551,6 @@ func (pm *Builder) loadBoards(platform *cores.PlatformRelease) error {
 //
 //   - xxx.upload_port.N.vid
 //   - xxx.upload_port.N.pid
-//
 func convertVidPidIdentificationPropertiesToPluggableDiscovery(boardProperties *properties.Map) {
 	n := 0
 	outputVidPid := func(vid, pid string) {

--- a/arduino/cores/packagemanager/loader.go
+++ b/arduino/cores/packagemanager/loader.go
@@ -534,11 +534,29 @@ func (pm *Builder) loadBoards(platform *cores.PlatformRelease) error {
 //   - xxx.monitor_port.serial.rts=off
 //   - xxx.monitor_port.serial.dtr=off
 func convertLegacySerialPortRTSDTRSettingsToPluggableMonitor(boardProperties *properties.Map) {
-	if boardProperties.GetBoolean("serial.disableDTR") {
-		boardProperties.Set("monitor_port.serial.dtr", "off")
+	disabledToOnOff := func(k string) string {
+		if boardProperties.GetBoolean(k) {
+			return "off" // Disabled
+		}
+		return "on" // Not disabled
 	}
-	if boardProperties.GetBoolean("serial.disableRTS") {
-		boardProperties.Set("monitor_port.serial.rts", "off")
+	if boardProperties.ContainsKey("serial.disableDTR") {
+		boardProperties.Set("monitor_port.serial.dtr", disabledToOnOff("serial.disableDTR"))
+	}
+	if boardProperties.ContainsKey("serial.disableRTS") {
+		boardProperties.Set("monitor_port.serial.rts", disabledToOnOff("serial.disableRTS"))
+	}
+	for _, k := range boardProperties.Keys() {
+		if strings.HasSuffix(k, ".serial.disableDTR") {
+			boardProperties.Set(
+				strings.TrimSuffix(k, ".serial.disableDTR")+".monitor_port.serial.dtr",
+				disabledToOnOff(k))
+		}
+		if strings.HasSuffix(k, ".serial.disableRTS") {
+			boardProperties.Set(
+				strings.TrimSuffix(k, ".serial.disableRTS")+".monitor_port.serial.rts",
+				disabledToOnOff(k))
+		}
 	}
 }
 

--- a/arduino/cores/packagemanager/loader_test.go
+++ b/arduino/cores/packagemanager/loader_test.go
@@ -108,8 +108,20 @@ arduino_zero_native.pid.3=0x024d
 
 func TestDisableDTRRTSConversionToPluggableMonitor(t *testing.T) {
 	m, err := properties.LoadFromBytes([]byte(`
+menu.rts=RTS
+menu.dtr=DTR
+foo.menu.rts.on=On
+foo.menu.rts.on.serial.disableRTS=false
+foo.menu.rts.off=Off
+foo.menu.rts.off.serial.disableRTS=true
+foo.menu.dtr.on=On
+foo.menu.dtr.on.serial.disableDTR=false
+foo.menu.dtr.off=Off
+foo.menu.dtr.off.serial.disableDTR=true
+
 arduino_zero.serial.disableDTR=true
 arduino_zero.serial.disableRTS=true
+
 arduino_zero_edbg.serial.disableDTR=false
 arduino_zero_edbg.serial.disableRTS=true
 `))
@@ -131,8 +143,27 @@ arduino_zero_edbg.serial.disableRTS=true
 		require.Equal(t, `properties.Map{
   "serial.disableDTR": "false",
   "serial.disableRTS": "true",
+  "monitor_port.serial.dtr": "on",
   "monitor_port.serial.rts": "off",
 }`, zeroEdbg.Dump())
+	}
+	{
+		foo := m.SubTree("foo")
+		convertLegacySerialPortRTSDTRSettingsToPluggableMonitor(foo)
+		require.Equal(t, `properties.Map{
+  "menu.rts.on": "On",
+  "menu.rts.on.serial.disableRTS": "false",
+  "menu.rts.off": "Off",
+  "menu.rts.off.serial.disableRTS": "true",
+  "menu.dtr.on": "On",
+  "menu.dtr.on.serial.disableDTR": "false",
+  "menu.dtr.off": "Off",
+  "menu.dtr.off.serial.disableDTR": "true",
+  "menu.rts.on.monitor_port.serial.rts": "on",
+  "menu.rts.off.monitor_port.serial.rts": "off",
+  "menu.dtr.on.monitor_port.serial.dtr": "on",
+  "menu.dtr.off.monitor_port.serial.dtr": "off",
+}`, foo.Dump())
 	}
 }
 

--- a/commands/monitor/monitor.go
+++ b/commands/monitor/monitor.go
@@ -128,12 +128,12 @@ func findMonitorAndSettingsForProtocolAndBoard(pme *packagemanager.Explorer, pro
 			return nil, nil, &arduino.InvalidFQBNError{Cause: err}
 		}
 
-		_, boardPlatform, board, boardProperties, _, err := pme.ResolveFQBN(fqbn)
+		_, boardPlatform, _, boardProperties, _, err := pme.ResolveFQBN(fqbn)
 		if err != nil {
 			return nil, nil, &arduino.UnknownFQBNError{Cause: err}
 		}
 
-		boardSettings = board.GetMonitorSettings(protocol)
+		boardSettings = cores.GetMonitorSettings(protocol, boardProperties)
 
 		if mon, ok := boardPlatform.Monitors[protocol]; ok {
 			monitorDepOrRecipe = mon

--- a/commands/monitor/monitor.go
+++ b/commands/monitor/monitor.go
@@ -67,7 +67,7 @@ func Monitor(ctx context.Context, req *rpc.MonitorRequest) (*PortProxy, *pluggab
 	}
 	defer release()
 
-	m, err := findMonitorForProtocolAndBoard(pme, req.GetPort().GetProtocol(), req.GetFqbn())
+	m, boardSettings, err := findMonitorAndSettingsForProtocolAndBoard(pme, req.GetPort().GetProtocol(), req.GetFqbn())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -82,17 +82,24 @@ func Monitor(ctx context.Context, req *rpc.MonitorRequest) (*PortProxy, *pluggab
 		return nil, nil, &arduino.FailedMonitorError{Cause: err}
 	}
 
-	monIO, err := m.Open(req.GetPort().GetAddress(), req.GetPort().GetProtocol())
-	if err != nil {
-		m.Quit()
-		return nil, nil, &arduino.FailedMonitorError{Cause: err}
-	}
+	// Apply user-requested settings
 	if portConfig := req.GetPortConfiguration(); portConfig != nil {
 		for _, setting := range portConfig.Settings {
+			boardSettings.Remove(setting.SettingId) // Remove board settings overridden by the user
 			if err := m.Configure(setting.SettingId, setting.Value); err != nil {
 				logrus.Errorf("Could not set configuration %s=%s: %s", setting.SettingId, setting.Value, err)
 			}
 		}
+	}
+	// Apply specific board settings
+	for setting, value := range boardSettings.AsMap() {
+		m.Configure(setting, value)
+	}
+
+	monIO, err := m.Open(req.GetPort().GetAddress(), req.GetPort().GetProtocol())
+	if err != nil {
+		m.Quit()
+		return nil, nil, &arduino.FailedMonitorError{Cause: err}
 	}
 
 	logrus.Infof("Port %s successfully opened", req.GetPort().GetAddress())
@@ -106,24 +113,27 @@ func Monitor(ctx context.Context, req *rpc.MonitorRequest) (*PortProxy, *pluggab
 	}, descriptor, nil
 }
 
-func findMonitorForProtocolAndBoard(pme *packagemanager.Explorer, protocol, fqbn string) (*pluggableMonitor.PluggableMonitor, error) {
+func findMonitorAndSettingsForProtocolAndBoard(pme *packagemanager.Explorer, protocol, fqbn string) (*pluggableMonitor.PluggableMonitor, *properties.Map, error) {
 	if protocol == "" {
-		return nil, &arduino.MissingPortProtocolError{}
+		return nil, nil, &arduino.MissingPortProtocolError{}
 	}
 
 	var monitorDepOrRecipe *cores.MonitorDependency
+	boardSettings := properties.NewMap()
 
 	// If a board is specified search the monitor in the board package first
 	if fqbn != "" {
 		fqbn, err := cores.ParseFQBN(fqbn)
 		if err != nil {
-			return nil, &arduino.InvalidFQBNError{Cause: err}
+			return nil, nil, &arduino.InvalidFQBNError{Cause: err}
 		}
 
-		_, boardPlatform, _, boardProperties, _, err := pme.ResolveFQBN(fqbn)
+		_, boardPlatform, board, boardProperties, _, err := pme.ResolveFQBN(fqbn)
 		if err != nil {
-			return nil, &arduino.UnknownFQBNError{Cause: err}
+			return nil, nil, &arduino.UnknownFQBNError{Cause: err}
 		}
+
+		boardSettings = board.GetMonitorSettings(protocol)
 
 		if mon, ok := boardPlatform.Monitors[protocol]; ok {
 			monitorDepOrRecipe = mon
@@ -132,10 +142,10 @@ func findMonitorForProtocolAndBoard(pme *packagemanager.Explorer, protocol, fqbn
 			cmdLine := boardProperties.ExpandPropsInString(recipe)
 			cmdArgs, err := properties.SplitQuotedString(cmdLine, `"'`, false)
 			if err != nil {
-				return nil, &arduino.InvalidArgumentError{Message: tr("Invalid recipe in platform.txt"), Cause: err}
+				return nil, nil, &arduino.InvalidArgumentError{Message: tr("Invalid recipe in platform.txt"), Cause: err}
 			}
 			id := fmt.Sprintf("%s-%s", boardPlatform, protocol)
-			return pluggableMonitor.New(id, cmdArgs...), nil
+			return pluggableMonitor.New(id, cmdArgs...), boardSettings, nil
 		}
 	}
 
@@ -150,17 +160,17 @@ func findMonitorForProtocolAndBoard(pme *packagemanager.Explorer, protocol, fqbn
 	}
 
 	if monitorDepOrRecipe == nil {
-		return nil, &arduino.NoMonitorAvailableForProtocolError{Protocol: protocol}
+		return nil, nil, &arduino.NoMonitorAvailableForProtocolError{Protocol: protocol}
 	}
 
 	// If it is a monitor dependency, resolve tool and create a monitor client
 	tool := pme.FindMonitorDependency(monitorDepOrRecipe)
 	if tool == nil {
-		return nil, &arduino.MonitorNotFoundError{Monitor: monitorDepOrRecipe.String()}
+		return nil, nil, &arduino.MonitorNotFoundError{Monitor: monitorDepOrRecipe.String()}
 	}
 
 	return pluggableMonitor.New(
 		monitorDepOrRecipe.Name,
 		tool.InstallDir.Join(monitorDepOrRecipe.Name).String(),
-	), nil
+	), boardSettings, nil
 }

--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -885,6 +885,30 @@ may contain any extra parameter in the formula: this is different from the monit
 
 We strongly recommend using this syntax only for development purposes and not on released platforms.
 
+#### Port configuration
+
+Each pluggable monitor has its own default settings that can be overridden using the following board properties:
+
+```
+BOARD_ID.monitor_port.PROTOCOL.SETTING_NAME=SETTING_VALUE
+```
+
+where:
+
+- `BOARD_ID` is the board identifier
+- `PROTOCOL` is the port protocol
+- `SETTING_NAME` and `SETTING_VALUE` are the port setting and the desired value
+
+For example, let's suppose that a board needs the `baudrate` setting of the `serial` port to be `9600`, then the
+corresponding properties in the `boards.txt` file will be:
+
+```
+myboard.monitor_port.serial.baudrate=9600
+```
+
+The settings available in a specific pluggable monitor can be
+[queried directly from it](pluggable-monitor-specification.md#describe-command).
+
 #### Built-in monitors
 
 If a platform supports only boards connected via serial ports it can easily use the `builtin:serial-monitor` tool
@@ -902,6 +926,23 @@ inherit `builtin:serial-monitor` (but not other `builtin` monitor tools that may
 will allow all legacy non-pluggable platforms to migrate to pluggable monitor without disruption.
 
 For detailed information, see the [Pluggable Monitor specification](pluggable-monitor-specification.md).
+
+#### Legacy `serial.disableRTS` and `serial.disableDTR` properties
+
+In the old Arduino IDE (<=1.8.x) we used the properties:
+
+```
+BOARD_ID.serial.disableRTS=true
+BOARD_ID.serial.disableDTR=true
+```
+
+to disable RTS and DTR when opening the serial monitor. To keep backward compatibilty the properties above are
+automatically converted to the corresponding pluggable monitor properties:
+
+```
+BOARD_ID.monitor_port.serial.rts=off
+BOARD_ID.monitor_port.serial.dtr=off
+```
 
 ### Verbose parameter
 
@@ -1190,47 +1231,6 @@ disappears).
 If the **upload.protocol** property is not defined for a board, the Arduino IDE's "Upload" process will use the same
 behavior as ["Upload Using Programmer"](#upload-using-an-external-programmer). This is convenient for boards which only
 support uploading via programmer.
-
-### Overriding the default monitor port settings
-
-Each pluggable monitor has its own default settings that can be overridden using the following board properties:
-
-```
-BOARD_ID.monitor_port.PROTOCOL.SETTING_NAME=SETTING_VALUE
-```
-
-where:
-
-- `BOARD_ID` is the board identifier
-- `PROTOCOL` is the port protocol
-- `SETTING_NAME` and `SETTING_VALUE` are the port setting and the desired value
-
-For example, let's suppose that a board needs the `baudrate` setting of the `serial` port to be `9600`, then the
-corresponding properties in the `boards.txt` file will be:
-
-```
-myboard.monitor_port.serial.baudrate=9600
-```
-
-The setting name and value can be anything available in the
-[pluggable monitor settings](pluggable-monitor-specification.md#describe-command).
-
-#### Legacy `serial.disableRTS` and `serial.disableDTR` properties
-
-In the old Arduino IDE (<=1.8.x) we used the properties:
-
-```
-BOARD_ID.serial.disableRTS=true
-BOARD_ID.serial.disableDTR=true
-```
-
-to disable RTS and DTR when opening the serial monitor. The keep backward compatibilty the properties above are
-automatically converted to the corresponding pluggable monitor properties:
-
-```
-BOARD_ID.monitor_port.serial.rts=off
-BOARD_ID.monitor_port.serial.dtr=off
-```
 
 ### Serial port
 

--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -1191,6 +1191,47 @@ If the **upload.protocol** property is not defined for a board, the Arduino IDE'
 behavior as ["Upload Using Programmer"](#upload-using-an-external-programmer). This is convenient for boards which only
 support uploading via programmer.
 
+### Overriding the default monitor port settings
+
+Each pluggable monitor has its own default settings that can be overridden using the following board properties:
+
+```
+BOARD_ID.monitor_port.PROTOCOL.SETTING_NAME=SETTING_VALUE
+```
+
+where:
+
+- `BOARD_ID` is the board identifier
+- `PROTOCOL` is the port protocol
+- `SETTING_NAME` and `SETTING_VALUE` are the port setting and the desired value
+
+For example, let's suppose that a board needs the `baudrate` setting of the `serial` port to be `9600`, then the
+corresponding properties in the `boards.txt` file will be:
+
+```
+myboard.monitor_port.serial.baudrate=9600
+```
+
+The setting name and value can be anything available in the
+[pluggable monitor settings](pluggable-monitor-specification.md#describe-command).
+
+#### Legacy `serial.disableRTS` and `serial.disableDTR` properties
+
+In the old Arduino IDE (<=1.8.x) we used the properties:
+
+```
+BOARD_ID.serial.disableRTS=true
+BOARD_ID.serial.disableDTR=true
+```
+
+to disable RTS and DTR when opening the serial monitor. The keep backward compatibilty the properties above are
+automatically converted to the corresponding pluggable monitor properties:
+
+```
+BOARD_ID.monitor_port.serial.rts=off
+BOARD_ID.monitor_port.serial.dtr=off
+```
+
 ### Serial port
 
 The full path (e.g., `/dev/ttyACM0`) of the port selected via the IDE or

--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -885,6 +885,24 @@ may contain any extra parameter in the formula: this is different from the monit
 
 We strongly recommend using this syntax only for development purposes and not on released platforms.
 
+#### Built-in monitors
+
+If a platform supports only boards connected via serial ports it can easily use the `builtin:serial-monitor` tool
+without creating a custom pluggable monitor:
+
+```
+pluggable_monitor.required.serial=builtin:serial-monitor
+```
+
+#### Backward compatibility
+
+For backward compatibility, if a platform does not declare any discovery or monitor tool (using the
+`pluggable_discovery.*` or `pluggable_monitor.*` properties in `platform.txt` respectively) it will automatically
+inherit `builtin:serial-monitor` (but not other `builtin` monitor tools that may be possibly added in the future). This
+will allow all legacy non-pluggable platforms to migrate to pluggable monitor without disruption.
+
+For detailed information, see the [Pluggable Monitor specification](pluggable-monitor-specification.md).
+
 #### Port configuration
 
 Each pluggable monitor has its own default settings that can be overridden using the following board properties:
@@ -908,24 +926,6 @@ myboard.monitor_port.serial.baudrate=9600
 
 The settings available in a specific pluggable monitor can be
 [queried directly from it](pluggable-monitor-specification.md#describe-command).
-
-#### Built-in monitors
-
-If a platform supports only boards connected via serial ports it can easily use the `builtin:serial-monitor` tool
-without creating a custom pluggable monitor:
-
-```
-pluggable_monitor.required.serial=builtin:serial-monitor
-```
-
-#### Backward compatibility
-
-For backward compatibility, if a platform does not declare any discovery or monitor tool (using the
-`pluggable_discovery.*` or `pluggable_monitor.*` properties in `platform.txt` respectively) it will automatically
-inherit `builtin:serial-monitor` (but not other `builtin` monitor tools that may be possibly added in the future). This
-will allow all legacy non-pluggable platforms to migrate to pluggable monitor without disruption.
-
-For detailed information, see the [Pluggable Monitor specification](pluggable-monitor-specification.md).
 
 #### Legacy `serial.disableRTS` and `serial.disableDTR` properties
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
  Adds the possibility for board developers to override the default port settings when the monitor is opened.
  This is useful in particular for the `serial` port settings of `dtr` and `rts` since the Arduino IDE 1.8.x allowed the following `board.txt` properties:
  ```
  BOARD_ID.serial.disableRTS=true
  BOARD_ID.serial.disableDTR=true
  ```
  To generalize the above to the Pluggable Monitor a new way to override specific port settings has been added:
  ```
  BOARD_ID.monitor_port.PROTOCOL.SETTING_NAME=SETTING_VALUE
  ```
  where:
  * `BOARD_ID` is the board identifier
  * `PROTOCOL` is the port protocol
  * `SETTING_NAME` and `SETTING_VALUE` are the port setting and the desired value

  this is general enough to cover also the old use case (`dtr` and `rts`).
  For backward compatibility we will automatically convert the old directives `disableRTS` and `disableDTR` to the new one.

- **What is the current behavior?**
  The directives:
  ```
  BOARD_ID.serial.disableRTS=true
  BOARD_ID.serial.disableDTR=true
  ```
  are ignored.

* **What is the new behavior?**
  The directives above are followed.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
  No

* **Other information**:
  Related:
  * issues with serial monitor related to wrong `rts` and `dtr` settings: https://github.com/arduino/serial-monitor/issues/17
  * a PR that adds support for setting `rts` and `dtr` on the serial-monitor: https://github.com/arduino/serial-monitor/pull/21 
