### PR TITLE
[skip-changelog] Temporarily disable 'precompiled-lib' tests

### DIFF
--- a/test/test_compile_part_1.py
+++ b/test/test_compile_part_1.py
@@ -224,22 +224,22 @@ def test_compile_without_precompiled_libraries(run_command, data_dir):
     assert run_command(["core", "update-index", f"--additional-urls={url}"])
     assert run_command(["core", "install", "arduino:mbed@1.3.1", f"--additional-urls={url}"])
 
-    # Precompiled version of Arduino_TensorflowLite
-    assert run_command(["lib", "install", "Arduino_LSM9DS1"])
-    assert run_command(["lib", "install", "Arduino_TensorflowLite@2.1.1-ALPHA-precompiled"])
-
-    sketch_path = Path(data_dir, "libraries", "Arduino_TensorFlowLite", "examples", "hello_world")
-    assert run_command(["compile", "-b", "arduino:mbed:nano33ble", sketch_path])
+    #    # Precompiled version of Arduino_TensorflowLite
+    #    assert run_command(["lib", "install", "Arduino_LSM9DS1"])
+    #    assert run_command(["lib", "install", "Arduino_TensorflowLite@2.1.1-ALPHA-precompiled"])
+    #
+    #    sketch_path = Path(data_dir, "libraries", "Arduino_TensorFlowLite", "examples", "hello_world")
+    #    assert run_command(["compile", "-b", "arduino:mbed:nano33ble", sketch_path])
 
     assert run_command(["core", "install", "arduino:samd@1.8.7", f"--additional-urls={url}"])
-    assert run_command(["core", "install", "adafruit:samd@1.6.4", f"--additional-urls={url}"])
-    # should work on adafruit too after https://github.com/arduino/arduino-cli/pull/1134
-    assert run_command(["compile", "-b", "adafruit:samd:adafruit_feather_m4", sketch_path])
-
-    # Non-precompiled version of Arduino_TensorflowLite
-    assert run_command(["lib", "install", "Arduino_TensorflowLite@2.1.0-ALPHA"])
-    assert run_command(["compile", "-b", "arduino:mbed:nano33ble", sketch_path])
-    assert run_command(["compile", "-b", "adafruit:samd:adafruit_feather_m4", sketch_path])
+    #    assert run_command(["core", "install", "adafruit:samd@1.6.4", f"--additional-urls={url}"])
+    #    # should work on adafruit too after https://github.com/arduino/arduino-cli/pull/1134
+    #    assert run_command(["compile", "-b", "adafruit:samd:adafruit_feather_m4", sketch_path])
+    #
+    #    # Non-precompiled version of Arduino_TensorflowLite
+    #    assert run_command(["lib", "install", "Arduino_TensorflowLite@2.1.0-ALPHA"])
+    #    assert run_command(["compile", "-b", "arduino:mbed:nano33ble", sketch_path])
+    #    assert run_command(["compile", "-b", "adafruit:samd:adafruit_feather_m4", sketch_path])
 
     # Bosch sensor library
     assert run_command(["lib", "install", "BSEC Software Library@1.5.1474"])

--- a/test/test_compile_part_3.py
+++ b/test/test_compile_part_3.py
@@ -18,25 +18,25 @@ from git import Repo
 from pathlib import Path
 
 
-def test_compile_with_fully_precompiled_library(run_command, data_dir):
-    assert run_command(["update"])
-
-    assert run_command(["core", "install", "arduino:mbed@1.3.1"])
-    fqbn = "arduino:mbed:nano33ble"
-
-    # Install fully precompiled library
-    # For more information see:
-    # https://arduino.github.io/arduino-cli/latest/library-specification/#precompiled-binaries
-    assert run_command(["lib", "install", "Arduino_TensorFlowLite@2.1.1-ALPHA-precompiled"])
-    sketch_folder = Path(data_dir, "libraries", "Arduino_TensorFlowLite", "examples", "hello_world")
-
-    # Install example dependency
-    # assert run_command("lib install Arduino_LSM9DS1")
-
-    # Compile and verify dependencies detection for fully precompiled library is skipped
-    result = run_command(["compile", "-b", fqbn, sketch_folder, "-v"])
-    assert result.ok
-    assert "Skipping dependencies detection for precompiled library Arduino_TensorFlowLite" in result.stdout
+# def test_compile_with_fully_precompiled_library(run_command, data_dir):
+#    assert run_command(["update"])
+#
+#    assert run_command(["core", "install", "arduino:mbed@1.3.1"])
+#    fqbn = "arduino:mbed:nano33ble"
+#
+#    # Install fully precompiled library
+#    # For more information see:
+#    # https://arduino.github.io/arduino-cli/latest/library-specification/#precompiled-binaries
+#    assert run_command(["lib", "install", "Arduino_TensorFlowLite@2.1.1-ALPHA-precompiled"])
+#    sketch_folder = Path(data_dir, "libraries", "Arduino_TensorFlowLite", "examples", "hello_world")
+#
+#    # Install example dependency
+#    # assert run_command("lib install Arduino_LSM9DS1")#
+#
+#    # Compile and verify dependencies detection for fully precompiled library is skipped
+#    result = run_command(["compile", "-b", fqbn, sketch_folder, "-v"])
+#    assert result.ok
+#    assert "Skipping dependencies detection for precompiled library Arduino_TensorFlowLite" in result.stdout
 
 
 def test_compile_sketch_with_pde_extension(run_command, data_dir):


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
Fix CI tests until we replace the removed library `Arduino_TensorflowLite` with another precompiled example.

- **What is the current behavior?**
Test fails

* **What is the new behavior?**
Test passes

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No