### PR TITLE
[skip-changelog] Proper handling of stdout/stderr copy in subprocess

### DIFF
--- a/executils/process.go
+++ b/executils/process.go
@@ -88,7 +88,7 @@ func (p *Process) StdinPipe() (io.WriteCloser, error) {
 // output when the command starts.
 //
 // Wait will close the pipe after seeing the command exit, so most callers
-// need not close the pipe themselves. It is thus incorrect to call Wait
+// don't need to close the pipe themselves. It is thus incorrect to call Wait
 // before all reads from the pipe have completed.
 // For the same reason, it is incorrect to call Run when using StdoutPipe.
 func (p *Process) StdoutPipe() (io.ReadCloser, error) {
@@ -99,7 +99,7 @@ func (p *Process) StdoutPipe() (io.ReadCloser, error) {
 // error when the command starts.
 //
 // Wait will close the pipe after seeing the command exit, so most callers
-// need not close the pipe themselves. It is thus incorrect to call Wait
+// don't need to close the pipe themselves. It is thus incorrect to call Wait
 // before all reads from the pipe have completed.
 // For the same reason, it is incorrect to use Run when using StderrPipe.
 func (p *Process) StderrPipe() (io.ReadCloser, error) {

--- a/executils/process.go
+++ b/executils/process.go
@@ -86,12 +86,22 @@ func (p *Process) StdinPipe() (io.WriteCloser, error) {
 
 // StdoutPipe returns a pipe that will be connected to the command's standard
 // output when the command starts.
+//
+// Wait will close the pipe after seeing the command exit, so most callers
+// need not close the pipe themselves. It is thus incorrect to call Wait
+// before all reads from the pipe have completed.
+// For the same reason, it is incorrect to call Run when using StdoutPipe.
 func (p *Process) StdoutPipe() (io.ReadCloser, error) {
 	return p.cmd.StdoutPipe()
 }
 
 // StderrPipe returns a pipe that will be connected to the command's standard
 // error when the command starts.
+//
+// Wait will close the pipe after seeing the command exit, so most callers
+// need not close the pipe themselves. It is thus incorrect to call Wait
+// before all reads from the pipe have completed.
+// For the same reason, it is incorrect to use Run when using StderrPipe.
 func (p *Process) StderrPipe() (io.ReadCloser, error) {
 	return p.cmd.StderrPipe()
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
Should fix this problem: https://github.com/arduino/arduino-cli/runs/8158553770?check_suite_focus=true#step:6:1752 

* **What is the current behavior?**
sometimes the output of the subprocess doesn't reach the output buffer:

```
=== RUN   TestCompletionNoArgs
>>> Running: /home/runner/work/arduino-cli/arduino-cli/arduino-cli completion
<<< Run completed (err = exit status 1)
    completion_test.go:32: 
        	Error Trace:	/home/runner/work/arduino-cli/arduino-cli/internal/integrationtest/completion/completion_test.go:32
        	Error:      	"" does not contain "Error: accepts 1 arg(s), received 0"
        	Test:       	TestCompletionNoArgs
--- FAIL: TestCompletionNoArgs (0.01s)
```

* **What is the new behavior?**
The issue above should be fixed

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No