### PR TITLE
Fixed `compile` regression

### DIFF
--- a/legacy/builder/hardware_loader.go
+++ b/legacy/builder/hardware_loader.go
@@ -50,11 +50,10 @@ func (s *HardwareLoader) Run(ctx *types.Context) error {
 
 		pm := pmb.Build()
 		pme, _ /* never release... */ := pm.NewExplorer()
-
-		ctx.AllTools = pme.GetAllInstalledToolsReleases()
 		ctx.PackageManager = pme
 	}
 
+	ctx.AllTools = ctx.PackageManager.GetAllInstalledToolsReleases()
 	ctx.Hardware = ctx.PackageManager.GetPackages()
 	return nil
 }

--- a/legacy/builder/test/tools_loader_test.go
+++ b/legacy/builder/test/tools_loader_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/arduino/arduino-cli/arduino/cores"
+	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/legacy/builder"
 	"github.com/arduino/arduino-cli/legacy/builder/types"
 	paths "github.com/arduino/go-paths-helper"
@@ -178,4 +179,21 @@ func TestLoadLotsOfTools(t *testing.T) {
 	idx++
 	require.Equal(t, "arduino:openocd@0.9.0-arduino", tools[idx].String())
 	requireEquivalentPaths(t, tools[idx].InstallDir.String(), "downloaded_board_manager_stuff/arduino/tools/openocd/0.9.0-arduino")
+}
+
+func TestAllToolsContextIsPopulated(t *testing.T) {
+	pmb := packagemanager.NewBuilder(nil, nil, nil, nil, "")
+	pmb.LoadHardwareFromDirectories(paths.NewPathList("downloaded_board_manager_stuff"))
+	pmb.LoadToolsFromBundleDirectory(paths.New("downloaded_tools", "tools_builtin"))
+	pm := pmb.Build()
+	pme, release := pm.NewExplorer()
+	defer release()
+
+	ctx := &types.Context{
+		PackageManager: pme,
+	}
+
+	hl := &builder.HardwareLoader{}
+	require.NoError(t, hl.Run(ctx))
+	require.NotEmpty(t, ctx.AllTools)
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
Fix a weird compile regression.

- **What is the current behavior?**
The `runtime.tools.PACKAGER-TOOL-VERSION.*` variables are not populated (unless they are specified as a platform dependcy in the package_xxx_index.json and that index file is present).

* **What is the new behavior?**
The above bug is fixed.

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No
