### PR TITLE
testsuite: arduino-cli should never panic during tests

### DIFF
--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -161,7 +161,10 @@ func (cli *ArduinoCLI) Run(args ...string) ([]byte, []byte, error) {
 	cliErr := cliProc.Wait()
 	fmt.Println(color.HiBlackString("<<< Run completed (err = %v)", cliErr))
 
-	return stdoutBuf.Bytes(), stderrBuf.Bytes(), cliErr
+	errBuf := stderrBuf.Bytes()
+	cli.t.NotContains(string(errBuf), "panic: runtime error:", "arduino-cli panicked")
+
+	return stdoutBuf.Bytes(), errBuf, cliErr
 }
 
 // StartDaemon starts the Arduino CLI daemon. It returns the address of the daemon.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
The testsuite is now able to detect arduino-cli panics when running integration tests.

- **What is the current behavior?**
  The following test
  ```go
	_, _, err = cli.Run("lib", "upgrade", "Servo")
	require.Error(t, err)
  ```
  may pass if `arduino-cli` panics, but this is wrong, `arduino-cli` should always return gracefully with a polite error message.

* **What is the new behavior?**
  The above test fails:
```
    arduino-cli.go:165: 
                Error Trace:    /home/megabug/Workspace/arduino-cli/internal/integrationtest/lib/arduino-cli.go:165
                                                        /home/megabug/Workspace/arduino-cli/internal/integrationtest/lib/lib_test.go:40
                Error:          "panic: runtime error: invalid memory address or nil pointer dereference
                                [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xba23e4]
                            
                                goroutine 1 [running]:
                                github.com/arduino/arduino-cli/commands/lib.upgrade(0xc000139440?, {0xc00047fcd8, 0x1, 0xc00047fca0?}, 0xc00047fca8?, 0x40f667?)
                                        /home/megabug/Workspace/arduino-cli/commands/lib/upgrade.go:61 +0x64
                                github.com/arduino/arduino-cli/commands/lib.LibraryUpgrade({0xc0000ec770?, 0x4?}, 0xc005a9acd0, 0x1?, 0x1?)
                                        /home/megabug/Workspace/arduino-cli/commands/lib/upgrade.go:55 +0x11d
                                github.com/arduino/arduino-cli/cli/lib.runUpgradeCommand(0xc000392a00?, {0xc000297990, 0x1, 0x1?})
                                        /home/megabug/Workspace/arduino-cli/cli/lib/upgrade.go:60 +0x2eb
                                github.com/spf13/cobra.(*Command).execute(0xc000392a00, {0xc000297970, 0x1, 0x1})
                                        /home/megabug/.gvm/pkgsets/go1.19/global/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:860 +0x663
                                github.com/spf13/cobra.(*Command).ExecuteC(0xc0002bc780)
                                        /home/megabug/.gvm/pkgsets/go1.19/global/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bd
                                github.com/spf13/cobra.(*Command).Execute(...)
                                        /home/megabug/.gvm/pkgsets/go1.19/global/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
                                main.main()
                                        /home/megabug/Workspace/arduino-cli/main.go:31 +0x77
                                " should not contain "panic: runtime error:"
                Test:           TestLibUpgradeCommand
                Messages:       arduino-cli panicked
--- FAIL: TestLibUpgradeCommand (22.90s)
```

- **Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
No