### PR TITLE
[skip-changelog] Add CopySketch to the testsuite library

### DIFF
--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -126,6 +126,18 @@ func (cli *ArduinoCLI) SketchbookDir() *paths.Path {
 	return cli.sketchbookDir
 }
 
+// CopySketch copies a sketch inside the testing environment and returns its path
+func (cli *ArduinoCLI) CopySketch(sketchName string) *paths.Path {
+	p, err := paths.Getwd()
+	cli.t.NoError(err)
+	cli.t.NotNil(p)
+	testSketch := p.Parent().Join("testdata", sketchName)
+	sketchPath := cli.SketchbookDir().Join(sketchName)
+	err = testSketch.CopyDirTo(sketchPath)
+	cli.t.NoError(err)
+	return sketchPath
+}
+
 // Run executes the given arduino-cli command and returns the output.
 func (cli *ArduinoCLI) Run(args ...string) ([]byte, []byte, error) {
 	return cli.RunWithCustomEnv(cli.cliEnvVars, args...)


### PR DESCRIPTION
CopySketch is a function that copies a sketch present in the "testdata" folder and copies it into the testing environment.

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure Enhancement

**What is the new behavior?**
<!-- if this is a feature change -->
CopySketch is a function that copies a sketch present in the `testdata` folder into the testing environment and returns its path.

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
