### PR TITLE
[skip-changelog] Use a matrix to create parallel builds for each OS

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -179,6 +179,13 @@ jobs:
           TAG="nightly-$(date -u +"%Y%m%d")"
           sha256sum ${{ env.PROJECT_NAME }}_${TAG}* >> ${TAG}-checksums.txt
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
+
       # - name: Upload release files on Arduino downloads servers
       #   uses: docker://plugins/s3
       #   env:

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -179,13 +179,6 @@ jobs:
           TAG="nightly-$(date -u +"%Y%m%d")"
           sha256sum ${{ env.PROJECT_NAME }}_${TAG}* >> ${TAG}-checksums.txt
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ env.DIST_DIR }}
-
       # - name: Upload release files on Arduino downloads servers
       #   uses: docker://plugins/s3
       #   env:

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -22,6 +22,19 @@ jobs:
   create-nightly-artifacts:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        os:
+          - Windows_32bit
+          - Windows_64bit
+          - Linux_32bit
+          - Linux_64bit
+          - Linux_ARMv6
+          - Linux_ARMv7
+          - Linux_ARM64
+          - macOS_64bit
+          - macOS_ARM64
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -35,7 +48,7 @@ jobs:
       - name: Build
         env:
           NIGHTLY: true
-        run: task dist:all
+        run: task dist:${{ matrix.os }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -179,31 +179,31 @@ jobs:
           TAG="nightly-$(date -u +"%Y%m%d")"
           sha256sum ${{ env.PROJECT_NAME }}_${TAG}* >> ${TAG}-checksums.txt
 
-      - name: Upload release files on Arduino downloads servers
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-          PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
-          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # - name: Upload release files on Arduino downloads servers
+      #   uses: docker://plugins/s3
+      #   env:
+      #     PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
+      #     PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
+      #     PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
+      #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-  report:
-    runs-on: ubuntu-latest
-    needs: publish-nightly
-    if: failure() # Run if publish-nightly or any of its job dependencies failed
+  #  report:
+  #    runs-on: ubuntu-latest
+  #    needs: publish-nightly
+  #    if: failure() # Run if publish-nightly or any of its job dependencies failed
 
-    steps:
-      - name: Report failure
-        uses: masci/datadog@v1
-        with:
-          api-key: ${{ secrets.DD_API_KEY }}
-          events: |
-            - title: "${{ env.PROJECT_NAME }} nightly build failed"
-              text: "Nightly build workflow has failed"
-              alert_type: "error"
-              host: ${{ github.repository }}
-              tags:
-                - "project:${{ env.PROJECT_NAME }}"
-                - "workflow:${{ github.workflow }}"
+  #    steps:
+  #      - name: Report failure
+  #        uses: masci/datadog@v1
+  #        with:
+  #          api-key: ${{ secrets.DD_API_KEY }}
+  #          events: |
+  #            - title: "${{ env.PROJECT_NAME }} nightly build failed"
+  #              text: "Nightly build workflow has failed"
+  #              alert_type: "error"
+  #              host: ${{ github.repository }}
+  #              tags:
+  #                - "project:${{ env.PROJECT_NAME }}"
+  #                - "workflow:${{ github.workflow }}"

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -179,31 +179,31 @@ jobs:
           TAG="nightly-$(date -u +"%Y%m%d")"
           sha256sum ${{ env.PROJECT_NAME }}_${TAG}* >> ${TAG}-checksums.txt
 
-      # - name: Upload release files on Arduino downloads servers
-      #   uses: docker://plugins/s3
-      #   env:
-      #     PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-      #     PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
-      #     PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-      #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Upload release files on Arduino downloads servers
+        uses: docker://plugins/s3
+        env:
+          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
+          PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
+          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-  #  report:
-  #    runs-on: ubuntu-latest
-  #    needs: publish-nightly
-  #    if: failure() # Run if publish-nightly or any of its job dependencies failed
+  report:
+    runs-on: ubuntu-latest
+    needs: publish-nightly
+    if: failure() # Run if publish-nightly or any of its job dependencies failed
 
-  #    steps:
-  #      - name: Report failure
-  #        uses: masci/datadog@v1
-  #        with:
-  #          api-key: ${{ secrets.DD_API_KEY }}
-  #          events: |
-  #            - title: "${{ env.PROJECT_NAME }} nightly build failed"
-  #              text: "Nightly build workflow has failed"
-  #              alert_type: "error"
-  #              host: ${{ github.repository }}
-  #              tags:
-  #                - "project:${{ env.PROJECT_NAME }}"
-  #                - "workflow:${{ github.workflow }}"
+    steps:
+      - name: Report failure
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.DD_API_KEY }}
+          events: |
+            - title: "${{ env.PROJECT_NAME }} nightly build failed"
+              text: "Nightly build workflow has failed"
+              alert_type: "error"
+              host: ${{ github.repository }}
+              tags:
+                - "project:${{ env.PROJECT_NAME }}"
+                - "workflow:${{ github.workflow }}"

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -140,14 +140,10 @@ jobs:
         run: |
           gon "${{ env.GON_CONFIG_PATH }}"
 
-      - name: Re-package binary and output checksum
+      - name: Re-package binary
         id: re-package
         working-directory: ${{ env.DIST_DIR }}
-        # This step performs the following:
-        # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
-        # 2. Recalculate package checksum
-        # 3. Output the new checksum to include in the nnnnnn-checksums.txt file
-        #    (it cannot be done there because of workflow job parallelization)
+        # Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         run: |
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
@@ -157,11 +153,9 @@ jobs:
           tar -czvf "$PACKAGE_FILENAME" \
           -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
-          CHECKSUM_LINE="$(shasum -a 256 $PACKAGE_FILENAME)"
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
-          echo "::set-output name=checksum-${{ matrix.artifact.name }}::$CHECKSUM_LINE"
 
-      - name: Upload artifacts
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
@@ -179,15 +173,11 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.DIST_DIR }}
 
-      - name: Update checksum
+      - name: Output checksum
+        working-directory: ${{ env.DIST_DIR}}
         run: |
-          declare -a checksum_lines=("${{ needs.notarize-macos.outputs.checksum-darwin_amd64 }}" "${{ needs.notarize-macos.outputs.checksum-darwin_arm64 }}")
-          for checksum_line in "${checksum_lines[@]}"
-          do
-            CHECKSUM=$(echo ${checksum_line} | cut -d " " -f 1)
-            PACKAGE_FILENAME=$(echo ${checksum_line} | cut -d " " -f 2)
-            perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CHECKSUM}  ${PACKAGE_FILENAME}/g;" ${{ env.DIST_DIR }}/*-checksums.txt
-          done
+          TAG="nightly-$(date -u +"%Y%m%d")"
+          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* >> ${TAG}-checksums.txt
 
       - name: Upload release files on Arduino downloads servers
         uses: docker://plugins/s3

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -55,6 +55,7 @@ jobs:
           echo "::set-output name=result::$RESULT"
 
   build:
+    name: Build ${{ matrix.os.name }}
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
@@ -62,15 +63,33 @@ jobs:
     strategy:
       matrix:
         os:
-          - Windows_32bit
-          - Windows_64bit
-          - Linux_32bit
-          - Linux_64bit
-          - Linux_ARMv6
-          - Linux_ARMv7
-          - Linux_ARM64
-          - macOS_64bit
-          - macOS_ARM64
+          - dist: Windows_32bit
+            path: "*Windows_32bit.zip"
+            name: Windows_X86-32
+          - dist: Windows_64bit
+            path: "*Windows_64bit.zip"
+            name: Windows_X86-64
+          - dist: Linux_32bit
+            path: "*Linux_32bit.tar.gz"
+            name: Linux_X86-32
+          - dist: Linux_64bit
+            path: "*Linux_64bit.tar.gz"
+            name: Linux_X86-64
+          - dist: Linux_ARMv6
+            path: "*Linux_ARMv6.tar.gz"
+            name: Linux_ARMv6
+          - dist: Linux_ARMv7
+            path: "*Linux_ARMv7.tar.gz"
+            name: Linux_ARMv7
+          - dist: Linux_ARM64
+            path: "*Linux_ARM64.tar.gz"
+            name: Linux_ARM64
+          - dist: macOS_64bit
+            path: "*macOS_64bit.tar.gz"
+            name: macOS_64
+          - dist: macOS_ARM64
+            path: "*macOS_ARM64.tar.gz"
+            name: macOS_ARM64
 
     steps:
       - name: Checkout repository
@@ -92,54 +111,25 @@ jobs:
           fi
           PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.sha }}-"
           export PACKAGE_NAME_PREFIX
-          task dist:${{ matrix.os }}
+          task dist:${{ matrix.os.dist }}
 
-      # Transfer builds to artifacts job
-      - name: Upload combined builds artifact
+      - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.DIST_DIR }}
-          name: ${{ env.BUILDS_ARTIFACT }}
+          path: ${{ env.DIST_DIR }}/${{ matrix.os.path }}
+          name: ${{ matrix.os.name }}
 
-  artifacts:
-    name: ${{ matrix.artifact.name }} artifact
+  checksums:
     needs: build
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        artifact:
-          - path: "*checksums.txt"
-            name: checksums
-          - path: "*Linux_32bit.tar.gz"
-            name: Linux_X86-32
-          - path: "*Linux_64bit.tar.gz"
-            name: Linux_X86-64
-          - path: "*Linux_ARM64.tar.gz"
-            name: Linux_ARM64
-          - path: "*Linux_ARMv6.tar.gz"
-            name: Linux_ARMv6
-          - path: "*Linux_ARMv7.tar.gz"
-            name: Linux_ARMv7
-          - path: "*macOS_64bit.tar.gz"
-            name: macOS_64
-          - path: "*macOS_ARM64.tar.gz"
-            name: macOS_ARM64
-          - path: "*Windows_32bit.zip"
-            name: Windows_X86-32
-          - path: "*Windows_64bit.zip"
-            name: Windows_X86-64
-
     steps:
-      - name: Download combined builds artifact
+      - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.BUILDS_ARTIFACT }}
           path: ${{ env.BUILDS_ARTIFACT }}
 
-      # Calculate checksums once
       - name: Output checksum
-        if: matrix.artifact.name == 'checksums'
         working-directory: ${{ env.BUILDS_ARTIFACT}}
         run: |
           PACKAGE_NAME_PREFIX="test"
@@ -148,20 +138,17 @@ jobs:
           fi
           PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.sha }}-"
           TAG="${PACKAGE_NAME_PREFIX}git-snapshot"
-          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* >> ${TAG}-checksums.txt
+          declare -a artifacts=($(ls -d */))
+          for artifact in ${artifacts[@]}
+          do
+            cd $artifact
+            checksum=$(sha256sum ${{ env.PROJECT_NAME }}_${TAG}*)
+            cd ..
+            echo $checksum >> ${TAG}-checksums.txt
+          done
 
-      - name: Upload individual build artifact
+      - name: Upload checksum artifact
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.BUILDS_ARTIFACT }}/${{ matrix.artifact.path }}
-          name: ${{ matrix.artifact.name }}
-
-  clean:
-    needs: artifacts
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Remove unneeded combined builds artifact
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: ${{ env.BUILDS_ARTIFACT }}
+          path: ${{ env.BUILDS_ARTIFACT }}/*checksums.txt
+          name: checksums

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -24,6 +24,8 @@ on:
   repository_dispatch:
 
 env:
+  # As defined by the Taskfile's PROJECT_NAME variable
+  PROJECT_NAME: arduino-cli
   # As defined by the Taskfile's DIST_DIR variable
   DIST_DIR: dist
   BUILDS_ARTIFACT: build-artifacts
@@ -134,6 +136,19 @@ jobs:
         with:
           name: ${{ env.BUILDS_ARTIFACT }}
           path: ${{ env.BUILDS_ARTIFACT }}
+
+      # Calculate checksums once
+      - name: Output checksum
+        if: matrix.artifact.name == 'checksums'
+        working-directory: ${{ env.BUILDS_ARTIFACT}}
+        run: |
+          PACKAGE_NAME_PREFIX="test"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.event.number }}"
+          fi
+          PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.sha }}-"
+          TAG="${PACKAGE_NAME_PREFIX}git-snapshot"
+          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* >> ${TAG}-checksums.txt
 
       - name: Upload individual build artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -57,6 +57,19 @@ jobs:
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        os:
+          - Windows_32bit
+          - Windows_64bit
+          - Linux_32bit
+          - Linux_64bit
+          - Linux_ARMv6
+          - Linux_ARMv7
+          - Linux_ARM64
+          - macOS_64bit
+          - macOS_ARM64
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -77,7 +90,7 @@ jobs:
           fi
           PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.sha }}-"
           export PACKAGE_NAME_PREFIX
-          task dist:all
+          task dist:${{ matrix.os }}
 
       # Transfer builds to artifacts job
       - name: Upload combined builds artifact

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -19,6 +19,19 @@ jobs:
   create-release-artifacts:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        os:
+          - Windows_32bit
+          - Windows_64bit
+          - Linux_32bit
+          - Linux_64bit
+          - Linux_ARMv6
+          - Linux_ARMv7
+          - Linux_ARM64
+          - macOS_64bit
+          - macOS_ARM64
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -40,7 +53,7 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:all
+        run: task dist:${{ matrix.os }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -39,6 +39,8 @@ jobs:
           fetch-depth: 0
 
       - name: Create changelog
+        # Avoid creating the same changelog for each os
+        if: matrix.os == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
           tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -145,14 +145,10 @@ jobs:
         run: |
           gon "${{ env.GON_CONFIG_PATH }}"
 
-      - name: Re-package binary and output checksum
+      - name: Re-package binary
         id: re-package
         working-directory: ${{ env.DIST_DIR }}
-        # This step performs the following:
-        # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
-        # 2. Recalculate package checksum
-        # 3. Output the new checksum to include in the nnnnnn-checksums.txt file
-        #    (it cannot be done there because of workflow job parallelization)
+        # Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         run: |
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
@@ -162,11 +158,9 @@ jobs:
           tar -czvf "$PACKAGE_FILENAME" \
           -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
-          CHECKSUM_LINE="$(shasum -a 256 $PACKAGE_FILENAME)"
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
-          echo "::set-output name=checksum-${{ matrix.artifact.name }}::$CHECKSUM_LINE"
 
-      - name: Upload artifacts
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
@@ -184,15 +178,11 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.DIST_DIR }}
 
-      - name: Update checksum
+      - name: Output checksum
+        working-directory: ${{ env.DIST_DIR}}
         run: |
-          declare -a checksum_lines=("${{ needs.notarize-macos.outputs.checksum-darwin_amd64 }}" "${{ needs.notarize-macos.outputs.checksum-darwin_arm64 }}")
-          for checksum_line in "${checksum_lines[@]}"
-          do
-            CHECKSUM=$(echo ${checksum_line} | cut -d " " -f 1)
-            PACKAGE_FILENAME=$(echo ${checksum_line} | cut -d " " -f 2)
-            perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CHECKSUM}  ${PACKAGE_FILENAME}/g;" ${{ env.DIST_DIR }}/*-checksums.txt
-          done
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* >> ${TAG}-checksums.txt
 
       - name: Identify Prerelease
         # This is a workaround while waiting for create-release action

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -206,19 +206,19 @@ jobs:
           # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
-      - name: Upload release files on Arduino downloads servers
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-          PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # - name: Upload release files on Arduino downloads servers
+      #   uses: docker://plugins/s3
+      #   env:
+      #     PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
+      #     PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
+      #     PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
+      #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Update Homebrew formula
-        if: steps.prerelease.outputs.IS_PRE != 'true'
-        uses: dawidd6/action-homebrew-bump-formula@v3
-        with:
-          token: ${{ secrets.ARDUINOBOT_GITHUB_TOKEN }}
-          formula: arduino-cli
+      # - name: Update Homebrew formula
+      #   if: steps.prerelease.outputs.IS_PRE != 'true'
+      #   uses: dawidd6/action-homebrew-bump-formula@v3
+      #   with:
+      #     token: ${{ secrets.ARDUINOBOT_GITHUB_TOKEN }}
+      #     formula: arduino-cli

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -206,19 +206,19 @@ jobs:
           # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
-      # - name: Upload release files on Arduino downloads servers
-      #   uses: docker://plugins/s3
-      #   env:
-      #     PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-      #     PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-      #     PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-      #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Upload release files on Arduino downloads servers
+        uses: docker://plugins/s3
+        env:
+          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
+          PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
+          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      # - name: Update Homebrew formula
-      #   if: steps.prerelease.outputs.IS_PRE != 'true'
-      #   uses: dawidd6/action-homebrew-bump-formula@v3
-      #   with:
-      #     token: ${{ secrets.ARDUINOBOT_GITHUB_TOKEN }}
-      #     formula: arduino-cli
+      - name: Update Homebrew formula
+        if: steps.prerelease.outputs.IS_PRE != 'true'
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.ARDUINOBOT_GITHUB_TOKEN }}
+          formula: arduino-cli

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -23,19 +23,6 @@ vars:
   CHECKSUM_FILE: "{{.VERSION}}-checksums.txt"
 
 tasks:
-  all:
-    desc: Build for distribution for all platforms
-    cmds:
-      - task: Windows_32bit
-      - task: Windows_64bit
-      - task: Linux_32bit
-      - task: Linux_64bit
-      - task: Linux_ARMv6
-      - task: Linux_ARMv7
-      - task: Linux_ARM64
-      - task: macOS_64bit
-      - task: macOS_ARM64
-
   Windows_32bit:
     desc: Builds Windows 32 bit binaries
     dir: "{{.DIST_DIR}}"

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -190,7 +190,7 @@ tasks:
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
 
     vars:
-      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
       BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/arm64"
       CONTAINER_TAG: "{{.GO_VERSION}}-arm"

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -20,7 +20,6 @@ version: "3"
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
   GO_VERSION: "1.17.8"
-  CHECKSUM_FILE: "{{.VERSION}}-checksums.txt"
 
 tasks:
   Windows_32bit:
@@ -35,7 +34,6 @@ tasks:
         -p "{{.BUILD_PLATFORM}}"
 
         zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_386"
@@ -57,7 +55,6 @@ tasks:
         -p "{{.BUILD_PLATFORM}}"
 
         zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_amd64"
@@ -79,7 +76,6 @@ tasks:
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd32"
@@ -101,7 +97,6 @@ tasks:
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd64"
@@ -123,7 +118,6 @@ tasks:
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
@@ -145,7 +139,6 @@ tasks:
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
@@ -195,7 +188,6 @@ tasks:
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
@@ -217,7 +209,6 @@ tasks:
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_amd64"
@@ -252,7 +243,6 @@ tasks:
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_arm64"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure Enhancement

**What is the current behavior?**
<!-- You can also link to an open issue here -->
[Release-go-task](https://github.com/arduino/arduino-cli/blob/master/.github/workflows/release-go-task.yml), [publish-go-nightly-task](https://github.com/arduino/arduino-cli/blob/master/.github/workflows/publish-go-nightly-task.yml) and [publish-go-tester-task](https://github.com/arduino/arduino-cli/blob/master/.github/workflows/publish-go-tester-task.yml) are currently using `task dist:all` to build and create the release artifacts. This is done by calling the tasks related to each OS consecutively. As a result, the finishing time of `task dist:all` is the sum of the finishing times of each individual `dist`. Furthermore, the checksums related to the files built are calculated more than once, unnecessarily.

**What is the new behavior?**
<!-- if this is a feature change -->
- Using a matrix to run each build task greatly improves performance, since they can all start concurrently. The finishing time of the job will be equal to the one of the longer task to build, instead of being the sum of each individual task's finishing time.
- Checksums are only being calculated once, during the final steps of the workflows.
- A check has been introduced to avoid creating the same changelog for each parallel building job.
- `publish-tester-build` now uploads a different artifact for each build during the first job, instead of creating a combined one that needs to be split later.

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No

**Other information**:
<!-- Any additional information that could help the review process -->
Release run: https://github.com/MatteoPologruto/arduino-cli/actions/runs/3128175485
Test release: https://github.com/MatteoPologruto/arduino-cli/releases/tag/0.0.3
Nightly build run: https://github.com/MatteoPologruto/arduino-cli/actions/runs/3128099818
Tester build run: https://github.com/MatteoPologruto/arduino-cli/actions/runs/3137219983

[Publish-go-tester-task](https://github.com/arduino/arduino-cli/blob/master/.github/workflows/publish-go-tester-task.yml) was correctly skipped after `run-determination` when I pushed the tag `0.0.2` onto my fork ([here](https://github.com/MatteoPologruto/arduino-cli/actions/runs/3104779344)). Out of curiosity, I triggered the workflow run manually on the same commit and the checksums' calculation was not correct ([here](https://github.com/MatteoPologruto/arduino-cli/actions/runs/3105007409)). Checksums calculated previously and afterwards seem to be correct, even though the workflow has not been modified. I think it might be worth mentioning.

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
