### PR TITLE
[skip-changelog] Set test environment directory as CLI WorkingDir

### DIFF
--- a/internal/integrationtest/compile/compile_part_1_test.go
+++ b/internal/integrationtest/compile/compile_part_1_test.go
@@ -164,10 +164,7 @@ func TestOutputFlagDefaultPath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test the --output-dir flag defaulting to current working dir
-	workingDir, err := paths.Getwd()
-	require.NoError(t, err)
-	target := workingDir.Join("test")
-	defer target.RemoveAll()
+	target := cli.WorkingDir().Join("test")
 	_, _, err = cli.Run("compile", "-b", fqbn, sketchPath.String(), "--output-dir", "test")
 	require.NoError(t, err)
 	require.DirExists(t, target.String())

--- a/internal/integrationtest/daemon/daemon_test.go
+++ b/internal/integrationtest/daemon/daemon_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/arduino/arduino-cli/internal/integrationtest"
-	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
 	"go.bug.st/testsuite"
 )
@@ -31,7 +30,7 @@ func createEnvForDaemon(t *testing.T) (*testsuite.Environment, *integrationtest.
 	env := testsuite.NewEnvironment(t)
 
 	cli := integrationtest.NewArduinoCliWithinEnvironment(env, &integrationtest.ArduinoCLIConfig{
-		ArduinoCLIPath:         paths.New("..", "..", "..", "arduino-cli"),
+		ArduinoCLIPath:         integrationtest.FindRepositoryRootPath(t).Join("arduino-cli"),
 		UseSharedStagingFolder: true,
 	})
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Infrastructure Enhancement

**What is the new behavior?**
<!-- if this is a feature change -->
By default, the working directory is the one containing the test.go file. This causes problems when executing commands that have to create files specifically in the working directory, because they either must be deleted manually or the user has to be aware of it and defer a deleting instruction. Furthermore, it messes with tests using relative paths. Setting the environment directory as the CLI's WorkingDir prevents the above mentioned issues from occurring.

**Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No

---

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
