### PR TITLE
Add windows `.msi` installer to the CI

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -36,6 +36,9 @@ jobs:
           - identifier: macOS signing certificate # Text used to identify certificate in notifications.
             certificate-secret: INSTALLER_CERT_MAC_P12 # Name of the secret that contains the certificate.
             password-secret: INSTALLER_CERT_MAC_PASSWORD # Name of the secret that contains the certificate password.
+          - identifier: Windows signing certificate
+            certificate-secret: WINDOWS_SIGNING_CERTIFICATE_PFX
+            password-secret: WINDOWS_SIGNING_CERTIFICATE_PASSWORD
 
     steps:
       - name: Set certificate path environment variable

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -37,8 +37,8 @@ jobs:
             certificate-secret: INSTALLER_CERT_MAC_P12 # Name of the secret that contains the certificate.
             password-secret: INSTALLER_CERT_MAC_PASSWORD # Name of the secret that contains the certificate password.
           - identifier: Windows signing certificate
-            certificate-secret: WINDOWS_SIGNING_CERTIFICATE_PFX
-            password-secret: WINDOWS_SIGNING_CERTIFICATE_PASSWORD
+            certificate-secret: INSTALLER_CERT_WINDOWS_PASSWORD
+            password-secret: INSTALLER_CERT_WINDOWS_PFX
 
     steps:
       - name: Set certificate path environment variable

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -162,9 +162,64 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
+  create-windows-installer:
+    runs-on: windows-latest
+    needs: create-nightly-artifacts
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      INSTALLER_CERT_WINDOWS_PFX: "/tmp/cert.pfx"
+      SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
+
+      - name: Prepare PATH
+        id: setupmsbuild
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Build MSI
+        id: buildmsi
+        env:
+          MSBUILD_PATH: ${{ steps.setupmsbuild.outputs.msbuildPath }}
+        run: |
+          WIX_TAG="0.0.0" # use 0.0.0 as version for the installer since wix is picky about other alternatives, this only affects nightly builds (error CNDL0242)
+          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_Windows_64bit"
+          SOURCE_DIR="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_windows_amd64/"
+          "${{ env.MSBUILD_PATH }}\MSBuild.exe" ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_TAG"
+
+      - name: Save Win signing certificate to file
+        run: echo "${{ secrets.INSTALLER_CERT_WINDOWS_PFX }}" | base64 --decode > ${{ env.INSTALLER_CERT_WINDOWS_PFX}}
+
+      - name: Sign MSI
+        env:
+          MSI_FILE: ${{ steps.buildmsi.outputs.msi }} # this comes from .installer/cli.wixproj
+          CERT_PASSWORD: ${{ secrets.INSTALLER_CERT_WINDOWS_PASSWORD }}
+        run: |
+          "${{ env.SIGNTOOL_PATH }}" sign -d "Arduino CLI" -f ${{ env.INSTALLER_CERT_WINDOWS_PFX}} -p ${{ env.CERT_PASSWORD }} -fd sha256 -tr http://timestamp.digicert.com -v "${{ env.MSI_FILE }}"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        env:
+          MSI_FILE: ${{ steps.buildmsi.outputs.msi }}
+        with:
+          if-no-files-found: error
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.MSI_FILE }}
+
   publish-nightly:
     runs-on: ubuntu-latest
-    needs: notarize-macos
+    needs: [notarize-macos, create-windows-installer]
 
     steps:
       - name: Download artifact

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -20,6 +20,8 @@ on:
 
 jobs:
   create-nightly-artifacts:
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -49,6 +51,12 @@ jobs:
         env:
           NIGHTLY: true
         run: task dist:${{ matrix.os }}
+
+      - name: Output Version
+        id: get-version
+        env:
+          NIGHTLY: true
+        run: echo "::set-output name=version::$(task get-version)"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -144,8 +152,8 @@ jobs:
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"
-          # Use of an array here is required for globbing
-          PACKAGE_FILENAME=(${{ env.PROJECT_NAME }}_nightly-*${{ matrix.artifact.path }})
+          VERSION=${{ needs.create-nightly-artifacts.outputs.version }}
+          PACKAGE_FILENAME=(${{ env.PROJECT_NAME }}_${VERSION}_${{ matrix.artifact.path }})
           tar -czvf "$PACKAGE_FILENAME" \
           -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
@@ -189,10 +197,11 @@ jobs:
       - name: Build MSI
         id: buildmsi
         run: |
-          WIX_TAG="0.0.0" # use 0.0.0 as version for the installer since wix is picky about other alternatives, this only affects nightly builds (error CNDL0242)
-          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_Windows_64bit"
+          VERSION=${{ needs.create-nightly-artifacts.outputs.version }}
+          WIX_VERSION="0.0.0" # use 0.0.0 as version for the installer since wix is picky about other alternatives, this only affects nightly builds (error CNDL0242)
+          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${VERSION}_Windows_64bit"
           SOURCE_DIR="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_windows_amd64/"
-          MSBuild.exe ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_TAG"
+          MSBuild.exe ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_VERSION"
 
       - name: Save Win signing certificate to file
         run: echo "${{ secrets.INSTALLER_CERT_WINDOWS_PFX }}" | base64 --decode > ${{ env.INSTALLER_CERT_WINDOWS_PFX}}
@@ -216,6 +225,7 @@ jobs:
   publish-nightly:
     runs-on: ubuntu-latest
     needs:
+      - create-nightly-artifacts
       - notarize-macos
       - create-windows-installer
 
@@ -229,8 +239,8 @@ jobs:
       - name: Create checksum file
         working-directory: ${{ env.DIST_DIR}}
         run: |
-          TAG="nightly-$(date -u +"%Y%m%d")"
-          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt
+          VERSION=${{ needs.create-nightly-artifacts.outputs.version }}
+          sha256sum ${{ env.PROJECT_NAME }}_${VERSION}* > ${VERSION}-checksums.txt
 
       # - name: Upload release files on Arduino downloads servers
       #   uses: docker://plugins/s3

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -234,15 +234,15 @@ jobs:
           TAG="nightly-$(date -u +"%Y%m%d")"
           sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt
 
-      - name: Upload release files on Arduino downloads servers
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-          PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
-          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # - name: Upload release files on Arduino downloads servers
+      #   uses: docker://plugins/s3
+      #   env:
+      #     PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
+      #     PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
+      #     PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
+      #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -172,7 +172,10 @@ jobs:
 
     env:
       INSTALLER_CERT_WINDOWS_PFX: "/tmp/cert.pfx"
-      SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe"
+      # We are hardcoding the path for signtool because is not present on the windows PATH env var by default.
+      # Keep in mind that this path could change when upgrading to a new runner version
+      # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#installed-windows-sdks
+      SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe"
 
     steps:
       - name: Checkout repository
@@ -206,7 +209,7 @@ jobs:
           MSI_FILE: ${{ steps.buildmsi.outputs.msi }} # this comes from .installer/cli.wixproj
           CERT_PASSWORD: ${{ secrets.INSTALLER_CERT_WINDOWS_PASSWORD }}
         run: |
-          "${{ env.SIGNTOOL_PATH }}" sign -d "Arduino CLI" -f ${{ env.INSTALLER_CERT_WINDOWS_PFX}} -p ${{ env.CERT_PASSWORD }} -fd sha256 -tr http://timestamp.digicert.com -v "${{ env.MSI_FILE }}"
+          "${{ env.SIGNTOOL_PATH }}" sign -d "Arduino CLI" -f ${{ env.INSTALLER_CERT_WINDOWS_PFX}} -p ${{ env.CERT_PASSWORD }} -fd sha256 -tr http://timestamp.digicert.com -td SHA256 -v "${{ env.MSI_FILE }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -215,7 +215,9 @@ jobs:
 
   publish-nightly:
     runs-on: ubuntu-latest
-    needs: [notarize-macos, create-windows-installer]
+    needs:
+      - notarize-macos
+      - create-windows-installer
 
     steps:
       - name: Download artifact

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -244,6 +244,13 @@ jobs:
       #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
+
   report:
     runs-on: ubuntu-latest
     needs: publish-nightly

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -56,7 +56,7 @@ jobs:
         id: get-version
         env:
           NIGHTLY: true
-        run: echo "::set-output name=version::$(task get-version)"
+        run: echo "::set-output name=version::$(task general:get-version)"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -61,9 +61,6 @@ jobs:
     name: Notarize ${{ matrix.artifact.name }}
     runs-on: macos-latest
     needs: create-nightly-artifacts
-    outputs:
-      checksum-darwin_amd64: ${{ steps.re-package.outputs.checksum-darwin_amd64 }}
-      checksum-darwin_arm64: ${{ steps.re-package.outputs.checksum-darwin_arm64 }}
 
     env:
       GON_CONFIG_PATH: gon.config.hcl
@@ -141,7 +138,6 @@ jobs:
           gon "${{ env.GON_CONFIG_PATH }}"
 
       - name: Re-package binary
-        id: re-package
         working-directory: ${{ env.DIST_DIR }}
         # Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         run: |

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -184,18 +184,15 @@ jobs:
           path: ${{ env.DIST_DIR }}
 
       - name: Prepare PATH
-        id: setupmsbuild
         uses: microsoft/setup-msbuild@v1
 
       - name: Build MSI
         id: buildmsi
-        env:
-          MSBUILD_PATH: ${{ steps.setupmsbuild.outputs.msbuildPath }}
         run: |
           WIX_TAG="0.0.0" # use 0.0.0 as version for the installer since wix is picky about other alternatives, this only affects nightly builds (error CNDL0242)
           PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_Windows_64bit"
           SOURCE_DIR="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_windows_amd64/"
-          "${{ env.MSBUILD_PATH }}\MSBuild.exe" ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_TAG"
+          MSBuild.exe ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_TAG"
 
       - name: Save Win signing certificate to file
         run: echo "${{ secrets.INSTALLER_CERT_WINDOWS_PFX }}" | base64 --decode > ${{ env.INSTALLER_CERT_WINDOWS_PFX}}

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -242,22 +242,15 @@ jobs:
           VERSION=${{ needs.create-nightly-artifacts.outputs.version }}
           sha256sum ${{ env.PROJECT_NAME }}_${VERSION}* > ${VERSION}-checksums.txt
 
-      # - name: Upload release files on Arduino downloads servers
-      #   uses: docker://plugins/s3
-      #   env:
-      #     PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-      #     PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
-      #     PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-      #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ env.DIST_DIR }}
+      - name: Upload release files on Arduino downloads servers
+        uses: docker://plugins/s3
+        env:
+          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
+          PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
+          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -223,7 +223,9 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
-    needs: [notarize-macos, create-windows-installer]
+    needs:
+      - notarize-macos
+      - create-windows-installer
 
     steps:
       - name: Download artifact

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Output Version
         id: get-version
-        run: echo "::set-output name=version::$(task get-version)"
+        run: echo "::set-output name=version::$(task general:get-version)"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -203,8 +203,8 @@ jobs:
           TAG="${GITHUB_REF/refs\/tags\//}"
           WIX_TAG="${TAG%%-*}" # removes "-rc*" since wix is not happy with it, this only affects RCs builds (error CNDL0108)
           PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_Windows_64bit"
-          SOURCE_DIR="${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_windows_amd64/${{ env.PROJECT_NAME }}.exe"
-          "${{ env.MSBUILD_PATH }}\MSBuild.exe" ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_TAG"
+          SOURCE_DIR="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_windows_amd64/"
+          "${{ env.MSBUILD_PATH }}\MSBuild.exe" ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_TAG"
 
       - name: Save Win signing certificate to file
         run: echo "${{ secrets.INSTALLER_CERT_WINDOWS_PFX }}" | base64 --decode > ${{ env.INSTALLER_CERT_WINDOWS_PFX}}

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -262,19 +262,19 @@ jobs:
           # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
-      - name: Upload release files on Arduino downloads servers
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-          PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # - name: Upload release files on Arduino downloads servers
+      #   uses: docker://plugins/s3
+      #   env:
+      #     PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
+      #     PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
+      #     PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
+      #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Update Homebrew formula
-        if: steps.prerelease.outputs.IS_PRE != 'true'
-        uses: dawidd6/action-homebrew-bump-formula@v3
-        with:
-          token: ${{ secrets.ARDUINOBOT_GITHUB_TOKEN }}
-          formula: arduino-cli
+      # - name: Update Homebrew formula
+      #   if: steps.prerelease.outputs.IS_PRE != 'true'
+      #   uses: dawidd6/action-homebrew-bump-formula@v3
+      #   with:
+      #     token: ${{ secrets.ARDUINOBOT_GITHUB_TOKEN }}
+      #     formula: arduino-cli

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -169,9 +169,64 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
+  create-windows-installer:
+    runs-on: windows-latest
+    needs: create-release-artifacts
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      INSTALLER_CERT_WINDOWS_PFX: "/tmp/cert.pfx"
+      SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
+
+      - name: Prepare PATH
+        id: setupmsbuild
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Build MSI
+        id: buildmsi
+        env:
+          MSBUILD_PATH: ${{ steps.setupmsbuild.outputs.msbuildPath }}
+        run: |
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_Windows_64bit"
+          SOURCE_DIR="${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_windows_amd64/${{ env.PROJECT_NAME }}.exe"
+          "${{ env.MSBUILD_PATH }}\MSBuild.exe" ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$TAG"
+
+      - name: Save Win signing certificate to file
+        run: echo "${{ secrets.INSTALLER_CERT_WINDOWS_PFX }}" | base64 --decode > ${{ env.INSTALLER_CERT_WINDOWS_PFX}}
+
+      - name: Sign MSI
+        env:
+          MSI_FILE: ${{ steps.buildmsi.outputs.msi }} # this comes from .installer/cli.wixproj
+          CERT_PASSWORD: ${{ secrets.INSTALLER_CERT_WINDOWS_PASSWORD }}
+        run: |
+          "${{ env.SIGNTOOL_PATH }}" sign -d "Arduino CLI" -f ${{ env.INSTALLER_CERT_WINDOWS_PFX}} -p ${{ env.CERT_PASSWORD }} -fd sha256 -tr http://timestamp.digicert.com -v "${{ env.MSI_FILE }}"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        env:
+          MSI_FILE: ${{ steps.buildmsi.outputs.msi }}
+        with:
+          if-no-files-found: error
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.MSI_FILE }}
+
   create-release:
     runs-on: ubuntu-latest
-    needs: notarize-macos
+    needs: [notarize-macos, create-windows-installer]
 
     steps:
       - name: Download artifact

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -201,9 +201,10 @@ jobs:
           MSBUILD_PATH: ${{ steps.setupmsbuild.outputs.msbuildPath }}
         run: |
           TAG="${GITHUB_REF/refs\/tags\//}"
+          WIX_TAG="${TAG%%-*}" # removes "-rc*" since wix is not happy with it, this only affects RCs builds (error CNDL0108)
           PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_Windows_64bit"
           SOURCE_DIR="${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_windows_amd64/${{ env.PROJECT_NAME }}.exe"
-          "${{ env.MSBUILD_PATH }}\MSBuild.exe" ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$TAG"
+          "${{ env.MSBUILD_PATH }}\MSBuild.exe" ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_TAG"
 
       - name: Save Win signing certificate to file
         run: echo "${{ secrets.INSTALLER_CERT_WINDOWS_PFX }}" | base64 --decode > ${{ env.INSTALLER_CERT_WINDOWS_PFX}}

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -179,7 +179,10 @@ jobs:
 
     env:
       INSTALLER_CERT_WINDOWS_PFX: "/tmp/cert.pfx"
-      SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe"
+      # We are hardcoding the path for signtool because is not present on the windows PATH env var by default.
+      # Keep in mind that this path could change when upgrading to a new runner version
+      # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#installed-windows-sdks
+      SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe"
 
     steps:
       - name: Checkout repository
@@ -214,7 +217,7 @@ jobs:
           MSI_FILE: ${{ steps.buildmsi.outputs.msi }} # this comes from .installer/cli.wixproj
           CERT_PASSWORD: ${{ secrets.INSTALLER_CERT_WINDOWS_PASSWORD }}
         run: |
-          "${{ env.SIGNTOOL_PATH }}" sign -d "Arduino CLI" -f ${{ env.INSTALLER_CERT_WINDOWS_PFX}} -p ${{ env.CERT_PASSWORD }} -fd sha256 -tr http://timestamp.digicert.com -v "${{ env.MSI_FILE }}"
+          "${{ env.SIGNTOOL_PATH }}" sign -d "Arduino CLI" -f ${{ env.INSTALLER_CERT_WINDOWS_PFX}} -p ${{ env.CERT_PASSWORD }} -fd sha256 -tr http://timestamp.digicert.com -td SHA256 -v "${{ env.MSI_FILE }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -68,9 +68,6 @@ jobs:
     name: Notarize ${{ matrix.artifact.name }}
     runs-on: macos-latest
     needs: create-release-artifacts
-    outputs:
-      checksum-darwin_amd64: ${{ steps.re-package.outputs.checksum-darwin_amd64 }}
-      checksum-darwin_arm64: ${{ steps.re-package.outputs.checksum-darwin_arm64 }}
 
     env:
       GON_CONFIG_PATH: gon.config.hcl
@@ -148,7 +145,6 @@ jobs:
           gon "${{ env.GON_CONFIG_PATH }}"
 
       - name: Re-package binary
-        id: re-package
         working-directory: ${{ env.DIST_DIR }}
         # Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         run: |

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -191,19 +191,16 @@ jobs:
           path: ${{ env.DIST_DIR }}
 
       - name: Prepare PATH
-        id: setupmsbuild
         uses: microsoft/setup-msbuild@v1
 
       - name: Build MSI
         id: buildmsi
-        env:
-          MSBUILD_PATH: ${{ steps.setupmsbuild.outputs.msbuildPath }}
         run: |
           TAG="${GITHUB_REF/refs\/tags\//}"
           WIX_TAG="${TAG%%-*}" # removes "-rc*" since wix is not happy with it, this only affects RCs builds (error CNDL0108)
           PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_Windows_64bit"
           SOURCE_DIR="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_windows_amd64/"
-          "${{ env.MSBUILD_PATH }}\MSBuild.exe" ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_TAG"
+          MSBuild.exe ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_TAG"
 
       - name: Save Win signing certificate to file
         run: echo "${{ secrets.INSTALLER_CERT_WINDOWS_PFX }}" | base64 --decode > ${{ env.INSTALLER_CERT_WINDOWS_PFX}}

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   create-release-artifacts:
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -56,6 +58,10 @@ jobs:
 
       - name: Build
         run: task dist:${{ matrix.os }}
+
+      - name: Output Version
+        id: get-version
+        run: echo "::set-output name=version::$(task get-version)"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -151,7 +157,7 @@ jobs:
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"
-          TAG="${GITHUB_REF/refs\/tags\//}"
+          TAG=${{ needs.create-release-artifacts.outputs.version }}
           PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.artifact.path }}"
           tar -czvf "$PACKAGE_FILENAME" \
           -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/" "${{ env.PROJECT_NAME }}" \
@@ -196,7 +202,7 @@ jobs:
       - name: Build MSI
         id: buildmsi
         run: |
-          TAG="${GITHUB_REF/refs\/tags\//}"
+          TAG=${{ needs.create-release-artifacts.outputs.version }}
           WIX_TAG="${TAG%%-*}" # removes "-rc*" since wix is not happy with it, this only affects RCs builds (error CNDL0108)
           PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_Windows_64bit"
           SOURCE_DIR="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_windows_amd64/"
@@ -224,6 +230,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     needs:
+      - create-release-artifacts
       - notarize-macos
       - create-windows-installer
 
@@ -237,7 +244,7 @@ jobs:
       - name: Create checksum file
         working-directory: ${{ env.DIST_DIR}}
         run: |
-          TAG="${GITHUB_REF/refs\/tags\//}"
+          TAG=${{ needs.create-release-artifacts.outputs.version }}
           sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt
 
       - name: Identify Prerelease
@@ -247,7 +254,7 @@ jobs:
         run: |
           wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.0.0.zip
           unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
-          if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
+          if [[ "$(/tmp/semver get prerel ${{ needs.create-release-artifacts.outputs.version }} )" ]]; then echo "::set-output name=IS_PRE::true"; fi
 
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -267,19 +267,19 @@ jobs:
           # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
-      # - name: Upload release files on Arduino downloads servers
-      #   uses: docker://plugins/s3
-      #   env:
-      #     PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-      #     PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-      #     PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-      #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Upload release files on Arduino downloads servers
+        uses: docker://plugins/s3
+        env:
+          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
+          PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
+          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      # - name: Update Homebrew formula
-      #   if: steps.prerelease.outputs.IS_PRE != 'true'
-      #   uses: dawidd6/action-homebrew-bump-formula@v3
-      #   with:
-      #     token: ${{ secrets.ARDUINOBOT_GITHUB_TOKEN }}
-      #     formula: arduino-cli
+      - name: Update Homebrew formula
+        if: steps.prerelease.outputs.IS_PRE != 'true'
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.ARDUINOBOT_GITHUB_TOKEN }}
+          formula: arduino-cli

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@
 /arduino/security/testdata/
 /.licenses/
 /site/
+/installer/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -327,6 +327,11 @@ tasks:
     cmds:
       - poetry run mkdocs serve
 
+  get-version:
+    desc: Returns the version used in the project
+    cmds:
+      - echo {{.VERSION}}
+
 vars:
   PROJECT_NAME: "arduino-cli"
   DIST_DIR: "dist"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -327,7 +327,7 @@ tasks:
     cmds:
       - poetry run mkdocs serve
 
-  get-version:
+  general:get-version:
     desc: Returns the version used in the project
     cmds:
       - echo {{.VERSION}}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,13 +58,14 @@ in your [`PATH`](https://en.wikipedia.org/wiki/PATH%5F%28variable%29) or add the
 
 ### Latest release
 
-| Platform  |                      |                      |
-| --------- | -------------------- | -------------------- |
-| Linux     | [32 bit][linux32]    | [64 bit][linux64]    |
-| Linux ARM | [32 bit][linuxarm32] | [64 bit][linuxarm64] |
-| Windows   | [32 bit][windows32]  | [64 bit][windows64]  |
-| macOS     |                      | [64 bit][macos64]    |
-| macOS ARM |                      | [64 bit][macosarm64] |
+| Platform    |                      |                        |
+| ----------- | -------------------- | ---------------------- |
+| Linux       | [32 bit][linux32]    | [64 bit][linux64]      |
+| Linux ARM   | [32 bit][linuxarm32] | [64 bit][linuxarm64]   |
+| Windows exe | [32 bit][windows32]  | [64 bit][windows64]    |
+| Windows msi |                      | [64 bit][windowsmsi64] |
+| macOS       |                      | [64 bit][macos64]      |
+| macOS ARM   |                      | [64 bit][macosarm64]   |
 
 [linux64]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_64bit.tar.gz
 [linux32]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_32bit.tar.gz
@@ -72,6 +73,7 @@ in your [`PATH`](https://en.wikipedia.org/wiki/PATH%5F%28variable%29) or add the
 [linuxarm32]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_ARMv7.tar.gz
 [windows64]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Windows_64bit.zip
 [windows32]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Windows_32bit.zip
+[windowsmsi64]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Windows_64bit.msi
 [macos64]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_macOS_64bit.tar.gz
 [macosarm64]: https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_macOS_ARM64.tar.gz
 
@@ -88,13 +90,14 @@ These are available from the "Assets" sections on the [releases page](https://gi
 These builds are generated every day at 01:00 GMT from the `master` branch and should be considered unstable. In order
 to get the latest nightly build available for the supported platform, use the following links:
 
-| Platform  |                              |                              |
-| --------- | ---------------------------- | ---------------------------- |
-| Linux     | [32 bit][linux32-nightly]    | [64 bit][linux64-nightly]    |
-| Linux ARM | [32 bit][linuxarm32-nightly] | [64 bit][linuxarm64-nightly] |
-| Windows   | [32 bit][windows32-nightly]  | [64 bit][windows64-nightly]  |
-| macOS     |                              | [64 bit][macos64-nightly]    |
-| macOS ARM |                              | [64 bit][macosarm64-nightly] |
+| Platform    |                              |                                |
+| ----------- | ---------------------------- | ------------------------------ |
+| Linux       | [32 bit][linux32-nightly]    | [64 bit][linux64-nightly]      |
+| Linux ARM   | [32 bit][linuxarm32-nightly] | [64 bit][linuxarm64-nightly]   |
+| Windows exe | [32 bit][windows32-nightly]  | [64 bit][windows64-nightly]    |
+| Windows msi |                              | [64 bit][windowsmsi64-nightly] |
+| macOS       |                              | [64 bit][macos64-nightly]      |
+| macOS ARM   |                              | [64 bit][macosarm64-nightly]   |
 
 [linux64-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_64bit.tar.gz
 [linux32-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_32bit.tar.gz
@@ -102,6 +105,7 @@ to get the latest nightly build available for the supported platform, use the fo
 [linuxarm32-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Linux_ARMv7.tar.gz
 [windows64-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Windows_64bit.zip
 [windows32-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Windows_32bit.zip
+[windowsmsi64-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_Windows_64bit.msi
 [macos64-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_macOS_64bit.tar.gz
 [macosarm64-nightly]: https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-latest_macOS_ARM64.tar.gz
 

--- a/installer/cli.wixproj
+++ b/installer/cli.wixproj
@@ -3,12 +3,11 @@
     <PropertyGroup>
         <Configuration>Release</Configuration>
         <Platform Condition="'$(Platform)' == ''">x64</Platform>
-        <!-- "ProductVersion" gets overridden when run with the commandline by the relese CI, this is usefull to define it if not defined -->
+        <!-- "ProductVersion" gets overridden when run with the commandline by the release CI, this is useful to define it if not defined -->
         <ProductVersion Condition="'$(ProductVersion)' == ''">0.1.0</ProductVersion>
         <!-- "OutputName" gets overridden when run with the commandline by the release CI, it's the name of the output file -->
         <OutputName Condition="'$(OutputName)' == ''">$(MSBuildProjectName)</OutputName>
         <OutputType>package</OutputType>
-        <!-- "OutputName" is set when run with the commandline by the release CI, it's the path of the output file -->
         <DefineConstants>
             $(DefineConstants);
             ProductVersion=$(ProductVersion);
@@ -33,7 +32,7 @@
         <WixExtension Include="WixUtilExtension"/>
     </ItemGroup>
     <Target Name="SetStepOutput" AfterTargets="Build" Condition="'$(GITHUB_ACTIONS)' != ''">
-        <!-- Make sure the correct target path is always set as the step output -->
+        <!-- Define a GitHub Actions workflow step output containing the target path -->
         <Message Importance="high" Text="::set-output name=msi::$(TargetPath)"/>
     </Target>
     <Import Project="$(WixTargetsPath)"/>

--- a/installer/cli.wixproj
+++ b/installer/cli.wixproj
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform Condition="'$(Platform)' == ''">x64</Platform>
+        <!-- "ProductVersion" gets overridden when run with the commandline by the relese CI, this is usefull to define it if not defined -->
+        <ProductVersion Condition="'$(ProductVersion)' == ''">0.1.0</ProductVersion>
+        <!-- "OutputName" gets overridden when run with the commandline by the release CI, it's the name of the output file -->
+        <OutputName Condition="'$(OutputName)' == ''">$(MSBuildProjectName)</OutputName>
+        <OutputType>package</OutputType>
+        <!-- "OutputName" is set when run with the commandline by the release CI, it's the path of the output file -->
+        <DefineConstants>
+            $(DefineConstants);
+            ProductVersion=$(ProductVersion);
+        </DefineConstants>
+        <WixTargetsPath Condition="'$(WixTargetsPath)' == ''">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
+    </PropertyGroup>
+    <ItemGroup>
+        <!-- path and name of the additional files that contains additional config for the installer generation and needs Compile -->
+        <Compile Include="cli.wxs"/>
+        <Compile Include="ui.wxs"/>
+    </ItemGroup>
+    <ItemGroup>
+        <!-- Include directories containing both user-specified output and unzipped release for ease -->
+        <!-- "SourceDir" is defined when run with the commandline by the release CI, it's the folder containing files to include in the installer  -->
+        <BindInputPaths Include="$(SourceDir)"/>
+    </ItemGroup>
+    <ItemGroup>
+        <!-- https://wixtoolset.org//documentation/manual/v3/wixui/wixui_dialog_library.html -->
+        <WixExtension Include="WixUIExtension"/>
+        <!-- we need the following to be able to broadcast the environment vars change -->
+        <WixExtension Include="WixUtilExtension"/>
+    </ItemGroup>
+    <Target Name="SetStepOutput" AfterTargets="Build" Condition="'$(GITHUB_ACTIONS)' != ''">
+        <!-- Make sure the correct target path is always set as the step output -->
+        <Message Importance="high" Text="::set-output name=msi::$(TargetPath)"/>
+    </Target>
+    <Import Project="$(WixTargetsPath)"/>
+</Project>

--- a/installer/cli.wixproj
+++ b/installer/cli.wixproj
@@ -13,6 +13,7 @@
             $(DefineConstants);
             ProductVersion=$(ProductVersion);
         </DefineConstants>
+        <DefineSolutionProperties>false</DefineSolutionProperties>
         <WixTargetsPath Condition="'$(WixTargetsPath)' == ''">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
     </PropertyGroup>
     <ItemGroup>

--- a/installer/cli.wxs
+++ b/installer/cli.wxs
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<?ifndef ProductVersion?>
+<?error ProductVersion property not defined?>
+<?endif?>
+
+<?define UpgradeCode = "96AEA20C-2FB2-431D-87A4-D7A6E57F70B7"?>
+
+<!-- Define a unique UpgradeCode per platform -->
+<?if $(var.Platform) = "x64"?>
+<?define ProgramFilesFolder = "ProgramFiles64Folder"?>
+<?elseif $(var.Platform) = "x86"?>
+<?define ProgramFilesFolder = "ProgramFilesFolder"?>
+<?endif?>
+
+<!-- https://www.add-in-express.com/docs/wix-setup-package.php -->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <!-- https://wixtoolset.org/documentation/manual/v3/xsd/wix/product.html -->
+    <Product Id="*" Name="Arduino CLI" Version="$(var.ProductVersion)" Language="1033" Manufacturer="Arduino Srl." UpgradeCode="$(var.UpgradeCode)">
+        <!-- https://wixtoolset.org/documentation/manual/v3/xsd/wix/package.html -->
+        <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine"/>
+        <!-- by adding this attribute, you create a single .MSI file as opposed to getting a CAB file along with the .MSI. -->
+        <MediaTemplate EmbedCab="yes"/>
+
+        <!-- Remove older product(s) early but within the transaction -->
+        <MajorUpgrade DowngradeErrorMessage="A newer version of !(bind.property.ProductName) is already installed."/>
+
+        <!-- directory structure to create -->
+        <!-- https://wixtoolset.org/documentation/manual/v3/howtos/files_and_registry/add_a_file.html -->
+        <!-- Outermost folder (kind of virtual). Fixed entry. -->
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <!-- "ProgramFilesFolder" is a variable containing the absolute path. -->
+            <!-- For a list of folder variables, see: http://msdn.microsoft.com/en-us/library/aa372057%28VS.85%29.aspx -->
+            <Directory Id="$(var.ProgramFilesFolder)" Name="Program Files">
+                <!-- All folders from here on are relative to their parent. -->
+                <!-- INSTALLDIR is a property name. We need it later for the UI (to be able to change the install dir. -->
+                <Directory Id="INSTALLDIR" Name="Arduino CLI"/>
+            </Directory>
+        </Directory>
+
+        <!-- Determine the directory of a previous installation (if one exists). If not INSTALLDIR stays empty -->
+        <Property Id="INSTALLDIR">
+            <RegistrySearch Id="InstallDir" Root="HKLM" Key="SOFTWARE\Arduino\CLI" Name="InstallDir" Type="directory"/>
+        </Property>
+
+        <!-- Features define which parts of the application can be installed in a custom installation -->
+        <Feature Id="DefaultFeature" ConfigurableDirectory="INSTALLDIR">
+            <Component Directory="INSTALLDIR">
+                <File Name="arduino-cli.exe"/>
+                <Environment Id="Path" Action="set" Name="PATH" Part="last" System="yes" Value="[INSTALLDIR]"/>
+            </Component>
+
+            <!-- Persist the INSTALLDIR and restore it in subsequent installs -->
+            <Component Directory="INSTALLDIR">
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Arduino\CLI" Name="InstallDir" Type="string" Value="[INSTALLDIR]"/>
+            </Component>
+        </Feature>
+
+        <!-- Broadcast environment variable changes -->
+        <!-- https://wixtoolset.org/documentation/manual/v3/customactions/wixsettingchange.html -->
+        <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+
+        <!-- Use customized WixUI_InstallDir that removes WixUI_LicenseAgreementDlg -->
+        <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"/>
+        <UIRef Id="ArduinoCLI_InstallDir"/>
+    </Product>
+</Wix>

--- a/installer/cli.wxs
+++ b/installer/cli.wxs
@@ -40,19 +40,19 @@
 
         <!-- Determine the directory of a previous installation (if one exists). If not INSTALLDIR stays empty -->
         <Property Id="INSTALLDIR">
-            <RegistrySearch Id="InstallDir" Root="HKLM" Key="SOFTWARE\Arduino\CLI" Name="InstallDir" Type="directory"/>
+            <RegistrySearch Id="InstallDir" Root="HKLM" Key="SOFTWARE\Arduino CLI" Name="InstallDir" Type="directory"/>
         </Property>
 
         <!-- Features define which parts of the application can be installed in a custom installation -->
         <Feature Id="DefaultFeature" ConfigurableDirectory="INSTALLDIR">
-            <Component Directory="INSTALLDIR">
-                <File Name="arduino-cli.exe"/>
+            <Component Directory="INSTALLDIR" Guid="0c407434-5d0f-428a-a855-d823f6acce8d">
+                <File Name="arduino-cli.exe" KeyPath="yes"/>
                 <Environment Id="Path" Action="set" Name="PATH" Part="last" System="yes" Value="[INSTALLDIR]"/>
             </Component>
 
             <!-- Persist the INSTALLDIR and restore it in subsequent installs -->
             <Component Directory="INSTALLDIR">
-                <RegistryValue Root="HKLM" Key="SOFTWARE\Arduino\CLI" Name="InstallDir" Type="string" Value="[INSTALLDIR]"/>
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Arduino CLI" Name="InstallDir" Type="string" Value="[INSTALLDIR]"/>
             </Component>
         </Feature>
 

--- a/installer/ui.wxs
+++ b/installer/ui.wxs
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <UI Id="ArduinoCLI_InstallDir">
+            <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
+            <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
+            <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
+
+            <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
+            <Property Id="WixUI_Mode" Value="InstallDir" />
+
+            <DialogRef Id="BrowseDlg" />
+            <DialogRef Id="DiskCostDlg" />
+            <DialogRef Id="ErrorDlg" />
+            <DialogRef Id="FatalError" />
+            <DialogRef Id="FilesInUse" />
+            <DialogRef Id="MsiRMFilesInUse" />
+            <DialogRef Id="PrepareDlg" />
+            <DialogRef Id="ProgressDlg" />
+            <DialogRef Id="ResumeDlg" />
+            <DialogRef Id="UserExit" />
+            
+            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath" Order="3">1</Publish>
+            <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
+
+            <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
+
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg">NOT Installed</Publish>
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
+
+            <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
+            <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
+            <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
+            
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg" Order="1">NOT Installed</Publish>
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">Installed AND PATCH</Publish>
+
+            <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
+
+            <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+            <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+            <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
+
+            <Property Id="ARPNOMODIFY" Value="1" />
+        </UI>
+
+        <UIRef Id="WixUI_Common" />
+    </Fragment>
+</Wix>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
build msi installer for windows

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
should solve #705 
* **What is the new behavior?**
<!-- if this is a feature change -->
we are able to build an msi installer for windows

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
nop
* **Other information**:
<!-- Any additional information that could help the review process -->
I already added the required secrets to the repo.

The installer is able to install the Arduino CLI to a specified path (by default in `C:\Program Files\Arduino CLI`) also being able to put that as PATH env variable. Upgrades between versions are working, and the installer should recognize the path of the previous installation, when upgrading.

---
See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
