### PR TITLE
[skip changelog] Fix pull request template markup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 ## Please check if the PR fulfills these requirements
 
+See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)
+
 - [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
       before creating one)
 - [ ] The PR follows
@@ -28,7 +30,3 @@ when upgrading from an older version of Arduino CLI? -->
 ## Other information
 
 <!-- Any additional information that could help the review process -->
-
----
-
-See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-**Please check if the PR fulfills these requirements**
+## Please check if the PR fulfills these requirements
 
 - [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
       before creating one)
@@ -8,21 +8,25 @@
 - [ ] Docs have been added / updated (for bug fixes / features)
 - [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
 
-* **What kind of change does this PR introduce?**
+## What kind of change does this PR introduce?
+
 <!-- Bug fix, feature, docs update, ... -->
 
-- **What is the current behavior?**
+## What is the current behavior?
+
 <!-- You can also link to an open issue here -->
 
-* **What is the new behavior?**
+## What is the new behavior?
+
 <!-- if this is a feature change -->
 
-- **Does this PR introduce a breaking change, and is
-[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**
+## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
+
 <!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
 when upgrading from an older version of Arduino CLI? -->
 
-* **Other information**:
+## Other information
+
 <!-- Any additional information that could help the review process -->
 
 ---


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Infrastructure fix

## What is the current behavior?

This repository uses a [pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates#pull-request-templates) in order to provide a standardized structure for pull request messages.

There are several problems with the markup used in the template which make the contribution experience unpleasant:

### Incorrect heading markup

The template imposes a framework for the organization of the pull request message by providing a section to contain each of the distinct types of important information to be included in the pull request. As should be obvious, the only correct formatting for section headings is [heading markup](https://www.markdownguide.org/basic-syntax/#headings), yet somehow [unordered list markup](https://www.markdownguide.org/basic-syntax/#unordered-lists) was chosen instead. This collides with the appropriate use of lists within the sections.

### Problematic use of horizontal rule

The template includes a link to the project's contributor guide. Previously, this link was at the bottom of the template, separated from the other content by [a horizontal rule](https://www.markdownguide.org/basic-syntax/#horizontal-rules). One of the unfortunate ambiguities of the Markdown syntax is that the horizontal rule syntax is the same as [the "setext-style" H2 heading syntax](https://www.markdownguide.org/basic-syntax/#alternate-syntax), with the differentiation depending on whether the prior line is empty. This results in text intended to be part of the "Other information" section of the PR message instead being formatted as an H2 heading if the contributor does not add an empty line at the end of the "**Other information**" section.

## What is the new behavior?

Use the correct markup for headings.

Avoid use of problematic horizontal rule markup.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.
