### PR TITLE
Prevent duplicate entries in board_manager.additional_urls

### DIFF
--- a/cli/config/add.go
+++ b/cli/config/add.go
@@ -96,12 +96,7 @@ func runAddCommand(cmd *cobra.Command, args []string) {
 	}
 
 	v := configuration.Settings.GetStringSlice(key)
-	// only insert values that do not already exist
-	// old code appended all except the first arg (which was the key)
 	v = append(v, args[1:]...)
-	// v now has the original values + the appended values
-	// but, the appended values might have already existed
-	// if so, remove them.
 	v = uniquifyStringSlice(v)
 	configuration.Settings.Set(key, v)
 

--- a/cli/config/add.go
+++ b/cli/config/add.go
@@ -26,6 +26,48 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// // TODO: When update to go 1.18 or later, convert to generic
+// //       to allow uniquify() on any slice that supports
+// //       `comparable`
+// //       See https://gosamples.dev/generics-remove-duplicates-slice/
+// func uniquify[T comparable](s []T) []T {
+// 	// use a map, which enforces unique keys
+// 	inResult := make(map[T]bool)
+// 	var result []T
+// 	// loop through input slice **in order**,
+// 	// to ensure output retains that order
+// 	// (except that it removes duplicates)
+// 	for i := 0; i < len(s); i++ {
+// 		// attempt to use the element as a key
+// 		if _, ok := inResult[s[i]]; !ok {
+// 			// if key didn't exist in map,
+// 			// add to map and append to result
+// 			inResult[s[i]] = true
+// 			result = append(result, s[i])
+// 		}
+// 	}
+// 	return result
+// }
+
+func uniquify_string_slice(s []string) []string {
+	// use a map, which enforces unique keys
+	inResult := make(map[string]bool)
+	var result []string
+	// loop through input slice **in order**,
+	// to ensure output retains that order
+	// (except that it removes duplicates)
+	for i := 0; i < len(s); i++ {
+		// attempt to use the element as a key
+		if _, ok := inResult[s[i]]; !ok {
+			// if key didn't exist in map,
+			// add to map and append to result
+			inResult[s[i]] = true
+			result = append(result, s[i])
+		}
+	}
+	return result
+}
+
 func initAddCommand() *cobra.Command {
 	addCommand := &cobra.Command{
 		Use:   "add",
@@ -54,7 +96,13 @@ func runAddCommand(cmd *cobra.Command, args []string) {
 	}
 
 	v := configuration.Settings.GetStringSlice(key)
+	// only insert values that do not already exist
+	// old code appended all except the first arg (which was the key)
 	v = append(v, args[1:]...)
+	// v now has the original values + the appended values
+	// but, the appended values might have already existed
+	// if so, remove them.
+	v = uniquify_string_slice(v)
 	configuration.Settings.Set(key, v)
 
 	if err := configuration.Settings.WriteConfig(); err != nil {

--- a/cli/config/add.go
+++ b/cli/config/add.go
@@ -49,7 +49,7 @@ import (
 // 	return result
 // }
 
-func uniquify_string_slice(s []string) []string {
+func uniquifyStringSlice(s []string) []string {
 	// use a map, which enforces unique keys
 	inResult := make(map[string]bool)
 	var result []string
@@ -102,7 +102,7 @@ func runAddCommand(cmd *cobra.Command, args []string) {
 	// v now has the original values + the appended values
 	// but, the appended values might have already existed
 	// if so, remove them.
-	v = uniquify_string_slice(v)
+	v = uniquifyStringSlice(v)
 	configuration.Settings.Set(key, v)
 
 	if err := configuration.Settings.WriteConfig(); err != nil {

--- a/cli/config/set.go
+++ b/cli/config/set.go
@@ -59,7 +59,7 @@ func runSetCommand(cmd *cobra.Command, args []string) {
 	var value interface{}
 	switch kind {
 	case reflect.Slice:
-		value = args[1:]
+		value = uniquifyStringSlice(args[1:])
 	case reflect.String:
 		value = args[1]
 	case reflect.Bool:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -545,6 +545,7 @@ def test_set_slice_with_multiple_arguments(run_command):
     assert urls[5] in settings_json["board_manager"]["additional_urls"]
     assert urls[6] in settings_json["board_manager"]["additional_urls"]
 
+
 def test_set_string_with_single_argument(run_command):
     # Create a config file
     assert run_command(["config", "init", "--dest-dir", "."])

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -277,6 +277,16 @@ def test_add_single_argument(run_command):
     settings_json = json.loads(result.stdout)
     assert ["https://example.com"] == settings_json["board_manager"]["additional_urls"]
 
+    # Adds the same URL (should not error)
+    url = "https://example.com"
+    assert run_command(["config", "add", "board_manager.additional_urls", url])
+
+    # Verifies a second copy has NOT been added
+    result = run_command(["config", "dump", "--format", "json"])
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert ["https://example.com"] == settings_json["board_manager"]["additional_urls"]
+
 
 def test_add_multiple_arguments(run_command):
     # Create a config file
@@ -302,6 +312,34 @@ def test_add_multiple_arguments(run_command):
     assert 2 == len(settings_json["board_manager"]["additional_urls"])
     assert urls[0] in settings_json["board_manager"]["additional_urls"]
     assert urls[1] in settings_json["board_manager"]["additional_urls"]
+
+    # Adds both the same URLs a second time
+    assert run_command(["config", "add", "board_manager.additional_urls"] + urls)
+
+    # Verifies no change in result array
+    result = run_command(["config", "dump", "--format", "json"])
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert 2 == len(settings_json["board_manager"]["additional_urls"])
+    assert urls[0] in settings_json["board_manager"]["additional_urls"]
+    assert urls[1] in settings_json["board_manager"]["additional_urls"]
+
+    # Adds multiple URLs ... the middle one is the only new URL
+    urls = [
+        "https://example.com/package_example_index.json",
+        "https://example.com/a_third_package_example_index.json",
+        "https://example.com/yet_another_package_example_index.json",
+    ]
+    assert run_command(["config", "add", "board_manager.additional_urls"] + urls)
+
+    # Verifies URL has been saved
+    result = run_command(["config", "dump", "--format", "json"])
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert 3 == len(settings_json["board_manager"]["additional_urls"])
+    assert urls[0] in settings_json["board_manager"]["additional_urls"]
+    assert urls[1] in settings_json["board_manager"]["additional_urls"]
+    assert urls[2] in settings_json["board_manager"]["additional_urls"]
 
 
 def test_add_on_unsupported_key(run_command):
@@ -482,6 +520,30 @@ def test_set_slice_with_multiple_arguments(run_command):
     assert urls[0] in settings_json["board_manager"]["additional_urls"]
     assert urls[1] in settings_json["board_manager"]["additional_urls"]
 
+    # Sets a third set of 7 URLs (with only 4 unique values)
+    urls = [
+        "https://example.com/first_package_index.json",
+        "https://example.com/second_package_index.json",
+        "https://example.com/first_package_index.json",
+        "https://example.com/fifth_package_index.json",
+        "https://example.com/second_package_index.json",
+        "https://example.com/sixth_package_index.json",
+        "https://example.com/first_package_index.json",
+    ]
+    assert run_command(["config", "set", "board_manager.additional_urls"] + urls)
+
+    # Verifies all unique values exist in config
+    result = run_command(["config", "dump", "--format", "json"])
+    assert result.ok
+    settings_json = json.loads(result.stdout)
+    assert 4 == len(settings_json["board_manager"]["additional_urls"])
+    assert urls[0] in settings_json["board_manager"]["additional_urls"]
+    assert urls[1] in settings_json["board_manager"]["additional_urls"]
+    assert urls[2] in settings_json["board_manager"]["additional_urls"]
+    assert urls[3] in settings_json["board_manager"]["additional_urls"]
+    assert urls[4] in settings_json["board_manager"]["additional_urls"]
+    assert urls[5] in settings_json["board_manager"]["additional_urls"]
+    assert urls[6] in settings_json["board_manager"]["additional_urls"]
 
 def test_set_string_with_single_argument(run_command):
     # Create a config file


### PR DESCRIPTION
Fixes #1437.

**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~Docs have been added / updated (for bug fixes / features)~
- [ ] ~`UPGRADING.md` has been updated with a migration guide (for breaking changes)~

* **What kind of change does this PR introduce?**

This change ensures that duplicate values are not introduced into configuration, such as for `board_manager.additional_urls`

- **What is the current behavior?**

The following will result in two identical entries in the config:

```bash
arduino-cli config add board_manager.additional_urls http://drazzy.com/package_drazzy.com_index.json
arduino-cli config add board_manager.additional_urls http://drazzy.com/package_drazzy.com_index.json
```

* **What is the new behavior?**

Entries that accept multiple values are ensured to be unique.  Care was taken to retain the order of entries.  No error is generated due to duplicate entries (no error was previously generated ... this just prevents useless growth of this array).

- **Does this PR introduce a breaking change, and is
[titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?**

This is not a breaking change.

* **Other information**:

Fixes #1437
