### PR TITLE
Fix integration test intermittent failure due to download/file in use

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -95,10 +95,12 @@ tasks:
       - task: go:build
     dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
+      # "-p 1" will not run test in parallel, this is required for integration tests
       - |
         go test \
           -v \
           -short \
+          -p 1 \
           -run '{{default ".*" .GO_TEST_REGEX}}' \
           {{default "-timeout 10m -coverpkg=./... -covermode=atomic" .GO_TEST_FLAGS}} \
           -coverprofile=coverage_unit.txt \

--- a/internal/integrationtest/upgrade/upgrade_test.go
+++ b/internal/integrationtest/upgrade/upgrade_test.go
@@ -28,9 +28,9 @@ func TestUpgrade(t *testing.T) {
 	defer env.CleanUp()
 
 	// Updates index for cores and libraries
-	_, _, err := cli.Run("core", "update-idex")
+	_, _, err := cli.Run("core", "update-index")
 	require.NoError(t, err)
-	_, _, err = cli.Run("lib", "update-idex")
+	_, _, err = cli.Run("lib", "update-index")
 	require.NoError(t, err)
 
 	// Installs an outdated core and library


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

A workaround to fix the integration test.

## What is the current behavior?

go-lang tests in each package are run in parallel (instead the tests inside each package are run sequentially). This is not good for tests in `integrationtest` because these share the download directory to save bandwidth.

## What is the new behavior?

The tests are run sequentially using the `-p 1` flag

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Maybe a better long term solution could be to move all integration tests in the same "package" under `internal/intergationtest`. @MatteoPologruto @umbynos 
