### PR TITLE
Download library index as a combined archive+signature

### DIFF
--- a/arduino/libraries/librariesmanager/download.go
+++ b/arduino/libraries/librariesmanager/download.go
@@ -27,3 +27,6 @@ var LibraryIndexGZURL, _ = url.Parse("https://downloads.arduino.cc/libraries/lib
 
 // LibraryIndexSignature is the URL where to get the library index signature.
 var LibraryIndexSignature, _ = url.Parse("https://downloads.arduino.cc/libraries/library_index.json.sig")
+
+// LibraryIndexWithSignatureArchiveURL is the URL where to get the library index.
+var LibraryIndexWithSignatureArchiveURL, _ = url.Parse("https://downloads.arduino.cc/libraries/library_index.tar.bz2")

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -479,8 +479,7 @@ func UpdateLibrariesIndex(ctx context.Context, req *rpc.UpdateLibrariesIndexRequ
 	defer tmp.RemoveAll()
 
 	indexResource := resources.IndexResource{
-		URL:          librariesmanager.LibraryIndexGZURL,
-		SignatureURL: librariesmanager.LibraryIndexSignature,
+		URL: librariesmanager.LibraryIndexWithSignatureArchiveURL,
 	}
 	if err := indexResource.Download(lm.IndexFile.Parent(), downloadCB); err != nil {
 		return err


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Download `library_index.json` as a combined index+signature archive from the new URL: https://downloads.arduino.cc/libraries/library_index.tar.bz2

## What is the current behavior?

Library index was downloaded separately from signature: this lead to sporadic incorrect signature verification.

## What is the new behavior?

The index and signature are obtained from a single tar.bz2 archive (that also provide a bit of saving of the file size).

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No