### PR TITLE
[skip-changelog] Reuse already installed platforms to speed up integration tests

### DIFF
--- a/internal/integrationtest/compile/compile_part_1_test.go
+++ b/internal/integrationtest/compile/compile_part_1_test.go
@@ -13,7 +13,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-package compile_part_1_test
+package compile_test
 
 import (
 	"crypto/md5"
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompileWithoutFqbn(t *testing.T) {
+func TestCompile(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
@@ -37,26 +37,33 @@ func TestCompileWithoutFqbn(t *testing.T) {
 	require.NoError(t, err)
 
 	// Install Arduino AVR Boards
-	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.3")
+	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.5")
 	require.NoError(t, err)
 
+	t.Run("WithoutFqbn", func(t *testing.T) { compileWithoutFqbn(t, env, cli) })
+	t.Run("ErrorMessage", func(t *testing.T) { compileErrorMessage(t, env, cli) })
+	t.Run("WithSimpleSketch", func(t *testing.T) { compileWithSimpleSketch(t, env, cli) })
+	t.Run("OutputFlagDefaultPath", func(t *testing.T) { compileOutputFlagDefaultPath(t, env, cli) })
+	t.Run("WithSketchWithSymlinkSelfloop", func(t *testing.T) { compileWithSketchWithSymlinkSelfloop(t, env, cli) })
+	t.Run("BlacklistedSketchname", func(t *testing.T) { compileBlacklistedSketchname(t, env, cli) })
+	t.Run("WithBuildPropertiesFlag", func(t *testing.T) { compileWithBuildPropertiesFlag(t, env, cli) })
+	t.Run("WithBuildPropertyContainingQuotes", func(t *testing.T) { compileWithBuildPropertyContainingQuotes(t, env, cli) })
+	t.Run("WithMultipleBuildPropertyFlags", func(t *testing.T) { compileWithMultipleBuildPropertyFlags(t, env, cli) })
+	t.Run("WithOutputDirFlag", func(t *testing.T) { compileWithOutputDirFlag(t, env, cli) })
+	t.Run("WithExportBinariesFlag", func(t *testing.T) { compileWithExportBinariesFlag(t, env, cli) })
+	t.Run("WithCustomBuildPath", func(t *testing.T) { compileWithCustomBuildPath(t, env, cli) })
+	t.Run("WithExportBinariesEnvVar", func(t *testing.T) { compileWithExportBinariesEnvVar(t, env, cli) })
+	t.Run("WithExportBinariesConfig", func(t *testing.T) { compileWithExportBinariesConfig(t, env, cli) })
+	t.Run("WithInvalidUrl", func(t *testing.T) { compileWithInvalidUrl(t, env, cli) })
+}
+
+func compileWithoutFqbn(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	// Build sketch without FQBN
-	_, _, err = cli.Run("compile")
+	_, _, err := cli.Run("compile")
 	require.Error(t, err)
 }
 
-func TestCompileErrorMessage(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Download latest AVR
-	_, _, err = cli.Run("core", "install", "arduino:avr")
-	require.NoError(t, err)
-
+func compileErrorMessage(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	// Run a batch of bogus compile in a temp dir to check the error messages
 	tmp, err := paths.MkTempDir("", "tmp_dir")
 	require.NoError(t, err)
@@ -90,20 +97,10 @@ func TestCompileErrorMessage(t *testing.T) {
 	require.Contains(t, string(stderr), "main file missing from sketch:")
 }
 
-func TestCompileWithSimpleSketch(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Download latest AVR
-	_, _, err = cli.Run("core", "install", "arduino:avr")
-	require.NoError(t, err)
-
+func compileWithSimpleSketch(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	sketchName := "CompileIntegrationTest"
 	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:avr:uno"
 
 	// Create a test sketch
@@ -145,22 +142,12 @@ func TestCompileWithSimpleSketch(t *testing.T) {
 	require.NoFileExists(t, sketchBuildDir.Join(sketchName+".ino.with_bootloader.hex").String())
 }
 
-func TestOutputFlagDefaultPath(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Install Arduino AVR Boards
-	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.3")
-	require.NoError(t, err)
-
+func compileOutputFlagDefaultPath(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	// Create a test sketch
 	sketchPath := cli.SketchbookDir().Join("test_output_flag_default_path")
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:avr:uno"
-	_, _, err = cli.Run("sketch", "new", sketchPath.String())
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
 	require.NoError(t, err)
 
 	// Test the --output-dir flag defaulting to current working dir
@@ -170,80 +157,64 @@ func TestOutputFlagDefaultPath(t *testing.T) {
 	require.DirExists(t, target.String())
 }
 
-func TestCompileWithSketchWithSymlinkSelfloop(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
+func compileWithSketchWithSymlinkSelfloop(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
+	{
+		sketchName := "CompileIntegrationTestSymlinkSelfLoop"
+		sketchPath := cli.SketchbookDir().Join(sketchName)
+		defer sketchPath.RemoveAll()
+		fqbn := "arduino:avr:uno"
 
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
+		// Create a test sketch
+		stdout, _, err := cli.Run("sketch", "new", sketchPath.String())
+		require.NoError(t, err)
+		require.Contains(t, string(stdout), "Sketch created in: "+sketchPath.String())
 
-	// Install Arduino AVR Boards
-	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.3")
-	require.NoError(t, err)
+		// create a symlink that loops on himself
+		loopFilePath := sketchPath.Join("loop")
+		err = os.Symlink(loopFilePath.String(), loopFilePath.String())
+		require.NoError(t, err)
 
-	sketchName := "CompileIntegrationTestSymlinkSelfLoop"
-	sketchPath := cli.SketchbookDir().Join(sketchName)
-	fqbn := "arduino:avr:uno"
+		// Build sketch for arduino:avr:uno
+		_, stderr, err := cli.Run("compile", "-b", fqbn, sketchPath.String())
+		// The assertion is a bit relaxed in this case because win behaves differently from macOs and linux
+		// returning a different error detailed message
+		require.Contains(t, string(stderr), "Error opening sketch:")
+		require.Error(t, err)
+	}
+	{
+		sketchName := "CompileIntegrationTestSymlinkDirLoop"
+		sketchPath := cli.SketchbookDir().Join(sketchName)
+		defer sketchPath.RemoveAll()
+		fqbn := "arduino:avr:uno"
 
-	// Create a test sketch
-	stdout, _, err := cli.Run("sketch", "new", sketchPath.String())
-	require.NoError(t, err)
-	require.Contains(t, string(stdout), "Sketch created in: "+sketchPath.String())
+		// Create a test sketch
+		stdout, _, err := cli.Run("sketch", "new", sketchPath.String())
+		require.NoError(t, err)
+		require.Contains(t, string(stdout), "Sketch created in: "+sketchPath.String())
 
-	// create a symlink that loops on himself
-	loopFilePath := sketchPath.Join("loop")
-	err = os.Symlink(loopFilePath.String(), loopFilePath.String())
-	require.NoError(t, err)
+		// create a symlink that loops on the upper level
+		loopDirPath := sketchPath.Join("loop_dir")
+		err = loopDirPath.Mkdir()
+		require.NoError(t, err)
+		loopDirSymlinkPath := loopDirPath.Join("loop_dir_symlink")
+		err = os.Symlink(loopDirPath.String(), loopDirSymlinkPath.String())
+		require.NoError(t, err)
 
-	// Build sketch for arduino:avr:uno
-	_, stderr, err := cli.Run("compile", "-b", fqbn, sketchPath.String())
-	// The assertion is a bit relaxed in this case because win behaves differently from macOs and linux
-	// returning a different error detailed message
-	require.Contains(t, string(stderr), "Error opening sketch:")
-	require.Error(t, err)
-
-	sketchName = "CompileIntegrationTestSymlinkDirLoop"
-	sketchPath = cli.SketchbookDir().Join(sketchName)
-
-	// Create a test sketch
-	stdout, _, err = cli.Run("sketch", "new", sketchPath.String())
-	require.NoError(t, err)
-	require.Contains(t, string(stdout), "Sketch created in: "+sketchPath.String())
-
-	// create a symlink that loops on the upper level
-	loopDirPath := sketchPath.Join("loop_dir")
-	err = loopDirPath.Mkdir()
-	require.NoError(t, err)
-	loopDirSymlinkPath := loopDirPath.Join("loop_dir_symlink")
-	err = os.Symlink(loopDirPath.String(), loopDirSymlinkPath.String())
-	require.NoError(t, err)
-
-	// Build sketch for arduino:avr:uno
-	_, stderr, err = cli.Run("compile", "-b", fqbn, sketchPath.String())
-	// The assertion is a bit relaxed in this case because win behaves differently from macOs and linux
-	// returning a different error detailed message
-	require.Contains(t, string(stderr), "Error opening sketch:")
-	require.Error(t, err)
+		// Build sketch for arduino:avr:uno
+		_, stderr, err := cli.Run("compile", "-b", fqbn, sketchPath.String())
+		// The assertion is a bit relaxed in this case because win behaves differently from macOs and linux
+		// returning a different error detailed message
+		require.Contains(t, string(stderr), "Error opening sketch:")
+		require.Error(t, err)
+	}
 }
 
-func TestCompileBlacklistedSketchname(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
+func compileBlacklistedSketchname(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	// Compile should ignore folders named `RCS`, `.git` and the likes, but
 	// it should be ok for a sketch to be named like RCS.ino
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Install Arduino AVR Boards
-	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.3")
-	require.NoError(t, err)
-
 	sketchName := "RCS"
 	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:avr:uno"
 
 	// Create a test sketch
@@ -310,72 +281,55 @@ func TestCompileWithoutPrecompiledLibraries(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestCompileWithBuildPropertiesFlag(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
+func compileWithBuildPropertiesFlag(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
+	{
+		sketchName := "sketch_with_single_string_define"
+		sketchPath := cli.CopySketch(sketchName)
+		defer sketchPath.RemoveAll()
+		fqbn := "arduino:avr:uno"
 
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
+		// Compile using a build property with quotes
+		_, stderr, err := cli.Run("compile", "-b", fqbn, "--build-properties=\"build.extra_flags=\"-DMY_DEFINE=\"hello world\"\"", sketchPath.String(), "--verbose", "--clean")
+		require.Error(t, err)
+		require.NotContains(t, string(stderr), "Flag --build-properties has been deprecated, please use --build-property instead.")
 
-	// Install Arduino AVR Boards
-	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.3")
-	require.NoError(t, err)
+		// Try again with quotes
+		_, stderr, err = cli.Run("compile", "-b", fqbn, "--build-properties=\"build.extra_flags=-DMY_DEFINE=\"hello\"\"", sketchPath.String(), "--verbose", "--clean")
+		require.Error(t, err)
+		require.NotContains(t, string(stderr), "Flag --build-properties has been deprecated, please use --build-property instead.")
+	}
+	{
+		sketchName := "sketch_with_single_int_define"
+		sketchPath := cli.CopySketch(sketchName)
+		defer sketchPath.RemoveAll()
+		fqbn := "arduino:avr:uno"
 
-	sketchName := "sketch_with_single_string_define"
-	sketchPath := cli.CopySketch(sketchName)
-	fqbn := "arduino:avr:uno"
+		// Try without quotes
+		stdout, stderr, err := cli.Run("compile", "-b", fqbn, "--build-properties=\"build.extra_flags=-DMY_DEFINE=1\"", sketchPath.String(), "--verbose", "--clean")
+		require.NoError(t, err)
+		require.Contains(t, string(stderr), "Flag --build-properties has been deprecated, please use --build-property instead.")
+		require.Contains(t, string(stdout), "-DMY_DEFINE=1")
+	}
+	{
+		sketchName := "sketch_with_multiple_int_defines"
+		sketchPath := cli.CopySketch(sketchName)
+		defer sketchPath.RemoveAll()
+		fqbn := "arduino:avr:uno"
 
-	// Compile using a build property with quotes
-	_, stderr, err := cli.Run("compile", "-b", fqbn, "--build-properties=\"build.extra_flags=\"-DMY_DEFINE=\"hello world\"\"", sketchPath.String(), "--verbose", "--clean")
-	require.Error(t, err)
-	require.NotContains(t, string(stderr), "Flag --build-properties has been deprecated, please use --build-property instead.")
-
-	// Try again with quotes
-	_, stderr, err = cli.Run("compile", "-b", fqbn, "--build-properties=\"build.extra_flags=-DMY_DEFINE=\"hello\"\"", sketchPath.String(), "--verbose", "--clean")
-	require.Error(t, err)
-	require.NotContains(t, string(stderr), "Flag --build-properties has been deprecated, please use --build-property instead.")
-
-	sketchName = "sketch_with_single_int_define"
-	sketchPath = cli.CopySketch(sketchName)
-
-	// Try without quotes
-	stdout, stderr, err := cli.Run("compile", "-b", fqbn, "--build-properties=\"build.extra_flags=-DMY_DEFINE=1\"", sketchPath.String(), "--verbose", "--clean")
-	require.NoError(t, err)
-	require.Contains(t, string(stderr), "Flag --build-properties has been deprecated, please use --build-property instead.")
-	require.Contains(t, string(stdout), "-DMY_DEFINE=1")
-
-	sketchName = "sketch_with_multiple_int_defines"
-	sketchPath = cli.CopySketch(sketchName)
-
-	stdout, stderr, err = cli.Run("compile",
-		"-b",
-		fqbn,
-		"--build-properties",
-		"build.extra_flags=-DFIRST_PIN=1,compiler.cpp.extra_flags=-DSECOND_PIN=2",
-		sketchPath.String(),
-		"--verbose",
-		"--clean")
-	require.NoError(t, err)
-	require.Contains(t, string(stderr), "Flag --build-properties has been deprecated, please use --build-property instead.")
-	require.Contains(t, string(stdout), "-DFIRST_PIN=1")
-	require.Contains(t, string(stdout), "-DSECOND_PIN=2")
+		stdout, stderr, err := cli.Run("compile", "-b", fqbn,
+			"--build-properties", "build.extra_flags=-DFIRST_PIN=1,compiler.cpp.extra_flags=-DSECOND_PIN=2",
+			sketchPath.String(), "--verbose", "--clean")
+		require.NoError(t, err)
+		require.Contains(t, string(stderr), "Flag --build-properties has been deprecated, please use --build-property instead.")
+		require.Contains(t, string(stdout), "-DFIRST_PIN=1")
+		require.Contains(t, string(stdout), "-DSECOND_PIN=2")
+	}
 }
 
-func TestCompileWithBuildPropertyContainingQuotes(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Install Arduino AVR Boards
-	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.3")
-	require.NoError(t, err)
-
+func compileWithBuildPropertyContainingQuotes(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	sketchName := "sketch_with_single_string_define"
 	sketchPath := cli.CopySketch(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:avr:uno"
 
 	// Compile using a build property with quotes
@@ -389,82 +343,51 @@ func TestCompileWithBuildPropertyContainingQuotes(t *testing.T) {
 	require.Contains(t, string(stdout), `-DMY_DEFINE=\"hello world\"`)
 }
 
-func TestCompileWithMultipleBuildPropertyFlags(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Install Arduino AVR Boards
-	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.3")
-	require.NoError(t, err)
-
+func compileWithMultipleBuildPropertyFlags(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	sketchName := "sketch_with_multiple_defines"
 	sketchPath := cli.CopySketch(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:avr:uno"
 
 	// Compile using multiple build properties separated by a space
-	_, _, err = cli.Run(
-		"compile",
-		"-b",
-		fqbn,
+	_, _, err := cli.Run("compile", "-b", fqbn,
 		"--build-property=compiler.cpp.extra_flags=\"-DPIN=2 -DSSID=\"This is a String\"\"",
-		sketchPath.String(),
-		"--verbose",
-		"--clean",
+		sketchPath.String(), "--verbose", "--clean",
 	)
 	require.Error(t, err)
 
 	// Compile using multiple build properties separated by a space and properly quoted
 	stdout, _, err := cli.Run(
-		"compile",
-		"-b",
-		fqbn,
+		"compile", "-b", fqbn,
 		"--build-property=compiler.cpp.extra_flags=-DPIN=2 \"-DSSID=\"This is a String\"\"",
-		sketchPath.String(),
-		"--verbose",
-		"--clean",
+		sketchPath.String(), "--verbose", "--clean",
 	)
 	require.NoError(t, err)
 	require.Contains(t, string(stdout), "-DPIN=2 \"-DSSID=\\\"This is a String\\\"\"")
 
 	// Tries compilation using multiple build properties separated by a comma
 	_, _, err = cli.Run(
-		"compile",
-		"-b",
-		fqbn,
+		"compile", "-b", fqbn,
 		"--build-property=compiler.cpp.extra_flags=\"-DPIN=2,-DSSID=\"This is a String\"\"",
-		sketchPath.String(),
-		"--verbose",
-		"--clean",
+		sketchPath.String(), "--verbose", "--clean",
 	)
 	require.Error(t, err)
 
 	stdout, _, err = cli.Run(
-		"compile",
-		"-b",
-		fqbn,
+		"compile", "-b", fqbn,
 		"--build-property=compiler.cpp.extra_flags=\"-DPIN=2\"",
 		"--build-property=compiler.cpp.extra_flags=\"-DSSID=\"This is a String\"\"",
-		sketchPath.String(),
-		"--verbose",
-		"--clean",
+		sketchPath.String(), "--verbose", "--clean",
 	)
 	require.Error(t, err)
 	require.NotContains(t, string(stdout), "-DPIN=2")
 	require.Contains(t, string(stdout), "-DSSID=\\\"This is a String\\\"")
 
 	stdout, _, err = cli.Run(
-		"compile",
-		"-b",
-		fqbn,
+		"compile", "-b", fqbn,
 		"--build-property=compiler.cpp.extra_flags=\"-DPIN=2\"",
 		"--build-property=build.extra_flags=\"-DSSID=\"hello world\"\"",
-		sketchPath.String(),
-		"--verbose",
-		"--clean",
+		sketchPath.String(), "--verbose", "--clean",
 	)
 	require.NoError(t, err)
 	require.Contains(t, string(stdout), "-DPIN=2")

--- a/internal/integrationtest/compile/compile_part_1_test.go
+++ b/internal/integrationtest/compile/compile_part_1_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/arduino/arduino-cli/internal/integrationtest"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
+	"go.bug.st/testifyjson/requirejson"
 )
 
 func TestCompile(t *testing.T) {
@@ -229,60 +230,6 @@ func compileBlacklistedSketchname(t *testing.T, env *integrationtest.Environment
 	require.NoError(t, err)
 }
 
-func TestCompileWithoutPrecompiledLibraries(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	url := "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json"
-	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url)
-	require.NoError(t, err)
-	_, _, err = cli.Run("core", "install", "arduino:mbed@1.3.1", "--additional-urls="+url)
-	require.NoError(t, err)
-
-	// // Precompiled version of Arduino_TensorflowLite
-	//	_, _, err = cli.Run("lib", "install", "Arduino_LSM9DS1")
-	//	require.NoError(t, err)
-	//	_, _, err = cli.Run("lib", "install", "Arduino_TensorflowLite@2.1.1-ALPHA-precompiled")
-	//	require.NoError(t, err)
-
-	//	sketchPath := cli.SketchbookDir().Join("libraries", "Arduino_TensorFlowLite", "examples", "hello_world")
-	//	_, _, err = cli.Run("compile", "-b", "arduino:mbed:nano33ble", sketchPath.String())
-	//	require.NoError(t, err)
-
-	_, _, err = cli.Run("core", "install", "arduino:samd@1.8.7", "--additional-urls="+url)
-	require.NoError(t, err)
-	//	_, _, err = cli.Run("core", "install", "adafruit:samd@1.6.4", "--additional-urls="+url)
-	//	require.NoError(t, err)
-	//	// should work on adafruit too after https://github.com/arduino/arduino-cli/pull/1134
-	//	_, _, err = cli.Run("compile", "-b", "adafruit:samd:adafruit_feather_m4", sketchPath.String())
-	//	require.NoError(t, err)
-
-	//	// Non-precompiled version of Arduino_TensorflowLite
-	//	_, _, err = cli.Run("lib", "install", "Arduino_TensorflowLite@2.1.0-ALPHA")
-	//	require.NoError(t, err)
-	//	_, _, err = cli.Run("compile", "-b", "arduino:mbed:nano33ble", sketchPath.String())
-	//	require.NoError(t, err)
-	//	_, _, err = cli.Run("compile", "-b", "adafruit:samd:adafruit_feather_m4", sketchPath.String())
-	//	require.NoError(t, err)
-
-	// Bosch sensor library
-	_, _, err = cli.Run("lib", "install", "BSEC Software Library@1.5.1474")
-	require.NoError(t, err)
-	sketchPath := cli.SketchbookDir().Join("libraries", "BSEC_Software_Library", "examples", "basic")
-	_, _, err = cli.Run("compile", "-b", "arduino:samd:mkr1000", sketchPath.String())
-	require.NoError(t, err)
-	_, _, err = cli.Run("compile", "-b", "arduino:mbed:nano33ble", sketchPath.String())
-	require.NoError(t, err)
-
-	// USBBlaster library
-	_, _, err = cli.Run("lib", "install", "USBBlaster@1.0.0")
-	require.NoError(t, err)
-	sketchPath = cli.SketchbookDir().Join("libraries", "USBBlaster", "examples", "USB_Blaster")
-	_, _, err = cli.Run("compile", "-b", "arduino:samd:mkrvidor4000", sketchPath.String())
-	require.NoError(t, err)
-}
-
 func compileWithBuildPropertiesFlag(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	{
 		sketchName := "sketch_with_single_string_define"
@@ -394,4 +341,188 @@ func compileWithMultipleBuildPropertyFlags(t *testing.T, env *integrationtest.En
 	require.NoError(t, err)
 	require.Contains(t, string(stdout), "-DPIN=2")
 	require.Contains(t, string(stdout), "-DSSID=\\\"hello world\\\"")
+}
+
+func compileWithOutputDirFlag(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
+	sketchName := "CompileWithOutputDir"
+	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
+	fqbn := "arduino:avr:uno"
+
+	// Create a test sketch
+	stdout, _, err := cli.Run("sketch", "new", sketchPath.String())
+	require.NoError(t, err)
+	require.Contains(t, string(stdout), "Sketch created in: "+sketchPath.String())
+
+	// Test the --output-dir flag with absolute path
+	outputDir := cli.SketchbookDir().Join("test_dir", "output_dir")
+	_, _, err = cli.Run("compile", "-b", fqbn, sketchPath.String(), "--output-dir", outputDir.String())
+	require.NoError(t, err)
+
+	// Verifies expected binaries have been built
+	md5 := md5.Sum(([]byte(sketchPath.String())))
+	sketchPathMd5 := strings.ToUpper(hex.EncodeToString(md5[:]))
+	require.NotEmpty(t, sketchPathMd5)
+	buildDir := paths.TempDir().Join("arduino-sketch-" + sketchPathMd5)
+	require.FileExists(t, buildDir.Join(sketchName+".ino.eep").String())
+	require.FileExists(t, buildDir.Join(sketchName+".ino.elf").String())
+	require.FileExists(t, buildDir.Join(sketchName+".ino.hex").String())
+	require.FileExists(t, buildDir.Join(sketchName+".ino.with_bootloader.bin").String())
+	require.FileExists(t, buildDir.Join(sketchName+".ino.with_bootloader.hex").String())
+
+	// Verifies binaries are exported when --output-dir flag is specified
+	require.DirExists(t, outputDir.String())
+	require.FileExists(t, outputDir.Join(sketchName+".ino.eep").String())
+	require.FileExists(t, outputDir.Join(sketchName+".ino.elf").String())
+	require.FileExists(t, outputDir.Join(sketchName+".ino.hex").String())
+	require.FileExists(t, outputDir.Join(sketchName+".ino.with_bootloader.bin").String())
+	require.FileExists(t, outputDir.Join(sketchName+".ino.with_bootloader.hex").String())
+}
+
+func compileWithExportBinariesFlag(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
+	sketchName := "CompileWithExportBinariesFlag"
+	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
+	fqbn := "arduino:avr:uno"
+
+	// Create a test sketch
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
+	require.NoError(t, err)
+
+	// Test the --output-dir flag with absolute path
+	_, _, err = cli.Run("compile", "-b", fqbn, sketchPath.String(), "--export-binaries")
+	require.NoError(t, err)
+	require.DirExists(t, sketchPath.Join("build").String())
+
+	// Verifies binaries are exported when --export-binaries flag is set
+	fqbn = strings.ReplaceAll(fqbn, ":", ".")
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.eep").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.elf").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.hex").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.bin").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.hex").String())
+}
+
+func compileWithCustomBuildPath(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
+	sketchName := "CompileWithBuildPath"
+	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
+	fqbn := "arduino:avr:uno"
+
+	// Create a test sketch
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
+	require.NoError(t, err)
+
+	// Test the --build-path flag with absolute path
+	buildPath := cli.DataDir().Join("test_dir", "build_dir")
+	_, _, err = cli.Run("compile", "-b", fqbn, sketchPath.String(), "--build-path", buildPath.String())
+	require.NoError(t, err)
+
+	// Verifies expected binaries have been built to build_path
+	require.DirExists(t, buildPath.String())
+	require.FileExists(t, buildPath.Join(sketchName+".ino.eep").String())
+	require.FileExists(t, buildPath.Join(sketchName+".ino.elf").String())
+	require.FileExists(t, buildPath.Join(sketchName+".ino.hex").String())
+	require.FileExists(t, buildPath.Join(sketchName+".ino.with_bootloader.bin").String())
+	require.FileExists(t, buildPath.Join(sketchName+".ino.with_bootloader.hex").String())
+
+	// Verifies there are no binaries in temp directory
+	md5 := md5.Sum(([]byte(sketchPath.String())))
+	sketchPathMd5 := strings.ToUpper(hex.EncodeToString(md5[:]))
+	require.NotEmpty(t, sketchPathMd5)
+	buildDir := paths.TempDir().Join("arduino-sketch-" + sketchPathMd5)
+	require.NoFileExists(t, buildDir.Join(sketchName+".ino.eep").String())
+	require.NoFileExists(t, buildDir.Join(sketchName+".ino.elf").String())
+	require.NoFileExists(t, buildDir.Join(sketchName+".ino.hex").String())
+	require.NoFileExists(t, buildDir.Join(sketchName+".ino.with_bootloader.bin").String())
+	require.NoFileExists(t, buildDir.Join(sketchName+".ino.with_bootloader.hex").String())
+}
+
+func compileWithExportBinariesEnvVar(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
+	sketchName := "CompileWithExportBinariesEnvVar"
+	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
+	fqbn := "arduino:avr:uno"
+
+	// Create a test sketch
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
+	require.NoError(t, err)
+
+	envVar := cli.GetDefaultEnv()
+	envVar["ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES"] = "true"
+
+	// Test compilation with export binaries env var set
+	_, _, err = cli.RunWithCustomEnv(envVar, "compile", "-b", fqbn, sketchPath.String())
+	require.NoError(t, err)
+	require.DirExists(t, sketchPath.Join("build").String())
+
+	// Verifies binaries are exported when export binaries env var is set
+	fqbn = strings.ReplaceAll(fqbn, ":", ".")
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.eep").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.elf").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.hex").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.bin").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.hex").String())
+}
+
+func compileWithExportBinariesConfig(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
+	sketchName := "CompileWithExportBinariesEnvVar"
+	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
+	fqbn := "arduino:avr:uno"
+
+	// Create a test sketch
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
+	require.NoError(t, err)
+
+	// Create settings with export binaries set to true
+	envVar := cli.GetDefaultEnv()
+	envVar["ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES"] = "true"
+	_, _, err = cli.RunWithCustomEnv(envVar, "config", "init", "--dest-dir", ".")
+	require.NoError(t, err)
+	defer cli.WorkingDir().Join("arduino-cli.yaml").Remove()
+
+	// Test if arduino-cli config file written in the previous run has the `always_export_binaries` flag set.
+	stdout, _, err := cli.Run("config", "dump", "--format", "json")
+	require.NoError(t, err)
+	requirejson.Contains(t, stdout, `
+		{
+			"sketch": {
+			"always_export_binaries": "true"
+	  		}
+		}`)
+
+	// Test compilation with export binaries env var set
+	_, _, err = cli.Run("compile", "-b", fqbn, sketchPath.String())
+	require.NoError(t, err)
+	require.DirExists(t, sketchPath.Join("build").String())
+
+	// Verifies binaries are exported when export binaries env var is set
+	fqbn = strings.ReplaceAll(fqbn, ":", ".")
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.eep").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.elf").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.hex").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.bin").String())
+	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.hex").String())
+}
+
+func compileWithInvalidUrl(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
+	sketchName := "CompileWithInvalidURL"
+	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
+	fqbn := "arduino:avr:uno"
+
+	// Create a test sketch
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
+	require.NoError(t, err)
+
+	_, _, err = cli.Run("config", "init", "--dest-dir", ".", "--additional-urls", "https://example.com/package_example_index.json")
+	require.NoError(t, err)
+	defer cli.WorkingDir().Join("arduino-cli.yaml").Remove()
+
+	_, stderr, err := cli.Run("compile", "-b", fqbn, sketchPath.String())
+	require.NoError(t, err)
+	require.Contains(t, string(stderr), "Error initializing instance: Loading index file: loading json index file")
+	expectedIndexfile := cli.DataDir().Join("package_example_index.json")
+	require.Contains(t, string(stderr), "loading json index file "+expectedIndexfile.String()+": open "+expectedIndexfile.String()+":")
 }

--- a/internal/integrationtest/compile/compile_part_1_test.go
+++ b/internal/integrationtest/compile/compile_part_1_test.go
@@ -40,21 +40,23 @@ func TestCompile(t *testing.T) {
 	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.5")
 	require.NoError(t, err)
 
-	t.Run("WithoutFqbn", func(t *testing.T) { compileWithoutFqbn(t, env, cli) })
-	t.Run("ErrorMessage", func(t *testing.T) { compileErrorMessage(t, env, cli) })
-	t.Run("WithSimpleSketch", func(t *testing.T) { compileWithSimpleSketch(t, env, cli) })
-	t.Run("OutputFlagDefaultPath", func(t *testing.T) { compileOutputFlagDefaultPath(t, env, cli) })
-	t.Run("WithSketchWithSymlinkSelfloop", func(t *testing.T) { compileWithSketchWithSymlinkSelfloop(t, env, cli) })
-	t.Run("BlacklistedSketchname", func(t *testing.T) { compileBlacklistedSketchname(t, env, cli) })
-	t.Run("WithBuildPropertiesFlag", func(t *testing.T) { compileWithBuildPropertiesFlag(t, env, cli) })
-	t.Run("WithBuildPropertyContainingQuotes", func(t *testing.T) { compileWithBuildPropertyContainingQuotes(t, env, cli) })
-	t.Run("WithMultipleBuildPropertyFlags", func(t *testing.T) { compileWithMultipleBuildPropertyFlags(t, env, cli) })
-	t.Run("WithOutputDirFlag", func(t *testing.T) { compileWithOutputDirFlag(t, env, cli) })
-	t.Run("WithExportBinariesFlag", func(t *testing.T) { compileWithExportBinariesFlag(t, env, cli) })
-	t.Run("WithCustomBuildPath", func(t *testing.T) { compileWithCustomBuildPath(t, env, cli) })
-	t.Run("WithExportBinariesEnvVar", func(t *testing.T) { compileWithExportBinariesEnvVar(t, env, cli) })
-	t.Run("WithExportBinariesConfig", func(t *testing.T) { compileWithExportBinariesConfig(t, env, cli) })
-	t.Run("WithInvalidUrl", func(t *testing.T) { compileWithInvalidUrl(t, env, cli) })
+	integrationtest.CLISubtests{
+		{"WithoutFqbn", compileWithoutFqbn},
+		{"ErrorMessage", compileErrorMessage},
+		{"WithSimpleSketch", compileWithSimpleSketch},
+		{"OutputFlagDefaultPath", compileOutputFlagDefaultPath},
+		{"WithSketchWithSymlinkSelfloop", compileWithSketchWithSymlinkSelfloop},
+		{"BlacklistedSketchname", compileBlacklistedSketchname},
+		{"WithBuildPropertiesFlag", compileWithBuildPropertiesFlag},
+		{"WithBuildPropertyContainingQuotes", compileWithBuildPropertyContainingQuotes},
+		{"WithMultipleBuildPropertyFlags", compileWithMultipleBuildPropertyFlags},
+		{"WithOutputDirFlag", compileWithOutputDirFlag},
+		{"WithExportBinariesFlag", compileWithExportBinariesFlag},
+		{"WithCustomBuildPath", compileWithCustomBuildPath},
+		{"WithExportBinariesEnvVar", compileWithExportBinariesEnvVar},
+		{"WithExportBinariesConfig", compileWithExportBinariesConfig},
+		{"WithInvalidUrl", compileWithInvalidUrl},
+	}.Run(t, env, cli)
 }
 
 func compileWithoutFqbn(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {

--- a/internal/integrationtest/compile/compile_part_2_test.go
+++ b/internal/integrationtest/compile/compile_part_2_test.go
@@ -13,7 +13,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-package compile_part_1_test
+package compile_test
 
 import (
 	"crypto/md5"
@@ -28,20 +28,10 @@ import (
 	"go.bug.st/testifyjson/requirejson"
 )
 
-func TestCompileWithOutputDirFlag(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Download latest AVR
-	_, _, err = cli.Run("core", "install", "arduino:avr")
-	require.NoError(t, err)
-
+func compileWithOutputDirFlag(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	sketchName := "CompileWithOutputDir"
 	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:avr:uno"
 
 	// Create a test sketch
@@ -74,24 +64,14 @@ func TestCompileWithOutputDirFlag(t *testing.T) {
 	require.FileExists(t, outputDir.Join(sketchName+".ino.with_bootloader.hex").String())
 }
 
-func TestCompileWithExportBinariesFlag(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Download latest AVR
-	_, _, err = cli.Run("core", "install", "arduino:avr")
-	require.NoError(t, err)
-
+func compileWithExportBinariesFlag(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	sketchName := "CompileWithExportBinariesFlag"
 	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:avr:uno"
 
 	// Create a test sketch
-	_, _, err = cli.Run("sketch", "new", sketchPath.String())
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
 	require.NoError(t, err)
 
 	// Test the --output-dir flag with absolute path
@@ -108,24 +88,14 @@ func TestCompileWithExportBinariesFlag(t *testing.T) {
 	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.hex").String())
 }
 
-func TestCompileWithCustomBuildPath(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Download latest AVR
-	_, _, err = cli.Run("core", "install", "arduino:avr")
-	require.NoError(t, err)
-
+func compileWithCustomBuildPath(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	sketchName := "CompileWithBuildPath"
 	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:avr:uno"
 
 	// Create a test sketch
-	_, _, err = cli.Run("sketch", "new", sketchPath.String())
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
 	require.NoError(t, err)
 
 	// Test the --build-path flag with absolute path
@@ -153,24 +123,14 @@ func TestCompileWithCustomBuildPath(t *testing.T) {
 	require.NoFileExists(t, buildDir.Join(sketchName+".ino.with_bootloader.hex").String())
 }
 
-func TestCompileWithExportBinariesEnvVar(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Download latest AVR
-	_, _, err = cli.Run("core", "install", "arduino:avr")
-	require.NoError(t, err)
-
+func compileWithExportBinariesEnvVar(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	sketchName := "CompileWithExportBinariesEnvVar"
 	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:avr:uno"
 
 	// Create a test sketch
-	_, _, err = cli.Run("sketch", "new", sketchPath.String())
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
 	require.NoError(t, err)
 
 	envVar := cli.GetDefaultEnv()
@@ -190,24 +150,14 @@ func TestCompileWithExportBinariesEnvVar(t *testing.T) {
 	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.hex").String())
 }
 
-func TestCompileWithExportBinariesConfig(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Download latest AVR
-	_, _, err = cli.Run("core", "install", "arduino:avr")
-	require.NoError(t, err)
-
+func compileWithExportBinariesConfig(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	sketchName := "CompileWithExportBinariesEnvVar"
 	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:avr:uno"
 
 	// Create a test sketch
-	_, _, err = cli.Run("sketch", "new", sketchPath.String())
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
 	require.NoError(t, err)
 
 	// Create settings with export binaries set to true
@@ -215,6 +165,7 @@ func TestCompileWithExportBinariesConfig(t *testing.T) {
 	envVar["ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES"] = "true"
 	_, _, err = cli.RunWithCustomEnv(envVar, "config", "init", "--dest-dir", ".")
 	require.NoError(t, err)
+	defer cli.WorkingDir().Join("arduino-cli.yaml").Remove()
 
 	// Test if arduino-cli config file written in the previous run has the `always_export_binaries` flag set.
 	stdout, _, err := cli.Run("config", "dump", "--format", "json")
@@ -240,28 +191,19 @@ func TestCompileWithExportBinariesConfig(t *testing.T) {
 	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.hex").String())
 }
 
-func TestCompileWithInvalidUrl(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	// Init the environment explicitly
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
-	// Download latest AVR
-	_, _, err = cli.Run("core", "install", "arduino:avr")
-	require.NoError(t, err)
-
+func compileWithInvalidUrl(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	sketchName := "CompileWithInvalidURL"
 	sketchPath := cli.SketchbookDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:avr:uno"
 
 	// Create a test sketch
-	_, _, err = cli.Run("sketch", "new", sketchPath.String())
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
 	require.NoError(t, err)
 
 	_, _, err = cli.Run("config", "init", "--dest-dir", ".", "--additional-urls", "https://example.com/package_example_index.json")
 	require.NoError(t, err)
+	defer cli.WorkingDir().Join("arduino-cli.yaml").Remove()
 
 	_, stderr, err := cli.Run("compile", "-b", fqbn, sketchPath.String())
 	require.NoError(t, err)

--- a/internal/integrationtest/compile/compile_part_2_test.go
+++ b/internal/integrationtest/compile/compile_part_2_test.go
@@ -16,200 +16,66 @@
 package compile_test
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/arduino/arduino-cli/internal/integrationtest"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
-	"go.bug.st/testifyjson/requirejson"
 )
 
-func compileWithOutputDirFlag(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
-	sketchName := "CompileWithOutputDir"
-	sketchPath := cli.SketchbookDir().Join(sketchName)
-	defer sketchPath.RemoveAll()
-	fqbn := "arduino:avr:uno"
+func TestCompileWithoutPrecompiledLibraries(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
 
-	// Create a test sketch
-	stdout, _, err := cli.Run("sketch", "new", sketchPath.String())
+	// Init the environment explicitly
+	url := "https://adafruit.github.io/arduino-board-index/package_adafruit_index.json"
+	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url)
 	require.NoError(t, err)
-	require.Contains(t, string(stdout), "Sketch created in: "+sketchPath.String())
-
-	// Test the --output-dir flag with absolute path
-	outputDir := cli.SketchbookDir().Join("test_dir", "output_dir")
-	_, _, err = cli.Run("compile", "-b", fqbn, sketchPath.String(), "--output-dir", outputDir.String())
+	_, _, err = cli.Run("core", "install", "arduino:mbed@1.3.1", "--additional-urls="+url)
 	require.NoError(t, err)
 
-	// Verifies expected binaries have been built
-	md5 := md5.Sum(([]byte(sketchPath.String())))
-	sketchPathMd5 := strings.ToUpper(hex.EncodeToString(md5[:]))
-	require.NotEmpty(t, sketchPathMd5)
-	buildDir := paths.TempDir().Join("arduino-sketch-" + sketchPathMd5)
-	require.FileExists(t, buildDir.Join(sketchName+".ino.eep").String())
-	require.FileExists(t, buildDir.Join(sketchName+".ino.elf").String())
-	require.FileExists(t, buildDir.Join(sketchName+".ino.hex").String())
-	require.FileExists(t, buildDir.Join(sketchName+".ino.with_bootloader.bin").String())
-	require.FileExists(t, buildDir.Join(sketchName+".ino.with_bootloader.hex").String())
+	// // Precompiled version of Arduino_TensorflowLite
+	//	_, _, err = cli.Run("lib", "install", "Arduino_LSM9DS1")
+	//	require.NoError(t, err)
+	//	_, _, err = cli.Run("lib", "install", "Arduino_TensorflowLite@2.1.1-ALPHA-precompiled")
+	//	require.NoError(t, err)
 
-	// Verifies binaries are exported when --output-dir flag is specified
-	require.DirExists(t, outputDir.String())
-	require.FileExists(t, outputDir.Join(sketchName+".ino.eep").String())
-	require.FileExists(t, outputDir.Join(sketchName+".ino.elf").String())
-	require.FileExists(t, outputDir.Join(sketchName+".ino.hex").String())
-	require.FileExists(t, outputDir.Join(sketchName+".ino.with_bootloader.bin").String())
-	require.FileExists(t, outputDir.Join(sketchName+".ino.with_bootloader.hex").String())
-}
+	//	sketchPath := cli.SketchbookDir().Join("libraries", "Arduino_TensorFlowLite", "examples", "hello_world")
+	//	_, _, err = cli.Run("compile", "-b", "arduino:mbed:nano33ble", sketchPath.String())
+	//	require.NoError(t, err)
 
-func compileWithExportBinariesFlag(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
-	sketchName := "CompileWithExportBinariesFlag"
-	sketchPath := cli.SketchbookDir().Join(sketchName)
-	defer sketchPath.RemoveAll()
-	fqbn := "arduino:avr:uno"
+	_, _, err = cli.Run("core", "install", "arduino:samd@1.8.7", "--additional-urls="+url)
+	require.NoError(t, err)
+	//	_, _, err = cli.Run("core", "install", "adafruit:samd@1.6.4", "--additional-urls="+url)
+	//	require.NoError(t, err)
+	//	// should work on adafruit too after https://github.com/arduino/arduino-cli/pull/1134
+	//	_, _, err = cli.Run("compile", "-b", "adafruit:samd:adafruit_feather_m4", sketchPath.String())
+	//	require.NoError(t, err)
 
-	// Create a test sketch
-	_, _, err := cli.Run("sketch", "new", sketchPath.String())
+	//	// Non-precompiled version of Arduino_TensorflowLite
+	//	_, _, err = cli.Run("lib", "install", "Arduino_TensorflowLite@2.1.0-ALPHA")
+	//	require.NoError(t, err)
+	//	_, _, err = cli.Run("compile", "-b", "arduino:mbed:nano33ble", sketchPath.String())
+	//	require.NoError(t, err)
+	//	_, _, err = cli.Run("compile", "-b", "adafruit:samd:adafruit_feather_m4", sketchPath.String())
+	//	require.NoError(t, err)
+
+	// Bosch sensor library
+	_, _, err = cli.Run("lib", "install", "BSEC Software Library@1.5.1474")
+	require.NoError(t, err)
+	sketchPath := cli.SketchbookDir().Join("libraries", "BSEC_Software_Library", "examples", "basic")
+	_, _, err = cli.Run("compile", "-b", "arduino:samd:mkr1000", sketchPath.String())
+	require.NoError(t, err)
+	_, _, err = cli.Run("compile", "-b", "arduino:mbed:nano33ble", sketchPath.String())
 	require.NoError(t, err)
 
-	// Test the --output-dir flag with absolute path
-	_, _, err = cli.Run("compile", "-b", fqbn, sketchPath.String(), "--export-binaries")
+	// USBBlaster library
+	_, _, err = cli.Run("lib", "install", "USBBlaster@1.0.0")
 	require.NoError(t, err)
-	require.DirExists(t, sketchPath.Join("build").String())
-
-	// Verifies binaries are exported when --export-binaries flag is set
-	fqbn = strings.ReplaceAll(fqbn, ":", ".")
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.eep").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.elf").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.hex").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.bin").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.hex").String())
-}
-
-func compileWithCustomBuildPath(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
-	sketchName := "CompileWithBuildPath"
-	sketchPath := cli.SketchbookDir().Join(sketchName)
-	defer sketchPath.RemoveAll()
-	fqbn := "arduino:avr:uno"
-
-	// Create a test sketch
-	_, _, err := cli.Run("sketch", "new", sketchPath.String())
+	sketchPath = cli.SketchbookDir().Join("libraries", "USBBlaster", "examples", "USB_Blaster")
+	_, _, err = cli.Run("compile", "-b", "arduino:samd:mkrvidor4000", sketchPath.String())
 	require.NoError(t, err)
-
-	// Test the --build-path flag with absolute path
-	buildPath := cli.DataDir().Join("test_dir", "build_dir")
-	_, _, err = cli.Run("compile", "-b", fqbn, sketchPath.String(), "--build-path", buildPath.String())
-	require.NoError(t, err)
-
-	// Verifies expected binaries have been built to build_path
-	require.DirExists(t, buildPath.String())
-	require.FileExists(t, buildPath.Join(sketchName+".ino.eep").String())
-	require.FileExists(t, buildPath.Join(sketchName+".ino.elf").String())
-	require.FileExists(t, buildPath.Join(sketchName+".ino.hex").String())
-	require.FileExists(t, buildPath.Join(sketchName+".ino.with_bootloader.bin").String())
-	require.FileExists(t, buildPath.Join(sketchName+".ino.with_bootloader.hex").String())
-
-	// Verifies there are no binaries in temp directory
-	md5 := md5.Sum(([]byte(sketchPath.String())))
-	sketchPathMd5 := strings.ToUpper(hex.EncodeToString(md5[:]))
-	require.NotEmpty(t, sketchPathMd5)
-	buildDir := paths.TempDir().Join("arduino-sketch-" + sketchPathMd5)
-	require.NoFileExists(t, buildDir.Join(sketchName+".ino.eep").String())
-	require.NoFileExists(t, buildDir.Join(sketchName+".ino.elf").String())
-	require.NoFileExists(t, buildDir.Join(sketchName+".ino.hex").String())
-	require.NoFileExists(t, buildDir.Join(sketchName+".ino.with_bootloader.bin").String())
-	require.NoFileExists(t, buildDir.Join(sketchName+".ino.with_bootloader.hex").String())
-}
-
-func compileWithExportBinariesEnvVar(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
-	sketchName := "CompileWithExportBinariesEnvVar"
-	sketchPath := cli.SketchbookDir().Join(sketchName)
-	defer sketchPath.RemoveAll()
-	fqbn := "arduino:avr:uno"
-
-	// Create a test sketch
-	_, _, err := cli.Run("sketch", "new", sketchPath.String())
-	require.NoError(t, err)
-
-	envVar := cli.GetDefaultEnv()
-	envVar["ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES"] = "true"
-
-	// Test compilation with export binaries env var set
-	_, _, err = cli.RunWithCustomEnv(envVar, "compile", "-b", fqbn, sketchPath.String())
-	require.NoError(t, err)
-	require.DirExists(t, sketchPath.Join("build").String())
-
-	// Verifies binaries are exported when export binaries env var is set
-	fqbn = strings.ReplaceAll(fqbn, ":", ".")
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.eep").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.elf").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.hex").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.bin").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.hex").String())
-}
-
-func compileWithExportBinariesConfig(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
-	sketchName := "CompileWithExportBinariesEnvVar"
-	sketchPath := cli.SketchbookDir().Join(sketchName)
-	defer sketchPath.RemoveAll()
-	fqbn := "arduino:avr:uno"
-
-	// Create a test sketch
-	_, _, err := cli.Run("sketch", "new", sketchPath.String())
-	require.NoError(t, err)
-
-	// Create settings with export binaries set to true
-	envVar := cli.GetDefaultEnv()
-	envVar["ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES"] = "true"
-	_, _, err = cli.RunWithCustomEnv(envVar, "config", "init", "--dest-dir", ".")
-	require.NoError(t, err)
-	defer cli.WorkingDir().Join("arduino-cli.yaml").Remove()
-
-	// Test if arduino-cli config file written in the previous run has the `always_export_binaries` flag set.
-	stdout, _, err := cli.Run("config", "dump", "--format", "json")
-	require.NoError(t, err)
-	requirejson.Contains(t, stdout, `
-		{
-			"sketch": {
-			"always_export_binaries": "true"
-	  		}
-		}`)
-
-	// Test compilation with export binaries env var set
-	_, _, err = cli.Run("compile", "-b", fqbn, sketchPath.String())
-	require.NoError(t, err)
-	require.DirExists(t, sketchPath.Join("build").String())
-
-	// Verifies binaries are exported when export binaries env var is set
-	fqbn = strings.ReplaceAll(fqbn, ":", ".")
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.eep").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.elf").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.hex").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.bin").String())
-	require.FileExists(t, sketchPath.Join("build", fqbn, sketchName+".ino.with_bootloader.hex").String())
-}
-
-func compileWithInvalidUrl(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
-	sketchName := "CompileWithInvalidURL"
-	sketchPath := cli.SketchbookDir().Join(sketchName)
-	defer sketchPath.RemoveAll()
-	fqbn := "arduino:avr:uno"
-
-	// Create a test sketch
-	_, _, err := cli.Run("sketch", "new", sketchPath.String())
-	require.NoError(t, err)
-
-	_, _, err = cli.Run("config", "init", "--dest-dir", ".", "--additional-urls", "https://example.com/package_example_index.json")
-	require.NoError(t, err)
-	defer cli.WorkingDir().Join("arduino-cli.yaml").Remove()
-
-	_, stderr, err := cli.Run("compile", "-b", fqbn, sketchPath.String())
-	require.NoError(t, err)
-	require.Contains(t, string(stderr), "Error initializing instance: Loading index file: loading json index file")
-	expectedIndexfile := cli.DataDir().Join("package_example_index.json")
-	require.Contains(t, string(stderr), "loading json index file "+expectedIndexfile.String()+": open "+expectedIndexfile.String()+":")
 }
 
 func TestCompileWithCustomLibraries(t *testing.T) {

--- a/internal/integrationtest/debug/debug_test.go
+++ b/internal/integrationtest/debug/debug_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDebuggerStarts(t *testing.T) {
+func TestDebug(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
@@ -34,12 +34,20 @@ func TestDebuggerStarts(t *testing.T) {
 	_, _, err = cli.Run("core", "install", "arduino:samd")
 	require.NoError(t, err)
 
+	integrationtest.CLISubtests{
+		{"Start", testDebuggerStarts},
+		{"WithPdeSketchStarts", testDebuggerWithPdeSketchStarts},
+	}.Run(t, env, cli)
+}
+
+func testDebuggerStarts(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	// Create sketch for testing
 	sketchName := "DebuggerStartTest"
 	sketchPath := cli.DataDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:samd:mkr1000"
 
-	_, _, err = cli.Run("sketch", "new", sketchPath.String())
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
 	require.NoError(t, err)
 
 	// Build sketch
@@ -52,22 +60,13 @@ func TestDebuggerStarts(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDebuggerWithPdeSketchStarts(t *testing.T) {
-	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
-
-	_, _, err := cli.Run("update")
-	require.NoError(t, err)
-
-	// Install core
-	_, _, err = cli.Run("core", "install", "arduino:samd")
-	require.NoError(t, err)
-
+func testDebuggerWithPdeSketchStarts(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
 	sketchName := "DebuggerPdeSketchStartTest"
 	sketchPath := cli.DataDir().Join(sketchName)
+	defer sketchPath.RemoveAll()
 	fqbn := "arduino:samd:mkr1000"
 
-	_, _, err = cli.Run("sketch", "new", sketchPath.String())
+	_, _, err := cli.Run("sketch", "new", sketchPath.String())
 	require.NoError(t, err)
 
 	// Looks for sketch file .ino

--- a/internal/integrationtest/subtests.go
+++ b/internal/integrationtest/subtests.go
@@ -1,0 +1,33 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2022 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package integrationtest
+
+import "testing"
+
+// CLISubtests is a suite of tests to run under the same integreationtest.Environment
+type CLISubtests []struct {
+	Name     string
+	Function func(*testing.T, *Environment, *ArduinoCLI)
+}
+
+// Run runs the test suite as subtests of the current test
+func (testSuite CLISubtests) Run(t *testing.T, env *Environment, cli *ArduinoCLI) {
+	for _, test := range testSuite {
+		t.Run(test.Name, func(t *testing.T) {
+			test.Function(t, env, cli)
+		})
+	}
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

A lot of tests (especially the compile ones) are doing something like:
* `core install arduino:avr` (slow)
* perform the test (very quick)

## What is the current behavior?

There are a lot of tests that take most part of the time just installing the same platform again and again.

## What is the new behavior?

All the tests that require the same platform installed as a prerequisite are grouped together in a bigger test that runs each of them as a sub-test.
This change requires a bit more attention on the cleanup of the sub-tests since the leftovers of one test can be retrieved in a later test.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

