### PR TITLE
Disable "fail fast" feature in "Test Go" workflow

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -62,6 +62,8 @@ jobs:
     if: needs.run-determination.outputs.result == 'true'
 
     strategy:
+      fail-fast: false
+
       matrix:
         operating-system:
           - ubuntu-latest


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->

Infrastructure enhancement

## What is the current behavior?

<!-- You can also link to an open issue here -->

To ensure functionality on all platforms, the "Test Go" GitHub Actions workflow runs the tests on Windows, Linux, and macOS. This is done via a "[job matrix](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix)", which runs the three jobs in parallel.

[By default GitHub Actions uses a "fail fast" behavior for job matrixes](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast), where all in progress or pending jobs of the matrix are immediately canceled upon failure of any job.

The benefit of this "fail fast" behavior is efficiency in the case where a failure is universal and those other jobs were certain to eventually fail. However, in other cases a failure is either specific to the configuration of a single job (e.g., a Windows-specific bug), or a spurious result of a transient network outage. In the latter case, canceling the other jobs is very harmful. Running the jobs for the other operating systems would highlight the nature of an OS-specific failure for the contributor. Canceling other jobs due to a transient failure means all those jobs must be reran instead of only the specific job that suffered the failure.


## What is the new behavior?

<!-- if this is a feature change -->

The workflow is configured to disable the "fail fast" behavior. All the matrix jobs will run even if one of them has failed.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

No breaking change

## Other information

Reference:

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
