### PR TITLE
[skip changelog] Move upload of coverage data to dedicated job in test workflow

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -122,14 +122,8 @@ jobs:
       - name: Send unit tests coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          file: ./coverage_unit.txt
-          flags: unit
-          fail_ci_if_error: ${{ github.repository == 'arduino/arduino-cli' }}
-
-      - name: Send legacy tests coverage to Codecov
-        if: runner.os == 'Linux'
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage_legacy.txt
+          files: >
+            ./coverage_unit.txt,
+            ./coverage_legacy.txt
           flags: unit
           fail_ci_if_error: ${{ github.repository == 'arduino/arduino-cli' }}

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -4,6 +4,7 @@ name: Test Go
 env:
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
+  COVERAGE_ARTIFACT: coverage-data
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
@@ -99,8 +100,26 @@ jobs:
         if: runner.os == 'Linux'
         run: task test-legacy
 
-      - name: Send unit tests coverage to Codecov
+      - name: Upload coverage data to workflow artifact
         if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: ${{ env.COVERAGE_ARTIFACT }}
+          path: |
+            ./coverage_unit.txt
+            ./coverage_legacy.txt
+
+  coverage-upload:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Download coverage data artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.COVERAGE_ARTIFACT }}
+
+      - name: Send unit tests coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage_unit.txt


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Infrastructure enhancement

## What is the current behavior?

The code coverage data generated by running the unit tests in the "Test Go" GitHub Actions workflow is uploaded to Codecov.

This upload is prone to occasional transient failures. With the previous workflow configuration this caused a failure of the Linux test run job. Contributors would need to review the logs to understand that these failures were not caused by a test failing.

The failure also causes the ongoing jobs that run the tests on other operating systems to be immediately canceled, meaning their full test results are not available. The entire test suite must be reran just to attempt the upload again.

## What is the new behavior?

Move the coverage data upload to a dedicated workflow job.

This makes it faster and easier for contributors to interpret the cause of a test failure.

It also allows the test suite to complete for all operating systems, making their results immediately available to the contributor even when the coverage data upload fails.

The coverage upload job can be reran, making recovery from a transient failure more efficient.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change