### PR TITLE
[skip-changelog] Added missing docs for 'recipe.hooks.prebuild.NUMBER.pattern'

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -437,6 +437,7 @@ no longer used.
 You can specify pre and post actions around each recipe. These are called "hooks". Here is the complete list of
 available hooks:
 
+- `recipe.hooks.prebuild.NUMBER.pattern` (called before sketch preprocessing and libraries discovery)
 - `recipe.hooks.sketch.prebuild.NUMBER.pattern` (called before sketch compilation)
 - `recipe.hooks.sketch.postbuild.NUMBER.pattern` (called after sketch compilation)
 - `recipe.hooks.libraries.prebuild.NUMBER.pattern` (called before libraries compilation)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Add missing docs for `recipe.hooks.prebuild.NUMBER.pattern` build hook.
Fix #1910 

## What is the current behavior?

No changes.

## What is the new behavior?

No changes.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No
