### PR TITLE
[skip-changelog] Fix copySketch testsuite function

### DIFF
--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -152,7 +152,7 @@ func (cli *ArduinoCLI) CopySketch(sketchName string) *paths.Path {
 	cli.t.NoError(err)
 	cli.t.NotNil(p)
 	testSketch := p.Parent().Join("testdata", sketchName)
-	sketchPath := cli.SketchbookDir().Join(sketchName)
+	sketchPath := cli.WorkingDir().Join(sketchName)
 	err = testSketch.CopyDirTo(sketchPath)
 	cli.t.NoError(err)
 	return sketchPath


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Infrastructure imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
Sketches are copied into `SketchbookDir`. This is not causing problems at the moment because, the tests that implement the `CopySketch()` function, use absolute paths. Nevertheless, this is incorrect and could cause problems when migrating other tests.
<!-- You can also link to an open issue here -->

## What is the new behavior?
The original copy sketch function written in [conftest.py](https://github.com/arduino/arduino-cli/blob/master/test/conftest.py#L228) copies sketches into the testsuite's working directory. Changing the copy sketch function present in the golang testsuite to match the original one, should prevent errors that could occur while migrating tests.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
