### PR TITLE
[skip-changelog] fix `check-certificates.yml` failing

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -37,8 +37,8 @@ jobs:
             certificate-secret: INSTALLER_CERT_MAC_P12 # Name of the secret that contains the certificate.
             password-secret: INSTALLER_CERT_MAC_PASSWORD # Name of the secret that contains the certificate password.
           - identifier: Windows signing certificate
-            certificate-secret: INSTALLER_CERT_WINDOWS_PASSWORD
-            password-secret: INSTALLER_CERT_WINDOWS_PFX
+            certificate-secret: INSTALLER_CERT_WINDOWS_PFX
+            password-secret: INSTALLER_CERT_WINDOWS_PASSWORD
 
     steps:
       - name: Set certificate path environment variable


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Infrastructure fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
The check-certificates workflow is failing not being able to decode the secret
<!-- You can also link to an open issue here -->

## What is the new behavior?
The workflow should be fixed
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
no
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
