### PR TITLE
Add task to collect proto files and add steps to release them with tester, nightly and stable builds

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -236,6 +236,15 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.DIST_DIR }}
 
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Collect proto files
+        run: task protoc:collect
+
       - name: Create checksum file
         working-directory: ${{ env.DIST_DIR}}
         run: |

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -132,6 +132,32 @@ jobs:
           path: ${{ env.DIST_DIR }}/${{ matrix.os.path }}
           name: ${{ matrix.os.name }}
 
+  proto-files:
+    needs:
+      - package-name-prefix
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Collect proto files
+        run: task protoc:collect
+
+      - name: Upload proto files zip
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.DIST_DIR }}/*.zip
+          name: rpc-protocol-files
+
   checksums:
     needs:
       - build

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -71,41 +71,44 @@ jobs:
 
           echo "::set-output name=prefix::$PACKAGE_NAME_PREFIX"
 
-  build:
+  create-artifacts:
     needs: package-name-prefix
-    name: Build ${{ matrix.os.name }}
+    name: Create artifact ${{ matrix.artifact.name }}
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        os:
-          - task: Windows_32bit
+        artifact:
+          - task: dist:Windows_32bit
             path: "*Windows_32bit.zip"
             name: Windows_X86-32
-          - task: Windows_64bit
+          - task: dist:Windows_64bit
             path: "*Windows_64bit.zip"
             name: Windows_X86-64
-          - task: Linux_32bit
+          - task: dist:Linux_32bit
             path: "*Linux_32bit.tar.gz"
             name: Linux_X86-32
-          - task: Linux_64bit
+          - task: dist:Linux_64bit
             path: "*Linux_64bit.tar.gz"
             name: Linux_X86-64
-          - task: Linux_ARMv6
+          - task: dist:Linux_ARMv6
             path: "*Linux_ARMv6.tar.gz"
             name: Linux_ARMv6
-          - task: Linux_ARMv7
+          - task: dist:Linux_ARMv7
             path: "*Linux_ARMv7.tar.gz"
             name: Linux_ARMv7
-          - task: Linux_ARM64
+          - task: dist:Linux_ARM64
             path: "*Linux_ARM64.tar.gz"
             name: Linux_ARM64
-          - task: macOS_64bit
+          - task: dist:macOS_64bit
             path: "*macOS_64bit.tar.gz"
             name: macOS_64
-          - task: macOS_ARM64
+          - task: dist:macOS_ARM64
             path: "*macOS_ARM64.tar.gz"
             name: macOS_ARM64
+          - task: protoc:collect
+            path: "*_proto.zip"
+            name: rpc-protocol-files
 
     steps:
       - name: Checkout repository
@@ -123,48 +126,18 @@ jobs:
         run: |
           PACKAGE_NAME_PREFIX=${{ needs.package-name-prefix.outputs.prefix }}
           export PACKAGE_NAME_PREFIX
-          task dist:${{ matrix.os.task }}
+          task ${{ matrix.artifact.task }}
 
       # Transfer builds to artifacts job
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.DIST_DIR }}/${{ matrix.os.path }}
-          name: ${{ matrix.os.name }}
-
-  proto-files:
-    needs:
-      - package-name-prefix
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install Task
-        uses: arduino/setup-task@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
-
-      - name: Collect proto files
-        run: |
-          PACKAGE_NAME_PREFIX=${{ needs.package-name-prefix.outputs.prefix }}
-          export PACKAGE_NAME_PREFIX
-          task protoc:collect
-
-      - name: Upload proto files zip
-        uses: actions/upload-artifact@v3
-        with:
-          path: ${{ env.DIST_DIR }}/*.zip
-          name: rpc-protocol-files
+          path: ${{ env.DIST_DIR }}/${{ matrix.artifact.path }}
+          name: ${{ matrix.artifact.name }}
 
   checksums:
     needs:
       - build
-      - proto-files
       - package-name-prefix
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -132,32 +132,6 @@ jobs:
           path: ${{ env.DIST_DIR }}/${{ matrix.os.path }}
           name: ${{ matrix.os.name }}
 
-  proto-files:
-    needs:
-      - package-name-prefix
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install Task
-        uses: arduino/setup-task@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
-
-      - name: Collect proto files
-        run: task protoc:collect
-
-      - name: Upload proto files zip
-        uses: actions/upload-artifact@v3
-        with:
-          path: ${{ env.DIST_DIR }}/*.zip
-          name: rpc-protocol-files
-
   checksums:
     needs:
       - build
@@ -185,3 +159,35 @@ jobs:
         with:
           path: ./*checksums.txt
           name: checksums
+
+  proto-files:
+    # Run this after checksums or the uploaded proto files zip
+    # will make the checksum job always fail
+    needs:
+      - checksums
+      - package-name-prefix
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Collect proto files
+        run: |
+          PACKAGE_NAME_PREFIX=${{ needs.package-name-prefix.outputs.prefix }}
+          export PACKAGE_NAME_PREFIX
+          task protoc:collect
+
+      - name: Upload proto files zip
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.DIST_DIR }}/*.zip
+          name: rpc-protocol-files

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -132,39 +132,8 @@ jobs:
           path: ${{ env.DIST_DIR }}/${{ matrix.os.path }}
           name: ${{ matrix.os.name }}
 
-  checksums:
-    needs:
-      - build
-      - package-name-prefix
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v3
-
-      - name: Output checksum
-        run: |
-          TAG="${{ needs.package-name-prefix.outputs.prefix }}git-snapshot"
-          declare -a artifacts=($(ls -d */))
-          for artifact in ${artifacts[@]}
-          do
-            cd $artifact
-            checksum=$(sha256sum ${{ env.PROJECT_NAME }}_${TAG}*)
-            cd ..
-            echo $checksum >> ${TAG}-checksums.txt
-          done
-
-      - name: Upload checksum artifact
-        uses: actions/upload-artifact@v3
-        with:
-          path: ./*checksums.txt
-          name: checksums
-
   proto-files:
-    # Run this after checksums or the uploaded proto files zip
-    # will make the checksum job always fail
     needs:
-      - checksums
       - package-name-prefix
     runs-on: ubuntu-latest
 
@@ -191,3 +160,32 @@ jobs:
         with:
           path: ${{ env.DIST_DIR }}/*.zip
           name: rpc-protocol-files
+
+  checksums:
+    needs:
+      - build
+      - proto-files
+      - package-name-prefix
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Output checksum
+        run: |
+          TAG="${{ needs.package-name-prefix.outputs.prefix }}git-snapshot"
+          declare -a artifacts=($(ls -d */))
+          for artifact in ${artifacts[@]}
+          do
+            cd $artifact
+            checksum=$(sha256sum ${{ env.PROJECT_NAME }}_${TAG}*)
+            cd ..
+            echo $checksum >> ${TAG}-checksums.txt
+          done
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./*checksums.txt
+          name: checksums

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -137,7 +137,7 @@ jobs:
 
   checksums:
     needs:
-      - build
+      - create-artifacts
       - package-name-prefix
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -256,6 +256,15 @@ jobs:
           unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel ${{ needs.create-release-artifacts.outputs.version }} )" ]]; then echo "::set-output name=IS_PRE::true"; fi
 
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Collect proto files
+        run: task protoc:collect
+
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -241,6 +241,15 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.DIST_DIR }}
 
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Collect proto files
+        run: task protoc:collect
+
       - name: Create checksum file
         working-directory: ${{ env.DIST_DIR}}
         run: |
@@ -255,15 +264,6 @@ jobs:
           wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.0.0.zip
           unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel ${{ needs.create-release-artifacts.outputs.version }} )" ]]; then echo "::set-output name=IS_PRE::true"; fi
-
-      - name: Install Task
-        uses: arduino/setup-task@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
-
-      - name: Collect proto files
-        run: task protoc:collect
 
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -215,6 +215,13 @@ tasks:
     cmds:
       - buf lint rpc
 
+  protoc:collect:
+    desc: Create a zip file containing all .proto files in DIST_DIR
+    dir: rpc
+    cmds:
+      - mkdir ../{{.DIST_DIR}}
+      - zip -r ../{{.DIST_DIR}}/{{.PROJECT_NAME}}_{{.VERSION}}_proto.zip  * -i \*.proto
+
   protoc:format:
     desc: Perform formatting of the protobuf definitions
     cmds:


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Adds a new task and changes the tester, nightly and stable build release processes.

## What is the current behavior?

Currently there is no easy way for developers to download only `.proto` files to work on projects that depend on them. 
Those files are necessary to generate other languages files to handle gRPC communication.
The only way as of now is to download the whole `arduino-cli` repo and copy the files.

## What is the new behavior?

A new command has been added to zip all the `.proto` files and save them in `dist`, the task is called `protoc:collect`.
The output zip will be called `arduino-cli_<version>_proto.zip`, `<version>` as defined [here](https://github.com/arduino/arduino-cli/blob/master/Taskfile.yml#L351). The command can be run locally and on CI.

This zip will also be included in the released files for tester, nightly and stable builds.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

None.

## Other information

Closes #588.
