### PR TITLE
Change lib deps CLI command output to sorted alphabetically

### DIFF
--- a/cli/lib/check_deps.go
+++ b/cli/lib/check_deps.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/arduino/arduino-cli/cli/arguments"
 	"github.com/arduino/arduino-cli/cli/errorcodes"
@@ -81,13 +82,19 @@ func (dr checkDepResult) Data() interface{} {
 
 func (dr checkDepResult) String() string {
 	res := ""
-	for _, dep := range dr.deps.GetDependencies() {
+	deps := dr.deps.Dependencies
+	sort.Slice(deps, func(i, j int) bool {
+		return deps[i].Name > deps[j].Name &&
+			deps[i].VersionInstalled > deps[j].VersionInstalled
+	})
+	for _, dep := range deps {
 		res += outputDep(dep)
 	}
 	return res
 }
 
 func outputDep(dep *rpc.LibraryDependencyStatus) string {
+
 	res := ""
 	green := color.New(color.FgGreen)
 	red := color.New(color.FgRed)

--- a/commands/lib/resolve_deps.go
+++ b/commands/lib/resolve_deps.go
@@ -18,6 +18,7 @@ package lib
 import (
 	"context"
 	"errors"
+	"sort"
 
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/libraries"
@@ -74,5 +75,8 @@ func LibraryResolveDependencies(ctx context.Context, req *rpc.LibraryResolveDepe
 			VersionInstalled: installed,
 		})
 	}
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].Name < res[j].Name
+	})
 	return &rpc.LibraryResolveDependenciesResponse{Dependencies: res}, nil
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Enhances output of an existing command.

## What is the current behavior?

`lib deps` command output is non deterministic and always changes on subsequent calls, both in plain text and JSON.

```
$ ino lib deps Arduino_ConnectionHandler
✕ Arduino_ConnectionHandler 0.6.5 deve essere installato.
✕ Arduino_DebugUtils 1.1.0 deve essere installato.
✓ WiFi101 0.16.1 è già installato.
✕ WiFiNINA 1.8.13 deve essere installato.
✕ MKRGSM 1.5.0 deve essere installato.
✕ MKRNB 1.5.1 deve essere installato.
✓ MKRWAN 1.1.0 è già installato.

$ ino lib deps Arduino_ConnectionHandler
✕ MKRNB 1.5.1 deve essere installato.
✓ MKRWAN 1.1.0 è già installato.
✕ Arduino_ConnectionHandler 0.6.5 deve essere installato.
✕ Arduino_DebugUtils 1.1.0 deve essere installato.
✓ WiFi101 0.16.1 è già installato.
✕ WiFiNINA 1.8.13 deve essere installato.
✕ MKRGSM 1.5.0 deve essere installato.

$ ino lib deps Arduino_ConnectionHandler
✕ WiFiNINA 1.8.13 deve essere installato.
✕ MKRGSM 1.5.0 deve essere installato.
✕ MKRNB 1.5.1 deve essere installato.
✓ MKRWAN 1.1.0 è già installato.
✕ Arduino_ConnectionHandler 0.6.5 deve essere installato.
✕ Arduino_DebugUtils 1.1.0 deve essere installato.
✓ WiFi101 0.16.1 è già installato.
```

## What is the new behavior?

Output of `lib deps` is now sorted alphabetically both in plain text and JSON.
In plain text it's also sorted by installation state, dependencies that are installed are shown first. 

Example plain text output:

```
$ ino lib deps Arduino_ConnectionHandler      
✓ MKRWAN 1.1.0 è già installato.
✓ WiFi101 0.16.1 è già installato.
✕ Arduino_ConnectionHandler 0.6.5 deve essere installato.
✕ Arduino_DebugUtils 1.1.0 deve essere installato.
✕ MKRGSM 1.5.0 deve essere installato.
✕ MKRNB 1.5.1 deve essere installato.
✕ WiFiNINA 1.8.13 deve essere installato.
```

Example json output:
```
$ ino lib deps Arduino_ConnectionHandler --format json
{
  "dependencies": [
    {
      "name": "Arduino_ConnectionHandler",
      "version_required": "0.6.5"
    },
    {
      "name": "Arduino_DebugUtils",
      "version_required": "1.1.0"
    },
    {
      "name": "MKRGSM",
      "version_required": "1.5.0"
    },
    {
      "name": "MKRNB",
      "version_required": "1.5.1"
    },
    {
      "name": "MKRWAN",
      "version_required": "1.1.0",
      "version_installed": "1.1.0"
    },
    {
      "name": "WiFi101",
      "version_required": "0.16.1",
      "version_installed": "0.16.1"
    },
    {
      "name": "WiFiNINA",
      "version_required": "1.8.13"
    }
  ]
}
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

Nope.

## Other information

This will ease integration testing for a PR that fixes #1856.
