### PR TITLE
Copy package to destination if move failed during resource installation

### DIFF
--- a/arduino/resources/install.go
+++ b/arduino/resources/install.go
@@ -91,7 +91,10 @@ func (release *DownloadResource) Install(downloadDir, tempPath, destDir *paths.P
 
 	// Move/rename the extracted root directory in the destination directory
 	if err := root.Rename(destDir); err != nil {
-		return fmt.Errorf(tr("moving extracted archive to destination dir: %s", err))
+		// Copy the extracted root directory to the destination directory, if move failed
+		if err := root.CopyDirTo(destDir); err != nil {
+			return fmt.Errorf(tr("moving extracted archive to destination dir: %s", err))
+		}
 	}
 
 	// TODO


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->

This PR improves compatibility with antivirus software.

## What is the current behavior?

<!-- You can also link to an open issue here -->

CLI reports

```
Installing Seeeduino:CMSIS@5.7.0...
Error during install: Cannot install tool Seeeduino:CMSIS@5.7.0: moving extracted archive to destination dir: rename C:\Users\XXX\AppData\Local\Arduino15\tmp\package-2842439214\ARM.CMSIS.5.7.0 c:\Users\XXX\AppData\Local\Arduino15\packages\Seeeduino\tools\CMSIS\5.7.0: Access is denied.
```

if an antivirus software is still scanning temp files when CLI trys to move them to destination dir. This is a common error if you are using an antivirus software, and there are lots of discussion.

All previous suggestion is to disable antivirus temporarily. It's not a good solution because:
- Disabling antivirus is risky, even just for a couple minutes to install a package, or you might forget to enable it again
- User might not allowed to disable antivirus, due to security policy, especially in a lab

Some related issues, all suggested to solve manually:
- https://github.com/arduino/arduino-cli/issues/636
- https://github.com/arduino/arduino-cli/issues/723
- https://github.com/arduino/arduino-ide/issues/1352
- https://forum.arduino.cc/t/failed-to-install-platform/967472

## What is the new behavior?

<!-- if this is a feature change -->

CLI will try to copy temp files if move failed, no error will be reported even if antivirus is scanning temp files.

To demonstrate new behavior, I've added debug logs in my demo and the output looks like:

```
Installing Seeeduino:CMSIS@5.7.0...
+Failed to move dir
+Copy succeeded
Seeeduino:CMSIS@5.7.0 installed
```


## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

No

## Other information

<!-- Any additional information that could help the review process -->

Copy takes a little bit more time than move, but it's only called if move failed. And it's definitely faster and safer than searching for error message, disabling antivirus, and rerun installation.

Temp files will not be left permanently, they will be removed by `defer tempDir.RemoveAll()` [here](https://github.com/arduino/arduino-cli/blob/5efa9b5d3596d4dd88f16813d1018f3f60481b05/arduino/resources/install.go#L50).
