### PR TITLE
Allow `locale` key to be used in `config ...` commands.

### DIFF
--- a/cli/config/validate.go
+++ b/cli/config/validate.go
@@ -33,6 +33,7 @@ var validMap = map[string]reflect.Kind{
 	"directories.builtin.tools":     reflect.String,
 	"directories.builtin.libraries": reflect.String,
 	"library.enable_unsafe_install": reflect.Bool,
+	"locale":                        reflect.String,
 	"logging.file":                  reflect.String,
 	"logging.format":                reflect.String,
 	"logging.level":                 reflect.String,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,8 +18,8 @@
   - `enable_unsafe_install` - set to `true` to enable the use of the `--git-url` and `--zip-file` flags with
     [`arduino-cli lib install`][arduino cli lib install]. These are considered "unsafe" installation methods because
     they allow installing files that have not passed through the Library Manager submission process.
-- `locale` - the language used by Arduino CLI, the parameter is the language identifier in the standard format
-  `<language>_<COUNTRY>.<encoding>` (for example `it` or `it_IT`, or `it_IT.UTF-8`).
+- `locale` - the language used by Arduino CLI to communicate to the user, the parameter is the language identifier in
+  the standard POSIX/Unix format `<language>_<COUNTRY>.<encoding>` (for example `it` or `it_IT`, or `it_IT.UTF-8`).
 - `logging` - configuration options for Arduino CLI's logs.
   - `file` - path to the file where logs will be written.
   - `format` - output format for the logs. Allowed values are `text` or `json`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,8 @@
   - `enable_unsafe_install` - set to `true` to enable the use of the `--git-url` and `--zip-file` flags with
     [`arduino-cli lib install`][arduino cli lib install]. These are considered "unsafe" installation methods because
     they allow installing files that have not passed through the Library Manager submission process.
+- `locale` - the language used by Arduino CLI, the parameter is the language identifier in the standard format
+  `<language>_<COUNTRY>.<encoding>` (for example `it` or `it_IT`, or `it_IT.UTF-8`).
 - `logging` - configuration options for Arduino CLI's logs.
   - `file` - path to the file where logs will be written.
   - `format` - output format for the logs. Allowed values are `text` or `json`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@
     [`arduino-cli lib install`][arduino cli lib install]. These are considered "unsafe" installation methods because
     they allow installing files that have not passed through the Library Manager submission process.
 - `locale` - the language used by Arduino CLI to communicate to the user, the parameter is the language identifier in
-  the standard POSIX/Unix format `<language>_<COUNTRY>.<encoding>` (for example `it` or `it_IT`, or `it_IT.UTF-8`).
+  the standard POSIX format `<language>[_<TERRITORY>[.<encoding>]]` (for example `it` or `it_IT`, or `it_IT.UTF-8`).
 - `logging` - configuration options for Arduino CLI's logs.
   - `file` - path to the file where logs will be written.
   - `format` - output format for the logs. Allowed values are `text` or `json`.


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Allows `locale` key to be used in config.

## What is the current behavior?

```
$ arduino-cli config set locale de
Settings key doesn't exist
$
```

## What is the new behavior?

The setting is correctly applied:
```
$ arduino-cli config set locale de
$
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #1928
