### PR TITLE
[skip changelog] Fix bugs related to protobuf archive generation

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -246,6 +246,8 @@ jobs:
           version: 3.x
 
       - name: Collect proto files
+        env:
+          NIGHTLY: true
         run: task protoc:collect
 
       - name: Create checksum file

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -230,6 +230,9 @@ jobs:
       - create-windows-installer
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -235,6 +235,9 @@ jobs:
       - create-windows-installer
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -236,7 +236,7 @@ tasks:
     desc: Create a zip file containing all .proto files in DIST_DIR
     dir: rpc
     cmds:
-      - mkdir ../{{.DIST_DIR}}
+      - mkdir --parents ../{{.DIST_DIR}}
       - zip -r ../{{.DIST_DIR}}/{{.PROJECT_NAME}}_{{.VERSION}}_proto.zip  * -i \*.proto
 
   protoc:format:


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Infrastructure fix

## What is the current behavior?

An additional operation was recently added to the GitHub Actions workflows that produce builds of Arduino CLI: the generation of [protocol buffer](https://developers.google.com/protocol-buffers) archive files to publish
along with the builds (https://github.com/arduino/arduino-cli/pull/1931).

Some bugs were introduced at that time which caused the nightly build and release workflows to fail.

## What is the new behavior?

Fix all the bugs introduced by the previous protocol buffer archive generation work:

- Add missing checkout steps to build publishing workflow jobs
- Don't error protobuf archive task if distribution folder already exists
- Set correct version for nightly build protobuf archive filename

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.

## Other information

- Tester: https://github.com/per1234/arduino-cli/actions/runs/3402302240
- Nightly: https://github.com/per1234/arduino-cli/actions/runs/3402177994
  - I modified the workflow to save the files that would normally be uploaded to Arduino's server into a workflow artifact named "final".
- Release: https://github.com/per1234/arduino-cli/actions/runs/3402179487 / https://github.com/per1234/arduino-cli/releases/tag/0.0.0-rc.5
