### PR TITLE
[skip changelog] Update all mentions of Arduino Pro IDE

### DIFF
--- a/docs/integration-options.md
+++ b/docs/integration-options.md
@@ -3,9 +3,9 @@
 The Arduino CLI is an open source Command Line Application written in [Golang] that can be used from a terminal to
 compile, verify and upload sketches to Arduino boards and that’s capable of managing all the software and tools needed
 in the process. But don’t get fooled by its name: Arduino CLI can do much more than the average console application, as
-shown by the [Arduino Pro IDE] and [Arduino Cloud], which rely on it for similar purposes but each one in a completely
-different way from the other. In this article we introduce the three pillars of the Arduino CLI, explaining how we
-designed the software so that it can be effectively leveraged under different scenarios.
+shown by [Arduino IDE 2.x][arduino ide 2.x] and [Arduino Cloud], which rely on it for similar purposes but each one in a
+completely different way from the other. In this article we introduce the three pillars of the Arduino CLI, explaining
+how we designed the software so that it can be effectively leveraged under different scenarios.
 
 ## The first pillar: command line interface
 
@@ -57,10 +57,10 @@ instance:
 
 gRPC is language agnostic: even if the example is written in Golang, the programming language used for the client can be
 Python, JavaScript or any of the many [supported ones][grpc supported languages], leading to a variety of possible
-scenarios. The new [Arduino Pro IDE] is a good example of how to leverage the daemon mode of the Arduino CLI with a
-clean separation of concerns: the Pro IDE knows nothing about how to download a core, compile a sketch or talk to an
+scenarios. [Arduino IDE 2.x][arduino ide 2.x] is a good example of how to leverage the daemon mode of the Arduino CLI
+with a clean separation of concerns: the IDE knows nothing about how to download a core, compile a sketch or talk to an
 Arduino board and it demands all these features of an Arduino CLI instance. Conversely, the Arduino CLI doesn’t even
-know that the client that’s connected is the Pro IDE, and neither does it care.
+know that the client that’s connected is the Arduino IDE, and neither does it care.
 
 For more information on Arduino CLI's gRPC interface, see the [gRPC interface reference].
 
@@ -88,7 +88,7 @@ designed the low level API, have a look at the [commands package] and don’t he
 tracker] if you’ve got a use case that doesn’t fit one of the three pillars.
 
 [golang]: https://go.dev/
-[arduino pro ide]: https://www.arduino.cc/pro/arduino-pro-ide
+[arduino ide 2.x]: https://github.com/arduino/arduino-ide
 [arduino cloud]: https://cloud.arduino.cc/home
 [continuous integration]: https://en.wikipedia.org/wiki/Continuous_integration
 [continuous deployment]: https://en.wikipedia.org/wiki/Continuous_deployment

--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -418,7 +418,7 @@ allowing the compilation to fail in a difficult to understand way):
 
 ## Old library format (pre-1.5)
 
-In order to support old libraries (from Arduino IDE 1.0.x), the Arduino IDE/Pro IDE and Arduino CLI will also compile
-libraries missing a library.properties metadata file. As a result, these libraries should behave as they did in Arduino
-IDE 1.0.x, although they will be available for all boards, including non-AVR ones (which wouldn’t have been present in
-Arduino IDE 1.0.x).
+In order to support old libraries (from Arduino IDE 1.0.x), Arduino IDE and Arduino CLI will also compile libraries
+missing a library.properties metadata file. As a result, these libraries should behave as they did in Arduino IDE 1.0.x,
+although they will be available for all boards, including non-AVR ones (which wouldn’t have been present in Arduino IDE
+1.0.x).

--- a/docs/package_index_json-specification.md
+++ b/docs/package_index_json-specification.md
@@ -2,8 +2,8 @@ Introduced in Arduino IDE 1.6.4, Boards Manager makes it easy to install and upd
 provide Boards Manager installation support for a platform, a JSON formatted index file must be published. This is the
 specification for that file.
 
-Boards Manager functionality is provided by [Arduino CLI](getting-started.md#adding-3rd-party-cores),
-[Arduino IDE](https://docs.arduino.cc/learn/starting-guide/cores), and Arduino Pro IDE.
+Boards Manager functionality is provided by [Arduino CLI](getting-started.md#adding-3rd-party-cores) and
+[Arduino IDE](https://docs.arduino.cc/learn/starting-guide/cores).
 
 ## Naming of the JSON index file
 
@@ -64,9 +64,8 @@ The metadata fields are:
 - `name`: the folder used for the installed cores. The
   [vendor folder](platform-specification.md#hardware-folders-structure) name of the installed package is determined by
   this field
-- `maintainer`: the extended name of the vendor that is displayed on the Arduino IDE/Pro IDE's Boards Manager GUI
-- `websiteURL`: the URL to the vendor's website, appears on the Arduino IDE/Pro IDE's Boards Manager as a "More info"
-  link
+- `maintainer`: the extended name of the vendor that is displayed on the Arduino IDE Boards Manager GUI
+- `websiteURL`: the URL to the vendor's website, appears on the Arduino IDE Boards Manager as a "More info" link
 - `email`: the email of the vendor/maintainer
 
 Now, before looking at `PLATFORMS`, let's explore first how `TOOLS` are made.
@@ -241,8 +240,8 @@ Each PLATFORM describes a core for a specific architecture. The fields needed ar
 - `help`/`online`: is a URL that is displayed on the Arduino IDE's Boards Manager as an "Online Help" link
 - `url`, `archiveFileName`, `size` and `checksum`: metadata of the core archive file. The meaning is the same as for the
   TOOLS
-- `boards`: the list of boards supported (note: just the names to display on the Arduino IDE and Arduino Pro IDE's
-  Boards Manager GUI! the real boards definitions are inside `boards.txt` inside the core archive file)
+- `boards`: the list of boards supported (note: just the names to display on the Arduino IDE's Boards Manager GUI! the
+  real boards definitions are inside `boards.txt` inside the core archive file)
 - `toolsDependencies`: the tools needed by this platform. They will be installed by Boards Manager along with the
   platform. Each tool is referenced by the triple (`packager`, `name`, `version`) as previously said. Note that you can
   reference tools available in other packages as well, even if no platform of that package is installed.

--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -1330,10 +1330,9 @@ platform's platform.txt is done as usual.
 
 ### Sketch debugging configuration
 
-Starting from Arduino CLI 0.9.0 / Arduino Pro IDE v0.0.5-alpha.preview, sketch debugging support is available for
-platforms.
+Starting from Arduino CLI 0.9.0 / Arduino IDE 2.x, sketch debugging support is available for platforms.
 
-The debug action is triggered when the user clicks the Debug button in the Arduino Pro IDE or runs the
+The debug action is triggered when the user clicks the Debug button in the Arduino IDE or runs the
 [`arduino-cli debug`](commands/arduino-cli_debug.md) command.
 
 The compiler optimization level that is appropriate for normal usage will often not provide a good experience while
@@ -1486,8 +1485,8 @@ myboard.bootloader.tool=arduino:avrdude
 [....]
 ```
 
-When using Arduino CLI or Arduino Pro IDE (but not Arduino IDE), properties used in the referenced tool recipe may be
-overridden in the referencing platform's platform.txt.
+When using Arduino CLI or Arduino IDE 2.x (but not Arduino IDE 1.x), properties used in the referenced tool recipe may
+be overridden in the referencing platform's platform.txt.
 
 Note that, unlike core references, referencing a tool recipe does _not_ result in any other resources being inherited
 from the referenced platform.
@@ -1548,8 +1547,8 @@ This script may be used to configure the user's system for the platform, such as
 The circumstances under which the post-install script will run are different depending on which Arduino development
 software is in use:
 
-- **Arduino IDE**: (all versions) runs the script when the installed platform is signed with Arduino's private key.
+- **Arduino IDE 1.x**: runs the script when the installed platform is signed with Arduino's private key.
+- **Arduino IDE 2.x**: runs the script for any installed platform.
 - **Arduino CLI**: (since 0.12.0) runs the script for any installed platform when Arduino CLI is in "interactive" mode.
   This behavior
   [can be configured](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_core_install/#options)
-- **Arduino Pro IDE**: (since 0.1.0) runs the script for any installed platform.


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Documentation fix/update

## What is the current behavior?

The Arduino Pro IDE application was mentioned several places throughout the documentation. That project became Arduino IDE 2.x 1.5 years ago while still in the alpha development phase.

All users of that application will now know it by the name "Arduino IDE 2.x".

The Arduino Pro IDE page on the Arduino website has been removed, which broke the link and caused the link check workflow to fail.

## What is the new behavior?

Update all mentions of Arduino Pro IDE in the documentation to use the final name of the project.

Fix broken link

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.