### PR TITLE
Fixed integration test `TestLibInstallMultipleSameLibrary`

### DIFF
--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -97,7 +97,10 @@ func TestLibInstallMultipleSameLibrary(t *testing.T) {
 	require.NoError(t, err)
 	jsonOut, _, err := cli.Run("lib", "list", "--format", "json")
 	require.NoError(t, err)
-	requirejson.Len(t, jsonOut, 1, "A duplicate library install has been detected")
+	// Count how many libraries with the name "Arduino SigFox for MKRFox1200" are installed
+	requirejson.Parse(t, jsonOut).
+		Query(`[.[].library.name | select(. == "Arduino SigFox for MKRFox1200")]`).
+		LengthMustEqualTo(1, "Found multiple installations of Arduino SigFox for MKRFox1200'")
 
 	// Check that 'lib upgrade' didn't create a double install
 	// https://github.com/arduino/arduino-cli/issues/1870
@@ -109,7 +112,10 @@ func TestLibInstallMultipleSameLibrary(t *testing.T) {
 	require.NoError(t, err)
 	jsonOut, _, err = cli.Run("lib", "list", "--format", "json")
 	require.NoError(t, err)
-	requirejson.Len(t, jsonOut, 1, "A duplicate library install has been detected")
+	// Count how many libraries with the name "Arduino SigFox for MKRFox1200" are installed
+	requirejson.Parse(t, jsonOut).
+		Query(`[.[].library.name | select(. == "Arduino SigFox for MKRFox1200")]`).
+		LengthMustEqualTo(1, "Found multiple installations of Arduino SigFox for MKRFox1200'")
 }
 
 func TestDuplicateLibInstallDetection(t *testing.T) {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Fixed an integration test:
```
<<< Run completed (err = <nil>)
    json.go:90: 
        	Error Trace:	/home/runner/work/arduino-cli/arduino-cli/internal/integrationtest/lib/json.go:90
        	            				/home/runner/work/arduino-cli/arduino-cli/internal/integrationtest/lib/json.go:144
        	            				/home/runner/work/arduino-cli/arduino-cli/internal/integrationtest/lib/lib_test.go:100
        	Error:      	json data length does not match: expected=1, actual=3
        	Test:       	TestLibInstallMultipleSameLibrary
        	Messages:   	A duplicate library install has been detected
```
https://github.com/arduino/arduino-cli/actions/runs/3410728596/jobs/5674051391#step:6:955

## What is the current behavior?

The test fails because a new release of the `Arduino SigFox for MKRFox1200` library now [has new dependencies](https://github.com/arduino-libraries/SigFox/commit/115e1c43ee7152a5af7bf4dc169ae9d0d211c681).

## What is the new behavior?

The test has been refined to actually check for duplicates installations of `Arduino SigFox for MKRFox1200` instead of merely counting all the installed libraries.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking changes
