### PR TITLE
Allow ISO8859-1 (non UTF-8) `.properties` files.

### DIFF
--- a/.licenses/go/github.com/arduino/go-properties-orderedmap.dep.yml
+++ b/.licenses/go/github.com/arduino/go-properties-orderedmap.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: github.com/arduino/go-properties-orderedmap
-version: v1.6.0
+version: v1.7.1
 type: go
 summary: Package properties is a library for handling maps of hierarchical properties.
 homepage: https://pkg.go.dev/github.com/arduino/go-properties-orderedmap

--- a/arduino/discovery/discovery_client/go.mod
+++ b/arduino/discovery/discovery_client/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	github.com/arduino/go-paths-helper v1.7.0 // indirect
-	github.com/arduino/go-properties-orderedmap v1.6.0 // indirect
+	github.com/arduino/go-properties-orderedmap v1.7.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/leonelquinteros/gotext v1.4.0 // indirect

--- a/arduino/discovery/discovery_client/go.sum
+++ b/arduino/discovery/discovery_client/go.sum
@@ -47,8 +47,8 @@ github.com/arduino/go-paths-helper v1.0.1/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3
 github.com/arduino/go-paths-helper v1.2.0/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3v5YYu35Yb+w31Ck=
 github.com/arduino/go-paths-helper v1.7.0 h1:S9l5BP2aogz1CgyqqnncXt0PLpK4yvwOW/wu/LaR3tc=
 github.com/arduino/go-paths-helper v1.7.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
-github.com/arduino/go-properties-orderedmap v1.6.0 h1:gp2JoWRETtqwsZ+UHu/PBuYWYH2x2+d+uipDxS4WmvM=
-github.com/arduino/go-properties-orderedmap v1.6.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
+github.com/arduino/go-properties-orderedmap v1.7.1 h1:HQ9Pn/mk3+XyfrE39EEvaZwJkrvgiVSY5Oq3JSEfOR4=
+github.com/arduino/go-properties-orderedmap v1.7.1/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b/go.mod h1:uwGy5PpN4lqW97FiLnbcx+xx8jly5YuPMJWfVwwjJiQ=
 github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b/go.mod h1:iIPnclBMYm1g32Q5kXoqng4jLhMStReIP7ZxaoUC2y8=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/arduino/libraries/libraries_test.go
+++ b/arduino/libraries/libraries_test.go
@@ -67,4 +67,10 @@ func TestLibrariesLoader(t *testing.T) {
 		require.False(t, lib.IsLegacy)
 		require.True(t, lib.InDevelopment)
 	}
+	{
+		lib, err := Load(paths.New("testdata", "LibWithNonUTF8Properties"), User)
+		require.NoError(t, err)
+		require.Equal(t, "LibWithNonUTF8Properties", lib.Name)
+		require.Equal(t, "àrduìnò", lib.Author)
+	}
 }

--- a/arduino/libraries/testdata/LibWithNonUTF8Properties/library.properties
+++ b/arduino/libraries/testdata/LibWithNonUTF8Properties/library.properties
@@ -1,0 +1,9 @@
+name=LibWithNonUTF8Properties
+version=1.0.3
+author=àrduìnò
+maintainer=
+sentence=A test lib
+paragraph=very powerful!
+category=Device Control
+url=http://www.arduino.cc/en/Reference/TestLib
+architectures=avr

--- a/client_example/go.sum
+++ b/client_example/go.sum
@@ -46,7 +46,7 @@ github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c/go.mod h1:
 github.com/arduino/go-paths-helper v1.0.1/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3v5YYu35Yb+w31Ck=
 github.com/arduino/go-paths-helper v1.2.0/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3v5YYu35Yb+w31Ck=
 github.com/arduino/go-paths-helper v1.7.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
-github.com/arduino/go-properties-orderedmap v1.6.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
+github.com/arduino/go-properties-orderedmap v1.7.1/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b/go.mod h1:uwGy5PpN4lqW97FiLnbcx+xx8jly5YuPMJWfVwwjJiQ=
 github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b/go.mod h1:iIPnclBMYm1g32Q5kXoqng4jLhMStReIP7ZxaoUC2y8=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/docsgen/go.mod
+++ b/docsgen/go.mod
@@ -13,7 +13,7 @@ require (
 require (
 	github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c // indirect
 	github.com/arduino/go-paths-helper v1.7.0 // indirect
-	github.com/arduino/go-properties-orderedmap v1.6.0 // indirect
+	github.com/arduino/go-properties-orderedmap v1.7.1 // indirect
 	github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b // indirect
 	github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b // indirect
 	github.com/cmaglie/pb v1.0.27 // indirect

--- a/docsgen/go.sum
+++ b/docsgen/go.sum
@@ -50,8 +50,8 @@ github.com/arduino/go-paths-helper v1.0.1/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3
 github.com/arduino/go-paths-helper v1.2.0/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3v5YYu35Yb+w31Ck=
 github.com/arduino/go-paths-helper v1.7.0 h1:S9l5BP2aogz1CgyqqnncXt0PLpK4yvwOW/wu/LaR3tc=
 github.com/arduino/go-paths-helper v1.7.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
-github.com/arduino/go-properties-orderedmap v1.6.0 h1:gp2JoWRETtqwsZ+UHu/PBuYWYH2x2+d+uipDxS4WmvM=
-github.com/arduino/go-properties-orderedmap v1.6.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
+github.com/arduino/go-properties-orderedmap v1.7.1 h1:HQ9Pn/mk3+XyfrE39EEvaZwJkrvgiVSY5Oq3JSEfOR4=
+github.com/arduino/go-properties-orderedmap v1.7.1/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b h1:9hDi4F2st6dbLC3y4i02zFT5quS4X6iioWifGlVwfy4=
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b/go.mod h1:uwGy5PpN4lqW97FiLnbcx+xx8jly5YuPMJWfVwwjJiQ=
 github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b h1:3PjgYG5gVPA7cipp7vIR2lF96KkEJIFBJ+ANnuv6J20=

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace github.com/mailru/easyjson => github.com/cmaglie/easyjson v0.8.1
 require (
 	github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c
 	github.com/arduino/go-paths-helper v1.7.0
-	github.com/arduino/go-properties-orderedmap v1.6.0
+	github.com/arduino/go-properties-orderedmap v1.7.1
 	github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b
 	github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b
 	github.com/cmaglie/pb v1.0.27

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/arduino/go-paths-helper v1.0.1/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3
 github.com/arduino/go-paths-helper v1.2.0/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3v5YYu35Yb+w31Ck=
 github.com/arduino/go-paths-helper v1.7.0 h1:S9l5BP2aogz1CgyqqnncXt0PLpK4yvwOW/wu/LaR3tc=
 github.com/arduino/go-paths-helper v1.7.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
-github.com/arduino/go-properties-orderedmap v1.6.0 h1:gp2JoWRETtqwsZ+UHu/PBuYWYH2x2+d+uipDxS4WmvM=
-github.com/arduino/go-properties-orderedmap v1.6.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
+github.com/arduino/go-properties-orderedmap v1.7.1 h1:HQ9Pn/mk3+XyfrE39EEvaZwJkrvgiVSY5Oq3JSEfOR4=
+github.com/arduino/go-properties-orderedmap v1.7.1/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b h1:9hDi4F2st6dbLC3y4i02zFT5quS4X6iioWifGlVwfy4=
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b/go.mod h1:uwGy5PpN4lqW97FiLnbcx+xx8jly5YuPMJWfVwwjJiQ=
 github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b h1:3PjgYG5gVPA7cipp7vIR2lF96KkEJIFBJ+ANnuv6J20=


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Previously `.properties` files (like `library.properties` or `platform.txt`) were considered always as UTF8 encoded. In some cases, this assumption leads to unwanted behavior.

Now the properties files are considered UTF8 if the files is a valid UTF8, otherwise, it is considered ISO8859-1.

## What is the current behavior?

See https://github.com/arduino/arduino-cli/issues/1907 for more details.

> Library Manager doesn't show libraries. Output console shows
> `[INFO] ERROR: 2019/10/21 21:46:10 grpc: server failed to encode response: rpc error: code = Internal desc = grpc: error while marshaling: proto: field "cc.arduino.cli.commands.Library.Maintainer" contains invalid UTF-8`

```
$ arduino-cli lib list "WiFi Link" --format json | jq .[].library.maintainer
"Juraj Andr�ssy <juraj.andrassy@gmail.com>"
```

## What is the new behavior?

The non-UTF8 file is handled correctly.

```
$ arduino-cli lib list "WiFi Link" --format json | jq .[].library.maintainer
"Juraj Andrássy <juraj.andrassy@gmail.com>"
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #1907
