### PR TITLE
Fix concurrency problem in `Board.buildConfigOptionsStructures`

### DIFF
--- a/arduino/cores/board.go
+++ b/arduino/cores/board.go
@@ -18,6 +18,7 @@ package cores
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/arduino/go-properties-orderedmap"
 )
@@ -27,6 +28,7 @@ type Board struct {
 	BoardID                  string
 	Properties               *properties.Map  `json:"-"`
 	PlatformRelease          *PlatformRelease `json:"-"`
+	configOptionsMux         sync.Mutex
 	configOptions            *properties.Map
 	configOptionValues       map[string]*properties.Map
 	configOptionProperties   map[string]*properties.Map
@@ -69,6 +71,8 @@ func (b *Board) String() string {
 }
 
 func (b *Board) buildConfigOptionsStructures() {
+	b.configOptionsMux.Lock()
+	defer b.configOptionsMux.Unlock()
 	if b.configOptions != nil {
 		return
 	}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

This is a tentative fix for #1970 

## What is the current behavior?

See #1970 

## What is the new behavior?

Should solve the nil pointer exception reported here: https://github.com/arduino/arduino-cli/issues/1970#issuecomment-1309533962
BTW I found no way to reproduce it, so testing is needed.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No