### PR TITLE
`lib search` returns exact match as the first result.

### DIFF
--- a/cli/lib/search.go
+++ b/cli/lib/search.go
@@ -72,7 +72,7 @@ func runSearchCommand(args []string, namesOnly bool) {
 
 	searchResp, err := lib.LibrarySearch(context.Background(), &rpc.LibrarySearchRequest{
 		Instance: inst,
-		Query:    (strings.Join(args, " ")),
+		Query:    strings.Join(args, " "),
 	})
 	if err != nil {
 		feedback.Errorf(tr("Error searching for Libraries: %v"), err)

--- a/cli/lib/search.go
+++ b/cli/lib/search.go
@@ -34,24 +34,23 @@ import (
 	semver "go.bug.st/relaxed-semver"
 )
 
-var (
-	namesOnly bool // if true outputs lib names only.
-)
-
 func initSearchCommand() *cobra.Command {
+	var namesOnly bool // if true outputs lib names only.
 	searchCommand := &cobra.Command{
 		Use:     fmt.Sprintf("search [%s]", tr("LIBRARY_NAME")),
 		Short:   tr("Searches for one or more libraries data."),
 		Long:    tr("Search for one or more libraries data (case insensitive search)."),
 		Example: "  " + os.Args[0] + " lib search audio",
 		Args:    cobra.ArbitraryArgs,
-		Run:     runSearchCommand,
+		Run: func(cmd *cobra.Command, args []string) {
+			runSearchCommand(args, namesOnly)
+		},
 	}
 	searchCommand.Flags().BoolVar(&namesOnly, "names", false, tr("Show library names only."))
 	return searchCommand
 }
 
-func runSearchCommand(cmd *cobra.Command, args []string) {
+func runSearchCommand(args []string, namesOnly bool) {
 	inst, status := instance.Create()
 	logrus.Info("Executing `arduino-cli lib search`")
 

--- a/cli/lib/search.go
+++ b/cli/lib/search.go
@@ -124,11 +124,6 @@ func (res result) String() string {
 		return tr("No libraries matching your search.")
 	}
 
-	// get a sorted slice of results
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Name < results[j].Name
-	})
-
 	var out strings.Builder
 
 	if res.results.GetStatus() == rpc.LibrarySearchStatus_LIBRARY_SEARCH_STATUS_FAILED {

--- a/commands/lib/search_test.go
+++ b/commands/lib/search_test.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"sort"
 	"strings"
 	"testing"
 
@@ -52,7 +51,6 @@ func TestSearchLibraryFields(t *testing.T) {
 		for _, lib := range searchLibrary(&rpc.LibrarySearchRequest{Query: q}, lm).Libraries {
 			libs = append(libs, lib.Name)
 		}
-		sort.Strings(libs)
 		return libs
 	}
 
@@ -76,4 +74,8 @@ func TestSearchLibraryFields(t *testing.T) {
 	require.Len(t, res, 2)
 	require.Equal(t, "Arduino_ConnectionHandler", res[0])
 	require.Equal(t, "FlashStorage_SAMD", res[1])
+
+	res = query("flashstorage")
+	require.Len(t, res, 19)
+	require.Equal(t, "FlashStorage", res[0])
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

When searching for libraries put the exact match as the first result.

## What is the current behavior?

```
$ arduino-cli lib search FlashStorage --names
Sto scaricando l'indice: library_index.tar.bz2 downloaded                                                                                                                                                   
Nome: "BlynkEthernet_Manager"
Nome: "Blynk_Esp8266AT_WM"
Nome: "Blynk_WiFiNINA_WM"
Nome: "DoubleResetDetector_Generic"
Nome: "DueFlashStorage"
Nome: "ESP_AT_WM_Lite"
Nome: "ESP_AT_WiFiManager"
Nome: "Ethernet_Manager"
Nome: "Ethernet_Manager_STM32"
Nome: "FlashStorage"
Nome: "FlashStorage_RTL8720"
Nome: "FlashStorage_SAMD"
Nome: "FlashStorage_STM32"
Nome: "FlashStorage_STM32F1"
Nome: "KonnektingFlashStorage"
Nome: "MultiResetDetector_Generic"
Nome: "WiFiManager_Generic_Lite"
Nome: "WiFiManager_NINA_Lite"
Nome: "WiFiManager_RTL8720"
```

## What is the new behavior?

```
$ arduino-cli lib search FlashStorage --names
Sto scaricando l'indice: library_index.tar.bz2 downloaded                                                                                                                                                   
Nome: "FlashStorage"
Nome: "BlynkEthernet_Manager"
Nome: "Blynk_Esp8266AT_WM"
Nome: "Blynk_WiFiNINA_WM"
Nome: "DoubleResetDetector_Generic"
Nome: "DueFlashStorage"
Nome: "ESP_AT_WM_Lite"
Nome: "ESP_AT_WiFiManager"
Nome: "Ethernet_Manager"
Nome: "Ethernet_Manager_STM32"
Nome: "FlashStorage_RTL8720"
Nome: "FlashStorage_SAMD"
Nome: "FlashStorage_STM32"
Nome: "FlashStorage_STM32F1"
Nome: "KonnektingFlashStorage"
Nome: "MultiResetDetector_Generic"
Nome: "WiFiManager_Generic_Lite"
Nome: "WiFiManager_NINA_Lite"
Nome: "WiFiManager_RTL8720"
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #1974
