### PR TITLE
Set `runtime.hardware.path` property during upload

### DIFF
--- a/arduino/cores/cores.go
+++ b/arduino/cores/cores.go
@@ -337,6 +337,7 @@ func (release *PlatformRelease) RuntimeProperties() *properties.Map {
 	res := properties.NewMap()
 	if release.InstallDir != nil {
 		res.Set("runtime.platform.path", release.InstallDir.String())
+		res.Set("runtime.hardware.path", release.InstallDir.Join("..").String())
 	}
 
 	return res

--- a/internal/integrationtest/compile_2/compile_propeties_test.go
+++ b/internal/integrationtest/compile_2/compile_propeties_test.go
@@ -1,0 +1,54 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2022 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package compile_test
+
+import (
+	"testing"
+
+	"github.com/arduino/arduino-cli/internal/integrationtest"
+	"github.com/arduino/go-paths-helper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileAndUploadRuntimeProperties(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	// https://github.com/arduino/arduino-cli/issues/1971
+	sketchbookHardwareDir := cli.SketchbookDir().Join("hardware")
+	require.NoError(t, sketchbookHardwareDir.MkdirAll())
+
+	// Copy test platform
+	testPlatform := paths.New("..", "testdata", "foo")
+	require.NoError(t, testPlatform.CopyDirTo(sketchbookHardwareDir.Join("foo")))
+
+	// Install dependencies of the demo platform
+	_, _, err := cli.Run("core", "update-index")
+	require.NoError(t, err)
+	_, _, err = cli.Run("core", "install", "arduino:avr")
+	require.NoError(t, err)
+
+	// Check compile runtime propeties expansion
+	bareMinimum := cli.CopySketch("bare_minimum")
+	stdout, _, err := cli.Run("compile", "--fqbn", "foo:avr:bar", "-v", bareMinimum.String())
+	require.NoError(t, err)
+	require.Contains(t, string(stdout), "PREBUILD-runtime.hardware.path="+sketchbookHardwareDir.String())
+
+	// Check upload runtime propeties expansion
+	stdout, _, err = cli.Run("upload", "--fqbn", "foo:avr:bar", bareMinimum.String())
+	require.NoError(t, err)
+	require.Contains(t, string(stdout), "UPLOAD-runtime.hardware.path="+sketchbookHardwareDir.String())
+}

--- a/internal/integrationtest/testdata/bare_minimum/bare_minimum.ino
+++ b/internal/integrationtest/testdata/bare_minimum/bare_minimum.ino
@@ -1,0 +1,2 @@
+void setup() {}
+void loop() {}

--- a/internal/integrationtest/testdata/foo/avr/boards.txt
+++ b/internal/integrationtest/testdata/foo/avr/boards.txt
@@ -1,0 +1,8 @@
+bar.name=Bar
+bar.upload.tool=baz
+bar.upload.protocol=
+bar.build.board=AVR_BAR
+bar.build.f_cpu=16000000L
+bar.build.mcu=atmega328p
+bar.build.core=arduino:arduino
+bar.build.variant=arduino:standard

--- a/internal/integrationtest/testdata/foo/avr/platform.txt
+++ b/internal/integrationtest/testdata/foo/avr/platform.txt
@@ -1,0 +1,10 @@
+name=Foo Platform
+version=0.0.0
+
+recipe.hooks.prebuild.0.pattern=echo PREBUILD-runtime.hardware.path={runtime.hardware.path}
+recipe.hooks.prebuild.0.pattern.windows=cmd /C echo PREBUILD-runtime.hardware.path={runtime.hardware.path}
+
+tools.baz.upload.params.quiet=
+tools.baz.upload.params.verbose=
+tools.baz.upload.pattern=echo UPLOAD-runtime.hardware.path={runtime.hardware.path}
+tools.baz.upload.pattern.windows=cmd /C echo UPLOAD-runtime.hardware.path={runtime.hardware.path}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Set `runtime.hardware.path` property during upload.

## What is the current behavior?

`runtime.hardware.path` property is empty during upload (it is only set for compile).

## What is the new behavior?

`runtime.hardware.path` property is set during upload too.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #1971 
