### PR TITLE
Fix download progress bar (not always displayed)

### DIFF
--- a/cli/output/rpc_progress.go
+++ b/cli/output/rpc_progress.go
@@ -89,6 +89,7 @@ func NewDownloadProgressBarCB() func(*rpc.DownloadProgress) {
 			} else {
 				feedback.Print(label + " " + msg)
 			}
+			started = false
 		}
 	}
 }

--- a/cli/output/rpc_progress.go
+++ b/cli/output/rpc_progress.go
@@ -64,7 +64,6 @@ func NewDownloadProgressBarCB() func(*rpc.DownloadProgress) {
 		mux.Lock()
 		defer mux.Unlock()
 
-		// fmt.Printf(">>> %v\n", curr)
 		if start := curr.GetStart(); start != nil {
 			label = start.GetLabel()
 			bar = pb.New(0)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Fix the progress bar.

## What is the current behavior?

In an operation with multiple downloads (for example a `core install` with many tools), the progress bar is displayed only for the first download, the remainder just displays `tool-X downloaded.`

## What is the new behavior?

The progress bar is displayed for all downloads.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

This is a regression from #1875 
