### PR TITLE
Improve `board list` detection via cloud API

### DIFF
--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -51,7 +51,7 @@ var (
 	validVidPid = regexp.MustCompile(`0[xX][a-fA-F\d]{4}`)
 )
 
-func cachedApiByVidPid(vid, pid string) ([]*rpc.BoardListItem, error) {
+func cachedAPIByVidPid(vid, pid string) ([]*rpc.BoardListItem, error) {
 	var resp []*rpc.BoardListItem
 
 	cacheKey := fmt.Sprintf("cache.builder-api.v3/boards/byvid/pid/%s/%s", vid, pid)
@@ -150,7 +150,7 @@ func identifyViaCloudAPI(port *discovery.Port) ([]*rpc.BoardListItem, error) {
 	}
 
 	logrus.Debug("Querying builder API for board identification...")
-	return cachedApiByVidPid(id.Get("vid"), id.Get("pid"))
+	return cachedAPIByVidPid(id.Get("vid"), id.Get("pid"))
 }
 
 // identify returns a list of boards checking first the installed platforms or the Cloud API

--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -185,8 +185,8 @@ func identify(pme *packagemanager.Explorer, port *discovery.Port) ([]*rpc.BoardL
 			// the board couldn't be detected, print a warning
 			logrus.Debug("Board not recognized")
 		} else if err != nil {
-			// this is bad, bail out
-			return nil, &arduino.UnavailableError{Message: tr("Error getting board info from Arduino Cloud")}
+			// this is bad, but keep going
+			logrus.WithError(err).Debug("Error querying builder API")
 		}
 
 		// add a DetectedPort entry in any case: the `Boards` field will

--- a/commands/board/list_test.go
+++ b/commands/board/list_test.go
@@ -71,9 +71,8 @@ func TestGetByVidPidNotFound(t *testing.T) {
 
 	vidPidURL = ts.URL
 	res, err := apiByVidPid("0x0420", "0x0069")
-	require.NotNil(t, err)
-	require.Equal(t, "board not found", err.Error())
-	require.Len(t, res, 0)
+	require.NoError(t, err)
+	require.Empty(t, res)
 }
 
 func TestGetByVidPid5xx(t *testing.T) {
@@ -108,7 +107,7 @@ func TestBoardDetectionViaAPIWithNonUSBPort(t *testing.T) {
 		Properties: properties.NewMap(),
 	}
 	items, err := identifyViaCloudAPI(port)
-	require.ErrorIs(t, err, ErrNotFound)
+	require.NoError(t, err)
 	require.Empty(t, items)
 }
 

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/arduino/arduino-cli/i18n"
 	"github.com/gofrs/uuid"
@@ -77,9 +78,14 @@ func generateInstallationData() error {
 	return nil
 }
 
+var writeStoreMux sync.Mutex
+
 // WriteStore writes the current information from Store to configFilePath.
 // Returns err if it fails.
 func WriteStore() error {
+	writeStoreMux.Lock()
+	defer writeStoreMux.Unlock()
+
 	configPath := filepath.Dir(configFilePath)
 
 	// Create config dir if not present,


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

* calls to builder-api are cached 24h
* do not error on `board list` if the network is not available (fix #1963)

## What is the current behavior?

`board list` terminate with an error if the network is not available and the board is not "known" (there are no platform installed for that board).

## What is the new behavior?

The `board list` command always complete even if the network is not available

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

