### PR TITLE
[breaking] Fixed detection of double-install using `lib install` with `--git-url` or `--zip-path`

### DIFF
--- a/arduino/libraries/librariesmanager/install.go
+++ b/arduino/libraries/librariesmanager/install.go
@@ -29,7 +29,6 @@ import (
 	"github.com/arduino/arduino-cli/arduino/utils"
 	paths "github.com/arduino/go-paths-helper"
 	"github.com/codeclysm/extract/v3"
-	"github.com/sirupsen/logrus"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
@@ -175,18 +174,8 @@ func (lm *LibrariesManager) InstallZipLib(ctx context.Context, archivePath strin
 		if !overwrite {
 			return fmt.Errorf(tr("library %s already installed"), libraryName)
 		}
-		logrus.
-			WithField("library name", libraryName).
-			WithField("install path", installPath).
-			Trace("Deleting library")
 		installPath.RemoveAll()
 	}
-
-	logrus.
-		WithField("library name", libraryName).
-		WithField("install path", installPath).
-		WithField("zip file", archivePath).
-		Trace("Installing library")
 
 	// Copy extracted library in the destination directory
 	if err := extractionPath.CopyDirTo(installPath); err != nil {
@@ -205,9 +194,6 @@ func (lm *LibrariesManager) InstallGitLib(gitURL string, overwrite bool) error {
 
 	libraryName, ref, err := parseGitURL(gitURL)
 	if err != nil {
-		logrus.
-			WithError(err).
-			Warn("Parsing git URL")
 		return err
 	}
 
@@ -217,21 +203,11 @@ func (lm *LibrariesManager) InstallGitLib(gitURL string, overwrite bool) error {
 		if !overwrite {
 			return fmt.Errorf(tr("library %s already installed"), libraryName)
 		}
-		logrus.
-			WithField("library name", libraryName).
-			WithField("install path", installPath).
-			Trace("Deleting library")
 		installPath.RemoveAll()
 	}
 	if installPath.Exist() {
 		return fmt.Errorf(tr("could not create directory %s: a file with the same name exists!", installPath))
 	}
-
-	logrus.
-		WithField("library name", libraryName).
-		WithField("install path", installPath).
-		WithField("git url", gitURL).
-		Trace("Installing library")
 
 	depth := 1
 	if ref != "" {
@@ -243,27 +219,15 @@ func (lm *LibrariesManager) InstallGitLib(gitURL string, overwrite bool) error {
 		Progress: os.Stdout,
 	})
 	if err != nil {
-		logrus.
-			WithError(err).
-			Warn("Cloning git repository")
 		return err
 	}
 
 	if ref != "" {
 		if h, err := repo.ResolveRevision(ref); err != nil {
-			logrus.
-				WithError(err).
-				Warnf("Resolving revision %s", ref)
 			return err
 		} else if w, err := repo.Worktree(); err != nil {
-			logrus.
-				WithError(err).
-				Warn("Finding worktree")
 			return err
 		} else if err := w.Checkout(&git.CheckoutOptions{Hash: plumbing.NewHash(h.String())}); err != nil {
-			logrus.
-				WithError(err).
-				Warnf("Checking out %s", h)
 			return err
 		}
 	}

--- a/arduino/libraries/librariesmanager/install.go
+++ b/arduino/libraries/librariesmanager/install.go
@@ -53,12 +53,9 @@ type LibraryInstallPlan struct {
 // install path, where the library should be installed and the possible library that is already
 // installed on the same folder and it's going to be replaced by the new one.
 func (lm *LibrariesManager) InstallPrerequisiteCheck(name string, version *semver.Version, installLocation libraries.LibraryLocation) (*LibraryInstallPlan, error) {
-	installDir := lm.getLibrariesDir(installLocation)
-	if installDir == nil {
-		if installLocation == libraries.User {
-			return nil, fmt.Errorf(tr("User directory not set"))
-		}
-		return nil, fmt.Errorf(tr("Builtin libraries directory not set"))
+	installDir, err := lm.getLibrariesDir(installLocation)
+	if err != nil {
+		return nil, err
 	}
 
 	libs := lm.FindByReference(&librariesindex.Reference{Name: name}, installLocation)
@@ -130,11 +127,6 @@ func (lm *LibrariesManager) Uninstall(lib *libraries.Library) error {
 
 // InstallZipLib installs a Zip library on the specified path.
 func (lm *LibrariesManager) InstallZipLib(ctx context.Context, archivePath *paths.Path, overwrite bool) error {
-	installDir := lm.getLibrariesDir(libraries.User)
-	if installDir == nil {
-		return fmt.Errorf(tr("User directory not set"))
-	}
-
 	// Clone library in a temporary directory
 	tmpDir, err := paths.MkTempDir("", "")
 	if err != nil {
@@ -207,11 +199,6 @@ func (lm *LibrariesManager) InstallZipLib(ctx context.Context, archivePath *path
 
 // InstallGitLib installs a library hosted on a git repository on the specified path.
 func (lm *LibrariesManager) InstallGitLib(gitURL string, overwrite bool) error {
-	installDir := lm.getLibrariesDir(libraries.User)
-	if installDir == nil {
-		return fmt.Errorf(tr("User directory not set"))
-	}
-
 	gitLibraryName, ref, err := parseGitURL(gitURL)
 	if err != nil {
 		return err

--- a/arduino/libraries/librariesmanager/librariesmanager.go
+++ b/arduino/libraries/librariesmanager/librariesmanager.go
@@ -16,6 +16,7 @@
 package librariesmanager
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -140,13 +141,20 @@ func (lm *LibrariesManager) RescanLibraries() []*status.Status {
 	return statuses
 }
 
-func (lm *LibrariesManager) getLibrariesDir(installLocation libraries.LibraryLocation) *paths.Path {
+func (lm *LibrariesManager) getLibrariesDir(installLocation libraries.LibraryLocation) (*paths.Path, error) {
 	for _, dir := range lm.LibrariesDir {
 		if dir.Location == installLocation {
-			return dir.Path
+			return dir.Path, nil
 		}
 	}
-	return nil
+	switch installLocation {
+	case libraries.User:
+		return nil, errors.New(tr("user directory not set"))
+	case libraries.IDEBuiltIn:
+		return nil, errors.New(tr("built-in libraries directory not set"))
+	default:
+		return nil, fmt.Errorf("libraries directory not set: %s", installLocation.String())
+	}
 }
 
 // LoadLibrariesFromDir loads all libraries in the given directory. Returns

--- a/commands/lib/install.go
+++ b/commands/lib/install.go
@@ -26,6 +26,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesmanager"
 	"github.com/arduino/arduino-cli/commands"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
+	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
 )
 
@@ -156,7 +157,7 @@ func installLibrary(lm *librariesmanager.LibrariesManager, libRelease *libraries
 // ZipLibraryInstall FIXMEDOC
 func ZipLibraryInstall(ctx context.Context, req *rpc.ZipLibraryInstallRequest, taskCB rpc.TaskProgressCB) error {
 	lm := commands.GetLibraryManager(req)
-	if err := lm.InstallZipLib(ctx, req.Path, req.Overwrite); err != nil {
+	if err := lm.InstallZipLib(ctx, paths.New(req.Path), req.Overwrite); err != nil {
 		return &arduino.FailedLibraryInstallError{Cause: err}
 	}
 	taskCB(&rpc.TaskProgress{Message: tr("Library installed"), Completed: true})

--- a/commands/lib/install.go
+++ b/commands/lib/install.go
@@ -77,28 +77,22 @@ func LibraryInstall(ctx context.Context, req *rpc.LibraryInstallRequest, downloa
 		if err != nil {
 			return err
 		}
-		libReleasesToInstall = append(libReleasesToInstall, libRelease)
-	}
-
-	// Check if any of the libraries to install is already installed and remove it from the list
-	j := 0
-	for i, libRelease := range libReleasesToInstall {
 		_, libReplaced, err := lm.InstallPrerequisiteCheck(libRelease.Library.Name, libRelease.Version, installLocation)
 		if errors.Is(err, librariesmanager.ErrAlreadyInstalled) {
 			taskCB(&rpc.TaskProgress{Message: tr("Already installed %s", libRelease), Completed: true})
-		} else if err != nil {
-			return err
-		} else {
-			libReleasesToInstall[j] = libReleasesToInstall[i]
-			j++
+			continue
 		}
+		if err != nil {
+			return err
+		}
+
 		if req.GetNoOverwrite() {
 			if libReplaced != nil {
 				return fmt.Errorf(tr("Library %[1]s is already installed, but with a different version: %[2]s", libRelease, libReplaced))
 			}
 		}
+		libReleasesToInstall = append(libReleasesToInstall, libRelease)
 	}
-	libReleasesToInstall = libReleasesToInstall[:j]
 
 	didInstall := false
 	for _, libRelease := range libReleasesToInstall {

--- a/commands/lib/install.go
+++ b/commands/lib/install.go
@@ -82,7 +82,7 @@ func LibraryInstall(ctx context.Context, req *rpc.LibraryInstallRequest, downloa
 	// Check if any of the libraries to install is already installed and remove it from the list
 	j := 0
 	for i, libRelease := range libReleasesToInstall {
-		_, libReplaced, err := lm.InstallPrerequisiteCheck(libRelease, installLocation)
+		_, libReplaced, err := lm.InstallPrerequisiteCheck(libRelease.Library.Name, libRelease.Version, installLocation)
 		if errors.Is(err, librariesmanager.ErrAlreadyInstalled) {
 			taskCB(&rpc.TaskProgress{Message: tr("Already installed %s", libRelease), Completed: true})
 		} else if err != nil {
@@ -127,7 +127,7 @@ func LibraryInstall(ctx context.Context, req *rpc.LibraryInstallRequest, downloa
 func installLibrary(lm *librariesmanager.LibrariesManager, libRelease *librariesindex.Release, installLocation libraries.LibraryLocation, taskCB rpc.TaskProgressCB) error {
 	taskCB(&rpc.TaskProgress{Name: tr("Installing %s", libRelease)})
 	logrus.WithField("library", libRelease).Info("Installing library")
-	libPath, libReplaced, err := lm.InstallPrerequisiteCheck(libRelease, installLocation)
+	libPath, libReplaced, err := lm.InstallPrerequisiteCheck(libRelease.Library.Name, libRelease.Version, installLocation)
 	if errors.Is(err, librariesmanager.ErrAlreadyInstalled) {
 		taskCB(&rpc.TaskProgress{Message: tr("Already installed %s", libRelease), Completed: true})
 		return err

--- a/commands/lib/install.go
+++ b/commands/lib/install.go
@@ -68,7 +68,7 @@ func LibraryInstall(ctx context.Context, req *rpc.LibraryInstallRequest, downloa
 	}
 
 	// Find the libReleasesToInstall to install
-	libReleasesToInstall := []*librariesindex.Release{}
+	libReleasesToInstall := map[*librariesindex.Release]*librariesmanager.LibraryInstallPlan{}
 	for _, lib := range toInstall {
 		libRelease, err := findLibraryIndexRelease(lm, &rpc.LibraryInstallRequest{
 			Name:    lib.Name,
@@ -77,73 +77,55 @@ func LibraryInstall(ctx context.Context, req *rpc.LibraryInstallRequest, downloa
 		if err != nil {
 			return err
 		}
-		_, libReplaced, err := lm.InstallPrerequisiteCheck(libRelease.Library.Name, libRelease.Version, installLocation)
-		if errors.Is(err, librariesmanager.ErrAlreadyInstalled) {
-			taskCB(&rpc.TaskProgress{Message: tr("Already installed %s", libRelease), Completed: true})
-			continue
-		}
+
+		installTask, err := lm.InstallPrerequisiteCheck(libRelease.Library.Name, libRelease.Version, installLocation)
 		if err != nil {
 			return err
 		}
+		if installTask.UpToDate {
+			taskCB(&rpc.TaskProgress{Message: tr("Already installed %s", libRelease), Completed: true})
+			continue
+		}
 
 		if req.GetNoOverwrite() {
-			if libReplaced != nil {
-				return fmt.Errorf(tr("Library %[1]s is already installed, but with a different version: %[2]s", libRelease, libReplaced))
+			if installTask.ReplacedLib != nil {
+				return fmt.Errorf(tr("Library %[1]s is already installed, but with a different version: %[2]s", libRelease, installTask.ReplacedLib))
 			}
 		}
-		libReleasesToInstall = append(libReleasesToInstall, libRelease)
+		libReleasesToInstall[libRelease] = installTask
 	}
 
-	didInstall := false
-	for _, libRelease := range libReleasesToInstall {
+	for libRelease, installTask := range libReleasesToInstall {
 		if err := downloadLibrary(lm, libRelease, downloadCB, taskCB); err != nil {
 			return err
 		}
-
-		if err := installLibrary(lm, libRelease, installLocation, taskCB); err != nil {
-			if errors.Is(err, librariesmanager.ErrAlreadyInstalled) {
-				continue
-			} else {
-				return err
-			}
-		}
-		didInstall = true
-	}
-
-	if didInstall {
-		if err := commands.Init(&rpc.InitRequest{Instance: req.Instance}, nil); err != nil {
+		if err := installLibrary(lm, libRelease, installTask, taskCB); err != nil {
 			return err
 		}
+	}
+
+	if err := commands.Init(&rpc.InitRequest{Instance: req.Instance}, nil); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-func installLibrary(lm *librariesmanager.LibrariesManager, libRelease *librariesindex.Release, installLocation libraries.LibraryLocation, taskCB rpc.TaskProgressCB) error {
+func installLibrary(lm *librariesmanager.LibrariesManager, libRelease *librariesindex.Release, installTask *librariesmanager.LibraryInstallPlan, taskCB rpc.TaskProgressCB) error {
 	taskCB(&rpc.TaskProgress{Name: tr("Installing %s", libRelease)})
 	logrus.WithField("library", libRelease).Info("Installing library")
-	libPath, libReplaced, err := lm.InstallPrerequisiteCheck(libRelease.Library.Name, libRelease.Version, installLocation)
-	if errors.Is(err, librariesmanager.ErrAlreadyInstalled) {
-		taskCB(&rpc.TaskProgress{Message: tr("Already installed %s", libRelease), Completed: true})
-		return err
-	}
 
-	if err != nil {
-		return &arduino.FailedInstallError{Message: tr("Checking lib install prerequisites"), Cause: err}
-	}
-
-	if libReplaced != nil {
+	if libReplaced := installTask.ReplacedLib; libReplaced != nil {
 		taskCB(&rpc.TaskProgress{Message: tr("Replacing %[1]s with %[2]s", libReplaced, libRelease)})
-	}
-
-	if err := lm.Install(libRelease, libPath); err != nil {
-		return &arduino.FailedLibraryInstallError{Cause: err}
-	}
-	if libReplaced != nil && !libReplaced.InstallDir.EquivalentTo(libPath) {
 		if err := lm.Uninstall(libReplaced); err != nil {
-			return fmt.Errorf("%s: %s", tr("could not remove old library"), err)
+			return &arduino.FailedLibraryInstallError{
+				Cause: fmt.Errorf("%s: %s", tr("could not remove old library"), err)}
 		}
 	}
+	if err := lm.Install(libRelease, installTask.TargetPath); err != nil {
+		return &arduino.FailedLibraryInstallError{Cause: err}
+	}
+
 	taskCB(&rpc.TaskProgress{Message: tr("Installed %s", libRelease), Completed: true})
 	return nil
 }

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -16,6 +16,29 @@ The `sketch.json` file is now completely ignored.
 The `cc.arduino.cli.commands.v1.BoardAttach` gRPC command has been removed. This feature is no longer available through
 gRPC.
 
+### golang API change in `github.com/arduino/arduino-cli/arduino/libraries/librariesmanager.LibrariesManager`
+
+The following `LibrariesManager.InstallPrerequisiteCheck` methods have changed prototype, from:
+
+```go
+func (lm *LibrariesManager) InstallPrerequisiteCheck(indexLibrary *librariesindex.Release, installLocation libraries.LibraryLocation) (*paths.Path, *libraries.Library, error) { ... }
+func (lm *LibrariesManager) InstallZipLib(ctx context.Context, archivePath string, overwrite bool) error { ... }
+```
+
+to
+
+```go
+func (lm *LibrariesManager) InstallPrerequisiteCheck(indexLibrary *librariesindex.Release, installLocation libraries.LibraryLocation) (*paths.Path, *libraries.Library, error) { ... }
+func (lm *LibrariesManager) InstallZipLib(ctx context.Context, archivePath *paths.Path, overwrite bool) error { ... }
+```
+
+`InstallPrerequisiteCheck` now requires an explicit `name` and `version` instead of a `librariesindex.Release`, becuase
+it can now be used to check any library, not only the libraries available in the index. Also the return value has
+changed to a `LibraryInstallPlan` structure, it contains the same information as before (`TargetPath` and `ReplacedLib`)
+plus `Name`, `Version`, and an `UpToDate` boolean flag.
+
+`InstallZipLib` method `archivePath` is now a `paths.Path` instead of a `string`.
+
 ## 0.29.0
 
 ### Removed gRPC API: `cc.arduino.cli.commands.v1.UpdateCoreLibrariesIndex`, `Outdated`, and `Upgrade`

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -32,7 +32,7 @@ func (lm *LibrariesManager) InstallPrerequisiteCheck(indexLibrary *librariesinde
 func (lm *LibrariesManager) InstallZipLib(ctx context.Context, archivePath *paths.Path, overwrite bool) error { ... }
 ```
 
-`InstallPrerequisiteCheck` now requires an explicit `name` and `version` instead of a `librariesindex.Release`, becuase
+`InstallPrerequisiteCheck` now requires an explicit `name` and `version` instead of a `librariesindex.Release`, because
 it can now be used to check any library, not only the libraries available in the index. Also the return value has
 changed to a `LibraryInstallPlan` structure, it contains the same information as before (`TargetPath` and `ReplacedLib`)
 plus `Name`, `Version`, and an `UpToDate` boolean flag.

--- a/internal/integrationtest/compile_1/compile_test.go
+++ b/internal/integrationtest/compile_1/compile_test.go
@@ -878,7 +878,7 @@ func TestCompileWithFullyPrecompiledLibrary(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = cli.Run("lib", "install", "--zip-path", wd.Parent().Join("testdata", "Arduino_TensorFlowLite-2.1.0-ALPHA-precompiled.zip").String())
 	require.NoError(t, err)
-	sketchFolder := cli.SketchbookDir().Join("libraries", "Arduino_TensorFlowLite-2.1.0-ALPHA-precompiled", "examples", "hello_world")
+	sketchFolder := cli.SketchbookDir().Join("libraries", "Arduino_TensorFlowLite", "examples", "hello_world")
 
 	// Install example dependency
 	_, _, err = cli.Run("lib", "install", "Arduino_LSM9DS1")

--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -17,10 +17,13 @@ package lib_test
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/arduino/arduino-cli/internal/integrationtest"
+	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
 	"go.bug.st/testifyjson/requirejson"
 )
@@ -161,6 +164,42 @@ func TestDuplicateLibInstallFromGitDetection(t *testing.T) {
 	jsonOut, _, err := cli.Run("lib", "list", "--format", "json")
 	require.NoError(t, err)
 	// Count how many libraries with the name "Arduino SigFox for MKRFox1200" are installed
+	requirejson.Parse(t, jsonOut).
+		Query(`[.[].library.name | select(. == "Arduino SigFox for MKRFox1200")]`).
+		LengthMustEqualTo(1, "Found multiple installations of Arduino SigFox for MKRFox1200'")
+
+	// Try to make a double install by upgrade
+	_, _, err = cli.Run("lib", "upgrade")
+	require.NoError(t, err)
+
+	// Check if double install happened
+	jsonOut, _, err = cli.Run("lib", "list", "--format", "json")
+	require.NoError(t, err)
+	requirejson.Parse(t, jsonOut).
+		Query(`[.[].library.name | select(. == "Arduino SigFox for MKRFox1200")]`).
+		LengthMustEqualTo(1, "Found multiple installations of Arduino SigFox for MKRFox1200'")
+
+	// Try to make a double install by zip-installing
+	tmp, err := paths.MkTempDir("", "")
+	require.NoError(t, err)
+	defer tmp.RemoveAll()
+	tmpZip := tmp.Join("SigFox.zip")
+	defer tmpZip.Remove()
+
+	f, err := tmpZip.Create()
+	require.NoError(t, err)
+	resp, err := http.Get("https://github.com/arduino-libraries/SigFox/archive/refs/tags/1.0.3.zip")
+	require.NoError(t, err)
+	_, err = io.Copy(f, resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, err = cli.RunWithCustomEnv(cliEnv, "lib", "install", "--zip-path", tmpZip.String())
+	require.NoError(t, err)
+
+	// Check if double install happened
+	jsonOut, _, err = cli.Run("lib", "list", "--format", "json")
+	require.NoError(t, err)
 	requirejson.Parse(t, jsonOut).
 		Query(`[.[].library.name | select(. == "Arduino SigFox for MKRFox1200")]`).
 		LengthMustEqualTo(1, "Found multiple installations of Arduino SigFox for MKRFox1200'")

--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -145,6 +145,27 @@ func TestDuplicateLibInstallDetection(t *testing.T) {
 	require.Contains(t, string(stdErr), "The library ArduinoOTA has multiple installations")
 }
 
+func TestDuplicateLibInstallFromGitDetection(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+	cliEnv := cli.GetDefaultEnv()
+	cliEnv["ARDUINO_LIBRARY_ENABLE_UNSAFE_INSTALL"] = "true"
+
+	// Make a double install in the sketchbook/user directory
+	_, _, err := cli.Run("lib", "install", "Arduino SigFox for MKRFox1200")
+	require.NoError(t, err)
+
+	_, _, err = cli.RunWithCustomEnv(cliEnv, "lib", "install", "--git-url", "https://github.com/arduino-libraries/SigFox#1.0.3")
+	require.NoError(t, err)
+
+	jsonOut, _, err := cli.Run("lib", "list", "--format", "json")
+	require.NoError(t, err)
+	// Count how many libraries with the name "Arduino SigFox for MKRFox1200" are installed
+	requirejson.Parse(t, jsonOut).
+		Query(`[.[].library.name | select(. == "Arduino SigFox for MKRFox1200")]`).
+		LengthMustEqualTo(1, "Found multiple installations of Arduino SigFox for MKRFox1200'")
+}
+
 func TestLibDepsOutput(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Fix double install detection running `lib install` with `--git-url` or `--zip-path` flags.

## What is the current behavior?

A double-install of a library may be the outcome of `lib install` command: it happens when a library is installed twice under two different subdirectories of the sketchbook's `libraries` folder.
See https://github.com/arduino/arduino-cli/issues/1871 for more details and examples.

## What is the new behavior?

The multiple install problem should be fixed.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

Yes

