### PR TITLE
[skip-changelog] Avoid running publish-go-tester-task if tag is set

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -49,7 +49,7 @@ jobs:
           if [[ \
             ("${{ github.event_name }}" != "create" || \
             "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX) && \
-            "$TAG" == "" \
+            ! "${{ github.ref }}" =~ $TAG_REGEX \
           ]]; then
             # Run the other jobs.
             RESULT="true"

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -35,14 +35,21 @@ jobs:
     outputs:
       result: ${{ steps.determination.outputs.result }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Determine if the rest of the workflow should run
         id: determination
         run: |
           RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          TAG="$(git tag --points-at=HEAD 2> /dev/null | head -n1)"
           # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
           if [[ \
-            "${{ github.event_name }}" != "create" || \
-            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+            ("${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX) && \
+            "$TAG" == "" \
           ]]; then
             # Run the other jobs.
             RESULT="true"

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -35,16 +35,11 @@ jobs:
     outputs:
       result: ${{ steps.determination.outputs.result }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
       - name: Determine if the rest of the workflow should run
         id: determination
         run: |
           RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
-          TAG="$(git tag --points-at=HEAD 2> /dev/null | head -n1)"
+          TAG_REGEX="refs/tags/.*"
           # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
           if [[ \
             ("${{ github.event_name }}" != "create" || \


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Infrastructure imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
[publish-go-tester-task](https://github.com/arduino/arduino-cli/blob/master/.github/workflows/publish-go-tester-task.yml) runs when a tag is pushed. Since the tag has priority when [version](https://github.com/arduino/arduino-cli/blob/master/Taskfile.yml#L378) is defined, the workflow fails because it does not find any build named `test-XXX-git-snapshot` when calculating the checksums. It recently happened here: https://github.com/arduino/arduino-cli/actions/runs/3480562942/jobs/5820576240#step:3:16
<!-- You can also link to an open issue here -->

## What is the new behavior?
During run determination, the workflow checks if [tag](https://github.com/arduino/arduino-cli/blob/master/Taskfile.yml#L377) is empty. If not, the run is skipped. Run examples:
- random word used as tag: https://github.com/MatteoPologruto/arduino-cli/actions/runs/3495348077
- x.x.x tag: https://github.com/MatteoPologruto/arduino-cli/actions/runs/3495377815
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
