### PR TITLE
Fixed integration test in `test_lib.py`

### DIFF
--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -500,7 +500,7 @@ def test_search(run_command):
     assert "Downloading index: library_index.tar.bz2 downloaded" in lines
     libs = [l[6:].strip('"') for l in lines if "Name:" in l]
 
-    expected = {"WiFi101", "WiFi101OTA", "Firebase Arduino based on WiFi101"}
+    expected = {"WiFi101", "WiFi101OTA", "Firebase Arduino based on WiFi101", "WiFi101_Generic"}
     assert expected == {lib for lib in libs if "WiFi101" in lib}
 
     result = run_command(["lib", "search", "--names", "--format", "json"])


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Fix:
```
=================================== FAILURES ===================================
_________________________________ test_search __________________________________

run_command = <function run_command.<locals>._run at 0x7f37384a3c10>

    def test_search(run_command):
        assert run_command(["update"])
    
        result = run_command(["lib", "search", "--names"])
        assert result.ok
        lines = [l.strip() for l in result.stdout.strip().splitlines()]
        assert "Downloading index: library_index.tar.bz2 downloaded" in lines
        libs = [l[6:].strip('"') for l in lines if "Name:" in l]
    
        expected = {"WiFi101", "WiFi101OTA", "Firebase Arduino based on WiFi101"}
>       assert expected == {lib for lib in libs if "WiFi101" in lib}
E       AssertionError: assert {'Firebase Ar... 'WiFi101OTA'} == {'Firebase Ar...i101_Generic'}
E         Extra items in the right set:
E         'WiFi101_Generic'
E         Full diff:
E           {
E            'Firebase Arduino based on WiFi101',
E            'WiFi101',
E            'WiFi101OTA',
E         -  'WiFi101_Generic',
E           }

test/test_lib.py:504: AssertionError
=========================== short test summary info ============================
FAILED test/test_lib.py::test_search - AssertionError: assert {'Firebase Ar.....
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
=================== 1 failed, 16 passed in 118.54s (0:01:58) ===================
```

## What is the current behavior?

The integration test fails

## What is the new behavior?

The integration test succeed

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No