### PR TITLE
[skip-changelog] Migrate twelve tests from `test_lib.py` to `lib_test.go`

### DIFF
--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -512,3 +512,21 @@ func TestLibDownload(t *testing.T) {
 	_, _, err = cli.Run("lib", "download", "AudioZ")
 	require.Error(t, err)
 }
+
+func TestInstall(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	libs := []string{"Arduino_BQ24195", "CMMC MQTT Connector", "WiFiNINA"}
+	// Should be safe to run install multiple times
+	_, _, err := cli.Run("lib", "install", libs[0], libs[1], libs[2])
+	require.NoError(t, err)
+	_, _, err = cli.Run("lib", "install", libs[0], libs[1], libs[2])
+	require.NoError(t, err)
+
+	// Test failing-install of library with wrong dependency
+	// (https://github.com/arduino/arduino-cli/issues/534)
+	_, stderr, err := cli.Run("lib", "install", "MD_Parola@3.2.0")
+	require.Error(t, err)
+	require.Contains(t, string(stderr), "No valid dependencies solution found: dependency 'MD_MAX72xx' is not available")
+}

--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -323,7 +323,7 @@ func TestList(t *testing.T) {
 	stdout, stderr, err := cli.Run("lib", "list")
 	require.NoError(t, err)
 	require.Empty(t, stderr)
-	require.Contains(t, strings.TrimSpace(string(stdout)), "No libraries installed.")
+	require.Contains(t, string(stdout), "No libraries installed.")
 	stdout, stderr, err = cli.Run("lib", "list", "--format", "json")
 	require.NoError(t, err)
 	require.Empty(t, stderr)
@@ -338,11 +338,11 @@ func TestList(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, stderr)
 	lines := strings.Split(strings.TrimSpace(string(stdout)), "\n")
-	require.Equal(t, 2, len(lines))
+	require.Len(t, lines, 2)
 	lines[1] = strings.Join(strings.Fields(lines[1]), " ")
 	toks := strings.SplitN(lines[1], " ", 5)
 	// Verifies the expected number of field
-	require.Equal(t, 5, len(toks))
+	require.Len(t, toks, 5)
 	// be sure line contain the current version AND the available version
 	require.NotEmpty(t, toks[1])
 	require.NotEmpty(t, toks[2])
@@ -355,7 +355,7 @@ func TestList(t *testing.T) {
 	require.Empty(t, stderr)
 	requirejson.Len(t, stdout, 1)
 	// be sure data contains the available version
-	requirejson.Query(t, stdout, ".[0] | .release | .version != \"\"", "true")
+	requirejson.Query(t, stdout, `.[0] | .release | .version != ""`, "true")
 
 	// Install something we can list without provides_includes field given in library.properties
 	_, _, err = cli.Run("lib", "install", "Arduino_APDS9960@1.0.3")
@@ -366,7 +366,7 @@ func TestList(t *testing.T) {
 	require.Empty(t, stderr)
 	requirejson.Len(t, stdout, 1)
 	// be sure data contains the correct provides_includes field
-	requirejson.Query(t, stdout, ".[0] | .library | .provides_includes | .[0]", "\"Arduino_APDS9960.h\"")
+	requirejson.Query(t, stdout, ".[0] | .library | .provides_includes | .[0]", `"Arduino_APDS9960.h"`)
 }
 
 func TestListExitCode(t *testing.T) {
@@ -445,8 +445,8 @@ func TestListWithFqbn(t *testing.T) {
 	requirejson.Len(t, stdout, 1)
 
 	// Verifies library is compatible
-	requirejson.Query(t, stdout, ".[0] | .library | .name", "\"ArduinoJson\"")
-	requirejson.Query(t, stdout, ".[0] | .library | .compatible_with | .\"arduino:avr:uno\"", "true")
+	requirejson.Query(t, stdout, `.[0] | .library | .name`, `"ArduinoJson"`)
+	requirejson.Query(t, stdout, `.[0] | .library | .compatible_with | ."arduino:avr:uno"`, `true`)
 }
 
 func TestListProvidesIncludesFallback(t *testing.T) {
@@ -550,7 +550,7 @@ func TestInstallLibraryWithDependencies(t *testing.T) {
 	// Verifies library's dependencies are correctly installed
 	stdout, _, err = cli.Run("lib", "list", "--format", "json")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, "[ .[] | .library | .name ] | sort", "[\"MD_MAX72XX\",\"MD_Parola\"]")
+	requirejson.Query(t, stdout, `[ .[] | .library | .name ] | sort`, `["MD_MAX72XX","MD_Parola"]`)
 
 	// Try upgrading with --no-overwrite (should fail) and without --no-overwrite (should succeed)
 	_, _, err = cli.Run("lib", "install", "MD_Parola@3.6.1", "--no-overwrite")
@@ -588,7 +588,7 @@ func TestInstallNoDeps(t *testing.T) {
 	// Verifies library's dependencies are not installed
 	stdout, _, err = cli.Run("lib", "list", "--format", "json")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".[] | .library | .name", "\"MD_Parola\"")
+	requirejson.Query(t, stdout, `.[] | .library | .name`, `"MD_Parola"`)
 }
 
 func TestInstallWithGitUrl(t *testing.T) {

--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -655,3 +655,12 @@ func TestInstallWithGitUrlFragmentAsBranch(t *testing.T) {
 	// Verifies library remains installed
 	require.DirExists(t, libInstallDir.String())
 }
+
+func TestUpdateIndex(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	stdout, _, err := cli.Run("lib", "update-index")
+	require.NoError(t, err)
+	require.Contains(t, string(stdout), "Downloading index: library_index.tar.bz2 downloaded")
+}

--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -664,3 +664,15 @@ func TestUpdateIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(stdout), "Downloading index: library_index.tar.bz2 downloaded")
 }
+
+func TestUninstall(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	libs := []string{"Arduino_BQ24195", "WiFiNINA"}
+	_, _, err := cli.Run("lib", "install", libs[0], libs[1])
+	require.NoError(t, err)
+
+	_, _, err = cli.Run("lib", "uninstall", libs[0], libs[1])
+	require.NoError(t, err)
+}

--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -568,3 +568,25 @@ func TestInstallLibraryWithDependencies(t *testing.T) {
 	_, _, err = cli.Run("lib", "install", "Arduino_Builtin", "--no-overwrite")
 	require.Error(t, err)
 }
+
+func TestInstallNoDeps(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	_, _, err := cli.Run("update")
+	require.NoError(t, err)
+
+	// Verifies libraries are not installed
+	stdout, _, err := cli.Run("lib", "list", "--format", "json")
+	require.NoError(t, err)
+	requirejson.Empty(t, stdout)
+
+	// Install library skipping dependencies installation
+	_, _, err = cli.Run("lib", "install", "MD_Parola@3.5.5", "--no-deps")
+	require.NoError(t, err)
+
+	// Verifies library's dependencies are not installed
+	stdout, _, err = cli.Run("lib", "list", "--format", "json")
+	require.NoError(t, err)
+	requirejson.Query(t, stdout, ".[] | .library | .name", "\"MD_Parola\"")
+}

--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -494,3 +494,21 @@ func TestListProvidesIncludesFallback(t *testing.T) {
 			]
 	  	}`)
 }
+
+func TestLibDownload(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	// Download a specific lib version
+	_, _, err := cli.Run("lib", "download", "AudioZero@1.0.0")
+	require.NoError(t, err)
+	require.FileExists(t, cli.DownloadDir().Join("libraries", "AudioZero-1.0.0.zip").String())
+
+	// Wrong lib version
+	_, _, err = cli.Run("lib", "download", "AudioZero@69.42.0")
+	require.Error(t, err)
+
+	// Wrong lib
+	_, _, err = cli.Run("lib", "download", "AudioZ")
+	require.Error(t, err)
+}

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -49,41 +49,6 @@ def download_lib(url, download_dir):
     z.close()
 
 
-def test_list_with_fqbn(run_command):
-    # Init the environment explicitly
-    assert run_command(["core", "update-index"])
-
-    # Install core
-    assert run_command(["core", "install", "arduino:avr"])
-
-    # Install some library
-    assert run_command(["lib", "install", "ArduinoJson"])
-    assert run_command(["lib", "install", "wm8978-esp32"])
-
-    # Look at the plain text output
-    result = run_command(["lib", "list", "-b", "arduino:avr:uno"])
-    assert result.ok
-    assert "" == result.stderr
-    lines = result.stdout.strip().splitlines()
-    assert 2 == len(lines)
-
-    # Verifies library is compatible
-    toks = [t.strip() for t in lines[1].split(maxsplit=4)]
-    assert 5 == len(toks)
-    assert "ArduinoJson" == toks[0]
-
-    # Look at the JSON output
-    result = run_command(["lib", "list", "-b", "arduino:avr:uno", "--format", "json"], hide=True)
-    assert result.ok
-    assert "" == result.stderr
-    data = json.loads(result.stdout)
-    assert 1 == len(data)
-
-    # Verifies library is compatible
-    assert data[0]["library"]["name"] == "ArduinoJson"
-    assert data[0]["library"]["compatible_with"]["arduino:avr:uno"]
-
-
 def test_list_provides_includes_fallback(run_command):
     # Verifies "provides_includes" field is returned even if libraries don't declare
     # the "includes" property in their "library.properties" file

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -49,21 +49,6 @@ def download_lib(url, download_dir):
     z.close()
 
 
-def test_lib_download(run_command, downloads_dir):
-
-    # Download a specific lib version
-    assert run_command(["lib", "download", "AudioZero@1.0.0"])
-    assert Path(downloads_dir, "libraries", "AudioZero-1.0.0.zip").exists()
-
-    # Wrong lib version
-    result = run_command(["lib", "download", "AudioZero@69.42.0"])
-    assert result.failed
-
-    # Wrong lib
-    result = run_command(["lib", "download", "AudioZ"])
-    assert result.failed
-
-
 def test_install(run_command):
     libs = ["Arduino_BQ24195", "CMMC MQTT Connector", "WiFiNINA"]
     # Should be safe to run install multiple times

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -49,32 +49,6 @@ def download_lib(url, download_dir):
     z.close()
 
 
-def test_list_provides_includes_fallback(run_command):
-    # Verifies "provides_includes" field is returned even if libraries don't declare
-    # the "includes" property in their "library.properties" file
-    assert run_command(["update"])
-
-    # Install core
-    assert run_command(["core", "install", "arduino:avr@1.8.3"])
-    assert run_command(["lib", "install", "ArduinoJson@6.17.2"])
-
-    # List all libraries, even the ones installed with the above core
-    result = run_command(["lib", "list", "--all", "--fqbn", "arduino:avr:uno", "--format", "json"], hide=True)
-    assert result.ok
-    assert "" == result.stderr
-
-    data = json.loads(result.stdout)
-    assert 6 == len(data)
-
-    libs = {l["library"]["name"]: l["library"]["provides_includes"] for l in data}
-    assert ["SoftwareSerial.h"] == libs["SoftwareSerial"]
-    assert ["Wire.h"] == libs["Wire"]
-    assert ["EEPROM.h"] == libs["EEPROM"]
-    assert ["HID.h"] == libs["HID"]
-    assert ["SPI.h"] == libs["SPI"]
-    assert ["ArduinoJson.h", "ArduinoJson.hpp"] == libs["ArduinoJson"]
-
-
 def test_lib_download(run_command, downloads_dir):
 
     # Download a specific lib version

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -49,29 +49,6 @@ def download_lib(url, download_dir):
     z.close()
 
 
-def test_install_no_deps(run_command):
-    assert run_command(["update"])
-
-    # Verifies libraries are not installed
-    res = run_command(["lib", "list", "--format", "json"])
-    assert res.ok
-    data = json.loads(res.stdout)
-    installed_libraries = [l["library"]["name"] for l in data]
-    assert "MD_Parola" not in installed_libraries
-    assert "MD_MAX72XX" not in installed_libraries
-
-    # Install library skipping dependencies installation
-    assert run_command(["lib", "install", "MD_Parola@3.5.5", "--no-deps"])
-
-    # Verifies library's dependencies are not installed
-    res = run_command(["lib", "list", "--format", "json"])
-    assert res.ok
-    data = json.loads(res.stdout)
-    installed_libraries = [l["library"]["name"] for l in data]
-    assert "MD_Parola" in installed_libraries
-    assert "MD_MAX72XX" not in installed_libraries
-
-
 def test_install_git_url_and_zip_path_flags_visibility(run_command, data_dir, downloads_dir):
     # Verifies installation fail because flags are not found
     git_url = "https://github.com/arduino-libraries/WiFi101.git"

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -146,14 +146,6 @@ def test_install_with_zip_path(run_command, data_dir, downloads_dir):
     assert lib_install_dir / "README.adoc" in files
 
 
-def test_uninstall(run_command):
-    libs = ["Arduino_BQ24195", "WiFiNINA"]
-    assert run_command(["lib", "install"] + libs)
-
-    result = run_command(["lib", "uninstall"] + libs)
-    assert result.ok
-
-
 def test_uninstall_spaces(run_command):
     key = "LiquidCrystal I2C"
     assert run_command(["lib", "install", key])

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -49,61 +49,6 @@ def download_lib(url, download_dir):
     z.close()
 
 
-def test_list(run_command):
-    # Init the environment explicitly
-    run_command(["core", "update-index"])
-
-    # When output is empty, nothing is printed out, no matter the output format
-    result = run_command(["lib", "list"])
-    assert result.ok
-    assert "" == result.stderr
-    assert "No libraries installed." in result.stdout.strip()
-    result = run_command(["lib", "list", "--format", "json"], hide=True)
-    assert result.ok
-    assert "" == result.stderr
-    assert 0 == len(json.loads(result.stdout))
-
-    # Install something we can list at a version older than latest
-    result = run_command(["lib", "install", "ArduinoJson@6.11.0"])
-    assert result.ok
-
-    # Look at the plain text output
-    result = run_command(["lib", "list"])
-    assert result.ok
-    assert "" == result.stderr
-    lines = result.stdout.strip().splitlines()
-    assert 2 == len(lines)
-    toks = [t.strip() for t in lines[1].split(maxsplit=4)]
-    # Verifies the expected number of field
-    assert 5 == len(toks)
-    # be sure line contain the current version AND the available version
-    assert "" != toks[1]
-    assert "" != toks[2]
-    # Verifies library sentence
-    assert "An efficient and elegant JSON library..." == toks[4]
-
-    # Look at the JSON output
-    result = run_command(["lib", "list", "--format", "json"], hide=True)
-    assert result.ok
-    assert "" == result.stderr
-    data = json.loads(result.stdout)
-    assert 1 == len(data)
-    # be sure data contains the available version
-    assert "" != data[0]["release"]["version"]
-
-    # Install something we can list without provides_includes field given in library.properties
-    result = run_command(["lib", "install", "Arduino_APDS9960@1.0.3"])
-    assert result.ok
-    # Look at the JSON output
-    result = run_command(["lib", "list", "Arduino_APDS9960", "--format", "json"])
-    assert result.ok
-    assert "" == result.stderr
-    data = json.loads(result.stdout)
-    assert 1 == len(data)
-    # be sure data contains the correct provides_includes field
-    assert "Arduino_APDS9960.h" == data[0]["library"]["provides_includes"][0]
-
-
 def test_list_exit_code(run_command):
     # Init the environment explicitly
     assert run_command(["core", "update-index"])

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -146,13 +146,6 @@ def test_install_with_zip_path(run_command, data_dir, downloads_dir):
     assert lib_install_dir / "README.adoc" in files
 
 
-def test_update_index(run_command):
-    result = run_command(["lib", "update-index"])
-    assert result.ok
-    lines = [l.strip() for l in result.stdout.splitlines()]
-    assert "Downloading index: library_index.tar.bz2 downloaded" in lines
-
-
 def test_uninstall(run_command):
     libs = ["Arduino_BQ24195", "WiFiNINA"]
     assert run_command(["lib", "install"] + libs)

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -96,37 +96,6 @@ def test_install_git_url_and_zip_path_flags_visibility(run_command, data_dir, do
     assert "--git-url and --zip-path flags allow installing untrusted files, use it at your own risk." in res.stdout
 
 
-def test_install_with_git_url(run_command, data_dir, downloads_dir):
-    # Initialize configs to enable --git-url flag
-    env = {
-        "ARDUINO_DATA_DIR": data_dir,
-        "ARDUINO_DOWNLOADS_DIR": downloads_dir,
-        "ARDUINO_SKETCHBOOK_DIR": data_dir,
-        "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL": "true",
-    }
-    assert run_command(["config", "init", "--dest-dir", "."], custom_env=env)
-
-    lib_install_dir = Path(data_dir, "libraries", "WiFi101")
-    # Verifies library is not already installed
-    assert not lib_install_dir.exists()
-
-    git_url = "https://github.com/arduino-libraries/WiFi101.git"
-
-    # Test git-url library install
-    res = run_command(["lib", "install", "--git-url", git_url])
-    assert res.ok
-    assert "--git-url and --zip-path flags allow installing untrusted files, use it at your own risk." in res.stdout
-
-    # Verifies library is installed in expected path
-    assert lib_install_dir.exists()
-
-    # Reinstall library
-    assert run_command(["lib", "install", "--git-url", git_url])
-
-    # Verifies library remains installed
-    assert lib_install_dir.exists()
-
-
 def test_install_with_git_url_fragment_as_branch(run_command, data_dir, downloads_dir):
     # Initialize configs to enable --git-url flag
     env = {

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -96,39 +96,6 @@ def test_install_git_url_and_zip_path_flags_visibility(run_command, data_dir, do
     assert "--git-url and --zip-path flags allow installing untrusted files, use it at your own risk." in res.stdout
 
 
-def test_install_with_git_url_fragment_as_branch(run_command, data_dir, downloads_dir):
-    # Initialize configs to enable --git-url flag
-    env = {
-        "ARDUINO_DATA_DIR": data_dir,
-        "ARDUINO_DOWNLOADS_DIR": downloads_dir,
-        "ARDUINO_SKETCHBOOK_DIR": data_dir,
-        "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL": "true",
-    }
-    assert run_command(["config", "init", "--dest-dir", "."], custom_env=env)
-
-    lib_install_dir = Path(data_dir, "libraries", "WiFi101")
-    # Verifies library is not already installed
-    assert not lib_install_dir.exists()
-
-    git_url = "https://github.com/arduino-libraries/WiFi101.git"
-
-    # Test that a bad ref fails
-    res = run_command(["lib", "install", "--git-url", git_url + "#x-ref-does-not-exist"])
-    assert res.failed
-
-    # Verifies library is installed in expected path
-    res = run_command(["lib", "install", "--git-url", git_url + "#0.16.0"])
-    assert res.ok
-    assert lib_install_dir.exists()
-
-    # Reinstall library at an existing ref
-    assert run_command(["lib", "install", "--git-url", git_url + "#master"])
-    assert res.ok
-
-    # Verifies library remains installed
-    assert lib_install_dir.exists()
-
-
 def test_install_with_zip_path(run_command, data_dir, downloads_dir):
     # Initialize configs to enable --zip-path flag
     env = {

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -49,41 +49,6 @@ def download_lib(url, download_dir):
     z.close()
 
 
-def test_install_library_with_dependencies(run_command):
-    assert run_command(["update"])
-
-    # Verifies libraries are not installed
-    res = run_command(["lib", "list", "--format", "json"])
-    assert res.ok
-    data = json.loads(res.stdout)
-    installed_libraries = [l["library"]["name"] for l in data]
-    assert "MD_Parola" not in installed_libraries
-    assert "MD_MAX72XX" not in installed_libraries
-
-    # Install library
-    assert run_command(["lib", "install", "MD_Parola@3.5.5"])
-
-    # Verifies library's dependencies are correctly installed
-    res = run_command(["lib", "list", "--format", "json"])
-    assert res.ok
-    data = json.loads(res.stdout)
-    installed_libraries = [l["library"]["name"] for l in data]
-    assert "MD_Parola" in installed_libraries
-    assert "MD_MAX72XX" in installed_libraries
-
-    # Try upgrading with --no-overwrite (should fail) and without --no-overwrite (should succeed)
-    res = run_command(["lib", "install", "MD_Parola@3.6.1", "--no-overwrite"])
-    assert res.failed
-    assert run_command(["lib", "install", "MD_Parola@3.6.1"])
-
-    # Test --no-overwrite with transitive dependencies
-    assert run_command(["lib", "install", "SD"])
-    assert run_command(["lib", "install", "Arduino_Builtin", "--no-overwrite"])
-    assert run_command(["lib", "install", "SD@1.2.3"])
-    res = run_command(["lib", "install", "Arduino_Builtin", "--no-overwrite"])
-    assert res.failed
-
-
 def test_install_no_deps(run_command):
     assert run_command(["update"])
 

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -49,19 +49,6 @@ def download_lib(url, download_dir):
     z.close()
 
 
-def test_install(run_command):
-    libs = ["Arduino_BQ24195", "CMMC MQTT Connector", "WiFiNINA"]
-    # Should be safe to run install multiple times
-    assert run_command(["lib", "install"] + libs)
-    assert run_command(["lib", "install"] + libs)
-
-    # Test failing-install of library with wrong dependency
-    # (https://github.com/arduino/arduino-cli/issues/534)
-    res = run_command(["lib", "install", "MD_Parola@3.2.0"])
-    assert res.failed
-    assert "No valid dependencies solution found: dependency 'MD_MAX72xx' is not available" in res.stderr
-
-
 def test_install_library_with_dependencies(run_command):
     assert run_command(["update"])
 

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -49,37 +49,6 @@ def download_lib(url, download_dir):
     z.close()
 
 
-def test_list_exit_code(run_command):
-    # Init the environment explicitly
-    assert run_command(["core", "update-index"])
-
-    assert run_command(["core", "list"])
-
-    # Verifies lib list doesn't fail when platform is not specified
-    result = run_command(["lib", "list"])
-    assert result.ok
-    assert result.stderr.strip() == ""
-
-    # Verify lib list command fails because specified platform is not installed
-    result = run_command(["lib", "list", "-b", "arduino:samd:mkr1000"])
-    assert result.failed
-    assert result.stderr.strip() == "Error listing Libraries: Unknown FQBN: platform arduino:samd is not installed"
-
-    assert run_command(["lib", "install", "AllThingsTalk LoRaWAN SDK"])
-
-    # Verifies lib list command keeps failing
-    result = run_command(["lib", "list", "-b", "arduino:samd:mkr1000"])
-    assert result.failed
-    assert result.stderr.strip() == "Error listing Libraries: Unknown FQBN: platform arduino:samd is not installed"
-
-    assert run_command(["core", "install", "arduino:samd"])
-
-    # Verifies lib list command now works since platform has been installed
-    result = run_command(["lib", "list", "-b", "arduino:samd:mkr1000"])
-    assert result.ok
-    assert result.stderr.strip() == ""
-
-
 def test_list_with_fqbn(run_command):
     # Init the environment explicitly
     assert run_command(["core", "update-index"])


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Infrastructure enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the new behavior?
The first 12 tests that were previously present in `test_lib.py` have been rewritten in `lib_test.go`, without changing their original purpose.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
