### PR TITLE
Include platform bundled libs when `-b` flag is used

### DIFF
--- a/commands/lib/list.go
+++ b/commands/lib/list.go
@@ -48,8 +48,9 @@ func LibraryList(ctx context.Context, req *rpc.LibraryListRequest) (*rpc.Library
 
 	nameFilter := strings.ToLower(req.GetName())
 
-	allLibs := listLibraries(lm, req.GetUpdatable(), req.GetAll())
+	var allLibs []*installedLib
 	if f := req.GetFqbn(); f != "" {
+		allLibs = listLibraries(lm, req.GetUpdatable(), true)
 		fqbn, err := cores.ParseFQBN(req.GetFqbn())
 		if err != nil {
 			return nil, &arduino.InvalidFQBNError{Cause: err}
@@ -93,6 +94,8 @@ func LibraryList(ctx context.Context, req *rpc.LibraryListRequest) (*rpc.Library
 		for _, lib := range filteredRes {
 			allLibs = append(allLibs, lib)
 		}
+	} else {
+		allLibs = listLibraries(lm, req.GetUpdatable(), req.GetAll())
 	}
 
 	installedLibs := []*rpc.InstalledLibrary{}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Code enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
Platform bundled libraries are not shown when `-b` flag is used. It is necessary to set the `--all` flag with it.
```
C:\Users\m.pologruto>arduino-cli lib list -b esp32:esp32:esp32 ArduinoOTA
No libraries installed.

C:\Users\m.pologruto>arduino-cli lib list -b esp32:esp32:esp32 ArduinoOTA --all
Name       Installed       Available     Location          Description
ArduinoOTA 1.0             1.0.8         esp32:esp32@1.0.6 Enables Over The Air upgrades, via wi...
```
<!-- You can also link to an open issue here -->

## What is the new behavior?
To show the bundled libraries, the `--all` flag is automatically set when the `-b` flag is used.
```
C:\Users\m.pologruto> ./arduino-cli lib list -b esp32:esp32:esp32 ArduinoOTA
Name       Installed       Available     Location          Description
ArduinoOTA 1.0             1.0.8         esp32:esp32@1.0.6 Enables Over The Air upgrades, via wi...
```
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
