### PR TITLE
[skip-changelog] Update urls to prevent tests from failing

### DIFF
--- a/arduino/resources/resources_test.go
+++ b/arduino/resources/resources_test.go
@@ -42,7 +42,7 @@ func TestDownloadAndChecksums(t *testing.T) {
 		CachePath:       "cache",
 		Checksum:        "SHA-256:6a338cf4d6d501176a2d352c87a8d72ac7488b8c5b82cdf2a4e2cef630391092",
 		Size:            486,
-		URL:             "https://raw.githubusercontent.com/arduino/arduino-cli/master/test/testdata/core.zip",
+		URL:             "https://raw.githubusercontent.com/arduino/arduino-cli/master/internal/integrationtest/testdata/core.zip",
 	}
 	digest, err := hex.DecodeString("6a338cf4d6d501176a2d352c87a8d72ac7488b8c5b82cdf2a4e2cef630391092")
 	require.NoError(t, err)

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -162,7 +162,7 @@ func TestCoreSearchNoArgs(t *testing.T) {
 		lines = append(lines, strings.Fields(strings.TrimSpace(v)))
 	}
 	// The header is printed on the first lines
-	require.Equal(t, []string{"test:x86", "2.0.0", "test_core"}, lines[19])
+	require.Equal(t, []string{"test:x86", "2.0.0", "test_core"}, lines[20])
 	numPlatforms := len(lines) - 1
 
 	// same thing in JSON format, also check the number of platforms found is the same
@@ -179,7 +179,7 @@ func TestCoreSearchNoArgs(t *testing.T) {
 		lines = append(lines, strings.Fields(strings.TrimSpace(v)))
 	}
 	// The header is printed on the first lines
-	require.Equal(t, []string{"test:x86", "2.0.0", "test_core"}, lines[20])
+	require.Equal(t, []string{"test:x86", "2.0.0", "test_core"}, lines[21])
 	numPlatforms = len(lines) - 1
 
 	// same thing in JSON format, also check the number of platforms found is the same
@@ -385,7 +385,7 @@ func TestCoreZipslip(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
-	url := "https://raw.githubusercontent.com/arduino/arduino-cli/master/test/testdata/test_index.json"
+	url := "https://raw.githubusercontent.com/arduino/arduino-cli/master/internal/integrationtest/testdata/test_index.json"
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url)
 	require.NoError(t, err)
 
@@ -399,7 +399,7 @@ func TestCoreBrokenInstall(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
-	url := "https://raw.githubusercontent.com/arduino/arduino-cli/master/test/testdata/test_index.json"
+	url := "https://raw.githubusercontent.com/arduino/arduino-cli/master/internal/integrationtest/testdata/test_index.json"
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url)
 	require.NoError(t, err)
 	_, _, err = cli.Run("core", "install", "brokenchecksum:x86", "--additional-urls="+url)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
Some tests are failing because urls are outdated after PR #2011  
<!-- You can also link to an open issue here -->

## What is the new behavior?
Updating the urls prevents the tests from failing.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
