### PR TITLE
chore: prevent empty codecov report

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -164,6 +164,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Download coverage data artifact
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

The CI pipeline is changed in order to prevent empty Codecov coverage reports. It follows [the workaround in the Codecov related issue](https://github.com/codecov/codecov-action/issues/844#issuecomment-1367603838)

## What is the current behavior?
Commit related Codecov reports are empty, see example screenshot:
<img width="1308" alt="image" src="https://user-images.githubusercontent.com/71259950/210357622-64de6460-bcc9-40c6-b5bd-dc7550ea1e89.png">

## What is the new behavior?

Coverage reports are shown correctly by Codecov

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
