### PR TITLE
fix: consistent boards list ordering

### DIFF
--- a/internal/integrationtest/board/board_test.go
+++ b/internal/integrationtest/board/board_test.go
@@ -33,7 +33,10 @@ func TestCorrectBoardListOrdering(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
-	_, _, err := cli.Run("core", "install", "arduino:avr")
+	// install two cores, boards must be ordered by package name and platform name
+	_, _, err := cli.Run("core", "install", "arduino:sam")
+	require.NoError(t, err)
+	_, _, err = cli.Run("core", "install", "arduino:avr")
 	require.NoError(t, err)
 	jsonOut, _, err := cli.Run("board", "listall", "--format", "json")
 	require.NoError(t, err)
@@ -64,7 +67,9 @@ func TestCorrectBoardListOrdering(t *testing.T) {
 		"arduino:avr:yunmini",
 		"arduino:avr:chiwawa",
 		"arduino:avr:one",
-		"arduino:avr:unowifi"
+		"arduino:avr:unowifi",
+		"arduino:sam:arduino_due_x_dbg",
+		"arduino:sam:arduino_due_x"
 	]`)
 }
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Makes the `board listall` command output order consistent across formats. The list items are ordered by the package and platforms names they belong too, other than the board names themselves.
The plain text format remains an exception to this as it's sorted alphabetically by board name. 

## What is the current behavior?

In output formats other than plain text the board list is inconsistently ordered: while the boards within a single package/platform are ordered alphabetically they might appear before or after the ones of an other package/platform.

## What is the new behavior?

The list is ordered by package, platform and board names.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

No

## Other information

<!-- Any additional information that could help the review process -->

Fixes #1909, although ordering between plain text and other formats remain different
