### PR TITLE
[skip-changelog] Remove `queryParameter` where it is not needed

### DIFF
--- a/commands/daemon/daemon.go
+++ b/commands/daemon/daemon.go
@@ -343,7 +343,6 @@ func (s *ArduinoCoreServerImpl) LibraryDownload(req *rpc.LibraryDownloadRequest,
 	resp, err := lib.LibraryDownload(
 		stream.Context(), req,
 		func(p *rpc.DownloadProgress) { stream.Send(&rpc.LibraryDownloadResponse{Progress: p}) },
-		"",
 	)
 	if err != nil {
 		return convertErrorToRPCStatus(err)
@@ -357,7 +356,6 @@ func (s *ArduinoCoreServerImpl) LibraryInstall(req *rpc.LibraryInstallRequest, s
 		stream.Context(), req,
 		func(p *rpc.DownloadProgress) { stream.Send(&rpc.LibraryInstallResponse{Progress: p}) },
 		func(p *rpc.TaskProgress) { stream.Send(&rpc.LibraryInstallResponse{TaskProgress: p}) },
-		"",
 	)
 	if err != nil {
 		return convertErrorToRPCStatus(err)

--- a/commands/lib/download.go
+++ b/commands/lib/download.go
@@ -32,8 +32,7 @@ var tr = i18n.Tr
 
 // LibraryDownload executes the download of the library.
 // A DownloadProgressCB callback function must be passed to monitor download progress.
-// queryParameter is passed for analysis purposes.
-func LibraryDownload(ctx context.Context, req *rpc.LibraryDownloadRequest, downloadCB rpc.DownloadProgressCB, queryParameter string) (*rpc.LibraryDownloadResponse, error) {
+func LibraryDownload(ctx context.Context, req *rpc.LibraryDownloadRequest, downloadCB rpc.DownloadProgressCB) (*rpc.LibraryDownloadResponse, error) {
 	logrus.Info("Executing `arduino-cli lib download`")
 
 	lm := commands.GetLibraryManager(req)
@@ -48,7 +47,7 @@ func LibraryDownload(ctx context.Context, req *rpc.LibraryDownloadRequest, downl
 		return nil, err
 	}
 
-	if err := downloadLibrary(lm, lib, downloadCB, func(*rpc.TaskProgress) {}, queryParameter); err != nil {
+	if err := downloadLibrary(lm, lib, downloadCB, func(*rpc.TaskProgress) {}, "download"); err != nil {
 		return nil, err
 	}
 

--- a/commands/lib/upgrade.go
+++ b/commands/lib/upgrade.go
@@ -73,7 +73,7 @@ func upgrade(instance *rpc.Instance, libs []*installedLib, downloadCB rpc.Downlo
 			NoDeps:      false,
 			NoOverwrite: false,
 		}
-		err := LibraryInstall(context.Background(), libInstallReq, downloadCB, taskCB, "upgrade")
+		err := LibraryInstall(context.Background(), libInstallReq, downloadCB, taskCB)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/lib/download.go
+++ b/internal/cli/lib/download.go
@@ -60,7 +60,7 @@ func runDownloadCommand(cmd *cobra.Command, args []string) {
 			Name:     library.Name,
 			Version:  library.Version,
 		}
-		_, err := lib.LibraryDownload(context.Background(), libraryDownloadRequest, feedback.ProgressBar(), "download")
+		_, err := lib.LibraryDownload(context.Background(), libraryDownloadRequest, feedback.ProgressBar())
 		if err != nil {
 			feedback.Fatal(tr("Error downloading %[1]s: %[2]v", library, err), feedback.ErrNetwork)
 		}

--- a/internal/cli/lib/install.go
+++ b/internal/cli/lib/install.go
@@ -130,7 +130,7 @@ func runInstallCommand(cmd *cobra.Command, args []string) {
 			NoDeps:      noDeps,
 			NoOverwrite: noOverwrite,
 		}
-		err := lib.LibraryInstall(context.Background(), libraryInstallRequest, feedback.ProgressBar(), feedback.TaskProgress(), "install")
+		err := lib.LibraryInstall(context.Background(), libraryInstallRequest, feedback.ProgressBar(), feedback.TaskProgress())
 		if err != nil {
 			feedback.Fatal(tr("Error installing %s: %v", libRef.Name, err), feedback.ErrGeneric)
 		}

--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -1518,5 +1518,4 @@ func TestLibQueryParameters(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(stdout),
 		"Starting download                             \x1b[36murl\x1b[0m=\"https://downloads.arduino.cc/libraries/github.com/arduino-libraries/WiFi101-0.16.1.zip?query=download\"\n")
-
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the new behavior?
Follow up to PR #2034.
`queryParameter` can be introduced for the first time inside `commands.lib.install.LibraryInstall`. For this reason, every prior declaration has been removed, avoiding breaking changes.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
