### PR TITLE
fix: scan libraries on install

### DIFF
--- a/arduino/libraries/librariesmanager/install.go
+++ b/arduino/libraries/librariesmanager/install.go
@@ -64,6 +64,7 @@ func (lm *LibrariesManager) InstallPrerequisiteCheck(name string, version *semve
 		return nil, err
 	}
 
+	lm.RescanLibraries()
 	libs := lm.FindByReference(&librariesindex.Reference{Name: name}, installLocation)
 
 	if len(libs) > 1 {

--- a/arduino/libraries/librariesmanager/librariesmanager.go
+++ b/arduino/libraries/librariesmanager/librariesmanager.go
@@ -130,8 +130,15 @@ func (lm *LibrariesManager) AddPlatformReleaseLibrariesDir(plaftormRelease *core
 	})
 }
 
+func (lm *LibrariesManager) ClearLibraries() {
+	for k := range lm.Libraries {
+		delete(lm.Libraries, k)
+	}
+}
+
 // RescanLibraries reload all installed libraries in the system.
 func (lm *LibrariesManager) RescanLibraries() []*status.Status {
+	lm.ClearLibraries()
 	statuses := []*status.Status{}
 	for _, dir := range lm.LibrariesDir {
 		if errs := lm.LoadLibrariesFromDir(dir); len(errs) > 0 {

--- a/arduino/libraries/librariesmanager/librariesmanager.go
+++ b/arduino/libraries/librariesmanager/librariesmanager.go
@@ -130,15 +130,9 @@ func (lm *LibrariesManager) AddPlatformReleaseLibrariesDir(plaftormRelease *core
 	})
 }
 
-func (lm *LibrariesManager) ClearLibraries() {
-	for k := range lm.Libraries {
-		delete(lm.Libraries, k)
-	}
-}
-
 // RescanLibraries reload all installed libraries in the system.
 func (lm *LibrariesManager) RescanLibraries() []*status.Status {
-	lm.ClearLibraries()
+	lm.clearLibraries()
 	statuses := []*status.Status{}
 	for _, dir := range lm.LibrariesDir {
 		if errs := lm.LoadLibrariesFromDir(dir); len(errs) > 0 {
@@ -223,4 +217,10 @@ func (lm *LibrariesManager) FindByReference(libRef *librariesindex.Reference, in
 		return nil
 	}
 	return alternatives.FilterByVersionAndInstallLocation(libRef.Version, installLocation)
+}
+
+func (lm *LibrariesManager) clearLibraries() {
+	for k := range lm.Libraries {
+		delete(lm.Libraries, k)
+	}
 }

--- a/arduino/libraries/librariesmanager/librariesmanager_test.go
+++ b/arduino/libraries/librariesmanager/librariesmanager_test.go
@@ -1,0 +1,18 @@
+package librariesmanager
+
+import (
+	"testing"
+
+	"github.com/arduino/arduino-cli/arduino/libraries"
+	"github.com/arduino/go-paths-helper"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RescanLibrariesCallClear(t *testing.T) {
+	baseDir := paths.New(t.TempDir())
+	lm := NewLibraryManager(baseDir.Join("index_dir"), baseDir.Join("downloads_dir"))
+	lm.Libraries["testLibA"] = libraries.List{}
+	lm.Libraries["testLibB"] = libraries.List{}
+	lm.RescanLibraries()
+	require.Len(t, lm.Libraries, 0)
+}

--- a/arduino/libraries/librariesmanager/librariesmanager_test.go
+++ b/arduino/libraries/librariesmanager/librariesmanager_test.go
@@ -1,3 +1,17 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
 package librariesmanager
 
 import (


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull 
Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->

Rescan libraries before installing new ones. Upon each installation request the libraries folders 
are rescanned.

## What is the current behavior?

<!-- You can also link to an open issue here -->

The installed libraries are scanned only at initialization time. If other are added 
while the program runs, especially in deamon mode, these are not known to the running instance.
This causes the execution to fail improperly if different installation attempts have an 
overlap/conflict in dependencies.

## What is the new behavior?

<!-- if this is a feature change -->

The installed libraries are reloaded before every installation request, so the logic has the updated 
status.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->

Fixes #1802
