### PR TITLE
[breaking] Remove `ip` flag from daemon command

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -4,6 +4,11 @@ Here you can find a list of migration guides to handle breaking changes between 
 
 ## 0.30.0
 
+### `daemon` CLI command's `--ip` flag removal
+
+The `daemon` CLI command no longer allows to set a custom ip for the gRPC communication. Currently there is not enough
+bandwith to support this feature. For this reason, the `--ip` flag has been removed.
+
 ### `board attach` CLI command changed behaviour
 
 The `board attach` CLI command has changed behaviour: now it just pick whatever port and FQBN is passed as parameter and

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -39,7 +39,6 @@ import (
 
 var (
 	tr           = i18n.Tr
-	ip           string
 	daemonize    bool
 	debug        bool
 	debugFile    string
@@ -56,7 +55,6 @@ func NewCommand() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Run:     runDaemonCommand,
 	}
-	daemonCommand.PersistentFlags().StringVar(&ip, "ip", "127.0.0.1", tr("The IP address the daemon will listen to"))
 	daemonCommand.PersistentFlags().String("port", "", tr("The TCP port the daemon will listen to"))
 	configuration.Settings.BindPFlag("daemon.port", daemonCommand.PersistentFlags().Lookup("port"))
 	daemonCommand.Flags().BoolVar(&daemonize, "daemonize", false, tr("Do not terminate daemon process if the parent process dies"))
@@ -120,6 +118,7 @@ func runDaemonCommand(cmd *cobra.Command, args []string) {
 		go feedback.ExitWhenParentProcessEnds()
 	}
 
+	ip := "127.0.0.1"
 	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%s", ip, port))
 	if err != nil {
 		// Invalid port, such as "Foo"


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Code security improvement
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
It is currently possible to use `--ip` to set a custom ip for listening to gRPC request.
<!-- You can also link to an open issue here -->

## What is the new behavior?
The `--ip` flag is removed and the default value is set to `127.0.0.1`.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
Yes
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
