### PR TITLE
Fixed error message capitalization

### DIFF
--- a/i18n/data/ar.po
+++ b/i18n/data/ar.po
@@ -871,7 +871,7 @@ msgid "Error installing tool %s"
 msgstr "خطأ اثناء تثبيت الاداة %s"
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr "خطا اثناء انشاء قائمة المكتبات : %v"
 
 #: cli/board/listall.go:64
@@ -953,7 +953,7 @@ msgid "Error searching boards: %v"
 msgstr "خطا اثناء البحث عن اللوحات : %v"
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr ""
 
 #: cli/core/search.go:87

--- a/i18n/data/de.po
+++ b/i18n/data/de.po
@@ -863,7 +863,7 @@ msgid "Error installing tool %s"
 msgstr "Fehler beim Installieren des Werkzeugs %s"
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr "Fehler beim Auflisten von Bibliotheken: %v"
 
 #: cli/board/listall.go:64
@@ -944,7 +944,7 @@ msgid "Error searching boards: %v"
 msgstr "Fehler bei der Suche nach Platinen: %v"
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr ""
 
 #: cli/core/search.go:87

--- a/i18n/data/en.po
+++ b/i18n/data/en.po
@@ -814,8 +814,8 @@ msgid "Error installing tool %s"
 msgstr "Error installing tool %s"
 
 #: cli/lib/list.go:76
-msgid "Error listing Libraries: %v"
-msgstr "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
+msgstr "Error listing libraries: %v"
 
 #: cli/board/listall.go:64
 msgid "Error listing boards: %v"

--- a/i18n/data/es.po
+++ b/i18n/data/es.po
@@ -869,7 +869,7 @@ msgid "Error installing tool %s"
 msgstr "Error instalando la herramienta %s"
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr "Error listando las librerías: %v"
 
 #: cli/board/listall.go:64
@@ -950,7 +950,7 @@ msgid "Error searching boards: %v"
 msgstr "Error en la búsqueda de placas: %v"
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr ""
 
 #: cli/core/search.go:87

--- a/i18n/data/fr.po
+++ b/i18n/data/fr.po
@@ -849,7 +849,7 @@ msgid "Error installing tool %s"
 msgstr "Erreur lors de l’installation de l'outil %s."
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr "Erreur lors du listage des librairies : %v"
 
 #: cli/board/listall.go:64
@@ -930,7 +930,7 @@ msgid "Error searching boards: %v"
 msgstr ""
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr ""
 
 #: cli/core/search.go:87

--- a/i18n/data/he.po
+++ b/i18n/data/he.po
@@ -845,7 +845,7 @@ msgid "Error installing tool %s"
 msgstr ""
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr ""
 
 #: cli/board/listall.go:64
@@ -926,7 +926,7 @@ msgid "Error searching boards: %v"
 msgstr ""
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr ""
 
 #: cli/core/search.go:87

--- a/i18n/data/it_IT.po
+++ b/i18n/data/it_IT.po
@@ -910,7 +910,7 @@ msgid "Error installing tool %s"
 msgstr "Errore durante l'installazione del tool %s"
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr ""
 "Si è verificato un errore durante la visualizzazione dell'elenco delle "
 "librerie: %v"
@@ -1010,7 +1010,7 @@ msgid "Error searching boards: %v"
 msgstr "Si è verificato un errore durante la ricerca delle schede: %v"
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr "Si è verificato un errore durante la ricerca delle librerie: %v"
 
 #: cli/core/search.go:87

--- a/i18n/data/ja.po
+++ b/i18n/data/ja.po
@@ -847,7 +847,7 @@ msgid "Error installing tool %s"
 msgstr ""
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries:  %v"
 msgstr ""
 
 #: cli/board/listall.go:64
@@ -928,7 +928,7 @@ msgid "Error searching boards: %v"
 msgstr ""
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries:  %v"
 msgstr ""
 
 #: cli/core/search.go:87
@@ -1432,7 +1432,7 @@ msgid "Loading index file: %v"
 msgstr ""
 
 #: commands/instances.go:442
-msgid "Loading libraries: %v"
+msgid "Loading libraries:  %v"
 msgstr ""
 
 #: cli/lib/list.go:131

--- a/i18n/data/ko.po
+++ b/i18n/data/ko.po
@@ -845,7 +845,7 @@ msgid "Error installing tool %s"
 msgstr ""
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr ""
 
 #: cli/board/listall.go:64
@@ -926,7 +926,7 @@ msgid "Error searching boards: %v"
 msgstr ""
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr ""
 
 #: cli/core/search.go:87

--- a/i18n/data/mn.po
+++ b/i18n/data/mn.po
@@ -847,7 +847,7 @@ msgid "Error installing tool %s"
 msgstr ""
 
 #: cli/lib/list.go:76
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr ""
 
 #: cli/board/listall.go:64

--- a/i18n/data/my_MM.po
+++ b/i18n/data/my_MM.po
@@ -841,7 +841,7 @@ msgid "Error installing tool %s"
 msgstr ""
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr ""
 
 #: cli/board/listall.go:64
@@ -922,7 +922,7 @@ msgid "Error searching boards: %v"
 msgstr ""
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr ""
 
 #: cli/core/search.go:87

--- a/i18n/data/pl.po
+++ b/i18n/data/pl.po
@@ -847,7 +847,7 @@ msgid "Error installing tool %s"
 msgstr ""
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr ""
 
 #: cli/board/listall.go:64
@@ -928,7 +928,7 @@ msgid "Error searching boards: %v"
 msgstr ""
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr ""
 
 #: cli/core/search.go:87

--- a/i18n/data/pt.po
+++ b/i18n/data/pt.po
@@ -850,7 +850,7 @@ msgid "Error installing tool %s"
 msgstr ""
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr ""
 
 #: cli/board/listall.go:64
@@ -931,7 +931,7 @@ msgid "Error searching boards: %v"
 msgstr ""
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr ""
 
 #: cli/core/search.go:87

--- a/i18n/data/ru.po
+++ b/i18n/data/ru.po
@@ -848,7 +848,7 @@ msgid "Error installing tool %s"
 msgstr ""
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr ""
 
 #: cli/board/listall.go:64
@@ -929,7 +929,7 @@ msgid "Error searching boards: %v"
 msgstr ""
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr ""
 
 #: cli/core/search.go:87

--- a/i18n/data/zh.po
+++ b/i18n/data/zh.po
@@ -848,7 +848,7 @@ msgid "Error installing tool %s"
 msgstr "安装 %s 工具时出错"
 
 #: cli/lib/list.go:79
-msgid "Error listing Libraries: %v"
+msgid "Error listing libraries: %v"
 msgstr "列出库列表时出错：%v"
 
 #: cli/board/listall.go:64
@@ -929,7 +929,7 @@ msgid "Error searching boards: %v"
 msgstr "搜索开发板时错误：%v"
 
 #: cli/lib/search.go:78
-msgid "Error searching for Libraries: %v"
+msgid "Error searching for libraries: %v"
 msgstr ""
 
 #: cli/core/search.go:87

--- a/internal/cli/lib/list.go
+++ b/internal/cli/lib/list.go
@@ -75,7 +75,7 @@ func List(instance *rpc.Instance, args []string, all bool, updatable bool) {
 		Fqbn:      fqbn.String(),
 	})
 	if err != nil {
-		feedback.Fatal(tr("Error listing Libraries: %v", err), feedback.ErrGeneric)
+		feedback.Fatal(tr("Error listing libraries: %v", err), feedback.ErrGeneric)
 	}
 
 	libs := []*rpc.InstalledLibrary{}

--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -393,7 +393,7 @@ func TestListExitCode(t *testing.T) {
 	// Verify lib list command fails because specified platform is not installed
 	_, stderr, err = cli.Run("lib", "list", "-b", "arduino:samd:mkr1000")
 	require.Error(t, err)
-	require.Contains(t, string(stderr), "Error listing Libraries: Unknown FQBN: platform arduino:samd is not installed")
+	require.Contains(t, string(stderr), "Error listing libraries: Unknown FQBN: platform arduino:samd is not installed")
 
 	_, _, err = cli.Run("lib", "install", "AllThingsTalk LoRaWAN SDK")
 	require.NoError(t, err)
@@ -401,7 +401,7 @@ func TestListExitCode(t *testing.T) {
 	// Verifies lib list command keeps failing
 	_, stderr, err = cli.Run("lib", "list", "-b", "arduino:samd:mkr1000")
 	require.Error(t, err)
-	require.Contains(t, string(stderr), "Error listing Libraries: Unknown FQBN: platform arduino:samd is not installed")
+	require.Contains(t, string(stderr), "Error listing libraries: Unknown FQBN: platform arduino:samd is not installed")
 
 	_, _, err = cli.Run("core", "install", "arduino:samd")
 	require.NoError(t, err)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Simple syntax changes to error messages.
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
Currently the message is incorrectly capitalized.
<!-- You can also link to an open issue here -->

## What is the new behavior?
Corrects capitalization on all "Libraries: " strings to "libraries: "
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No, the changes made in this pull request are trivial and should not impact operation
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
