### PR TITLE
Added regex based input validation when creating a new sketch

### DIFF
--- a/internal/cli/sketch/new.go
+++ b/internal/cli/sketch/new.go
@@ -40,7 +40,7 @@ func initNewCommand() *cobra.Command {
 		Example: "  " + os.Args[0] + " sketch new MultiBlinker",
 		Args:    cobra.ExactArgs(1),
 		Run:     func(cmd *cobra.Command, args []string) {
-			re := regexp.MustCompile("^[0-9a-zA-Z][0-9a-zA-Z_.-]{0,62}$")
+			re := regexp.MustCompile("^/[0-9a-zA-Z][0-9a-zA-Z_.-]{0,62}$")
 			if !re.MatchString(args[0]) {
 				fmt.Println("Sketch names must start with a letter or number, followed by letters, numbers, dashes, dots and underscores. Maximum length is 63 characters.")
 				return

--- a/internal/cli/sketch/new.go
+++ b/internal/cli/sketch/new.go
@@ -19,7 +19,8 @@ import (
 	"context"
 	"os"
 	"strings"
-
+	"regexp"
+	"fmt"
 	"github.com/arduino/arduino-cli/arduino/globals"
 	sk "github.com/arduino/arduino-cli/commands/sketch"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
@@ -38,7 +39,14 @@ func initNewCommand() *cobra.Command {
 		Long:    tr("Create a new Sketch"),
 		Example: "  " + os.Args[0] + " sketch new MultiBlinker",
 		Args:    cobra.ExactArgs(1),
-		Run:     func(cmd *cobra.Command, args []string) { runNewCommand(args, overwrite) },
+		Run:     func(cmd *cobra.Command, args []string) {
+			re := regexp.MustCompile("^[a-zA-Z].")
+			if !re.MatchString(args[0]) {
+				fmt.Println("Error: Value can only contain alphabetic characters")
+				return
+			}
+			runNewCommand(args, overwrite)
+		},
 	}
 
 	newCommand.Flags().BoolVarP(&overwrite, "overwrite", "f", false, tr("Overwrites an existing .ino sketch."))

--- a/internal/cli/sketch/new.go
+++ b/internal/cli/sketch/new.go
@@ -40,9 +40,9 @@ func initNewCommand() *cobra.Command {
 		Example: "  " + os.Args[0] + " sketch new MultiBlinker",
 		Args:    cobra.ExactArgs(1),
 		Run:     func(cmd *cobra.Command, args []string) {
-			re := regexp.MustCompile("^[a-zA-Z].")
+			re := regexp.MustCompile("^[0-9a-zA-Z][0-9a-zA-Z_.-]{0,62}$")
 			if !re.MatchString(args[0]) {
-				fmt.Println("Error: Value can only contain alphabetic characters")
+				fmt.Println("Sketch names must start with a letter or number, followed by letters, numbers, dashes, dots and underscores. Maximum length is 63 characters.")
 				return
 			}
 			runNewCommand(args, overwrite)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Bug fix.
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
Users are allowed inputs like 'sketch new $%^[].cpp'
<!-- You can also link to an open issue here -->

## What is the new behavior?
When 'sketch new' is called the input is checked against a regular expression to verify there are only alphabetic characters.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
This code does not introduce any breaking changes.
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information
Fixes issue #2043.
<!-- Any additional information that could help the review process -->
