### PR TITLE
[breaking] fix: validate sketch name

### DIFF
--- a/commands/sketch/new.go
+++ b/commands/sketch/new.go
@@ -37,7 +37,7 @@ void loop() {
 
 // sketchNameMaxLength could be part of the regex, but it's intentionally left out for clearer error reporting
 var sketchNameMaxLength = 63
-var sketchNameValidationRegex = regexp.MustCompile(`^[0-9a-zA-Z]{1}[0-9a-zA-Z_\.-]*$`)
+var sketchNameValidationRegex = regexp.MustCompile(`^[0-9a-zA-Z][0-9a-zA-Z_\.-]*$`)
 
 // NewSketch creates a new sketch via gRPC
 func NewSketch(ctx context.Context, req *rpc.NewSketchRequest) (*rpc.NewSketchResponse, error) {
@@ -71,12 +71,14 @@ func NewSketch(ctx context.Context, req *rpc.NewSketchRequest) (*rpc.NewSketchRe
 }
 
 func validateSketchName(name string) error {
+	if name == "" {
+		return &arduino.CantCreateSketchError{Cause: errors.New(tr("sketch name cannot be empty"))}
+	}
 	if len(name) > sketchNameMaxLength {
 		return &arduino.CantCreateSketchError{Cause: errors.New(tr("sketch name too long (%d characters). Maximum allowed length is %d",
 			len(name),
 			sketchNameMaxLength))}
 	}
-
 	if !sketchNameValidationRegex.MatchString(name) {
 		return &arduino.CantCreateSketchError{Cause: errors.New(tr("invalid sketch name \"%s\". Required pattern %s",
 			name,

--- a/commands/sketch/new_test.go
+++ b/commands/sketch/new_test.go
@@ -32,6 +32,17 @@ func Test_SketchNameWrongPattern(t *testing.T) {
 	}
 }
 
+func Test_SketchNameEmpty(t *testing.T) {
+	emptyName := ""
+	_, err := NewSketch(context.Background(), &commands.NewSketchRequest{
+		SketchName: emptyName,
+		SketchDir:  t.TempDir(),
+	})
+	require.NotNil(t, err)
+
+	require.Error(t, err, `Can't create sketch: sketch name cannot be empty`)
+}
+
 func Test_SketchNameTooLong(t *testing.T) {
 	tooLongName := make([]byte, sketchNameMaxLength+1)
 	for i := range tooLongName {

--- a/commands/sketch/new_test.go
+++ b/commands/sketch/new_test.go
@@ -1,0 +1,71 @@
+package sketch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_SketchNameWrongPattern(t *testing.T) {
+	invalidNames := []string{
+		"&",
+		"",
+		".hello",
+		"_hello",
+		"-hello",
+		"hello*",
+		"||||||||||||||",
+		",`hack[}attempt{];",
+	}
+	for _, name := range invalidNames {
+		_, err := NewSketch(context.Background(), &commands.NewSketchRequest{
+			SketchName: name,
+			SketchDir:  t.TempDir(),
+		})
+		require.NotNil(t, err)
+
+		require.Error(t, err, `Can't create sketch: invalid sketch name "%s". Required pattern %s`,
+			name,
+			sketchNameValidationRegex)
+	}
+}
+
+func Test_SketchNameTooLong(t *testing.T) {
+	tooLongName := make([]byte, sketchNameMaxLength+1)
+	for i := range tooLongName {
+		tooLongName[i] = 'a'
+	}
+	_, err := NewSketch(context.Background(), &commands.NewSketchRequest{
+		SketchName: string(tooLongName),
+		SketchDir:  t.TempDir(),
+	})
+	require.NotNil(t, err)
+
+	require.Error(t, err, `Can't create sketch: sketch name too long (%d characters). Maximum allowed length is %d`,
+		len(tooLongName),
+		sketchNameMaxLength)
+}
+
+func Test_SketchNameOk(t *testing.T) {
+	lengthLimitName := make([]byte, sketchNameMaxLength)
+	for i := range lengthLimitName {
+		lengthLimitName[i] = 'a'
+	}
+	validNames := []string{
+		"h",
+		"h.ello",
+		"h..ello-world",
+		"h..ello-world.",
+		"hello_world__",
+		string(lengthLimitName),
+	}
+	for _, name := range validNames {
+		_, err := NewSketch(context.Background(), &commands.NewSketchRequest{
+			SketchName: name,
+			SketchDir:  t.TempDir(),
+		})
+		require.Nil(t, err)
+	}
+}

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -4,6 +4,14 @@ Here you can find a list of migration guides to handle breaking changes between 
 
 ## 0.30.0
 
+### Sketch name validation
+
+The sketch name submitted via the `sketch new` command of the CLI or the gRPC command
+`cc.arduino.cli.commands.v1.NewSketch` are now validated. The applied rules follow the
+[sketch specifications](https://arduino.github.io/arduino-cli/dev/sketch-specification).
+
+Existing sketch names that don't respect the new constraints need to be updated.
+
 ### `daemon` CLI command's `--ip` flag removal
 
 The `daemon` CLI command no longer allows to set a custom ip for the gRPC communication. Currently there is not enough

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -10,8 +10,7 @@ The sketch name submitted via the `sketch new` command of the CLI or the gRPC co
 `cc.arduino.cli.commands.v1.NewSketch` are now validated. The applied rules follow the
 [sketch specifications](https://arduino.github.io/arduino-cli/dev/sketch-specification).
 
-Existing sketch names that don't respect the new constraints need to be updated.
-
+Existing sketch names violating the new constraint need to be updated.
 ### `daemon` CLI command's `--ip` flag removal
 
 The `daemon` CLI command no longer allows to set a custom ip for the gRPC communication. Currently there is not enough

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -11,6 +11,7 @@ The sketch name submitted via the `sketch new` command of the CLI or the gRPC co
 [sketch specifications](https://arduino.github.io/arduino-cli/dev/sketch-specification).
 
 Existing sketch names violating the new constraint need to be updated.
+
 ### `daemon` CLI command's `--ip` flag removal
 
 The `daemon` CLI command no longer allows to set a custom ip for the gRPC communication. Currently there is not enough

--- a/internal/integrationtest/sketch/sketch_test.go
+++ b/internal/integrationtest/sketch/sketch_test.go
@@ -73,6 +73,16 @@ func TestSketchNew(t *testing.T) {
 	require.FileExists(t, currentSketchPath.Join(sketchName).String()+".ino")
 }
 
+func TestSketchNewEmptyName(t *testing.T) {
+	// testing that we fail nicely. It panicked in the past
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	sketchName := ""
+	_, _, err := cli.Run("sketch", "new", sketchName)
+	require.Error(t, err, "Can't create sketch: sketch name cannot be empty")
+}
+
 func verifyZipContainsSketchExcludingBuildDir(t *testing.T, files []*zip.File) {
 	require.Len(t, files, 8)
 	require.Equal(t, paths.New("sketch_simple", "doc.txt").String(), files[0].Name)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->

It alignes the validation of sketch names to the documentation
https://arduino.github.io/arduino-cli/dev/sketch-specification/#sketch-folders-and-files
Sketch creation request that don't respect the validation rules are rejected

## What is the current behavior?

<!-- You can also link to an open issue here -->

No validation is performed on the sketch name

## What is the new behavior?

<!-- if this is a feature change -->

Sketch names that don't respect the required pattern, consisting in alphanumeric characters, dots, underscores and dashes, or that are longer 
than 63 characters cause the request to be rejected.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

Yes! Freeform sketch names that were in use before will not be compatible anymore.

## Other information

<!-- Any additional information that could help the review process -->

Fixes #2043
