### PR TITLE
Do not show available updates with `version` if `updater.enable_notification=false`

### DIFF
--- a/internal/cli/version/version.go
+++ b/internal/cli/version/version.go
@@ -59,7 +59,7 @@ func runVersionCommand(cmd *cobra.Command, args []string) {
 	if err != nil {
 		feedback.Fatal(fmt.Sprintf("Error parsing current version: %s", err), feedback.ErrGeneric)
 	}
-	latestVersion := updater.ForceCheckForUpdate(currentVersion)
+	latestVersion := updater.CheckForUpdate(currentVersion)
 
 	if feedback.GetFormat() != feedback.Text && latestVersion != nil {
 		// Set this only we managed to get the latest version


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Code enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
The command `arduino-cli version` always shows if there is an available update, even if `updater.enable_notification` is set to `false`.
<!-- You can also link to an open issue here -->

## What is the new behavior?
`arduino-cli version` no longer ignores the flag `updater.enable_notification`.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No.
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information
To test this change, I manually modified the `ldflags` to build an outdated version of the CLI, then set `updater.enable_notification` to `false`.
```
PS C:\Users\m.pologruto\Desktop\Arduino\arduino-cli> .\arduino-cli config dump                                 
board_manager:
  additional_urls: []
daemon:
  port: "50051"
directories:
  data: C:\Users\m.pologruto\AppData\Local\Arduino15
  downloads: C:\Users\m.pologruto\AppData\Local\Arduino15\staging
  user: C:\Users\m.pologruto\Documents\Arduino
library:
  enable_unsafe_install: true
logging:
  file: ""
  format: text
  level: info
metrics:
  addr: :9090
  enabled: true
output:
  no_color: false
sketch:
  always_export_binaries: false
updater:
  enable_notification: false

PS C:\Users\m.pologruto\Desktop\Arduino\arduino-cli> .\arduino-cli version                                     
arduino-cli.exe  Version: 0.17.0 Commit: 60a8aa96 Date: 2023-01-31T11:44:05Z
```
If `updater.enable_notification` is set to `true`, the command behaves normally. I must point out that, as of now, `arduino-cli version` shows if any updates are available only once every 24h, since `CheckForUpdate()` relies also on this check:
```
if inventory.Store.IsSet("updater.last_check_time") && time.Since(inventory.Store.GetTime("updater.last_check_time")).Hours() < 24 {
		// Checked less than 24 hours ago, let's wait
		return false
	}
```
Here is an example:
```
PS C:\Users\m.pologruto\Desktop\Arduino\arduino-cli> .\arduino-cli config set updater.enable_notification true 
PS C:\Users\m.pologruto\Desktop\Arduino\arduino-cli> .\arduino-cli version
arduino-cli.exe  Version: 0.17.0 Commit: 60a8aa96 Date: 2023-01-31T11:44:05Z


A new release of Arduino CLI is available: 0.17.0 → 0.29.0
https://arduino.github.io/arduino-cli/latest/installation/#latest-packages
PS C:\Users\m.pologruto\Desktop\Arduino\arduino-cli> .\arduino-cli version
arduino-cli.exe  Version: 0.17.0 Commit: 60a8aa96 Date: 2023-01-31T11:51:11Z
```
<!-- Any additional information that could help the review process -->
