### PR TITLE
fix: sketch name validation error messages

### DIFF
--- a/commands/sketch/new.go
+++ b/commands/sketch/new.go
@@ -75,14 +75,13 @@ func validateSketchName(name string) error {
 		return &arduino.CantCreateSketchError{Cause: errors.New(tr("sketch name cannot be empty"))}
 	}
 	if len(name) > sketchNameMaxLength {
-		return &arduino.CantCreateSketchError{Cause: errors.New(tr("sketch name too long (%d characters). Maximum allowed length is %d",
+		return &arduino.CantCreateSketchError{Cause: errors.New(tr("sketch name too long (%[1]d characters). Maximum allowed length is %[2]d",
 			len(name),
 			sketchNameMaxLength))}
 	}
 	if !sketchNameValidationRegex.MatchString(name) {
-		return &arduino.CantCreateSketchError{Cause: errors.New(tr("invalid sketch name \"%s\". Required pattern %s",
-			name,
-			sketchNameValidationRegex.String()))}
+		return &arduino.CantCreateSketchError{Cause: errors.New(tr(`invalid sketch name \"%[1]s\": the first character must be alphanumeric, the following ones can also contain "_", "-", and ".".`,
+			name))}
 	}
 	return nil
 }

--- a/commands/sketch/new.go
+++ b/commands/sketch/new.go
@@ -80,7 +80,7 @@ func validateSketchName(name string) error {
 			sketchNameMaxLength))}
 	}
 	if !sketchNameValidationRegex.MatchString(name) {
-		return &arduino.CantCreateSketchError{Cause: errors.New(tr(`invalid sketch name \"%[1]s\": the first character must be alphanumeric, the following ones can also contain "_", "-", and ".".`,
+		return &arduino.CantCreateSketchError{Cause: errors.New(tr(`invalid sketch name "%[1]s": the first character must be alphanumeric, the following ones can also contain "_", "-", and ".".`,
 			name))}
 	}
 	return nil

--- a/commands/sketch/new_test.go
+++ b/commands/sketch/new_test.go
@@ -2,6 +2,7 @@ package sketch
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
@@ -11,7 +12,6 @@ import (
 func Test_SketchNameWrongPattern(t *testing.T) {
 	invalidNames := []string{
 		"&",
-		"",
 		".hello",
 		"_hello",
 		"-hello",
@@ -24,11 +24,9 @@ func Test_SketchNameWrongPattern(t *testing.T) {
 			SketchName: name,
 			SketchDir:  t.TempDir(),
 		})
-		require.NotNil(t, err)
 
-		require.Error(t, err, `Can't create sketch: invalid sketch name "%s". Required pattern %s`,
-			name,
-			sketchNameValidationRegex)
+		require.EqualError(t, err, fmt.Sprintf(`Can't create sketch: invalid sketch name "%s": the first character must be alphanumeric, the following ones can also contain "_", "-", and ".".`,
+			name))
 	}
 }
 
@@ -38,9 +36,8 @@ func Test_SketchNameEmpty(t *testing.T) {
 		SketchName: emptyName,
 		SketchDir:  t.TempDir(),
 	})
-	require.NotNil(t, err)
 
-	require.Error(t, err, `Can't create sketch: sketch name cannot be empty`)
+	require.EqualError(t, err, `Can't create sketch: sketch name cannot be empty`)
 }
 
 func Test_SketchNameTooLong(t *testing.T) {
@@ -52,11 +49,10 @@ func Test_SketchNameTooLong(t *testing.T) {
 		SketchName: string(tooLongName),
 		SketchDir:  t.TempDir(),
 	})
-	require.NotNil(t, err)
 
-	require.Error(t, err, `Can't create sketch: sketch name too long (%d characters). Maximum allowed length is %d`,
+	require.EqualError(t, err, fmt.Sprintf(`Can't create sketch: sketch name too long (%d characters). Maximum allowed length is %d`,
 		len(tooLongName),
-		sketchNameMaxLength)
+		sketchNameMaxLength))
 }
 
 func Test_SketchNameOk(t *testing.T) {

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -11,7 +11,6 @@ The sketch name submitted via the `sketch new` command of the CLI or the gRPC co
 [sketch specifications](https://arduino.github.io/arduino-cli/dev/sketch-specification).
 
 Existing sketch names violating the new constraint need to be updated.
-
 ### `daemon` CLI command's `--ip` flag removal
 
 The `daemon` CLI command no longer allows to set a custom ip for the gRPC communication. Currently there is not enough

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -11,6 +11,7 @@ The sketch name submitted via the `sketch new` command of the CLI or the gRPC co
 [sketch specifications](https://arduino.github.io/arduino-cli/dev/sketch-specification).
 
 Existing sketch names violating the new constraint need to be updated.
+
 ### `daemon` CLI command's `--ip` flag removal
 
 The `daemon` CLI command no longer allows to set a custom ip for the gRPC communication. Currently there is not enough


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->
Follow up on https://github.com/arduino/arduino-cli/pull/2051. Fixing the error messages returned when validating the sketch name

## What is the current behavior?

<!-- You can also link to an open issue here -->
Errors are difficult to understand

## What is the new behavior?

<!-- if this is a feature change -->
Errors are more human readable

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
