### PR TITLE
fix: discovery cleanup and watchers continuity upon core install 

### DIFF
--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -103,6 +103,7 @@ func (pmb *Builder) BuildIntoExistingPackageManager(target *PackageManager) {
 	} else {
 		target.discoveryManager = pmb.discoveryManager
 	}
+	target.discoveryManager.AddAllDiscoveriesFrom(pmb.discoveryManager)
 	target.userAgent = pmb.userAgent
 }
 

--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -98,7 +98,11 @@ func (pmb *Builder) BuildIntoExistingPackageManager(target *PackageManager) {
 	target.tempDir = pmb.tempDir
 	target.packagesCustomGlobalProperties = pmb.packagesCustomGlobalProperties
 	target.profile = pmb.profile
-	target.discoveryManager = pmb.discoveryManager
+	if target.discoveryManager != nil {
+		target.discoveryManager.Clear()
+	} else {
+		target.discoveryManager = pmb.discoveryManager
+	}
 	target.userAgent = pmb.userAgent
 }
 

--- a/arduino/cores/packagemanager/package_manager.go
+++ b/arduino/cores/packagemanager/package_manager.go
@@ -98,20 +98,25 @@ func (pmb *Builder) BuildIntoExistingPackageManager(target *PackageManager) {
 	target.tempDir = pmb.tempDir
 	target.packagesCustomGlobalProperties = pmb.packagesCustomGlobalProperties
 	target.profile = pmb.profile
-	if target.discoveryManager != nil {
-		target.discoveryManager.Clear()
-	} else {
-		target.discoveryManager = pmb.discoveryManager
-	}
+	target.discoveryManager.Clear()
 	target.discoveryManager.AddAllDiscoveriesFrom(pmb.discoveryManager)
 	target.userAgent = pmb.userAgent
 }
 
 // Build builds a new PackageManager.
 func (pmb *Builder) Build() *PackageManager {
-	res := &PackageManager{}
-	pmb.BuildIntoExistingPackageManager(res)
-	return res
+	return &PackageManager{
+		log:                            pmb.log,
+		packages:                       pmb.packages,
+		IndexDir:                       pmb.IndexDir,
+		PackagesDir:                    pmb.PackagesDir,
+		DownloadDir:                    pmb.DownloadDir,
+		tempDir:                        pmb.tempDir,
+		packagesCustomGlobalProperties: pmb.packagesCustomGlobalProperties,
+		profile:                        pmb.profile,
+		discoveryManager:               pmb.discoveryManager,
+		userAgent:                      pmb.userAgent,
+	}
 }
 
 // NewBuilder creates a Builder with the same configuration

--- a/arduino/cores/packagemanager/package_manager_test.go
+++ b/arduino/cores/packagemanager/package_manager_test.go
@@ -13,7 +13,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-package packagemanager_test
+package packagemanager
 
 import (
 	"fmt"
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/arduino/arduino-cli/arduino/cores"
-	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/configuration"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
@@ -39,7 +38,7 @@ var dataDir1 = paths.New("testdata", "data_dir_1")
 var extraHardware = paths.New("testdata", "extra_hardware")
 
 func TestFindBoardWithFQBN(t *testing.T) {
-	pmb := packagemanager.NewBuilder(customHardware, customHardware, customHardware, customHardware, "test")
+	pmb := NewBuilder(customHardware, customHardware, customHardware, customHardware, "test")
 	pmb.LoadHardwareFromDirectory(customHardware)
 	pm := pmb.Build()
 	pme, release := pm.NewExplorer()
@@ -57,7 +56,7 @@ func TestFindBoardWithFQBN(t *testing.T) {
 
 func TestResolveFQBN(t *testing.T) {
 	// Pass nil, since these paths are only used for installing
-	pmb := packagemanager.NewBuilder(nil, nil, nil, nil, "test")
+	pmb := NewBuilder(nil, nil, nil, nil, "test")
 	// Hardware from main packages directory
 	pmb.LoadHardwareFromDirectory(dataDir1.Join("packages"))
 	// This contains the arduino:avr core
@@ -181,7 +180,7 @@ func TestResolveFQBN(t *testing.T) {
 }
 
 func TestBoardOptionsFunctions(t *testing.T) {
-	pmb := packagemanager.NewBuilder(customHardware, customHardware, customHardware, customHardware, "test")
+	pmb := NewBuilder(customHardware, customHardware, customHardware, customHardware, "test")
 	pmb.LoadHardwareFromDirectory(customHardware)
 	pm := pmb.Build()
 	pme, release := pm.NewExplorer()
@@ -221,13 +220,13 @@ func TestBoardOptionsFunctions(t *testing.T) {
 }
 
 func TestBoardOrdering(t *testing.T) {
-	pmb := packagemanager.NewBuilder(dataDir1, dataDir1.Join("packages"), nil, nil, "")
+	pmb := NewBuilder(dataDir1, dataDir1.Join("packages"), nil, nil, "")
 	_ = pmb.LoadHardwareFromDirectories(paths.NewPathList(dataDir1.Join("packages").String()))
 	pm := pmb.Build()
 	pme, release := pm.NewExplorer()
 	defer release()
 
-	pl := pme.FindPlatform(&packagemanager.PlatformReference{
+	pl := pme.FindPlatform(&PlatformReference{
 		Package:              "arduino",
 		PlatformArchitecture: "avr",
 	})
@@ -273,7 +272,7 @@ func TestBoardOrdering(t *testing.T) {
 func TestFindToolsRequiredForBoard(t *testing.T) {
 	os.Setenv("ARDUINO_DATA_DIR", dataDir1.String())
 	configuration.Settings = configuration.Init("")
-	pmb := packagemanager.NewBuilder(
+	pmb := NewBuilder(
 		dataDir1,
 		configuration.PackagesDir(configuration.Settings),
 		configuration.DownloadsDir(configuration.Settings),
@@ -314,7 +313,7 @@ func TestFindToolsRequiredForBoard(t *testing.T) {
 	})
 	require.NotNil(t, esptool0413)
 
-	testPlatform := pme.FindPlatformRelease(&packagemanager.PlatformReference{
+	testPlatform := pme.FindPlatformRelease(&PlatformReference{
 		Package:              "test",
 		PlatformArchitecture: "avr",
 		PlatformVersion:      semver.MustParse("1.1.0")})
@@ -407,7 +406,7 @@ func TestFindToolsRequiredForBoard(t *testing.T) {
 }
 
 func TestIdentifyBoard(t *testing.T) {
-	pmb := packagemanager.NewBuilder(customHardware, customHardware, customHardware, customHardware, "test")
+	pmb := NewBuilder(customHardware, customHardware, customHardware, customHardware, "test")
 	pmb.LoadHardwareFromDirectory(customHardware)
 	pm := pmb.Build()
 	pme, release := pm.NewExplorer()
@@ -434,12 +433,12 @@ func TestIdentifyBoard(t *testing.T) {
 
 func TestPackageManagerClear(t *testing.T) {
 	// Create a PackageManager and load the harware
-	pmb := packagemanager.NewBuilder(customHardware, customHardware, customHardware, customHardware, "test")
+	pmb := NewBuilder(customHardware, customHardware, customHardware, customHardware, "test")
 	pmb.LoadHardwareFromDirectory(customHardware)
 	pm := pmb.Build()
 
 	// Creates another PackageManager but don't load the hardware
-	emptyPmb := packagemanager.NewBuilder(customHardware, customHardware, customHardware, customHardware, "test")
+	emptyPmb := NewBuilder(customHardware, customHardware, customHardware, customHardware, "test")
 	emptyPm := emptyPmb.Build()
 
 	// Verifies they're not equal
@@ -448,7 +447,10 @@ func TestPackageManagerClear(t *testing.T) {
 	// Clear the first PackageManager that contains loaded hardware
 	emptyPmb.BuildIntoExistingPackageManager(pm)
 
-	// Verifies both PackageManagers are now equal
+	// the discovery manager is maintained
+	require.NotEqual(t, pm.discoveryManager, emptyPm.discoveryManager)
+	// Verifies all other fields are assigned to target
+	pm.discoveryManager = emptyPm.discoveryManager
 	require.Equal(t, pm, emptyPm)
 }
 
@@ -456,7 +458,7 @@ func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 	// Create all the necessary data to load discoveries
 	fakePath := paths.New("fake-path")
 
-	pmb := packagemanager.NewBuilder(fakePath, fakePath, fakePath, fakePath, "test")
+	pmb := NewBuilder(fakePath, fakePath, fakePath, fakePath, "test")
 	pack := pmb.GetOrCreatePackage("arduino")
 
 	{
@@ -559,13 +561,13 @@ func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 }
 
 func TestFindPlatformReleaseDependencies(t *testing.T) {
-	pmb := packagemanager.NewBuilder(nil, nil, nil, nil, "test")
+	pmb := NewBuilder(nil, nil, nil, nil, "test")
 	pmb.LoadPackageIndexFromFile(paths.New("testdata", "package_tooltest_index.json"))
 	pm := pmb.Build()
 	pme, release := pm.NewExplorer()
 	defer release()
 
-	pl, tools, err := pme.FindPlatformReleaseDependencies(&packagemanager.PlatformReference{Package: "test", PlatformArchitecture: "avr"})
+	pl, tools, err := pme.FindPlatformReleaseDependencies(&PlatformReference{Package: "test", PlatformArchitecture: "avr"})
 	require.NoError(t, err)
 	require.NotNil(t, pl)
 	require.Len(t, tools, 3)
@@ -574,7 +576,7 @@ func TestFindPlatformReleaseDependencies(t *testing.T) {
 
 func TestLegacyPackageConversionToPluggableDiscovery(t *testing.T) {
 	// Pass nil, since these paths are only used for installing
-	pmb := packagemanager.NewBuilder(nil, nil, nil, nil, "test")
+	pmb := NewBuilder(nil, nil, nil, nil, "test")
 	// Hardware from main packages directory
 	pmb.LoadHardwareFromDirectory(dataDir1.Join("packages"))
 	pm := pmb.Build()

--- a/arduino/cores/packagemanager/package_manager_test.go
+++ b/arduino/cores/packagemanager/package_manager_test.go
@@ -645,7 +645,7 @@ func TestLegacyPackageConversionToPluggableDiscovery(t *testing.T) {
 }
 
 func TestRunPostInstall(t *testing.T) {
-	pmb := packagemanager.NewBuilder(nil, nil, nil, nil, "test")
+	pmb := NewBuilder(nil, nil, nil, nil, "test")
 	pm := pmb.Build()
 	pme, release := pm.NewExplorer()
 	defer release()

--- a/arduino/discovery/discovery.go
+++ b/arduino/discovery/discovery.go
@@ -381,6 +381,7 @@ func (disc *PluggableDiscovery) Quit() {
 	if _, err := disc.waitMessage(time.Second * 5); err != nil {
 		logrus.Errorf("Quitting discovery %s: %s", disc.id, err)
 	}
+	disc.stopSync()
 	disc.killProcess()
 }
 

--- a/arduino/discovery/discoverymanager/discoverymanager.go
+++ b/arduino/discovery/discoverymanager/discoverymanager.go
@@ -280,7 +280,7 @@ func (dm *DiscoveryManager) List() []*discovery.Port {
 
 // AddAllDiscoveriesFrom transfers discoveries from src to the receiver
 func (dm *DiscoveryManager) AddAllDiscoveriesFrom(src *DiscoveryManager) {
-	for id, d := range src.discoveries {
+	for _, d := range src.discoveries {
 		dm.Add(d)
 	}
 }

--- a/arduino/discovery/discoverymanager/discoverymanager.go
+++ b/arduino/discovery/discoverymanager/discoverymanager.go
@@ -65,13 +65,7 @@ func (dm *DiscoveryManager) Clear() {
 			logrus.Infof("Closed and removed discovery %s", d.GetID())
 		}
 	}
-	dm.discoveriesRunning = false
 	dm.discoveries = map[string]*discovery.PluggableDiscovery{}
-}
-
-// AreDiscoveriesRunning returns a boolean representing the running status of discoveries
-func (dm *DiscoveryManager) AreDiscoveriesRunning() bool {
-	return dm.discoveriesRunning
 }
 
 // IDs returns the list of discoveries' ids in this DiscoveryManager
@@ -282,4 +276,15 @@ func (dm *DiscoveryManager) List() []*discovery.Port {
 		}
 	}
 	return res
+}
+
+// AddAllDiscoveriesFrom transfers discoveries from src to the receiver
+func (dm *DiscoveryManager) AddAllDiscoveriesFrom(src *DiscoveryManager) {
+	for id, d := range src.discoveries {
+		dm.discoveries[id] = d
+	}
+
+	if src.discoveriesRunning {
+		dm.Start()
+	}
 }

--- a/arduino/discovery/discoverymanager/discoverymanager.go
+++ b/arduino/discovery/discoverymanager/discoverymanager.go
@@ -281,10 +281,6 @@ func (dm *DiscoveryManager) List() []*discovery.Port {
 // AddAllDiscoveriesFrom transfers discoveries from src to the receiver
 func (dm *DiscoveryManager) AddAllDiscoveriesFrom(src *DiscoveryManager) {
 	for id, d := range src.discoveries {
-		dm.discoveries[id] = d
-	}
-
-	if src.discoveriesRunning {
-		dm.Start()
+		dm.Add(d)
 	}
 }

--- a/arduino/discovery/discoverymanager/discoverymanager.go
+++ b/arduino/discovery/discoverymanager/discoverymanager.go
@@ -203,7 +203,6 @@ func (dm *DiscoveryManager) startDiscovery(d *discovery.PluggableDiscovery) (dis
 	go func(d *discovery.PluggableDiscovery) {
 		// Transfer all incoming events from this discovery to the feed channel
 		for ev := range eventCh {
-			// here from discovery to discovery manager
 			dm.feed <- ev
 		}
 		logrus.Infof("Discovery event channel closed %s. Exiting goroutine.", d.GetID())

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -268,9 +268,6 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 		// after reinitializing an instance after installing or uninstalling a core.
 		// If this is not done the information of the uninstall core is kept in memory,
 		// even if it should not.
-
-		// register whether the discoveries are running, if so we need to start them in
-		// order for the previous watchers to keep receiving events
 		pmb, commitPackageManager := instance.pm.NewBuilder()
 
 		loadBuiltinTools := func() []error {

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -261,7 +261,7 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 			},
 		})
 	}
-	var shouldRestartDiscovery bool
+
 	{
 		// We need to rebuild the PackageManager currently in use by this instance
 		// in case this is not the first Init on this instances, that might happen
@@ -271,7 +271,6 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 
 		// register whether the discoveries are running, if so we need to start them in
 		// order for the previous watchers to keep receiving events
-		shouldRestartDiscovery = areDiscoveriesRunning(instance.pm)
 		pmb, commitPackageManager := instance.pm.NewBuilder()
 
 		loadBuiltinTools := func() []error {
@@ -467,28 +466,12 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 		responseError(s)
 	}
 
-	if shouldRestartDiscovery {
-		pme.DiscoveryManager().Start()
-	}
 	// Refreshes the locale used, this will change the
 	// language of the CLI if the locale is different
 	// after started.
 	i18n.Init(configuration.Settings.GetString("locale"))
 
 	return nil
-}
-
-func areDiscoveriesRunning(pm *packagemanager.PackageManager) bool {
-	if pm == nil {
-		return false
-	}
-	exp, release := pm.NewExplorer()
-	defer release()
-
-	if exp.DiscoveryManager() != nil && exp.DiscoveryManager().AreDiscoveriesRunning() {
-		return true
-	}
-	return false
 }
 
 // Destroy FIXMEDOC


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->

It introduces a teardown of the running discovery processes when installing a new core, restarting them after to keep the watchers receiving events.

## What is the current behavior?

<!-- You can also link to an open issue here -->
When a new core is installed the running discovery processes are not terminated. Alive watchers freeze and don't receive any new events.

## What is the new behavior?

<!-- if this is a feature change -->
When a new core is installed all running discovery processes are terminated, also those not interested by the update. They are restarted after the installation completed and watchers are reconnected to the new stream of events.

Connected boards face first a "remove" and then an "add" event.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
Fixes #1960
Fixes #1588