### PR TITLE
[skip-changelog] Fix upload test according to CLI output refactoring

### DIFF
--- a/internal/integrationtest/upload/upload_test.go
+++ b/internal/integrationtest/upload/upload_test.go
@@ -445,7 +445,6 @@ func TestUploadWithInputDirContainingMultipleBinaries(t *testing.T) {
 		// Verifies upload fails because multiple binaries are found
 		_, stderr, err := cli.Run("upload", "-b", board.fqbn, "-p", board.address, "--input-dir", binariesDir.String())
 		require.Error(t, err)
-		require.Contains(t, string(stderr), "Error during Upload: ")
 		require.Contains(t, string(stderr), "Error finding build artifacts: ")
 		require.Contains(t, string(stderr), "autodetect build artifact: ")
 		require.Contains(t, string(stderr), "multiple build artifacts found:")


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
`TestUploadWithInputDirContainingMultipleBinaries` fails because the error output was slightly changed in PR #2003 and no longer contains the message `Error during upload`.
<!-- You can also link to an open issue here -->

## What is the new behavior?
The test works correctly:
```
PS C:\Users\m.pologruto\Desktop\Arduino\arduino-cli> go test github.com/arduino/arduino-cli/internal/integrationtest/upload -run TestUploadWithInputDirContainingMultipleBinaries
ok      github.com/arduino/arduino-cli/internal/integrationtest/upload  41.566s
```
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information
No
<!-- Any additional information that could help the review process -->
