### PR TITLE
[skip-changelog] Do not force `update index` every time `lib search` is executed

### DIFF
--- a/internal/cli/lib/search.go
+++ b/internal/cli/lib/search.go
@@ -192,7 +192,7 @@ func versionsFromSearchedLibrary(library *rpc.SearchedLibrary) []*semver.Version
 
 // indexNeedsUpdating returns whether library_index.json need updating.
 // A positive duration string must be provided to calculate the time threshold
-// used to update the index (default: +24 hours).
+// used to update the index.
 // Valid duration units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 // Use a duration of 0 to always update the index.
 func indexNeedsUpdating(duration string) bool {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Code enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
Executing `lib search` always downloads and updates `library_index.json`.
<!-- You can also link to an open issue here -->

## What is the new behavior?
A timeout has been introduced to avoid updating the index every time `lib search` is executed.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information
This is a duplicate of #1789. Since the original author did not make any recent update, I'm simply rebasing his commits and applying the suggestions. Once this PR is merged, the original can be closed.

Close #1789 