### PR TITLE
[breaking] Add post install script support for tools

### DIFF
--- a/commands/instances.go
+++ b/commands/instances.go
@@ -138,7 +138,7 @@ func installTool(pm *packagemanager.PackageManager, tool *cores.ToolRelease, dow
 		return fmt.Errorf(tr("downloading %[1]s tool: %[2]s"), tool, err)
 	}
 	taskCB(&rpc.TaskProgress{Completed: true})
-	if err := pme.InstallTool(tool, taskCB); err != nil {
+	if err := pme.InstallTool(tool, taskCB, true); err != nil {
 		return fmt.Errorf(tr("installing %[1]s tool: %[2]s"), tool, err)
 	}
 	return nil

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -2,6 +2,31 @@
 
 Here you can find a list of migration guides to handle breaking changes between releases of the CLI.
 
+## 0.31.0
+
+### Added `post_install` script support for tools
+
+The `post_install` script now runs when a tool is correctly installed and the CLI is in "interactive" mode. This
+behavior can be [configured](https://arduino.github.io/arduino-cli/0.30/commands/arduino-cli_core_install/#options).
+
+### golang API: methods in `github.com/arduino/arduino-cli/arduino/cores/packagemanager` changed signature
+
+The following methods in `github.com/arduino/arduino-cli/arduino/cores/packagemanager`:
+
+```go
+func (pme *Explorer) InstallTool(toolRelease *cores.ToolRelease, taskCB rpc.TaskProgressCB) error { ... }
+func (pme *Explorer) RunPostInstallScript(platformRelease *cores.PlatformRelease) error { ... }
+```
+
+have changed. `InstallTool` requires the new `skipPostInstall` parameter, which must be set to `true` to skip the post
+install script. `RunPostInstallScript` does not require a `*cores.PlatformRelease` parameter but requires a
+`*paths.Path` parameter:
+
+```go
+func (pme *Explorer) InstallTool(toolRelease *cores.ToolRelease, taskCB rpc.TaskProgressCB, skipPostInstall bool) error {...}
+func (pme *Explorer) RunPostInstallScript(installDir *paths.Path) error { ... }
+```
+
 ## 0.30.0
 
 ### Sketch name validation

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -992,3 +992,18 @@ func TestCoreInstallCreatesInstalledJson(t *testing.T) {
 	sortedExpected := requirejson.Parse(t, expectedInstalledJson).Query("walk(if type == \"array\" then sort else . end)").String()
 	require.JSONEq(t, sortedExpected, sortedInstalled)
 }
+
+func TestCoreInstallRunsToolPostInstallScript(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	url := "http://drazzy.com/package_drazzy.com_index.json"
+
+	_, _, err := cli.Run("core", "update-index", "--additional-urls", url)
+	require.NoError(t, err)
+
+	// Checks that the post_install script is correctly skipped on the CI
+	stdout, _, err := cli.Run("core", "install", "ATTinyCore:avr", "--verbose", "--additional-urls", url)
+	require.NoError(t, err)
+	require.Contains(t, string(stdout), "Skipping tool configuration.")
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Code enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
`post_install` scripts are not handled after the tool installation.
<!-- You can also link to an open issue here -->

## What is the new behavior?
`post_install` scripts for tools are handled the same way the ones related to platforms are.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
