### PR TITLE
Added `--install-in-builtin-dir` flag to `lib install` command

### DIFF
--- a/commands/lib/install.go
+++ b/commands/lib/install.go
@@ -103,6 +103,9 @@ func LibraryInstall(ctx context.Context, req *rpc.LibraryInstallRequest, downloa
 			if installTask.ReplacedLib != nil {
 				downloadReason = "upgrade"
 			}
+			if installLocation == libraries.IDEBuiltIn {
+				downloadReason += "-builtin"
+			}
 		}
 		if err := downloadLibrary(lm, libRelease, downloadCB, taskCB, downloadReason); err != nil {
 			return err

--- a/internal/cli/lib/install.go
+++ b/internal/cli/lib/install.go
@@ -39,6 +39,7 @@ func initInstallCommand() *cobra.Command {
 	var noOverwrite bool
 	var gitURL bool
 	var zipPath bool
+	var useBuiltinLibrariesDir bool
 	installCommand := &cobra.Command{
 		Use:   fmt.Sprintf("install %s[@%s]...", tr("LIBRARY"), tr("VERSION_NUMBER")),
 		Short: tr("Installs one or more specified libraries into the system."),
@@ -51,7 +52,7 @@ func initInstallCommand() *cobra.Command {
 			"  " + os.Args[0] + " lib install --zip-path /path/to/WiFi101.zip /path/to/ArduinoBLE.zip\n",
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			runInstallCommand(args, noDeps, noOverwrite, gitURL, zipPath)
+			runInstallCommand(args, noDeps, noOverwrite, gitURL, zipPath, useBuiltinLibrariesDir)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return arguments.GetInstallableLibs(), cobra.ShellCompDirectiveDefault
@@ -61,10 +62,11 @@ func initInstallCommand() *cobra.Command {
 	installCommand.Flags().BoolVar(&noOverwrite, "no-overwrite", false, tr("Do not overwrite already installed libraries."))
 	installCommand.Flags().BoolVar(&gitURL, "git-url", false, tr("Enter git url for libraries hosted on repositories"))
 	installCommand.Flags().BoolVar(&zipPath, "zip-path", false, tr("Enter a path to zip file"))
+	installCommand.Flags().BoolVar(&useBuiltinLibrariesDir, "install-in-builtin-dir", false, tr("Install libraries in the IDE-Builtin directory"))
 	return installCommand
 }
 
-func runInstallCommand(args []string, noDeps bool, noOverwrite bool, gitURL bool, zipPath bool) {
+func runInstallCommand(args []string, noDeps bool, noOverwrite bool, gitURL bool, zipPath bool, useBuiltinLibrariesDir bool) {
 	instance := instance.CreateAndInit()
 	logrus.Info("Executing `arduino-cli lib install`")
 
@@ -79,6 +81,10 @@ func runInstallCommand(args []string, noDeps bool, noOverwrite bool, gitURL bool
 			feedback.Fatal(tr("--git-url and --zip-path are disabled by default, for more information see: %v", documentationURL), feedback.ErrGeneric)
 		}
 		feedback.Print(tr("--git-url and --zip-path flags allow installing untrusted files, use it at your own risk."))
+
+		if useBuiltinLibrariesDir {
+			feedback.Fatal(tr("--git-url or --zip-path can't be used with --install-in-builtin-dir"), feedback.ErrGeneric)
+		}
 	}
 
 	if zipPath {
@@ -122,12 +128,17 @@ func runInstallCommand(args []string, noDeps bool, noOverwrite bool, gitURL bool
 	}
 
 	for _, libRef := range libRefs {
+		installLocation := rpc.LibraryInstallLocation_LIBRARY_INSTALL_LOCATION_USER
+		if useBuiltinLibrariesDir {
+			installLocation = rpc.LibraryInstallLocation_LIBRARY_INSTALL_LOCATION_BUILTIN
+		}
 		libraryInstallRequest := &rpc.LibraryInstallRequest{
-			Instance:    instance,
-			Name:        libRef.Name,
-			Version:     libRef.Version,
-			NoDeps:      noDeps,
-			NoOverwrite: noOverwrite,
+			Instance:        instance,
+			Name:            libRef.Name,
+			Version:         libRef.Version,
+			NoDeps:          noDeps,
+			NoOverwrite:     noOverwrite,
+			InstallLocation: installLocation,
 		}
 		err := lib.LibraryInstall(context.Background(), libraryInstallRequest, feedback.ProgressBar(), feedback.TaskProgress())
 		if err != nil {

--- a/internal/cli/lib/install.go
+++ b/internal/cli/lib/install.go
@@ -34,14 +34,11 @@ import (
 	semver "go.bug.st/relaxed-semver"
 )
 
-var (
-	noDeps      bool
-	noOverwrite bool
-	gitURL      bool
-	zipPath     bool
-)
-
 func initInstallCommand() *cobra.Command {
+	var noDeps bool
+	var noOverwrite bool
+	var gitURL bool
+	var zipPath bool
 	installCommand := &cobra.Command{
 		Use:   fmt.Sprintf("install %s[@%s]...", tr("LIBRARY"), tr("VERSION_NUMBER")),
 		Short: tr("Installs one or more specified libraries into the system."),
@@ -53,7 +50,9 @@ func initInstallCommand() *cobra.Command {
 			"  " + os.Args[0] + " lib install --git-url https://github.com/arduino-libraries/WiFi101.git#0.16.0 # " + tr("for the specific version.") + "\n" +
 			"  " + os.Args[0] + " lib install --zip-path /path/to/WiFi101.zip /path/to/ArduinoBLE.zip\n",
 		Args: cobra.MinimumNArgs(1),
-		Run:  runInstallCommand,
+		Run: func(cmd *cobra.Command, args []string) {
+			runInstallCommand(args, noDeps, noOverwrite, gitURL, zipPath)
+		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return arguments.GetInstallableLibs(), cobra.ShellCompDirectiveDefault
 		},
@@ -65,7 +64,7 @@ func initInstallCommand() *cobra.Command {
 	return installCommand
 }
 
-func runInstallCommand(cmd *cobra.Command, args []string) {
+func runInstallCommand(args []string, noDeps bool, noOverwrite bool, gitURL bool, zipPath bool) {
 	instance := instance.CreateAndInit()
 	logrus.Info("Executing `arduino-cli lib install`")
 

--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -1518,4 +1518,18 @@ func TestLibQueryParameters(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(stdout),
 		"Starting download                             \x1b[36murl\x1b[0m=\"https://downloads.arduino.cc/libraries/github.com/arduino-libraries/WiFi101-0.16.1.zip?query=download\"\n")
+
+	// Check query=install-builtin when a library dependency is installed in builtin-directory
+	cliEnv := cli.GetDefaultEnv()
+	cliEnv["ARDUINO_DIRECTORIES_BUILTIN_LIBRARIES"] = cli.DataDir().Join("libraries").String()
+	stdout, _, err = cli.RunWithCustomEnv(cliEnv, "lib", "install", "Firmata@2.5.3", "--install-in-builtin-dir", "-v", "--log-level", "debug")
+	require.NoError(t, err)
+	require.Contains(t, string(stdout),
+		"Starting download                             \x1b[36murl\x1b[0m=\"https://downloads.arduino.cc/libraries/github.com/firmata/Firmata-2.5.3.zip?query=install-builtin\"\n")
+
+	// Check query=update-builtin when a library dependency is updated in builtin-directory
+	stdout, _, err = cli.RunWithCustomEnv(cliEnv, "lib", "install", "Firmata@2.5.9", "--install-in-builtin-dir", "-v", "--log-level", "debug")
+	require.NoError(t, err)
+	require.Contains(t, string(stdout),
+		"Starting download                             \x1b[36murl\x1b[0m=\"https://downloads.arduino.cc/libraries/github.com/firmata/Firmata-2.5.9.zip?query=upgrade-builtin\"\n")
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Adds `--install-in-builtin-dir` flag to `lib install` command.

## What is the current behavior?

## What is the new behavior?

When the `--install-in-builtin-dir` flag is set, the libraries are installed in the directory specified by the `directories.builtin.libraries` configuration setting:

```yaml
directories:
  builtin.libraries: /home/user/.....
```

The libraries installed inside the builtin directory are not automatically upgraded via `lib upgrade`. They can be upgraded anyway, by forcing an install of an already installed library.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

<!-- Any additional information that could help the review process -->
