### PR TITLE
Fixed compiler output capture in JSON mode

### DIFF
--- a/internal/integrationtest/compile_3/testdata/blink_with_wrong_cpp/blink_with_wrong_cpp.ino
+++ b/internal/integrationtest/compile_3/testdata/blink_with_wrong_cpp/blink_with_wrong_cpp.ino
@@ -1,0 +1,2 @@
+void setup() {}
+void loop() {}

--- a/internal/integrationtest/compile_3/testdata/blink_with_wrong_cpp/wrong.cpp
+++ b/internal/integrationtest/compile_3/testdata/blink_with_wrong_cpp/wrong.cpp
@@ -1,0 +1,1 @@
+void wrong() {

--- a/legacy/builder/builder.go
+++ b/legacy/builder/builder.go
@@ -152,7 +152,7 @@ func (s *Preprocess) Run(ctx *types.Context) error {
 	}
 
 	// Output arduino-preprocessed source
-	ctx.Stdout.Write([]byte(ctx.Source))
+	ctx.WriteStdout([]byte(ctx.Source))
 	return nil
 }
 

--- a/legacy/builder/builder_utils/utils.go
+++ b/legacy/builder/builder_utils/utils.go
@@ -190,7 +190,15 @@ func compileFileWithRecipe(ctx *types.Context, sourcePath *paths.Path, source *p
 		ctx.CompilationDatabase.Add(source, command)
 	}
 	if !objIsUpToDate && !ctx.OnlyUpdateCompilationDatabase {
-		_, _, err = utils.ExecCommand(ctx, command, utils.ShowIfVerbose /* stdout */, utils.Show /* stderr */)
+		// Since this compile could be multithreaded, we first capture the command output
+		stdout, stderr, err := utils.ExecCommand(ctx, command, utils.Capture, utils.Capture)
+		// and transfer all at once at the end...
+		if ctx.Verbose {
+			ctx.WriteStdout(stdout)
+		}
+		ctx.WriteStderr(stderr)
+
+		// ...and then return the error
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/legacy/builder/container_find_includes.go
+++ b/legacy/builder/container_find_includes.go
@@ -408,7 +408,7 @@ func findIncludesUntilDone(ctx *types.Context, cache *includeCache, sourceFile t
 					return errors.New(tr("Internal error in cache"))
 				}
 			}
-			ctx.Stderr.Write(preproc_stderr)
+			ctx.WriteStderr(preproc_stderr)
 			return errors.WithStack(preproc_err)
 		}
 

--- a/legacy/builder/preprocess_sketch.go
+++ b/legacy/builder/preprocess_sketch.go
@@ -146,6 +146,6 @@ func (s *OutputCodeCompletions) Run(ctx *types.Context) error {
 		// we assume it is a json, let's make it compliant at least
 		ctx.CodeCompletions = "[]"
 	}
-	fmt.Fprintln(ctx.Stdout, ctx.CodeCompletions)
+	ctx.WriteStdout([]byte(ctx.CodeCompletions))
 	return nil
 }

--- a/legacy/builder/types/context.go
+++ b/legacy/builder/types/context.go
@@ -249,3 +249,21 @@ func (ctx *Context) Warn(msg string) {
 	}
 	ctx.stdLock.Unlock()
 }
+
+func (ctx *Context) WriteStdout(data []byte) (int, error) {
+	ctx.stdLock.Lock()
+	defer ctx.stdLock.Unlock()
+	if ctx.Stdout == nil {
+		return os.Stdout.Write(data)
+	}
+	return ctx.Stdout.Write(data)
+}
+
+func (ctx *Context) WriteStderr(data []byte) (int, error) {
+	ctx.stdLock.Lock()
+	defer ctx.stdLock.Unlock()
+	if ctx.Stderr == nil {
+		return os.Stderr.Write(data)
+	}
+	return ctx.Stderr.Write(data)
+}

--- a/legacy/builder/utils/utils.go
+++ b/legacy/builder/utils/utils.go
@@ -184,13 +184,6 @@ const (
 )
 
 func ExecCommand(ctx *types.Context, command *exec.Cmd, stdout int, stderr int) ([]byte, []byte, error) {
-	if ctx.Stdout == nil {
-		ctx.Stdout = os.Stdout
-	}
-	if ctx.Stderr == nil {
-		ctx.Stderr = os.Stderr
-	}
-
 	if ctx.Verbose {
 		ctx.Info(PrintableCommand(command.Args))
 	}
@@ -198,15 +191,23 @@ func ExecCommand(ctx *types.Context, command *exec.Cmd, stdout int, stderr int) 
 	if stdout == Capture {
 		buffer := &bytes.Buffer{}
 		command.Stdout = buffer
-	} else if stdout == Show || stdout == ShowIfVerbose && ctx.Verbose {
-		command.Stdout = ctx.Stdout
+	} else if stdout == Show || (stdout == ShowIfVerbose && ctx.Verbose) {
+		if ctx.Stdout != nil {
+			command.Stdout = ctx.Stdout
+		} else {
+			command.Stdout = os.Stdout
+		}
 	}
 
 	if stderr == Capture {
 		buffer := &bytes.Buffer{}
 		command.Stderr = buffer
-	} else if stderr == Show || stderr == ShowIfVerbose && ctx.Verbose {
-		command.Stderr = ctx.Stderr
+	} else if stderr == Show || (stderr == ShowIfVerbose && ctx.Verbose) {
+		if ctx.Stderr != nil {
+			command.Stderr = ctx.Stderr
+		} else {
+			command.Stderr = os.Stderr
+		}
 	}
 
 	err := command.Start()


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

In some cases, while running a compile with JSON output format, the stderr of the compiler is lost.
See #1698 for details

## What is the current behavior?

```
$ cat Blink.ino 

void setup() {
}

void loop() {
}
$ cat test.cpp 

void aaa() {

$ arduino-cli compile -b arduino:avr:uno --format json | jq .compiler_err
"\n"
```

## What is the new behavior?

With the same setup:
```
$ arduino-cli compile -b arduino:avr:uno --format json | jq .compiler_err
"/home/cmaglie/Arduino/Blink/test.cpp: In function 'void aaa()':\n/home/megabug/Arduino/Blink/test.cpp:2:12: error: expected '}' at end of input\n void aaa() {\n            ^\n\n"
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information
