### PR TITLE
[skip changelog] Remove comment that breaks gRPC documentation structure

### DIFF
--- a/rpc/cc/arduino/cli/commands/v1/commands.proto
+++ b/rpc/cc/arduino/cli/commands/v1/commands.proto
@@ -31,9 +31,6 @@ import "cc/arduino/cli/commands/v1/lib.proto";
 
 // The main Arduino Platform service API
 service ArduinoCoreService {
-  // BOOTSTRAP COMMANDS
-  //-------------------
-
   // Create a new Arduino Core instance
   rpc Create(CreateRequest) returns (CreateResponse) {}
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?

Documentation fix

## What is the current behavior?

The ["gPRC Reference" section](https://arduino.github.io/arduino-cli/dev/rpc/commands/) of the documentation website is automatically generated from the code and comments in the project's Protocol Buffers files. The documentation is automatically structured according to the structure of the Protocol Buffers code using heading levels, and the documentation website uses these heading levels to generate a table of contents to allow easy navigation of the documentation and an overview of its structure.

The generation happens in two steps:

[Protocol Buffers](https://github.com/arduino/arduino-cli/tree/master/rpc/cc/arduino/cli) [->](https://github.com/pseudomuto/protoc-gen-doc) Markdown [->](https://www.mkdocs.org/) [HTML](https://github.com/arduino/arduino-cli/tree/gh-pages)

A comment in a Protocol Buffers file included a decorative underline formed from a series of `-` characters. This happens to be [markup for an H2 heading](https://www.markdownguide.org/basic-syntax/#alternate-syntax) in the Markup language. This caused an inadvertent creation of an inappropriate H2 heading named "BOOTSTRAP COMMANDS", which resulted in the documentation having the following incorrect structure:

- Protocol Documentation
  - [...]
  - `cc/arduino/cli/commands/v1/board.proto`
    - [...]
  - `cc/arduino/cli/commands/v1/commands.proto`
    - [...]
    - `ArduinoCoreService`
  - BOOTSTRAP COMMANDS
    - \<List of `cc.arduino.cli.commands.v1.ArduinoCoreService` methods\>
  - `cc/arduino/cli/commands/v1/common.proto`
    - [...]
  - [...]

![image](https://user-images.githubusercontent.com/8572152/219987091-936b4231-65b7-4cf2-906c-30cbadcf629f.png)

## What is the new behavior?

The problematic decorative comment is removed to produce the correct documentation structure:

- Protocol Documentation
  - [...]
  - `cc/arduino/cli/commands/v1/board.proto`
    - [...]
  - `cc/arduino/cli/commands/v1/commands.proto`
    - [...]
    - `ArduinoCoreService`
      - \<List of `cc.arduino.cli.commands.v1.ArduinoCoreService` methods\>
  - `cc/arduino/cli/commands/v1/common.proto`
    - [...]
  - [...]

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.

## Other information

I also removed the "BOOTSTRAP COMMANDS" comment because I don't see any value in it and it introduced unpleasant caps lock prose content into the documentation.
