### PR TITLE
[skip-changelog] Exclude libraries with a missing `.h` file from `lib list`

### DIFF
--- a/arduino/libraries/libraries_test.go
+++ b/arduino/libraries/libraries_test.go
@@ -73,4 +73,15 @@ func TestLibrariesLoader(t *testing.T) {
 		require.Equal(t, "LibWithNonUTF8Properties", lib.Name)
 		require.Equal(t, "àrduìnò", lib.Author)
 	}
+	{
+		lib, err := Load(paths.New("testdata", "EmptyLib"), User)
+		require.Error(t, err)
+		require.Nil(t, lib)
+	}
+	{
+		lib, err := Load(paths.New("testdata", "LegacyLib"), User)
+		require.NoError(t, err)
+		require.Equal(t, "LegacyLib", lib.Name)
+		require.True(t, lib.IsLegacy)
+	}
 }

--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -419,6 +419,6 @@ allowing the compilation to fail in a difficult to understand way):
 ## Old library format (pre-1.5)
 
 In order to support old libraries (from Arduino IDE 1.0.x), Arduino IDE and Arduino CLI will also compile libraries
-missing a library.properties metadata file. As a result, these libraries should behave as they did in Arduino IDE 1.0.x,
-although they will be available for all boards, including non-AVR ones (which wouldn’t have been present in Arduino IDE
-1.0.x).
+missing a library.properties metadata file (the header file is still required). As a result, these libraries should
+behave as they did in Arduino IDE 1.0.x, although they will be available for all boards, including non-AVR ones (which
+wouldn’t have been present in Arduino IDE 1.0.x).


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)

## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
Empty folders under `<directories.user>/libraries` show up as `is_legacy: true` libraries.
<!-- You can also link to an open issue here -->

## What is the new behavior?
Folders that do not contain a `library.properties` or a `.h` file are ignored when `lib list` is executed.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
