### PR TITLE
[skip-changelog] Add hooks `hooks.savehex.presavehex` and `hooks.savehex.postsavehex`

### DIFF
--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -260,6 +260,11 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 		exportBinaries = false
 	}
 	if exportBinaries {
+		presaveHex := builder.RecipeByPrefixSuffixRunner{Prefix: "recipe.hooks.savehex.presavehex", Suffix: ".pattern"}
+		if err := presaveHex.Run(builderCtx); err != nil {
+			return r, err
+		}
+
 		var exportPath *paths.Path
 		if exportDir := req.GetExportDir(); exportDir != "" {
 			exportPath = paths.New(exportDir)
@@ -292,6 +297,11 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 			if err = buildFile.CopyTo(exportedFile); err != nil {
 				return r, &arduino.PermissionDeniedError{Message: tr("Error copying output file %s", buildFile), Cause: err}
 			}
+		}
+
+		postsaveHex := builder.RecipeByPrefixSuffixRunner{Prefix: "recipe.hooks.savehex.postsavehex", Suffix: ".pattern"}
+		if err := postsaveHex.Run(builderCtx); err != nil {
+			return r, err
 		}
 	}
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Code enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
There is currently no support for `hooks.savehex.presavehex` and `hooks.savehex.postsavehex`.
<!-- You can also link to an open issue here -->

## What is the new behavior?
`hooks.savehex.presavehex` and `hooks.savehex.postsavehex` run if `exportBinaries` if set to `true`.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
