### PR TITLE
[skip-changelog] Add remediation path when tool is not available for an OS

### DIFF
--- a/arduino/cores/packagemanager/download.go
+++ b/arduino/cores/packagemanager/download.go
@@ -125,7 +125,7 @@ func (pme *Explorer) DownloadToolRelease(tool *cores.ToolRelease, config *downlo
 	if resource == nil {
 		return &arduino.FailedDownloadError{
 			Message: tr("Error downloading tool %s", tool),
-			Cause:   errors.New(tr("no versions available for the current OS"))}
+			Cause:   errors.New(tr("no versions available for the current OS, try contacting %s", tool.Tool.Package.Email))}
 	}
 	return resource.Download(pme.DownloadDir, config, tool.String(), progressCB, "")
 }

--- a/arduino/cores/packagemanager/install_uninstall.go
+++ b/arduino/cores/packagemanager/install_uninstall.go
@@ -313,7 +313,8 @@ func (pme *Explorer) InstallTool(toolRelease *cores.ToolRelease, taskCB rpc.Task
 
 	toolResource := toolRelease.GetCompatibleFlavour()
 	if toolResource == nil {
-		return fmt.Errorf(tr("no compatible version of %s tools found for the current os"), toolRelease.Tool.Name)
+		return fmt.Errorf(tr("no compatible version of %s tools found for the current os, try contacting %s"),
+			toolRelease.Tool.Name, toolRelease.Tool.Package.Email)
 	}
 	destDir := pme.PackagesDir.Join(
 		toolRelease.Tool.Package.Name,

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -80,7 +80,7 @@ func TestCoreSearch(t *testing.T) {
 	// show all versions
 	out, _, err = cli.Run("core", "search", "test_core", "--all", "--format", "json", "--additional-urls="+url.String())
 	require.NoError(t, err)
-	requirejson.Len(t, out, 2)
+	requirejson.Len(t, out, 3)
 
 	checkPlatformIsInJSONOutput := func(stdout []byte, id, version string) {
 		jqquery := fmt.Sprintf(`[{id:"%s", latest:"%s"}]`, id, version)
@@ -150,7 +150,7 @@ func TestCoreSearchNoArgs(t *testing.T) {
 	// update custom index and install test core (installed cores affect `core search`)
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
 	require.NoError(t, err)
-	_, _, err = cli.Run("core", "install", "test:x86", "--additional-urls="+url.String())
+	_, _, err = cli.Run("core", "install", "test:x86@2.0.0", "--additional-urls="+url.String())
 	require.NoError(t, err)
 
 	// list all with no additional urls, ensure the test core won't show up
@@ -161,7 +161,7 @@ func TestCoreSearchNoArgs(t *testing.T) {
 		lines = append(lines, strings.Fields(strings.TrimSpace(v)))
 	}
 	// The header is printed on the first lines
-	require.Equal(t, []string{"test:x86", "2.0.0", "test_core"}, lines[20])
+	require.Equal(t, []string{"test:x86", "2.0.0", "test_core"}, lines[21])
 	numPlatforms := len(lines) - 1
 
 	// same thing in JSON format, also check the number of platforms found is the same
@@ -178,7 +178,7 @@ func TestCoreSearchNoArgs(t *testing.T) {
 		lines = append(lines, strings.Fields(strings.TrimSpace(v)))
 	}
 	// The header is printed on the first lines
-	require.Equal(t, []string{"test:x86", "2.0.0", "test_core"}, lines[21])
+	require.Equal(t, []string{"test:x86", "3.0.0", "test_core"}, lines[22])
 	numPlatforms = len(lines) - 1
 
 	// same thing in JSON format, also check the number of platforms found is the same
@@ -725,7 +725,7 @@ func TestCoreListSortedResults(t *testing.T) {
 	require.NoError(t, err)
 
 	// install some core for testing
-	_, _, err = cli.Run("core", "install", "test:x86", "Retrokits-RK002:arm", "Package:x86", "--additional-urls="+url.String())
+	_, _, err = cli.Run("core", "install", "test:x86@2.0.0", "Retrokits-RK002:arm", "Package:x86", "--additional-urls="+url.String())
 	require.NoError(t, err)
 
 	// list all with additional url specified
@@ -1005,4 +1005,22 @@ func TestCoreInstallRunsToolPostInstallScript(t *testing.T) {
 	stdout, _, err := cli.Run("core", "install", "ATTinyCore:avr", "--verbose", "--additional-urls", url)
 	require.NoError(t, err)
 	require.Contains(t, string(stdout), "Skipping tool configuration.")
+}
+
+func TestCoreBrokenDependency(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	// Set up an http server to serve our custom index file
+	test_index := paths.New("..", "testdata", "test_index.json")
+	url := env.HTTPServeFile(8000, test_index)
+
+	// Run update-index with our test index
+	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
+	require.NoError(t, err)
+
+	// Check that the download fails and the correct message is displayed
+	_, stderr, err := cli.Run("core", "install", "test:x86@3.0.0", "--additional-urls="+url.String())
+	require.Error(t, err)
+	require.Contains(t, string(stderr), "try contacting test@example.com")
 }

--- a/internal/integrationtest/testdata/test_index.json
+++ b/internal/integrationtest/testdata/test_index.json
@@ -44,9 +44,40 @@
               "name": "Test Board"
             }
           ]
+        },
+        {
+          "category": "Test Category",
+          "help": {
+            "online": "https://github.com/Arduino/arduino-cli"
+          },
+          "url": "https://raw.githubusercontent.com/arduino/arduino-cli/master/internal/integrationtest/testdata/core.zip",
+          "checksum": "SHA-256:6a338cf4d6d501176a2d352c87a8d72ac7488b8c5b82cdf2a4e2cef630391092",
+          "name": "test_core",
+          "version": "3.0.0",
+          "architecture": "x86",
+          "archiveFileName": "core.zip",
+          "size": "486",
+          "toolsDependencies": [
+            {
+              "packager": "test",
+              "version": "1.0.6",
+              "name": "rp2040tools"
+            }
+          ],
+          "boards": [
+            {
+              "name": "Test Board"
+            }
+          ]
         }
       ],
-      "tools": [],
+      "tools": [
+        {
+          "name": "rp2040tools",
+          "version": "1.0.6",
+          "systems": []
+        }
+      ],
       "email": "test@example.com",
       "name": "test"
     },


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Code enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
No instructions are provided when a tool download/install fails because it is not available for the OS in use.
<!-- You can also link to an open issue here -->

## What is the new behavior?
The error message has been enhanced by adding the `email` field of the package that provides the tool.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
