### PR TITLE
Added machine-readable `IP:PORT` in text-mode daemon

### DIFF
--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -16,6 +16,7 @@
 package daemon
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -173,5 +174,6 @@ func (r daemonResult) Data() interface{} {
 }
 
 func (r daemonResult) String() string {
-	return tr("Daemon is now listening on %s:%s", r.IP, r.Port)
+	j, _ := json.Marshal(r)
+	return fmt.Sprintln(tr("Daemon is now listening on %s:%s", r.IP, r.Port)) + fmt.Sprintln(string(j))
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

When running the daemon in text mode a line with a parable JSON is printed together with the text. This will allow the Arduino IDE to pick this up when running in text-mode with `-v` logging and `--debug` enabled.

## What is the current behavior?

```
$ arduino-cli daemon -v --debug
INFO[0000] Using config file: /home/megabug/.arduino15/arduino-cli.yaml 
INFO[0000] arduino-cli version 0.0.0-git                
INFO[0000] Executing `arduino-cli daemon`               
Deamon è ora in ascolto su 127.0.0.1:50051
```

## What is the new behavior?

A line with a machine-readable JSON is added to the output:

```
$ arduino-cli daemon -v --debug
INFO[0000] Using config file: /home/megabug/.arduino15/arduino-cli.yaml 
INFO[0000] arduino-cli version 0.0.0-git                
INFO[0000] Executing `arduino-cli daemon`               
Deamon è ora in ascolto su 127.0.0.1:50051
{"IP":"127.0.0.1","Port":"50051"}
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information
