### PR TITLE
Allow leading underscore in sketch filenames

### DIFF
--- a/commands/sketch/new.go
+++ b/commands/sketch/new.go
@@ -37,7 +37,7 @@ void loop() {
 
 // sketchNameMaxLength could be part of the regex, but it's intentionally left out for clearer error reporting
 var sketchNameMaxLength = 63
-var sketchNameValidationRegex = regexp.MustCompile(`^[0-9a-zA-Z][0-9a-zA-Z_\.-]*$`)
+var sketchNameValidationRegex = regexp.MustCompile(`^[0-9a-zA-Z_][0-9a-zA-Z_\.-]*$`)
 
 // NewSketch creates a new sketch via gRPC
 func NewSketch(ctx context.Context, req *rpc.NewSketchRequest) (*rpc.NewSketchResponse, error) {
@@ -80,7 +80,7 @@ func validateSketchName(name string) error {
 			sketchNameMaxLength))}
 	}
 	if !sketchNameValidationRegex.MatchString(name) {
-		return &arduino.CantCreateSketchError{Cause: errors.New(tr(`invalid sketch name "%[1]s": the first character must be alphanumeric, the following ones can also contain "_", "-", and ".".`,
+		return &arduino.CantCreateSketchError{Cause: errors.New(tr(`invalid sketch name "%[1]s": the first character must be alphanumeric or "_", the following ones can also contain "-" and ".".`,
 			name))}
 	}
 	return nil

--- a/commands/sketch/new_test.go
+++ b/commands/sketch/new_test.go
@@ -13,7 +13,6 @@ func Test_SketchNameWrongPattern(t *testing.T) {
 	invalidNames := []string{
 		"&",
 		".hello",
-		"_hello",
 		"-hello",
 		"hello*",
 		"||||||||||||||",
@@ -25,7 +24,7 @@ func Test_SketchNameWrongPattern(t *testing.T) {
 			SketchDir:  t.TempDir(),
 		})
 
-		require.EqualError(t, err, fmt.Sprintf(`Can't create sketch: invalid sketch name "%s": the first character must be alphanumeric, the following ones can also contain "_", "-", and ".".`,
+		require.EqualError(t, err, fmt.Sprintf(`Can't create sketch: invalid sketch name "%s": the first character must be alphanumeric or "_", the following ones can also contain "-" and ".".`,
 			name))
 	}
 }
@@ -66,6 +65,7 @@ func Test_SketchNameOk(t *testing.T) {
 		"h..ello-world",
 		"h..ello-world.",
 		"hello_world__",
+		"_hello_world",
 		string(lengthLimitName),
 	}
 	for _, name := range validNames {

--- a/docs/sketch-specification.md
+++ b/docs/sketch-specification.md
@@ -5,10 +5,13 @@ The programs that run on Arduino boards are called "sketches". This term was inh
 
 ## Sketch folders and files
 
-The sketch root folder name and code file names must start with a basic letter (`A`-`Z` or `a`-`z`) or number (`0`-`9`),
-followed by basic letters, numbers, underscores (`_`), dots (`.`) and dashes (`-`). The maximum length is 63 characters.
+The sketch root folder name and code file names must start with a basic letter (`A`-`Z` or `a`-`z`), number (`0`-`9`)
+[<sup>1</sup>](#leading-number-note), or underscore (`_`) [<sup>2</sup>](#leading-underscore-note) followed by basic
+letters, numbers, underscores, dots (`.`) and dashes (`-`). The maximum length is 63 characters.
 
-Support for names starting with a number was added in Arduino IDE 1.8.4.
+<a id="leading-number-note"></a> <sup>1</sup> Supported from Arduino IDE 1.8.4. <br />
+<a id="leading-underscore-note"></a> <sup>2</sup> Supported in all versions except Arduino IDE 2.0.4/Arduino CLI
+0.30.0 - 0.30.1.
 
 ### Sketch root folder
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Enhancement

## What is the current behavior?

The Arduino Sketch Specification defines the allowed format of sketch folder names and sketch code filenames.

The origin of the specification is the text of the error message shown in Arduino IDE when the user attempts to save to a name that contains disallowed characters:

https://github.com/arduino/Arduino/blob/89539b1131f8cde9f7a83225f21c811071af53a8/app/src/processing/app/SketchController.java#L847-L853

However, the implementation of the restriction in the IDE codebase has a bug that allows a leading underscore (because the code uses _ as the replacement character).

After the restriction was implemented correctly in Arduino IDE 2.x, it was discovered that the loss of compatibility with these non-compliant names was impactful:

https://forum.arduino.cc/t/invalid-sketch-filename-dialog-when-opening-sketch-in-2-0-4/1096040

One of the primary purposes for the specification and restrictions is to ensure sketches can be used in any tool. Since the tools support this name format and there is no technical reason to disallow it, the best thing to do is change the sketch specification to follow the historic tool behavior (even if that behavior was unintended).

## What is the new behavior?

Leading underscores in sketch folder names and sketch code filenames are permitted by the Arduino Sketch Specification and `arduino-cli sketch new`.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change (validation is made more permissive).
