### PR TITLE
[skip-changelog] Recover from interrupted builtin tool installation

### DIFF
--- a/arduino/cores/packagemanager/loader_test.go
+++ b/arduino/cores/packagemanager/loader_test.go
@@ -170,6 +170,8 @@ arduino_zero_edbg.serial.disableRTS=true
 func TestLoadDiscoveries(t *testing.T) {
 	// Create all the necessary data to load discoveries
 	fakePath := paths.New("fake-path")
+	require.NoError(t, fakePath.Join("LICENSE").MkdirAll())
+	defer fakePath.RemoveAll()
 
 	createTestPackageManager := func() *PackageManager {
 		pmb := NewBuilder(fakePath, fakePath, fakePath, fakePath, "test")
@@ -277,6 +279,8 @@ func TestLoadDiscoveries(t *testing.T) {
 		require.Contains(t, discoveries, "teensy")
 		pmeRelease()
 	}
+
+	require.NoError(t, fakePath.RemoveAll())
 }
 
 func TestConvertUploadToolsToPluggableDiscovery(t *testing.T) {

--- a/arduino/cores/packagemanager/package_manager_test.go
+++ b/arduino/cores/packagemanager/package_manager_test.go
@@ -457,6 +457,8 @@ func TestPackageManagerClear(t *testing.T) {
 func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 	// Create all the necessary data to load discoveries
 	fakePath := paths.New("fake-path")
+	require.NoError(t, fakePath.Join("LICENSE").MkdirAll())
+	defer fakePath.RemoveAll()
 
 	pmb := NewBuilder(fakePath, fakePath, fakePath, fakePath, "test")
 	pack := pmb.GetOrCreatePackage("arduino")

--- a/arduino/cores/tools.go
+++ b/arduino/cores/tools.go
@@ -106,7 +106,11 @@ func (tool *Tool) String() string {
 
 // IsInstalled returns true if the ToolRelease is installed
 func (tr *ToolRelease) IsInstalled() bool {
-	return tr.InstallDir != nil
+	if tr.InstallDir == nil {
+		return false
+	}
+	dirContent, _ := tr.InstallDir.ReadDir()
+	return dirContent.Len() != 0
 }
 
 func (tr *ToolRelease) String() string {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
The recovery from an interrupted builtin tool installation must be manually performed by deleting the empty tool directory.
<!-- You can also link to an open issue here -->

## What is the new behavior?
If the `installDir` of a tool is an empty directory, the tool is not considered as installed, so it will be downloaded again when necessary.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
