### PR TITLE
Removed no more needed checks to go sub-programs

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -61,10 +61,6 @@ jobs:
       matrix:
         module:
           - path: ./
-          - path: arduino/discovery/discovery_client
-          - path: client_example
-          - path: commands/daemon/term_example
-          - path: docsgen
 
     steps:
       - name: Checkout repository
@@ -98,10 +94,6 @@ jobs:
       matrix:
         module:
           - path: ./
-          - path: arduino/discovery/discovery_client
-          - path: client_example
-          - path: commands/daemon/term_example
-          - path: docsgen
 
     steps:
       - name: Checkout repository
@@ -138,10 +130,6 @@ jobs:
       matrix:
         module:
           - path: ./
-          - path: arduino/discovery/discovery_client
-          - path: client_example
-          - path: commands/daemon/term_example
-          - path: docsgen
 
     steps:
       - name: Checkout repository
@@ -178,10 +166,6 @@ jobs:
       matrix:
         module:
           - path: ./
-          - path: arduino/discovery/discovery_client
-          - path: client_example
-          - path: commands/daemon/term_example
-          - path: docsgen
 
     steps:
       - name: Checkout repository
@@ -218,9 +202,6 @@ jobs:
       matrix:
         module:
           - path: ./
-          - path: arduino/discovery/discovery_client
-          - path: client_example
-          - path: docsgen
 
     steps:
       - name: Checkout repository

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -7,10 +7,6 @@ cache_path: .licenses/
 
 apps:
   - source_path: ./
-  - source_path: arduino/discovery/discovery_client/
-  - source_path: client_example/
-  - source_path: commands/daemon/term_example/
-  - source_path: docsgen/
 
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/GPL-3.0/.licensed.yml
 allowed:


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Since the following:

* `arduino/discovery/discovery_client`
* `client_example`
* `commands/daemon/term_example`
* `docsgen`

are no more separate go modules there is no more need to run `vet`, `fix`, `lint`, `fmt`, and `tidy` on all of them.

## What is the current behavior?

## What is the new behavior?

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

## Other information
