### PR TITLE
Fix invalid JSON and YAML outputs for `outdated` command

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -7,6 +7,48 @@ Here you can find a list of migration guides to handle breaking changes between 
 Configuration file lookup in current working directory and its parents is dropped. The command line flag `--config-file`
 must be specified to use an alternative configuration file from the one in the data directory.
 
+### Command `outdated` output change
+
+For `text` format (default), the command prints now a single table for platforms and libraries instead of two separate
+tables.
+
+Similarly, for JSON and YAML formats, the command prints now a single valid object, with `platform` and `libraries`
+top-level keys. For example, for JSON output:
+
+```
+$ arduino-cli outdated --format json
+{
+  "platforms": [
+    {
+      "id": "arduino:avr",
+      "installed": "1.6.3",
+      "latest": "1.8.6",
+      "name": "Arduino AVR Boards",
+      ...
+    }
+  ],
+  "libraries": [
+    {
+      "library": {
+        "name": "USBHost",
+        "author": "Arduino",
+        "maintainer": "Arduino \u003cinfo@arduino.cc\u003e",
+        "category": "Device Control",
+        "version": "1.0.0",
+        ...
+      },
+      "release": {
+        "author": "Arduino",
+        "version": "1.0.5",
+        "maintainer": "Arduino \u003cinfo@arduino.cc\u003e",
+        "category": "Device Control",
+        ...
+      }
+    }
+  ]
+}
+```
+
 ## 0.31.0
 
 ### Added `post_install` script support for tools

--- a/internal/cli/core/list.go
+++ b/internal/cli/core/list.go
@@ -52,8 +52,14 @@ func runListCommand(args []string, all bool, updatableOnly bool) {
 	List(inst, all, updatableOnly)
 }
 
-// List print a list of installed platforms.
+// List gets and prints a list of installed platforms.
 func List(inst *rpc.Instance, all bool, updatableOnly bool) {
+	platforms := GetList(inst, all, updatableOnly)
+	feedback.PrintResult(installedResult{platforms})
+}
+
+// GetList returns a list of installed platforms.
+func GetList(inst *rpc.Instance, all bool, updatableOnly bool) []*rpc.Platform {
 	platforms, err := core.GetPlatforms(&rpc.PlatformListRequest{
 		Instance:      inst,
 		UpdatableOnly: updatableOnly,
@@ -62,8 +68,7 @@ func List(inst *rpc.Instance, all bool, updatableOnly bool) {
 	if err != nil {
 		feedback.Fatal(tr("Error listing platforms: %v", err), feedback.ErrGeneric)
 	}
-
-	feedback.PrintResult(installedResult{platforms})
+	return platforms
 }
 
 // output from this command requires special formatting, let's create a dedicated

--- a/internal/cli/lib/list.go
+++ b/internal/cli/lib/list.go
@@ -60,8 +60,23 @@ func runListCommand(args []string, all bool, updatable bool) {
 	List(instance, args, all, updatable)
 }
 
-// List lists all the installed libraries.
+// List gets and prints a list of installed libraries.
 func List(instance *rpc.Instance, args []string, all bool, updatable bool) {
+	installedLibs := GetList(instance, args, all, updatable)
+	feedback.PrintResult(installedResult{
+		onlyUpdates:   updatable,
+		installedLibs: installedLibs,
+	})
+	logrus.Info("Done")
+}
+
+// GetList returns a list of installed libraries.
+func GetList(
+	instance *rpc.Instance,
+	args []string,
+	all bool,
+	updatable bool,
+) []*rpc.InstalledLibrary {
 	name := ""
 	if len(args) > 0 {
 		name = args[0]
@@ -95,11 +110,7 @@ func List(instance *rpc.Instance, args []string, all bool, updatable bool) {
 		libs = []*rpc.InstalledLibrary{}
 	}
 
-	feedback.PrintResult(installedResult{
-		onlyUpdates:   updatable,
-		installedLibs: libs,
-	})
-	logrus.Info("Done")
+	return libs
 }
 
 // output from this command requires special formatting, let's create a dedicated

--- a/internal/integrationtest/outdated/outdated_test.go
+++ b/internal/integrationtest/outdated/outdated_test.go
@@ -53,7 +53,7 @@ func TestOutdated(t *testing.T) {
 		lines[i] = strings.TrimSpace(lines[i])
 	}
 	require.Contains(t, lines[1], "Arduino AVR Boards")
-	require.Contains(t, lines[4], "USBHost")
+	require.Contains(t, lines[2], "USBHost")
 }
 
 func TestOutdatedUsingLibraryWithInvalidVersion(t *testing.T) {

--- a/internal/integrationtest/update/update_test.go
+++ b/internal/integrationtest/update/update_test.go
@@ -67,7 +67,7 @@ func TestUpdateShowingOutdated(t *testing.T) {
 	require.Contains(t, lines[0], "Downloading index: library_index.tar.bz2 downloaded")
 	require.Contains(t, lines[1], "Downloading index: package_index.tar.bz2 downloaded")
 	require.Contains(t, lines[3], "Arduino AVR Boards")
-	require.Contains(t, lines[6], "USBHost")
+	require.Contains(t, lines[4], "USBHost")
 }
 
 func TestUpdateWithUrlNotFound(t *testing.T) {

--- a/internal/integrationtest/upgrade/upgrade_test.go
+++ b/internal/integrationtest/upgrade/upgrade_test.go
@@ -50,7 +50,7 @@ func TestUpgrade(t *testing.T) {
 	require.NoError(t, err)
 	lines := strings.Split(string(stdout), "\n")
 	require.Contains(t, lines[1], "Arduino AVR Boards")
-	require.Contains(t, lines[4], "USBHost")
+	require.Contains(t, lines[2], "USBHost")
 
 	_, _, err = cli.Run("upgrade")
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestUpgrade(t *testing.T) {
 	// Verifies cores and libraries have been updated
 	stdout, _, err = cli.Run("outdated")
 	require.NoError(t, err)
-	require.Contains(t, string(stdout), "No libraries update is available.")
+	require.Contains(t, string(stdout), "No outdated platforms or libraries found.")
 }
 
 func TestUpgradeUsingLibraryWithInvalidVersion(t *testing.T) {


### PR DESCRIPTION
Fixes issue #2104

The code for `internal/cli/core` and `internal/cli/lib` has been
refactored so that we can use only the `Get` functions from
`internal/cli/outdated` package and compose there composited object.

For regular text output, the new table will have some extra fields that
either for platforms or for libraries will be blank.

For JSON and YAML output, the resulting object will have the top-level
keys `platforms` and `libraries` which contain, respectively, the array
of outaded platforms and outdated libraries.

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fixes #2104

## What is the current behavior?

`outdated` commands prints two tables for text mode, and two objects for JSON mode:

Text (default):

```
>>> Running: /home/lluis/go/src/github.com/arduino/arduino-cli/arduino-cli outdated
ID          Installed Latest Name
arduino:avr 1.6.3     1.8.6  Arduino AVR Boards

Name    Installed     Available     Location              Description
USBHost 1.0.0         1.0.5         LIBRARY_LOCATION_USER Allows the communication with USB per...
```

and JSON:

```
$ arduino-cli outdated --format json
[]
[
  {
    "library": {
      "name": "FastLED",
      "author": "Daniel Garcia",
      "maintainer": "Daniel Garcia \u003cdgarcia@fastled.io\u003e",
      "sentence": "Multi-platform library for controlling dozens of different types of LEDs along with optimized math, effect, and noise functions.",
      "paragraph": "Multi-platform library for controlling dozens of different types of LEDs along with optimized math, effect, and noise functions.",
      "website": "https://github.com/FastLED/FastLED",
      "category": "Display",
      "architectures": [
        "*"
      ],
      "install_dir": "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED",
      "source_dir": "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED",
      "version": "3.3.2",
      "license": "Unspecified",
      "location": 1,
      "examples": [
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\AnalogOutput",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Blink",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\ColorPalette",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\ColorTemperature",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Cylon",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\DemoReel100",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Fire2012",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Fire2012WithPalette",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\FirstLight",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Multiple\\ArrayOfLedArrays",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Multiple\\MirroringSample",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Multiple\\MultiArrays",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Multiple\\MultipleStripsInOneArray",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Multiple\\OctoWS2811Demo",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Multiple\\ParallelOutputDemo",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Noise",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\NoisePlayground",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\NoisePlusPalette",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Pintest",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\Ports\\PJRCSpectrumAnalyzer",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\RGBCalibrate",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\RGBSetDemo",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\SmartMatrix",
        "C:\\Users\\gaspa\\Documents\\Arduino\\libraries\\FastLED\\examples\\XYMatrix"
      ],
      "provides_includes": [
        "FastLED.h",
        "bitswap.h",
        "chipsets.h",
        "color.h",
        "colorpalettes.h",
        "colorutils.h",
        "controller.h",
        "cpp_compat.h",
        "dmx.h",
        "fastled_config.h",
        "fastled_delay.h",
        "fastled_progmem.h",
        "fastpin.h",
        "fastspi.h",
        "fastspi_bitbang.h",
        "fastspi_dma.h",
        "fastspi_nop.h",
        "fastspi_ref.h",
        "fastspi_types.h",
        "hsv2rgb.h",
        "led_sysdefs.h",
        "lib8tion.h",
        "noise.h",
        "pixelset.h",
        "pixeltypes.h",
        "platforms.h",
        "power_mgt.h"
      ]
    },
    "release": {
      "author": "Daniel Garcia",
      "version": "3.5.0",
      "maintainer": "Daniel Garcia \u003cdgarcia@fastled.io\u003e",
      "sentence": "Multi-platform library for controlling dozens of different types of LEDs along with optimized math, effect, and noise functions.",
      "paragraph": "Multi-platform library for controlling dozens of different types of LEDs along with optimized math, effect, and noise functions.",
      "website": "https://github.com/FastLED/FastLED",
      "category": "Display",
      "architectures": [
        "*"
      ],
      "types": [
        "Contributed"
      ]
    }
  }
]
```

## What is the new behavior?

`outdated` commands prints one merged table for text mode, and one object for JSON mode:

Text (default):

```
>>> Running: /home/lluis/go/src/github.com/arduino/arduino-cli/arduino-cli outdated
ID          Name               Installed Latest Location              Description
arduino:avr Arduino AVR Boards 1.6.3     1.8.6
            USBHost            1.0.0     1.0.5  LIBRARY_LOCATION_USER Allows the communication with USB per...
```

and JSON:

```
./arduino-cli outdated --format json
[
  [],
  [
    {
      "library": {
        "architectures": [
          "*"
        ],
        "author": "Daniel Garcia",
        "category": "Display",
        "examples": [
          "/home/lluis/Arduino/libraries/FastLED/examples/AnalogOutput",
          "/home/lluis/Arduino/libraries/FastLED/examples/Blink",
          "/home/lluis/Arduino/libraries/FastLED/examples/ColorPalette",
          "/home/lluis/Arduino/libraries/FastLED/examples/ColorTemperature",
          "/home/lluis/Arduino/libraries/FastLED/examples/Cylon",
          "/home/lluis/Arduino/libraries/FastLED/examples/DemoReel100",
          "/home/lluis/Arduino/libraries/FastLED/examples/Fire2012",
          "/home/lluis/Arduino/libraries/FastLED/examples/Fire2012WithPalette",
          "/home/lluis/Arduino/libraries/FastLED/examples/FirstLight",
          "/home/lluis/Arduino/libraries/FastLED/examples/Multiple/ArrayOfLedArrays",
          "/home/lluis/Arduino/libraries/FastLED/examples/Multiple/MirroringSample",
          "/home/lluis/Arduino/libraries/FastLED/examples/Multiple/MultiArrays",
          "/home/lluis/Arduino/libraries/FastLED/examples/Multiple/MultipleStripsInOneArray",
          "/home/lluis/Arduino/libraries/FastLED/examples/Multiple/OctoWS2811Demo",
          "/home/lluis/Arduino/libraries/FastLED/examples/Multiple/ParallelOutputDemo",
          "/home/lluis/Arduino/libraries/FastLED/examples/Noise",
          "/home/lluis/Arduino/libraries/FastLED/examples/NoisePlayground",
          "/home/lluis/Arduino/libraries/FastLED/examples/NoisePlusPalette",
          "/home/lluis/Arduino/libraries/FastLED/examples/Pintest",
          "/home/lluis/Arduino/libraries/FastLED/examples/Ports/PJRCSpectrumAnalyzer",
          "/home/lluis/Arduino/libraries/FastLED/examples/RGBCalibrate",
          "/home/lluis/Arduino/libraries/FastLED/examples/RGBSetDemo",
          "/home/lluis/Arduino/libraries/FastLED/examples/SmartMatrix",
          "/home/lluis/Arduino/libraries/FastLED/examples/XYMatrix"
        ],
        "install_dir": "/home/lluis/Arduino/libraries/FastLED",
        "license": "Unspecified",
        "location": 1,
        "maintainer": "Daniel Garcia \u003cdgarcia@fastled.io\u003e",
        "name": "FastLED",
        "paragraph": "Multi-platform library for controlling dozens of different types of LEDs along with optimized math, effect, and noise functions.",
        "provides_includes": [
          "FastLED.h",
          "bitswap.h",
          "chipsets.h",
          "color.h",
          "colorpalettes.h",
          "colorutils.h",
          "controller.h",
          "cpp_compat.h",
          "dmx.h",
          "fastled_config.h",
          "fastled_delay.h",
          "fastled_progmem.h",
          "fastpin.h",
          "fastspi.h",
          "fastspi_bitbang.h",
          "fastspi_dma.h",
          "fastspi_nop.h",
          "fastspi_ref.h",
          "fastspi_types.h",
          "hsv2rgb.h",
          "led_sysdefs.h",
          "lib8tion.h",
          "noise.h",
          "pixelset.h",
          "pixeltypes.h",
          "platforms.h",
          "power_mgt.h"
        ],
        "sentence": "Multi-platform library for controlling dozens of different types of LEDs along with optimized math, effect, and noise functions.",
        "source_dir": "/home/lluis/Arduino/libraries/FastLED",
        "version": "3.3.2",
        "website": "https://github.com/FastLED/FastLED"
      },
      "release": {
        "architectures": [
          "*"
        ],
        "author": "Daniel Garcia",
        "category": "Display",
        "maintainer": "Daniel Garcia \u003cdgarcia@fastled.io\u003e",
        "paragraph": "Multi-platform library for controlling dozens of different types of LEDs along with optimized math, effect, and noise functions.",
        "sentence": "Multi-platform library for controlling dozens of different types of LEDs along with optimized math, effect, and noise functions.",
        "types": [
          "Contributed"
        ],
        "version": "3.4.0",
        "website": "https://github.com/FastLED/FastLED"
      }
    }
  ]
]
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

See comment in https://github.com/arduino/arduino-cli/issues/2104#issuecomment-1467678692
