### PR TITLE
Automatically download indexes, if missing, in gRPC `Init` call

### DIFF
--- a/commands/core/list.go
+++ b/commands/core/list.go
@@ -25,9 +25,9 @@ import (
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
-// GetPlatforms returns a list of installed platforms, optionally filtered by
+// PlatformList returns a list of installed platforms, optionally filtered by
 // those requiring an update.
-func GetPlatforms(req *rpc.PlatformListRequest) ([]*rpc.Platform, error) {
+func PlatformList(req *rpc.PlatformListRequest) (*rpc.PlatformListResponse, error) {
 	pme, release := commands.GetPackageManagerExplorer(req)
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
@@ -85,5 +85,5 @@ func GetPlatforms(req *rpc.PlatformListRequest) ([]*rpc.Platform, error) {
 		}
 		return false
 	})
-	return res, nil
+	return &rpc.PlatformListResponse{InstalledPlatforms: res}, nil
 }

--- a/commands/daemon/daemon.go
+++ b/commands/daemon/daemon.go
@@ -284,11 +284,8 @@ func (s *ArduinoCoreServerImpl) PlatformSearch(ctx context.Context, req *rpc.Pla
 
 // PlatformList FIXMEDOC
 func (s *ArduinoCoreServerImpl) PlatformList(ctx context.Context, req *rpc.PlatformListRequest) (*rpc.PlatformListResponse, error) {
-	platforms, err := core.GetPlatforms(req)
-	if err != nil {
-		return nil, convertErrorToRPCStatus(err)
-	}
-	return &rpc.PlatformListResponse{InstalledPlatforms: platforms}, nil
+	platforms, err := core.PlatformList(req)
+	return platforms, convertErrorToRPCStatus(err)
 }
 
 // Upload FIXMEDOC

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -240,9 +240,6 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 		})
 	}
 
-	// Perform first-update of indexes if needed
-	firstUpdate(context.Background(), req.GetInstance(), downloadCallback)
-
 	// Try to extract profile if specified
 	var profile *sketch.Profile
 	if req.GetProfile() != "" {
@@ -265,20 +262,11 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 		})
 	}
 
-	{
-		// We need to rebuild the PackageManager currently in use by this instance
-		// in case this is not the first Init on this instances, that might happen
-		// after reinitializing an instance after installing or uninstalling a core.
-		// If this is not done the information of the uninstall core is kept in memory,
-		// even if it should not.
-		pmb, commitPackageManager := instance.pm.NewBuilder()
-
-		// Load packages index
-		urls := []string{globals.DefaultIndexURL}
-		if profile == nil {
-			urls = append(urls, configuration.Settings.GetStringSlice("board_manager.additional_urls")...)
-		}
-		for _, u := range urls {
+	// Perform first-update of indexes if needed
+	defaultIndexURL, _ := utils.URLParse(globals.DefaultIndexURL)
+	allPackageIndexUrls := []*url.URL{defaultIndexURL}
+	if profile == nil {
+		for _, u := range configuration.Settings.GetStringSlice("board_manager.additional_urls") {
 			URL, err := utils.URLParse(u)
 			if err != nil {
 				e := &arduino.InitFailedError{
@@ -289,7 +277,21 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 				responseError(e.ToRPCStatus())
 				continue
 			}
+			allPackageIndexUrls = append(allPackageIndexUrls, URL)
+		}
+	}
+	firstUpdate(context.Background(), req.GetInstance(), downloadCallback, allPackageIndexUrls)
 
+	{
+		// We need to rebuild the PackageManager currently in use by this instance
+		// in case this is not the first Init on this instances, that might happen
+		// after reinitializing an instance after installing or uninstalling a core.
+		// If this is not done the information of the uninstall core is kept in memory,
+		// even if it should not.
+		pmb, commitPackageManager := instance.pm.NewBuilder()
+
+		// Load packages index
+		for _, URL := range allPackageIndexUrls {
 			if URL.Scheme == "file" {
 				_, err := pmb.LoadPackageIndexFromFile(paths.New(URL.Path))
 				if err != nil {
@@ -601,11 +603,10 @@ func LoadSketch(ctx context.Context, req *rpc.LoadSketchRequest) (*rpc.LoadSketc
 
 // firstUpdate downloads libraries and packages indexes if they don't exist.
 // This ideally is only executed the first time the CLI is run.
-func firstUpdate(ctx context.Context, instance *rpc.Instance, downloadCb func(msg *rpc.DownloadProgress)) error {
+func firstUpdate(ctx context.Context, instance *rpc.Instance, downloadCb func(msg *rpc.DownloadProgress), externalPackageIndexes []*url.URL) error {
 	// Gets the data directory to verify if library_index.json and package_index.json exist
 	dataDir := configuration.DataDir(configuration.Settings)
 	libraryIndex := dataDir.Join("library_index.json")
-	packageIndex := dataDir.Join("package_index.json")
 
 	if libraryIndex.NotExist() {
 		// The library_index.json file doesn't exists, that means the CLI is run for the first time
@@ -616,13 +617,22 @@ func firstUpdate(ctx context.Context, instance *rpc.Instance, downloadCb func(ms
 		}
 	}
 
-	if packageIndex.NotExist() {
-		// The package_index.json file doesn't exists, that means the CLI is run for the first time,
-		// similarly to the library update we download that file and all the other package indexes
-		// from additional_urls
-		req := &rpc.UpdateIndexRequest{Instance: instance, IgnoreCustomPackageIndexes: true}
-		if err := UpdateIndex(ctx, req, downloadCb); err != nil {
-			return err
+	for _, URL := range externalPackageIndexes {
+		if URL.Scheme == "file" {
+			continue
+		}
+		packageIndexFileName := (&resources.IndexResource{URL: URL}).IndexFileName()
+		packageIndexFile := dataDir.Join(packageIndexFileName)
+		if packageIndexFile.NotExist() {
+			// The index file doesn't exists, that means the CLI is run for the first time,
+			// or the 3rd party package index URL has just been added. Similarly to the
+			// library update we download that file and all the other package indexes from
+			// additional_urls
+			req := &rpc.UpdateIndexRequest{Instance: instance}
+			if err := UpdateIndex(ctx, req, downloadCb); err != nil {
+				return err
+			}
+			break
 		}
 	}
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -118,6 +118,40 @@ has been removed as well.
 
 That method was outdated and must not be used.
 
+### golang API: method `github.com/arduino/arduino-cli/commands/core/GetPlatforms` renamed
+
+The following method in `github.com/arduino/arduino-cli/commands/core`:
+
+```go
+func GetPlatforms(req *rpc.PlatformListRequest) ([]*rpc.Platform, error) { ... }
+```
+
+has been changed to:
+
+```go
+func PlatformList(req *rpc.PlatformListRequest) (*rpc.PlatformListResponse, error) { ... }
+```
+
+now it better follows the gRPC API interface. Old code like the following:
+
+```go
+platforms, _ := core.GetPlatforms(&rpc.PlatformListRequest{Instance: inst})
+for _, i := range platforms {
+    ...
+}
+```
+
+must be changed as follows:
+
+```go
+// Use PlatformList function instead of GetPlatforms
+platforms, _ := core.PlatformList(&rpc.PlatformListRequest{Instance: inst})
+// Access installed platforms through the .InstalledPlatforms field
+for _, i := range platforms.InstalledPlatforms {
+    ...
+}
+```
+
 ## 0.31.0
 
 ### Added `post_install` script support for tools

--- a/internal/cli/arguments/completion.go
+++ b/internal/cli/arguments/completion.go
@@ -124,14 +124,14 @@ func GetInstalledProgrammers() []string {
 func GetUninstallableCores() []string {
 	inst := instance.CreateAndInit()
 
-	platforms, _ := core.GetPlatforms(&rpc.PlatformListRequest{
+	platforms, _ := core.PlatformList(&rpc.PlatformListRequest{
 		Instance:      inst,
 		UpdatableOnly: false,
 		All:           false,
 	})
 	var res []string
 	// transform the data structure for the completion
-	for _, i := range platforms {
+	for _, i := range platforms.InstalledPlatforms {
 		res = append(res, i.Id+"\t"+i.Name)
 	}
 	return res

--- a/internal/cli/arguments/reference.go
+++ b/internal/cli/arguments/reference.go
@@ -92,15 +92,15 @@ func ParseReference(arg string) (*Reference, error) {
 	ret.Architecture = toks[1]
 
 	// Now that we have the required informations in `ret` we can
-	// try to use core.GetPlatforms to optimize what the user typed
+	// try to use core.PlatformList to optimize what the user typed
 	// (by replacing the PackageName and Architecture in ret with the content of core.GetPlatform())
-	platforms, _ := core.GetPlatforms(&rpc.PlatformListRequest{
+	platforms, _ := core.PlatformList(&rpc.PlatformListRequest{
 		Instance:      instance.CreateAndInit(),
 		UpdatableOnly: false,
 		All:           true, // this is true because we want also the installable platforms
 	})
 	foundPlatforms := []string{}
-	for _, platform := range platforms {
+	for _, platform := range platforms.InstalledPlatforms {
 		platformID := platform.GetId()
 		platformUser := ret.PackageName + ":" + ret.Architecture
 		// At first we check if the platform the user is searching for matches an available one,

--- a/internal/cli/core/list.go
+++ b/internal/cli/core/list.go
@@ -60,7 +60,7 @@ func List(inst *rpc.Instance, all bool, updatableOnly bool) {
 
 // GetList returns a list of installed platforms.
 func GetList(inst *rpc.Instance, all bool, updatableOnly bool) []*rpc.Platform {
-	platforms, err := core.GetPlatforms(&rpc.PlatformListRequest{
+	platforms, err := core.PlatformList(&rpc.PlatformListRequest{
 		Instance:      inst,
 		UpdatableOnly: updatableOnly,
 		All:           all,
@@ -68,7 +68,7 @@ func GetList(inst *rpc.Instance, all bool, updatableOnly bool) []*rpc.Platform {
 	if err != nil {
 		feedback.Fatal(tr("Error listing platforms: %v", err), feedback.ErrGeneric)
 	}
-	return platforms
+	return platforms.InstalledPlatforms
 }
 
 // output from this command requires special formatting, let's create a dedicated

--- a/internal/cli/core/search.go
+++ b/internal/cli/core/search.go
@@ -58,19 +58,15 @@ func initSearchCommand() *cobra.Command {
 const indexUpdateInterval = "24h"
 
 func runSearchCommand(cmd *cobra.Command, args []string) {
-	inst, status := instance.Create()
-	if status != nil {
-		feedback.Fatal(tr("Error creating instance: %v", status), feedback.ErrGeneric)
-	}
+	inst := instance.CreateAndInit()
 
 	if indexesNeedUpdating(indexUpdateInterval) {
 		err := commands.UpdateIndex(context.Background(), &rpc.UpdateIndexRequest{Instance: inst}, feedback.ProgressBar())
 		if err != nil {
 			feedback.FatalError(err, feedback.ErrGeneric)
 		}
+		instance.Init(inst)
 	}
-
-	instance.Init(inst)
 
 	arguments := strings.ToLower(strings.Join(args, " "))
 	logrus.Infof("Executing `arduino-cli core search` with args: '%s'", arguments)

--- a/internal/cli/core/update_index.go
+++ b/internal/cli/core/update_index.go
@@ -40,7 +40,7 @@ func initUpdateIndexCommand() *cobra.Command {
 }
 
 func runUpdateIndexCommand(cmd *cobra.Command, args []string) {
-	inst := instance.CreateInstanceAndRunFirstUpdate()
+	inst := instance.CreateAndInit()
 	logrus.Info("Executing `arduino-cli core update-index`")
 	UpdateIndex(inst)
 }

--- a/internal/cli/core/upgrade.go
+++ b/internal/cli/core/upgrade.go
@@ -60,7 +60,7 @@ func runUpgradeCommand(args []string, skipPostInstall bool) {
 func Upgrade(inst *rpc.Instance, args []string, skipPostInstall bool) {
 	// if no platform was passed, upgrade allthethings
 	if len(args) == 0 {
-		targets, err := core.GetPlatforms(&rpc.PlatformListRequest{
+		targets, err := core.PlatformList(&rpc.PlatformListRequest{
 			Instance:      inst,
 			UpdatableOnly: true,
 		})
@@ -68,12 +68,12 @@ func Upgrade(inst *rpc.Instance, args []string, skipPostInstall bool) {
 			feedback.Fatal(tr("Error retrieving core list: %v", err), feedback.ErrGeneric)
 		}
 
-		if len(targets) == 0 {
+		if len(targets.InstalledPlatforms) == 0 {
 			feedback.Print(tr("All the cores are already at the latest version"))
 			return
 		}
 
-		for _, t := range targets {
+		for _, t := range targets.InstalledPlatforms {
 			args = append(args, t.Id)
 		}
 	}

--- a/internal/cli/instance/instance.go
+++ b/internal/cli/instance/instance.go
@@ -38,7 +38,7 @@ func CreateAndInit() *rpc.Instance {
 // If Create fails the CLI prints an error and exits since to execute further operations a valid Instance is mandatory.
 // If Init returns errors they're printed only.
 func CreateAndInitWithProfile(profileName string, sketchPath *paths.Path) (*rpc.Instance, *rpc.Profile) {
-	instance, err := Create()
+	instance, err := create()
 	if err != nil {
 		feedback.Fatal(tr("Error creating instance: %v", err), feedback.ErrGeneric)
 	}
@@ -46,8 +46,8 @@ func CreateAndInitWithProfile(profileName string, sketchPath *paths.Path) (*rpc.
 	return instance, profile
 }
 
-// Create and return a new Instance.
-func Create() (*rpc.Instance, error) {
+// create and return a new Instance.
+func create() (*rpc.Instance, error) {
 	res, err := commands.Create(&rpc.CreateRequest{})
 	if err != nil {
 		return nil, err

--- a/internal/cli/lib/search.go
+++ b/internal/cli/lib/search.go
@@ -55,12 +55,9 @@ func initSearchCommand() *cobra.Command {
 const indexUpdateInterval = 60 * time.Minute
 
 func runSearchCommand(args []string, namesOnly bool, omitReleasesDetails bool) {
-	inst, status := instance.Create()
-	logrus.Info("Executing `arduino-cli lib search`")
+	inst := instance.CreateAndInit()
 
-	if status != nil {
-		feedback.Fatal(tr("Error creating instance: %v", status), feedback.ErrGeneric)
-	}
+	logrus.Info("Executing `arduino-cli lib search`")
 
 	if indexNeedsUpdating(indexUpdateInterval) {
 		if err := commands.UpdateLibrariesIndex(
@@ -70,9 +67,8 @@ func runSearchCommand(args []string, namesOnly bool, omitReleasesDetails bool) {
 		); err != nil {
 			feedback.Fatal(tr("Error updating library index: %v", err), feedback.ErrGeneric)
 		}
+		instance.Init(inst)
 	}
-
-	instance.Init(inst)
 
 	searchResp, err := lib.LibrarySearch(context.Background(), &rpc.LibrarySearchRequest{
 		Instance:            inst,

--- a/internal/cli/lib/update_index.go
+++ b/internal/cli/lib/update_index.go
@@ -40,7 +40,7 @@ func initUpdateIndexCommand() *cobra.Command {
 }
 
 func runUpdateIndexCommand(cmd *cobra.Command, args []string) {
-	inst := instance.CreateInstanceAndRunFirstUpdate()
+	inst := instance.CreateAndInit()
 	logrus.Info("Executing `arduino-cli lib update-index`")
 	UpdateIndex(inst)
 }

--- a/internal/cli/update/update.go
+++ b/internal/cli/update/update.go
@@ -47,7 +47,7 @@ func NewCommand() *cobra.Command {
 }
 
 func runUpdateCommand(showOutdated bool) {
-	inst := instance.CreateInstanceAndRunFirstUpdate()
+	inst := instance.CreateAndInit()
 	logrus.Info("Executing `arduino-cli update`")
 	lib.UpdateIndex(inst)
 	core.UpdateIndex(inst)

--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -470,3 +470,11 @@ func (inst *ArduinoCLIInstance) PlatformUpgrade(ctx context.Context, packager, a
 	logCallf(">>> PlatformUpgrade(%v:%v)\n", packager, arch)
 	return installCl, err
 }
+
+// PlatformList calls the "PlatformList" gRPC method.
+func (inst *ArduinoCLIInstance) PlatformList(ctx context.Context) (*commands.PlatformListResponse, error) {
+	req := &commands.PlatformListRequest{Instance: inst.instance}
+	logCallf(">>> PlatformList(%+v)\n", req)
+	resp, err := inst.cli.daemonClient.PlatformList(ctx, req)
+	return resp, err
+}

--- a/internal/integrationtest/daemon/daemon_test.go
+++ b/internal/integrationtest/daemon/daemon_test.go
@@ -83,6 +83,23 @@ func TestArduinoCliDaemon(t *testing.T) {
 	testWatcher()
 }
 
+func TestDaemonAutoUpdateIndexOnFirstInit(t *testing.T) {
+	// https://github.com/arduino/arduino-cli/issues/1529
+
+	env, cli := createEnvForDaemon(t)
+	defer env.CleanUp()
+
+	grpcInst := cli.Create()
+	require.NoError(t, grpcInst.Init("", "", func(ir *commands.InitResponse) {
+		fmt.Printf("INIT> %v\n", ir.GetMessage())
+	}))
+
+	_, err := grpcInst.PlatformList(context.Background())
+	require.NoError(t, err)
+
+	require.FileExists(t, cli.DataDir().Join("package_index.json").String())
+}
+
 // createEnvForDaemon performs the minimum required operations to start the arduino-cli daemon.
 // It returns a testsuite.Environment and an ArduinoCLI client to perform the integration tests.
 // The Environment must be disposed by calling the CleanUp method via defer.

--- a/internal/integrationtest/daemon/daemon_test.go
+++ b/internal/integrationtest/daemon/daemon_test.go
@@ -111,9 +111,6 @@ func createEnvForDaemon(t *testing.T) (*integrationtest.Environment, *integratio
 		UseSharedStagingFolder: true,
 	})
 
-	_, _, err := cli.Run("core", "update-index")
-	require.NoError(t, err)
-
 	_ = cli.StartDaemon(false)
 	return env, cli
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [X] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This PR changes the behavior of the `Init` function of the gRPC API.

## What is the current behavior?

Previously if the main indexes `package_index.json` or `library_index.json` were missing (for example after installing on a clean system) the gRPC client had to call `UpdateIndex` or `UpdateLibrariesIndex` to download the indexes and re-`Init` the gRPC instance.

## What is the new behavior?

The indexes download is performed automatically.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

It changes some golang API calls as described in the `UPGRADING.md`.
The gRPC is backward compatible, but the old clients may not be optimized and may force the download of the index twice.

## Other information

Fix #1529 
