### PR TITLE
Reactivated disabled integration test

### DIFF
--- a/internal/integrationtest/daemon/daemon_test.go
+++ b/internal/integrationtest/daemon/daemon_test.go
@@ -31,8 +31,6 @@ import (
 func TestArduinoCliDaemon(t *testing.T) {
 	// See: https://github.com/arduino/arduino-cli/pull/1804
 
-	t.SkipNow() // TO BE Removed once the bug is fixed
-
 	env, cli := createEnvForDaemon(t)
 	defer env.CleanUp()
 


### PR DESCRIPTION
Since https://github.com/arduino/arduino-cli/pull/1804 has been fixed.

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Do not skip an integration test anymore.

## What is the current behavior?

The test was skipped because it was written to check the gRPC test-suite functionality, not to actually fix the underlying bug.
So we kept the test but skipped it.

## What is the new behavior?

Since the original bug has been fixed, this PR re-enable the test.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Original bug #1804 