### PR TITLE
[skip-changelog] Sort `board search` results with the same name using their platform ID

### DIFF
--- a/commands/board/search.go
+++ b/commands/board/search.go
@@ -103,7 +103,10 @@ func Search(ctx context.Context, req *rpc.BoardSearchRequest) (*rpc.BoardSearchR
 	}
 
 	sort.Slice(res.Boards, func(i, j int) bool {
-		return res.Boards[i].Name < res.Boards[j].Name
+		if res.Boards[i].Name != res.Boards[j].Name {
+			return res.Boards[i].Name < res.Boards[j].Name
+		}
+		return res.Boards[i].Platform.Id < res.Boards[j].Platform.Id
 	})
 	return res, nil
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
The order of `board search` results is not always the same.
<!-- You can also link to an open issue here -->

## What is the new behavior?
The ordering is done checking the board's name first and then its platform's ID to add consistency.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
