### PR TITLE
[Skip-changelog] Improve documentation regarding `ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,12 +76,20 @@ variable sets the `directories.user` configuration option.
 On Linux or macOS, you can use the [`export` command][export command] to set environment variables. On Windows cmd, you
 can use the [`set` command][set command].
 
+`ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS` environment variables can be a list of space-separated URLs.
+
 #### Example
 
 Setting an additional Boards Manager URL using the `ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS` environment variable:
 
 ```sh
 $ export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS=https://downloads.arduino.cc/packages/package_staging_index.json
+```
+
+Setting multiple additional Boards Manager URLs using the `ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS` environment variable:
+
+```sh
+$ export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS="https://downloads.arduino.cc/packages/package_staging_index.json https://downloads.arduino.cc/packages/package_mbed_index.json"
 ```
 
 ### Configuration file

--- a/internal/cli/config/init.go
+++ b/internal/cli/config/init.go
@@ -17,6 +17,7 @@ package config
 
 import (
 	"os"
+	"strings"
 
 	"github.com/arduino/arduino-cli/configuration"
 	"github.com/arduino/arduino-cli/internal/cli/arguments"
@@ -96,6 +97,13 @@ func runInitCommand(cmd *cobra.Command, args []string) {
 	newSettings := viper.New()
 	configuration.SetDefaults(newSettings)
 	configuration.BindFlags(cmd, newSettings)
+
+	for _, url := range newSettings.GetStringSlice("board_manager.additional_urls") {
+		if strings.Contains(url, ",") {
+			feedback.Fatal(tr("Urls cannot contain commas. Separate multiple urls exported as env var with a space:\n%s", url),
+				feedback.ErrGeneric)
+		}
+	}
 
 	if err := newSettings.WriteConfigAs(configFileAbsPath.String()); err != nil {
 		feedback.Fatal(tr("Cannot create config file: %v", err), feedback.ErrGeneric)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Documentation enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the new behavior?
The documentation has been improved by adding the correct format for the environment variable `ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS`. Also, `config init` now fails if a URL saved in `additional_urls` contains a comma.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
