### PR TITLE
[skip-changelog] Issue a warning when the signature verification fails

### DIFF
--- a/arduino/cores/packageindex/index.go
+++ b/arduino/cores/packageindex/index.go
@@ -381,18 +381,22 @@ func LoadIndex(jsonIndexFile *paths.Path) (*Index, error) {
 	}
 
 	jsonSignatureFile := jsonIndexFile.Parent().Join(jsonIndexFile.Base() + ".sig")
-	trusted, _, err := security.VerifyArduinoDetachedSignature(jsonIndexFile, jsonSignatureFile)
-	if err != nil {
-		logrus.
-			WithField("index", jsonIndexFile).
-			WithField("signatureFile", jsonSignatureFile).
-			WithError(err).Infof("Checking signature")
+	if jsonSignatureFile.Exist() {
+		trusted, _, err := security.VerifyArduinoDetachedSignature(jsonIndexFile, jsonSignatureFile)
+		if err != nil {
+			logrus.
+				WithField("index", jsonIndexFile).
+				WithField("signatureFile", jsonSignatureFile).
+				WithError(err).Warnf("Checking signature")
+		} else {
+			logrus.
+				WithField("index", jsonIndexFile).
+				WithField("signatureFile", jsonSignatureFile).
+				WithField("trusted", trusted).Infof("Checking signature")
+			index.IsTrusted = trusted
+		}
 	} else {
-		logrus.
-			WithField("index", jsonIndexFile).
-			WithField("signatureFile", jsonSignatureFile).
-			WithField("trusted", trusted).Infof("Checking signature")
-		index.IsTrusted = trusted
+		logrus.WithField("index", jsonIndexFile).Infof("Missing signature file")
 	}
 	return &index, nil
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
The verification of the signature on the package index fails silently.
<!-- You can also link to an open issue here -->

## What is the new behavior?
A warning is issued if the signature verification fails.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
