### PR TITLE
fix: library loading errors genereates unneeded compile failures

### DIFF
--- a/commands/instances.go
+++ b/commands/instances.go
@@ -458,9 +458,9 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 		}
 	}
 
-	for _, err := range lm.RescanLibraries() {
-		s := status.Newf(codes.FailedPrecondition, tr("Loading libraries: %v"), err)
-		responseError(s)
+	for _, status := range lm.RescanLibraries() {
+		logrus.WithError(status.Err()).Warnf("Error loading library")
+		// TODO: report as warning: responseError(err)
 	}
 
 	// Refreshes the locale used, this will change the

--- a/legacy/builder/libraries_loader.go
+++ b/legacy/builder/libraries_loader.go
@@ -56,14 +56,16 @@ func (s *LibrariesLoader) Run(ctx *types.Context) error {
 			lm.AddLibrariesDir(folder, libraries.User)
 		}
 
-		if errs := lm.RescanLibraries(); len(errs) > 0 {
+		for _, status := range lm.RescanLibraries() {
 			// With the refactoring of the initialization step of the CLI we changed how
 			// errors are returned when loading platforms and libraries, that meant returning a list of
 			// errors instead of a single one to enhance the experience for the user.
 			// I have no intention right now to start a refactoring of the legacy package too, so
 			// here's this shitty solution for now.
 			// When we're gonna refactor the legacy package this will be gone.
-			return errors.WithStack(errs[0].Err())
+			if ctx.Verbose {
+				ctx.Warn(status.Message())
+			}
 		}
 
 		for _, dir := range ctx.LibraryDirs {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

- The library loading errors do not affect compile results anymore.
- Fixed an error message
- Library loading warnings are reported only in verbose compile

## What is the current behavior?

If an invalid library is installed in the system, all sketch compilations will fail, even if the library is not used:

```
$ arduino-cli compile -b arduino:avr:uno
Error initializing instance: Loading libraries: &{0xc001c760c0}


Used platform Version Path                                                        
arduino:avr   1.8.5   /home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.5
Error during build: rpc error: code = Internal desc = loading library from /home/megabug/Workspace/sketchbook-cores-beta/libraries/Empty: invalid library: no header files found
```

This behavior has been worsened after merging https://github.com/arduino/arduino-cli/pull/2083 which caused more libraries to be reported as invalid.

## What is the new behavior?

Any invalid library is silently ignored unless the verbose output is enabled. In that case, a warning is printed explaining the error:

```
$ arduino-cli compile -b arduino:avr:uno
Sketch uses 444 bytes (1%) of program storage space. Maximum is 32256 bytes.
Global variables use 9 bytes (0%) of dynamic memory, leaving 2039 bytes for local variables. Maximum is 2048 bytes.

Used platform Version Path                                                        
arduino:avr   1.8.5   /home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.5

$ arduino-cli compile -b arduino:avr:uno -v
FQBN: arduino:avr:uno
Using board 'uno' from platform in folder: /home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.5
Using core 'arduino' from platform in folder: /home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.5

loading library from /home/megabug/Workspace/sketchbook-cores-beta/libraries/Empty: invalid library: no header files found
Detecting libraries used...
/home/megabug/.arduino15/packages/arduino/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7/bin/avr-g++ -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -flto -w -x c++ -E -CC -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino -I/home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.5/variants/standard /tmp/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/sketch/Blink.ino.cpp -o /dev/null
Using cached library dependencies for file: /tmp/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/sketch/Blink.cpp
Generating function prototypes...
/home/megabug/.arduino15/packages/arduino/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7/bin/avr-g++ -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -flto -w -x c++ -E -CC -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino -I/home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.5/variants/standard /tmp/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/sketch/Blink.ino.cpp -o /tmp/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/preproc/ctags_target_for_gcc_minus_e.cpp
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
