### PR TITLE
Fix preprocess output (do not print stats after the preprocessed source)

### DIFF
--- a/internal/cli/compile/compile.go
+++ b/internal/cli/compile/compile.go
@@ -330,6 +330,7 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 		ProfileOut:         profileOut,
 		Success:            compileError == nil,
 		showPropertiesMode: showProperties,
+		hideStats:          preprocess,
 	}
 
 	if compileError != nil {
@@ -394,6 +395,7 @@ type compileResult struct {
 	Error         string               `json:"error,omitempty"`
 
 	showPropertiesMode arguments.ShowPropertiesMode
+	hideStats          bool
 }
 
 func (r *compileResult) Data() interface{} {
@@ -403,6 +405,10 @@ func (r *compileResult) Data() interface{} {
 func (r *compileResult) String() string {
 	if r.showPropertiesMode != arguments.ShowPropertiesDisabled {
 		return strings.Join(r.BuilderResult.GetBuildProperties(), fmt.Sprintln())
+	}
+
+	if r.hideStats {
+		return ""
 	}
 
 	titleColor := color.New(color.FgHiGreen)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Do not print compilation stats at the end of the `compile --preprocess` output.

## What is the current behavior?

```
$ arduino-cli compile -b arduino:avr:uno ~/Arduino/Blink/ --preprocess
#include <Arduino.h>
#line 1 "/home/megabug/Arduino/Blink/Blink.ino"
#line 1 "/home/megabug/Arduino/Blink/Blink.ino"
void setup();
#line 3 "/home/megabug/Arduino/Blink/Blink.ino"
void loop();
#line 1 "/home/megabug/Arduino/Blink/Blink.ino"
void setup() {
}
void loop() {
}


Used platform Version Path                                                        
arduino:avr   1.8.6   /home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.6
$
```

## What is the new behavior?

```
$ arduino-cli compile -b arduino:avr:uno ~/Arduino/Blink/ --preprocess
#include <Arduino.h>
#line 1 "/home/megabug/Arduino/Blink/Blink.ino"
#line 1 "/home/megabug/Arduino/Blink/Blink.ino"
void setup();
#line 3 "/home/megabug/Arduino/Blink/Blink.ino"
void loop();
#line 1 "/home/megabug/Arduino/Blink/Blink.ino"
void setup() {
}
void loop() {
}

$
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2150
