### PR TITLE
[skip-changelog] Override default pluggable monitor for `serial` protocol

### DIFF
--- a/arduino/cores/packagemanager/loader.go
+++ b/arduino/cores/packagemanager/loader.go
@@ -315,7 +315,7 @@ func (pm *Builder) loadPlatformRelease(platform *cores.PlatformRelease, path *pa
 		return fmt.Errorf(tr("loading %[1]s: %[2]s"), platformTxtLocalPath, err)
 	}
 
-	if platform.Properties.SubTree("pluggable_discovery").Size() > 0 {
+	if platform.Properties.SubTree("pluggable_discovery").Size() > 0 || platform.Properties.SubTree("pluggable_monitor").Size() > 0 {
 		platform.PluggableDiscoveryAware = true
 	} else {
 		platform.Properties.Set("pluggable_discovery.required.0", "builtin:serial-discovery")


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
Platform authors cannot use a custom monitor tool for the `serial` protocol.
```
$ echo "pluggable_monitor.pattern.serial=foobar" >> ~/.arduino15/packages/arduino/hardware/avr/1.8.3/platform.txt
$ arduino-cli monitor --port /dev/ttyACM0 --fqbn arduino:avr:leonardo --protocol serial
Connected to /dev/ttyACM0! Press CTRL-C to exit.
Hello world from the Arduino Leonardo's serial port!
^C

$ echo "pluggable_monitor.pattern.myprotocol=bazqux" >> ~/.arduino15/packages/arduino/hardware/avr/1.8.3/platform.txt
$ arduino-cli monitor --port /dev/ttyACM0 --fqbn arduino:avr:leonardo --protocol myprotocol
Error getting port settings details: Port monitor error: exec: "bazqux": executable file not found in $PATH
```
The command is also expected to fail when `--protocol serial` is used.
<!-- You can also link to an open issue here -->

## What is the new behavior?
Platform authors can now use a custom monitor tool for the `serial` protocol.
```
$ echo "pluggable_monitor.pattern.serial=foobar" >> ~/.arduino15/packages/arduino/hardware/avr/1.8.3/platform.txt
$ arduino-cli monitor --port /dev/ttyACM0 --fqbn arduino:avr:leonardo --protocol serial
Error getting port settings details: Port monitor error: exec: "foobar": executable file not found in %PATH%
```
The command now fails as expected.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
