### PR TITLE
Respect the order of menu, when computing the config options

### DIFF
--- a/arduino/cores/board.go
+++ b/arduino/cores/board.go
@@ -79,15 +79,13 @@ func (b *Board) buildConfigOptionsStructures() {
 
 	b.configOptions = properties.NewMap()
 	allConfigs := b.Properties.SubTree("menu")
+	allConfigOptions := allConfigs.FirstLevelOf()
 
 	// Used to show the config options in the same order as the menu, defined at the begging of platform.txt
 	if b.PlatformRelease.Menus != nil {
 		for _, menuOption := range b.PlatformRelease.Menus.FirstLevelKeys() {
-			for _, option := range allConfigs.FirstLevelKeys() {
-				if menuOption == option {
-					b.configOptions.Set(option, b.PlatformRelease.Menus.Get(menuOption))
-					break
-				}
+			if _, ok := allConfigOptions[menuOption]; ok {
+				b.configOptions.Set(menuOption, b.PlatformRelease.Menus.Get(menuOption))
 			}
 		}
 	}
@@ -95,7 +93,7 @@ func (b *Board) buildConfigOptionsStructures() {
 	b.configOptionValues = map[string]*properties.Map{}
 	b.configOptionProperties = map[string]*properties.Map{}
 	b.defaultConfig = properties.NewMap()
-	for option, optionProps := range allConfigs.FirstLevelOf() {
+	for option, optionProps := range allConfigOptions {
 		b.configOptionValues[option] = properties.NewMap()
 		values := optionProps.FirstLevelKeys()
 		b.defaultConfig.Set(option, values[0])

--- a/arduino/cores/board.go
+++ b/arduino/cores/board.go
@@ -81,7 +81,7 @@ func (b *Board) buildConfigOptionsStructures() {
 	allConfigs := b.Properties.SubTree("menu")
 	allConfigOptions := allConfigs.FirstLevelOf()
 
-	// Used to show the config options in the same order as the menu, defined at the begging of platform.txt
+	// Used to show the config options in the same order as the menu, defined at the begging of boards.txt
 	if b.PlatformRelease.Menus != nil {
 		for _, menuOption := range b.PlatformRelease.Menus.FirstLevelKeys() {
 			if _, ok := allConfigOptions[menuOption]; ok {

--- a/arduino/cores/board.go
+++ b/arduino/cores/board.go
@@ -79,8 +79,17 @@ func (b *Board) buildConfigOptionsStructures() {
 
 	b.configOptions = properties.NewMap()
 	allConfigs := b.Properties.SubTree("menu")
-	for _, option := range allConfigs.FirstLevelKeys() {
-		b.configOptions.Set(option, b.PlatformRelease.Menus.Get(option))
+
+	// Used to show the config options in the same order as the menu, defined at the begging of platform.txt
+	if b.PlatformRelease.Menus != nil {
+		for _, menuOption := range b.PlatformRelease.Menus.FirstLevelKeys() {
+			for _, option := range allConfigs.FirstLevelKeys() {
+				if menuOption == option {
+					b.configOptions.Set(option, b.PlatformRelease.Menus.Get(menuOption))
+					break
+				}
+			}
+		}
 	}
 
 	b.configOptionValues = map[string]*properties.Map{}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This will change the output sorting when calling the boards details.

## What is the current behavior?

When launching the `arduino-cli boards details -b esp8266:esp8266:generic --format json` the order of the
config options doesn't follow the order of the menu declared in the first lines of `boards.txt` file.

## What is the new behavior?

We now ensure that the order of the config options are following the order of the menus fields declared at the beginning of `boards.txt`

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

Nope

## Other information
