### PR TITLE
fix: Allow build-path to be in a different drive than current sketch

### DIFF
--- a/.licenses/go/github.com/arduino/go-paths-helper.dep.yml
+++ b/.licenses/go/github.com/arduino/go-paths-helper.dep.yml
@@ -1,8 +1,8 @@
 ---
 name: github.com/arduino/go-paths-helper
-version: v1.8.0
+version: v1.9.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/arduino/go-paths-helper
 license: gpl-2.0-or-later
 licenses:

--- a/arduino/cores/packagemanager/install_uninstall.go
+++ b/arduino/cores/packagemanager/install_uninstall.go
@@ -265,10 +265,7 @@ func (pme *Explorer) IsManagedPlatformRelease(platformRelease *cores.PlatformRel
 	if packagesDir.FollowSymLink() != nil {
 		return false
 	}
-	managed, err := installDir.IsInsideDir(packagesDir)
-	if err != nil {
-		return false
-	}
+	managed := installDir.IsInsideDir(packagesDir)
 	return managed
 }
 
@@ -371,10 +368,7 @@ func (pme *Explorer) IsManagedToolRelease(toolRelease *cores.ToolRelease) bool {
 	if packagesDir.FollowSymLink() != nil {
 		return false
 	}
-	managed, err := installDir.IsInsideDir(packagesDir)
-	if err != nil {
-		return false
-	}
+	managed := installDir.IsInsideDir(packagesDir)
 	return managed
 }
 

--- a/arduino/sketch/sketch.go
+++ b/arduino/sketch/sketch.go
@@ -135,7 +135,7 @@ func New(path *paths.Path) (*Sketch, error) {
 		} else if _, found := globals.AdditionalFileValidExtensions[ext]; found {
 			// If the user exported the compiles binaries to the Sketch "build" folder
 			// they would be picked up but we don't want them, so we skip them like so
-			if isInBuildFolder, err := p.IsInsideDir(sketch.FullPath.Join("build")); isInBuildFolder || err != nil {
+			if p.IsInsideDir(sketch.FullPath.Join("build")) {
 				continue
 			}
 

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -131,9 +131,7 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 	var buildPath *paths.Path
 	if buildPathArg := req.GetBuildPath(); buildPathArg != "" {
 		buildPath = paths.New(req.GetBuildPath()).Canonical()
-		if in, err := buildPath.IsInsideDir(sk.FullPath); err != nil {
-			return nil, &arduino.NotFoundError{Message: tr("Cannot find build path"), Cause: err}
-		} else if in && buildPath.IsDir() {
+		if in := buildPath.IsInsideDir(sk.FullPath); in && buildPath.IsDir() {
 			if sk.AdditionalFiles, err = removeBuildFromSketchFiles(sk.AdditionalFiles, buildPath); err != nil {
 				return nil, err
 			}
@@ -385,9 +383,7 @@ func removeBuildFromSketchFiles(files paths.PathList, build *paths.Path) (paths.
 	var res paths.PathList
 	ignored := false
 	for _, file := range files {
-		if in, err := file.IsInsideDir(build); err != nil {
-			return nil, &arduino.NotFoundError{Message: tr("Cannot find build path"), Cause: err}
-		} else if !in {
+		if !file.IsInsideDir(build) {
 			res = append(res, file)
 		} else if !ignored {
 			ignored = true

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.20
 replace github.com/mailru/easyjson => github.com/cmaglie/easyjson v0.8.1
 
 require (
-	github.com/arduino/go-paths-helper v1.8.0
+	github.com/arduino/go-paths-helper v1.9.0
 	github.com/arduino/go-properties-orderedmap v1.7.1
 	github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b
 	github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/arduino/go-paths-helper v1.0.1/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3v5YYu35Yb+w31Ck=
-github.com/arduino/go-paths-helper v1.8.0 h1:BfA1bq1XktnlqwfUDCoKbUqB3YFPe6X7szPSZj6Rdpk=
-github.com/arduino/go-paths-helper v1.8.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
+github.com/arduino/go-paths-helper v1.9.0 h1:IjWhDSF24n5bK/30NyApmzoVH9brWzc52KNPpBsRmMc=
+github.com/arduino/go-paths-helper v1.9.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
 github.com/arduino/go-properties-orderedmap v1.7.1 h1:HQ9Pn/mk3+XyfrE39EEvaZwJkrvgiVSY5Oq3JSEfOR4=
 github.com/arduino/go-properties-orderedmap v1.7.1/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b h1:9hDi4F2st6dbLC3y4i02zFT5quS4X6iioWifGlVwfy4=


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This issue is mainly seen on Windows.

## What is the current behavior?

(copied from original issue: https://github.com/arduino/arduino-cli/issues/2156)

```
$ arduino-cli sketch new "e:/FooSketch"
Sketch created in: e:\FooSketch

$ arduino-cli compile --build-path "c:/Users/per/AppData/Local/Temp/build-path" --fqbn arduino:avr:uno "e:/FooSketch"
Error during build: Cannot find build path: Rel: can't make c:\Users\per\AppData\Local\Temp\build-path relative to E:\FooSketch
```

## What is the new behavior?

Compiles succeed as expected.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

The actual patch is here: https://github.com/arduino/go-paths-helper/pull/20

Fix https://github.com/arduino/arduino-cli/issues/2156
