### PR TITLE
[skip-changelog] Verify installation of builtin tools by checking that their executable is present

### DIFF
--- a/arduino/cores/packagemanager/loader_test.go
+++ b/arduino/cores/packagemanager/loader_test.go
@@ -169,8 +169,8 @@ arduino_zero_edbg.serial.disableRTS=true
 
 func TestLoadDiscoveries(t *testing.T) {
 	// Create all the necessary data to load discoveries
-	fakePath := paths.New("fake-path")
-	require.NoError(t, fakePath.Join("LICENSE").MkdirAll())
+	fakePath, err := paths.TempDir().MkTempDir("fake-path")
+	require.NoError(t, err)
 	defer fakePath.RemoveAll()
 
 	createTestPackageManager := func() *PackageManager {
@@ -181,6 +181,9 @@ func TestLoadDiscoveries(t *testing.T) {
 		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("1.0.0"))
 		// We set this to fake the tool is installed
 		toolRelease.InstallDir = fakePath
+		f, err := toolRelease.InstallDir.Join(toolRelease.Tool.Name + ".exe").Create()
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 		tool.GetOrCreateRelease(semver.ParseRelaxed("0.1.0"))
 
 		// serial-discovery tool
@@ -189,6 +192,9 @@ func TestLoadDiscoveries(t *testing.T) {
 		toolRelease = tool.GetOrCreateRelease(semver.ParseRelaxed("0.1.0"))
 		// We set this to fake the tool is installed
 		toolRelease.InstallDir = fakePath
+		f, err = toolRelease.InstallDir.Join(toolRelease.Tool.Name + ".exe").Create()
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 
 		platform := pack.GetOrCreatePlatform("avr")
 		release := platform.GetOrCreateRelease(semver.MustParse("1.0.0"))
@@ -279,8 +285,6 @@ func TestLoadDiscoveries(t *testing.T) {
 		require.Contains(t, discoveries, "teensy")
 		pmeRelease()
 	}
-
-	require.NoError(t, fakePath.RemoveAll())
 }
 
 func TestConvertUploadToolsToPluggableDiscovery(t *testing.T) {

--- a/arduino/cores/packagemanager/package_manager_test.go
+++ b/arduino/cores/packagemanager/package_manager_test.go
@@ -617,8 +617,8 @@ func TestPackageManagerClear(t *testing.T) {
 
 func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 	// Create all the necessary data to load discoveries
-	fakePath := paths.New("fake-path")
-	require.NoError(t, fakePath.Join("LICENSE").MkdirAll())
+	fakePath, err := paths.TempDir().MkTempDir("fake-path")
+	require.NoError(t, err)
 	defer fakePath.RemoveAll()
 
 	pmb := NewBuilder(fakePath, fakePath, fakePath, fakePath, "test")
@@ -630,6 +630,9 @@ func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("4.2.0"))
 		// We set this to fake the tool is installed
 		toolRelease.InstallDir = fakePath
+		f, err := toolRelease.InstallDir.Join(toolRelease.Tool.Name + ".exe").Create()
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 	}
 
 	{
@@ -646,6 +649,9 @@ func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("6.6.6"))
 		// We set this to fake the tool is installed
 		toolRelease.InstallDir = fakePath
+		f, err := toolRelease.InstallDir.Join(toolRelease.Tool.Name + ".exe").Create()
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 	}
 
 	{
@@ -654,6 +660,9 @@ func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("1.0.0"))
 		// We set this to fake the tool is installed
 		toolRelease.InstallDir = fakePath
+		f, err := toolRelease.InstallDir.Join(toolRelease.Tool.Name + ".exe").Create()
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 		tool.GetOrCreateRelease(semver.ParseRelaxed("0.1.0"))
 	}
 
@@ -664,6 +673,9 @@ func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("0.1.0"))
 		// We set this to fake the tool is installed
 		toolRelease.InstallDir = fakePath
+		f, err := toolRelease.InstallDir.Join(toolRelease.Tool.Name + ".exe").Create()
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 	}
 
 	{
@@ -672,6 +684,9 @@ func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("1.0.0"))
 		// We set this to fake the tool is installed
 		toolRelease.InstallDir = fakePath
+		f, err := toolRelease.InstallDir.Join(toolRelease.Tool.Name + ".exe").Create()
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 		tool.GetOrCreateRelease(semver.ParseRelaxed("0.1.0"))
 	}
 
@@ -682,6 +697,9 @@ func TestFindToolsRequiredFromPlatformRelease(t *testing.T) {
 		toolRelease := tool.GetOrCreateRelease(semver.ParseRelaxed("0.1.0"))
 		// We set this to fake the tool is installed
 		toolRelease.InstallDir = fakePath
+		f, err := toolRelease.InstallDir.Join(toolRelease.Tool.Name + ".exe").Create()
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 	}
 
 	platform := pack.GetOrCreatePlatform("avr")

--- a/arduino/cores/tools.go
+++ b/arduino/cores/tools.go
@@ -106,11 +106,10 @@ func (tool *Tool) String() string {
 
 // IsInstalled returns true if the ToolRelease is installed
 func (tr *ToolRelease) IsInstalled() bool {
-	if tr.InstallDir == nil {
-		return false
+	if tr.Tool.Package.Name == "builtin" && tr.InstallDir != nil {
+		return tr.InstallDir.Join(tr.Tool.Name+".exe").Exist() || tr.InstallDir.Join(tr.Tool.Name).Exist()
 	}
-	dirContent, _ := tr.InstallDir.ReadDir()
-	return dirContent.Len() != 0
+	return tr.InstallDir != nil
 }
 
 func (tr *ToolRelease) String() string {

--- a/internal/integrationtest/board/board_test.go
+++ b/internal/integrationtest/board/board_test.go
@@ -573,7 +573,6 @@ func TestBoardListWithFailedBuiltinInstallation(t *testing.T) {
 	// remove files from serial-discovery directory to simulate a failed installation
 	serialDiscovery, err := cli.DataDir().Join("packages", "builtin", "tools", "serial-discovery").ReadDir()
 	require.NoError(t, err)
-	require.NoError(t, serialDiscovery[0].Join("LICENSE.txt").Remove())
 	require.NoError(t, serialDiscovery[0].Join("serial-discovery.exe").Remove())
 
 	// board list should install serial-discovery again


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the new behavior?
The CLI checks if an executable file is present inside the installation directory of a builtin tool. If not, that tool is marked as not installed.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
