### PR TITLE
Easier recovery from soft bricked native USB boards

### DIFF
--- a/arduino/serialutils/serialutils.go
+++ b/arduino/serialutils/serialutils.go
@@ -106,6 +106,8 @@ func Reset(portToTouch string, wait bool, cb *ResetProgressCallbacks, dryRun boo
 			}
 			if strings.HasSuffix(emulatedPort, "999") {
 				emulatedPort += "0"
+			} else if emulatedPort == "" {
+				emulatedPort = "newport"
 			}
 			return res, nil
 		}

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -195,7 +195,10 @@ func runProgramAction(pme *packagemanager.Explorer,
 	if burnBootloader && programmerID == "" {
 		return &arduino.MissingProgrammerError{}
 	}
-
+	if port == nil {
+		// For no-port uploads use "default" protocol
+		port = &rpc.Port{Protocol: "default"}
+	}
 	logrus.WithField("port", port).Tracef("Upload port")
 
 	fqbn, err := cores.ParseFQBN(fqbnIn)

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -361,11 +361,24 @@ func runProgramAction(pme *packagemanager.Explorer,
 		uploadProperties.Set("build.project_name", sketchName)
 	}
 
+	// Force port wait to make easier to unbrick boards like the Arduino Leonardo, or similar with native USB,
+	// when a sketch causes a crash and the native USB serial port is lost.
+	// See https://github.com/arduino/arduino-cli/issues/1943 for the details.
+	//
+	// In order to trigger the forced serial-port-wait the following conditions must be met:
+	// - No upload port specified (protocol == "default")
+	// - "upload.wait_for_upload_port" == true (developers requested the touch + port wait)
+	// - "upload.tool.serial" not defained, or
+	//   "upload.tool.serial" is the same as "upload.tool.default"
+	forcedSerialPortWait := port.Protocol == "default" && // this is the value when no port is specified
+		uploadProperties.GetBoolean("upload.wait_for_upload_port") &&
+		(!uploadProperties.ContainsKey("upload.tool.serial") ||
+			uploadProperties.Get("upload.tool.serial") == uploadProperties.Get("upload.tool.default"))
+
 	// If not using programmer perform some action required
 	// to set the board in bootloader mode
 	actualPort := port
-	if programmer == nil && !burnBootloader && port.Protocol == "serial" {
-
+	if programmer == nil && !burnBootloader && (port.Protocol == "serial" || forcedSerialPortWait) {
 		// Perform reset via 1200bps touch if requested and wait for upload port also if requested.
 		touch := uploadProperties.GetBoolean("upload.use_1200bps_touch")
 		wait := false
@@ -425,7 +438,7 @@ func runProgramAction(pme *packagemanager.Explorer,
 	if actualPort.Address != "" {
 		// Set serial port property
 		uploadProperties.Set("serial.port", actualPort.Address)
-		if actualPort.Protocol == "serial" {
+		if actualPort.Protocol == "serial" || actualPort.Protocol == "default" {
 			// This must be done only for serial ports
 			portFile := strings.TrimPrefix(actualPort.Address, "/dev/")
 			uploadProperties.Set("serial.port.file", portFile)

--- a/internal/integrationtest/upload_mock/upload_mock_test.go
+++ b/internal/integrationtest/upload_mock/upload_mock_test.go
@@ -162,10 +162,22 @@ func TestUploadSketch(t *testing.T) {
 			Output:     "Performing 1200-bps touch reset on serial port /dev/ttyACM999\nWaiting for upload port...\nUpload port found on /dev/ttyACM9990\n\"{data_dir}/packages/arduino/tools/avrdude/6.3.0-arduino17/bin/avrdude\" \"-C{data_dir}/packages/arduino/tools/avrdude/6.3.0-arduino17/etc/avrdude.conf\" -v -V -patmega32u4 -cavr109 \"-P/dev/ttyACM9990\" -b57600 -D \"-Uflash:w:{build_dir}/{sketch_name}.ino.hex:i\"\n",
 		},
 		{
+			Fqbn:       "arduino:avr:leonardo",
+			UploadPort: "",
+			Programmer: "",
+			Output:     "Skipping 1200-bps touch reset: no serial port selected!\nWaiting for upload port...\nUpload port found on newport\n\"{data_dir}/packages/arduino/tools/avrdude/6.3.0-arduino17/bin/avrdude\" \"-C{data_dir}/packages/arduino/tools/avrdude/6.3.0-arduino17/etc/avrdude.conf\" -v -V -patmega32u4 -cavr109 \"-Pnewport\" -b57600 -D \"-Uflash:w:{build_dir}/{sketch_name}.ino.hex:i\"\n",
+		},
+		{
 			Fqbn:       "arduino:avr:micro",
 			UploadPort: "/dev/ttyACM999",
 			Programmer: "",
 			Output:     "Performing 1200-bps touch reset on serial port /dev/ttyACM999\nWaiting for upload port...\nUpload port found on /dev/ttyACM9990\n\"{data_dir}/packages/arduino/tools/avrdude/6.3.0-arduino17/bin/avrdude\" \"-C{data_dir}/packages/arduino/tools/avrdude/6.3.0-arduino17/etc/avrdude.conf\" -v -V -patmega32u4 -cavr109 \"-P/dev/ttyACM9990\" -b57600 -D \"-Uflash:w:{build_dir}/{sketch_name}.ino.hex:i\"\n",
+		},
+		{
+			Fqbn:       "arduino:avr:micro",
+			UploadPort: "",
+			Programmer: "",
+			Output:     "Skipping 1200-bps touch reset: no serial port selected!\nWaiting for upload port...\nUpload port found on newport\n\"{data_dir}/packages/arduino/tools/avrdude/6.3.0-arduino17/bin/avrdude\" \"-C{data_dir}/packages/arduino/tools/avrdude/6.3.0-arduino17/etc/avrdude.conf\" -v -V -patmega32u4 -cavr109 \"-Pnewport\" -b57600 -D \"-Uflash:w:{build_dir}/{sketch_name}.ino.hex:i\"\n",
 		},
 		{
 			Fqbn:       "arduino:avr:circuitplay32u4cat",
@@ -500,6 +512,16 @@ func TestUploadSketch(t *testing.T) {
 				"darwin": "Performing 1200-bps touch reset on serial port /dev/ttyACM0\nWaiting for upload port...\nNo upload port found, using /dev/ttyACM0 as fallback\n\"{data_dir}/packages/arduino/tools/bossac/1.7.0-arduino3/bossac\" -i -d --port=ttyACM0 -U true -i -e -w -v \"{build_dir}/{sketch_name}.ino.bin\" -R\n",
 				"linux":  "Performing 1200-bps touch reset on serial port /dev/ttyACM0\nWaiting for upload port...\nNo upload port found, using /dev/ttyACM0 as fallback\n\"{data_dir}/packages/arduino/tools/bossac/1.7.0-arduino3/bossac\" -i -d --port=ttyACM0 -U true -i -e -w -v \"{build_dir}/{sketch_name}.ino.bin\" -R\n",
 				"win32":  "Performing 1200-bps touch reset on serial port /dev/ttyACM0\nWaiting for upload port...\nNo upload port found, using /dev/ttyACM0 as fallback\n\"{data_dir}/packages/arduino/tools/bossac/1.7.0-arduino3/bossac.exe\" -i -d --port=ttyACM0 -U true -i -e -w -v \"{build_dir}/{sketch_name}.ino.bin\" -R\n",
+			},
+		},
+		{
+			Fqbn:       "arduino:samd:mkr1000",
+			UploadPort: "",
+			Programmer: "",
+			Output: map[string]string{
+				"darwin": "Skipping 1200-bps touch reset: no serial port selected!\nWaiting for upload port...\nUpload port found on newport\n\"{data_dir}/packages/arduino/tools/bossac/1.7.0-arduino3/bossac\" -i -d --port=newport -U true -i -e -w -v \"{build_dir}/{sketch_name}.ino.bin\" -R\n",
+				"linux":  "Skipping 1200-bps touch reset: no serial port selected!\nWaiting for upload port...\nUpload port found on newport\n\"{data_dir}/packages/arduino/tools/bossac/1.7.0-arduino3/bossac\" -i -d --port=newport -U true -i -e -w -v \"{build_dir}/{sketch_name}.ino.bin\" -R\n",
+				"win32":  "Skipping 1200-bps touch reset: no serial port selected!\nWaiting for upload port...\nUpload port found on newport\n\"{data_dir}/packages/arduino/tools/bossac/1.7.0-arduino3/bossac.exe\" -i -d --port=newport -U true -i -e -w -v \"{build_dir}/{sketch_name}.ino.bin\" -R\n",
 			},
 		},
 		{


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This PR should make it easier to recover from soft-bricked boards with native USB (in cases where the serial port is unavailable because the bootloader has a too-short timeout).

## What is the current behavior?

Trying the upload without a port selected would cause the upload to immediately fail, without leaving any room for the user to synchronize with the upload by tapping the reset button. See #1943 for more details.

## What is the new behavior?

The upload should wait a reasonable amount of time for the user to tap the reset button and make the bootloader avaiable.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No, in theory...

## Other information

Fix #1943 
