### PR TITLE
[skip changelog] Automate license headers checks in CI

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -219,6 +219,41 @@ jobs:
       - name: Check whether any tidying was needed
         run: git diff --color --exit-code
 
+  check-license-headers:
+    name: check-license-headers (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check for missing license headers
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
+        run: |
+          task go:add-license-headers
+          git diff --color --exit-code
+
   # Do a simple "smoke test" build for the modules with no other form of validation
   build:
     name: build (${{ matrix.module.path }})

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -142,6 +142,12 @@ tasks:
       - easyjson arduino/cores/packageindex/index.go
       - easyjson arduino/libraries/librariesindex/json.go
 
+  go:add-license-headers:
+    desc: Add missing go license headers
+    cmds:
+      - go install github.com/google/addlicense@v1.1.1
+      - addlicense -c "ARDUINO SA (http://www.arduino.cc/)" -f ./license_header.tpl **/*.go
+
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
   markdown:check-links:
     desc: Check for broken links

--- a/arduino/discovery/testdata/cat/main.go
+++ b/arduino/discovery/testdata/cat/main.go
@@ -1,3 +1,18 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2023 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
 // Echo stdin to stdout.
 // This program is used for testing purposes, to make it available on all
 // OS a tool equivalent to UNIX "cat".

--- a/commands/lib/search_test.go
+++ b/commands/lib/search_test.go
@@ -1,3 +1,18 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2023 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
 package lib
 
 import (

--- a/commands/sketch/new_test.go
+++ b/commands/sketch/new_test.go
@@ -1,3 +1,18 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2023 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
 package sketch
 
 import (

--- a/configuration/configuration_schema_test.go
+++ b/configuration/configuration_schema_test.go
@@ -1,3 +1,18 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2023 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
 package configuration
 
 import (

--- a/executils/testdata/delay/main.go
+++ b/executils/testdata/delay/main.go
@@ -1,3 +1,18 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2023 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
 package main
 
 import (

--- a/i18n/cmd/po/merge_test.go
+++ b/i18n/cmd/po/merge_test.go
@@ -1,3 +1,18 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2023 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
 package po
 
 import (

--- a/internal/cli/arguments/completion.go
+++ b/internal/cli/arguments/completion.go
@@ -1,3 +1,18 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2023 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
 package arguments
 
 import (

--- a/license_header.tpl
+++ b/license_header.tpl
@@ -1,0 +1,14 @@
+This file is part of arduino-cli.
+
+Copyright{{ if .Year }} {{.Year}}{{ end }} {{.Holder}}
+
+This software is released under the GNU General Public License version 3,
+which covers the main part of arduino-cli.
+The terms of this license can be found at:
+https://www.gnu.org/licenses/gpl-3.0.en.html
+
+You can be released from the requirements of the above licenses by purchasing
+a commercial license. Buying such a license is mandatory if you want to
+modify or otherwise use the software for commercial activities involving the
+Arduino software without disclosing the source code of your own applications.
+To purchase a commercial license, send an email to license@arduino.cc.


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This adds a new CI check for new go files missing the license headers. 
We have to put in the root of the folder a template called: `license_header.tpl`. This file will be used by `addlicense` to add any missing license header in the go file.

## What is the current behavior?

If we create a new go file and forget to add a license header we can spot it only by a manual CR which might be error-prone if the PR is large.

## What is the new behavior?

Every time a new golang file is pushed with a missing license header the CI will fail and warn the user.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Any suggestion are welcomed