### PR TITLE
[skip-changelog] Handle errors that occur during reset

### DIFF
--- a/arduino/serialutils/serialutils.go
+++ b/arduino/serialutils/serialutils.go
@@ -131,8 +131,8 @@ func Reset(portToTouch string, wait bool, cb *ResetProgressCallbacks, dryRun boo
 		if dryRun {
 			// do nothing!
 		} else {
-			if err := TouchSerialPortAt1200bps(portToTouch); err != nil {
-				fmt.Println(tr("TOUCH: error during reset: %s", err))
+			if err := TouchSerialPortAt1200bps(portToTouch); err != nil && !wait {
+				return "", errors.Errorf(tr("TOUCH: error during reset: %s", err))
 			}
 		}
 	}

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -430,7 +430,7 @@ func runProgramAction(pme *packagemanager.Explorer,
 		}
 
 		if newPortAddress, err := serialutils.Reset(portToTouch, wait, cb, dryRun); err != nil {
-			outStream.Write([]byte(fmt.Sprintln(tr("Cannot perform port reset: %s", err))))
+			errStream.Write([]byte(fmt.Sprintln(tr("Cannot perform port reset: %s", err))))
 		} else {
 			if newPortAddress != "" {
 				actualPort.Address = newPortAddress


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
Trying to upload a sketch when the serial port is busy correctly fails, but the error is displayed as simple output text.
```
$ grpcurl \
  -plaintext \
  -import-path ./rpc \
  -proto cc/arduino/cli/commands/v1/commands.proto \
  127.0.0.1:50051 \
  cc.arduino.cli.commands.v1.ArduinoCoreService.Create

{
  "instance": {
    "id": 1
  }
}

$ grpcurl \
  -plaintext \
  -import-path ./rpc \
  -proto cc/arduino/cli/commands/v1/commands.proto \
  -d '{"instance": {"id": 1}}' \
  127.0.0.1:50051 \
  cc.arduino.cli.commands.v1.ArduinoCoreService.Init

$ grpcurl \
  -plaintext \
  -import-path ./rpc \
  -proto cc/arduino/cli/commands/v1/commands.proto \
  -d '{"instance": {"id": 1}, "fqbn": "arduino:mbed_nano:nanorp2040connect", "sketch_path": "C:/Users/m.pologruto/Documents/Arduino/sketch_simple", "port": {"address": "COM3", "protocol": "serial"}, "verbose": true}' \
  127.0.0.1:50051 \
  cc.arduino.cli.commands.v1.ArduinoCoreService.Upload

{
  "outStream": "UGVyZm9ybWluZyAxMjAwLWJwcyB0b3VjaCByZXNldCBvbiBzZXJpYWwgcG9ydCBDT00zCg=="
}
{
  "outStream": "IkM6XFVzZXJzXG0ucG9sb2dydXRvXEFwcERhdGFcTG9jYWxcQXJkdWlubzE1XHBhY2thZ2VzXGFyZHVpbm9cdG9vbHNccnAyMDQwdG9vbHNcMS4wLjYvcnAyMDQwbG9hZCIgLXYgLUQgIkM6XFVzZXJzXG0ucG9sb2dydXRvXEFwcERhdGFcTG9jYWxcVGVtcFxhcmR1aW5vXHNrZXRjaGVzXEY1NEYxRUNFMTE2RTgzMTk2NzJBMTcyM0QzOUMwOUYwL3NrZXRjaF9zaW1wbGUuaW5vLmVsZiIKcnAyMDQwbG9hZCAxLjAuNiAtIGNvbXBpbGVkIHdpdGggZ28xLjE2LjIKLg=="
}
ERROR:
  Code: Internal
  Message: Failed uploading: uploading error: exit status 1
```
```
CALLED: /cc.arduino.cli.commands.v1.ArduinoCoreService/Upload STREAM_RESP
4 |  REQ:  {
4 |    "instance": {
4 |      "id": 1
4 |    },
4 |    "fqbn": "arduino:mbed_nano:nanorp2040connect",
4 |    "sketch_path": "C:/Users/m.pologruto/Documents/Arduino/sketch_simple",
4 |    "port": {
4 |      "address": "COM3",
4 |      "protocol": "serial"
4 |    },
4 |    "verbose": true
4 |  }
TOUCH: error during reset: opening port at 1200bps: Serial port busy
4 |  RESP: {
4 |    "out_stream": "UGVyZm9ybWluZyAxMjAwLWJwcyB0b3VjaCByZXNldCBvbiBzZXJpYWwgcG9ydCBDT00zCg=="
4 |  }
4 |  RESP: {
4 |    "out_stream": "IkM6XFVzZXJzXG0ucG9sb2dydXRvXEFwcERhdGFcTG9jYWxcQXJkdWlubzE1XHBhY2thZ2VzXGFyZHVpbm9cdG9vbHNccnAyMDQwdG9vbHNcMS4wLjYvcnAyMDQwbG9hZCIgLXYgLUQgIkM6XFVzZXJzXG0ucG9sb2dydXRvXEFwcERhdGFcTG9jYWxcVGVtcFxhcmR1aW5vXHNrZXRjaGVzXEY1NEYxRUNFMTE2RTgzMTk2NzJBMTcyM0QzOUMwOUYwL3NrZXRjaF9zaW1wbGUuaW5vLmVsZiIKcnAyMDQwbG9hZCAxLjAuNiAtIGNvbXBpbGVkIHdpdGggZ28xLjE2LjIKLg=="
4 |  }
```
<!-- You can also link to an open issue here -->

## What is the new behavior?
The error is displayed on the `errStream`.
```
{
  "outStream": "UGVyZm9ybWluZyAxMjAwLWJwcyB0b3VjaCByZXNldCBvbiBzZXJpYWwgcG9ydCBDT00zCg=="
}
{
  "errStream": "Q2Fubm90IHBlcmZvcm0gcG9ydCByZXNldDogVE9VQ0g6IGVycm9yIGR1cmluZyByZXNldDogb3BlbmluZyBwb3J0IGF0IDEyMDBicHM6IFNlcmlhbCBwb3J0IGJ1c3kK"
}
{
  "outStream": "IkM6XFVzZXJzXG0ucG9sb2dydXRvXEFwcERhdGFcTG9jYWxcQXJkdWlubzE1XHBhY2thZ2VzXGFyZHVpbm9cdG9vbHNccnAyMDQwdG9vbHNcMS4wLjYvcnAyMDQwbG9hZCIgLXYgLUQgIkM6XFVzZXJzXG0ucG9sb2dydXRvXEFwcERhdGFcTG9jYWxcVGVtcFxhcmR1aW5vXHNrZXRjaGVzXEY1NEYxRUNFMTE2RTgzMTk2NzJBMTcyM0QzOUMwOUYwL3NrZXRjaF9zaW1wbGUuaW5vLmVsZiIK"
}
{
  "outStream": "cnAyMDQwbG9hZCAxLjAuNiAtIGNvbXBpbGVkIHdpdGggZ28xLjE2LjIKLg=="
}
ERROR:
  Code: Internal
  Message: Failed uploading: uploading error: exit status 1
```
```
3 CALLED: /cc.arduino.cli.commands.v1.ArduinoCoreService/Upload STREAM_RESP
3 |  REQ:  {
3 |    "instance": {
3 |      "id": 1
3 |    },
3 |    "fqbn": "arduino:mbed_nano:nanorp2040connect",
3 |    "sketch_path": "C:/Users/m.pologruto/Documents/Arduino/sketch_simple",
3 |    "port": {
3 |      "address": "COM3",
3 |      "protocol": "serial"
3 |    },
3 |    "verbose": true
3 |  }
3 |  RESP: {
3 |    "out_stream": "UGVyZm9ybWluZyAxMjAwLWJwcyB0b3VjaCByZXNldCBvbiBzZXJpYWwgcG9ydCBDT00zCg=="
3 |  }
3 |  RESP: {
3 |    "err_stream": "Q2Fubm90IHBlcmZvcm0gcG9ydCByZXNldDogVE9VQ0g6IGVycm9yIGR1cmluZyByZXNldDogb3BlbmluZyBwb3J0IGF0IDEyMDBicHM6IFNlcmlhbCBwb3J0IGJ1c3kK"
3 |  }
3 |  RESP: {
3 |    "out_stream": "IkM6XFVzZXJzXG0ucG9sb2dydXRvXEFwcERhdGFcTG9jYWxcQXJkdWlubzE1XHBhY2thZ2VzXGFyZHVpbm9cdG9vbHNccnAyMDQwdG9vbHNcMS4wLjYvcnAyMDQwbG9hZCIgLXYgLUQgIkM6XFVzZXJzXG0ucG9sb2dydXRvXEFwcERhdGFcTG9jYWxcVGVtcFxhcmR1aW5vXHNrZXRjaGVzXEY1NEYxRUNFMTE2RTgzMTk2NzJBMTcyM0QzOUMwOUYwL3NrZXRjaF9zaW1wbGUuaW5vLmVsZiIK"
3 |  }
3 |  RESP: {
3 |    "out_stream": "cnAyMDQwbG9hZCAxLjAuNiAtIGNvbXBpbGVkIHdpdGggZ28xLjE2LjIKLg=="
3 |  }
3 |  ERROR:  rpc error: code = Internal desc = Failed uploading: uploading error: exit status 1
3 STREAM CLOSED
```
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
