### PR TITLE
Fixed integration test

### DIFF
--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -1520,9 +1520,14 @@ func TestLibQueryParameters(t *testing.T) {
 	require.Contains(t, string(stdout), `"url":"https://downloads.arduino.cc/libraries/github.com/arduino-libraries/USBHost-1.0.5.zip?query=upgrade"`)
 
 	// Check query=depends when a library dependency is installed
+	stdout, _, err = cli.Run("lib", "deps", "MD_Parola@3.5.5", "--format", "json")
+	require.NoError(t, err)
+	// determine the version installed as dependency
+	MDMAX72XXversion := strings.Trim(requirejson.Parse(t, stdout).Query(`.dependencies[0].version_required`).String(), `"`)
+
 	stdout, _, err = cli.Run("lib", "install", "MD_Parola@3.5.5", "-v", "--log-level", "debug", "--log-format", "json")
 	require.NoError(t, err)
-	require.Contains(t, string(stdout), `"url":"https://downloads.arduino.cc/libraries/github.com/MajicDesigns/MD_MAX72XX-3.3.1.zip?query=depends"`)
+	require.Contains(t, string(stdout), `"url":"https://downloads.arduino.cc/libraries/github.com/MajicDesigns/MD_MAX72XX-`+MDMAX72XXversion+`.zip?query=depends"`)
 
 	// Check query=download when a library is downloaded
 	stdout, _, err = cli.Run("lib", "download", "WiFi101@0.16.1", "-v", "--log-level", "debug", "--log-format", "json")

--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -1510,42 +1510,36 @@ func TestLibQueryParameters(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check query=install when a library is installed
-	stdout, _, err := cli.Run("lib", "install", "USBHost@1.0.0", "-v", "--log-level", "debug")
+	stdout, _, err := cli.Run("lib", "install", "USBHost@1.0.0", "-v", "--log-level", "debug", "--log-format", "json")
 	require.NoError(t, err)
-	require.Contains(t, string(stdout),
-		"Starting download                             \x1b[36murl\x1b[0m=\"https://downloads.arduino.cc/libraries/github.com/arduino-libraries/USBHost-1.0.0.zip?query=install\"\n")
+	require.Contains(t, string(stdout), `"url":"https://downloads.arduino.cc/libraries/github.com/arduino-libraries/USBHost-1.0.0.zip?query=install"`)
 
 	// Check query=upgrade when a library is upgraded
-	stdout, _, err = cli.Run("lib", "upgrade", "USBHost", "-v", "--log-level", "debug")
+	stdout, _, err = cli.Run("lib", "upgrade", "USBHost", "-v", "--log-level", "debug", "--log-format", "json")
 	require.NoError(t, err)
-	require.Contains(t, string(stdout),
-		"Starting download                             \x1b[36murl\x1b[0m=\"https://downloads.arduino.cc/libraries/github.com/arduino-libraries/USBHost-1.0.5.zip?query=upgrade\"\n")
+	require.Contains(t, string(stdout), `"url":"https://downloads.arduino.cc/libraries/github.com/arduino-libraries/USBHost-1.0.5.zip?query=upgrade"`)
 
 	// Check query=depends when a library dependency is installed
-	stdout, _, err = cli.Run("lib", "install", "MD_Parola@3.5.5", "-v", "--log-level", "debug")
+	stdout, _, err = cli.Run("lib", "install", "MD_Parola@3.5.5", "-v", "--log-level", "debug", "--log-format", "json")
 	require.NoError(t, err)
-	require.Contains(t, string(stdout),
-		"Starting download                             \x1b[36murl\x1b[0m=\"https://downloads.arduino.cc/libraries/github.com/MajicDesigns/MD_MAX72XX-3.3.1.zip?query=depends\"\n")
+	require.Contains(t, string(stdout), `"url":"https://downloads.arduino.cc/libraries/github.com/MajicDesigns/MD_MAX72XX-3.3.1.zip?query=depends"`)
 
 	// Check query=download when a library is downloaded
-	stdout, _, err = cli.Run("lib", "download", "WiFi101@0.16.1", "-v", "--log-level", "debug")
+	stdout, _, err = cli.Run("lib", "download", "WiFi101@0.16.1", "-v", "--log-level", "debug", "--log-format", "json")
 	require.NoError(t, err)
-	require.Contains(t, string(stdout),
-		"Starting download                             \x1b[36murl\x1b[0m=\"https://downloads.arduino.cc/libraries/github.com/arduino-libraries/WiFi101-0.16.1.zip?query=download\"\n")
+	require.Contains(t, string(stdout), `"url":"https://downloads.arduino.cc/libraries/github.com/arduino-libraries/WiFi101-0.16.1.zip?query=download"`)
 
 	// Check query=install-builtin when a library dependency is installed in builtin-directory
 	cliEnv := cli.GetDefaultEnv()
 	cliEnv["ARDUINO_DIRECTORIES_BUILTIN_LIBRARIES"] = cli.DataDir().Join("libraries").String()
-	stdout, _, err = cli.RunWithCustomEnv(cliEnv, "lib", "install", "Firmata@2.5.3", "--install-in-builtin-dir", "-v", "--log-level", "debug")
+	stdout, _, err = cli.RunWithCustomEnv(cliEnv, "lib", "install", "Firmata@2.5.3", "--install-in-builtin-dir", "-v", "--log-level", "debug", "--log-format", "json")
 	require.NoError(t, err)
-	require.Contains(t, string(stdout),
-		"Starting download                             \x1b[36murl\x1b[0m=\"https://downloads.arduino.cc/libraries/github.com/firmata/Firmata-2.5.3.zip?query=install-builtin\"\n")
+	require.Contains(t, string(stdout), `"url":"https://downloads.arduino.cc/libraries/github.com/firmata/Firmata-2.5.3.zip?query=install-builtin`)
 
 	// Check query=update-builtin when a library dependency is updated in builtin-directory
-	stdout, _, err = cli.RunWithCustomEnv(cliEnv, "lib", "install", "Firmata@2.5.9", "--install-in-builtin-dir", "-v", "--log-level", "debug")
+	stdout, _, err = cli.RunWithCustomEnv(cliEnv, "lib", "install", "Firmata@2.5.9", "--install-in-builtin-dir", "-v", "--log-level", "debug", "--log-format", "json")
 	require.NoError(t, err)
-	require.Contains(t, string(stdout),
-		"Starting download                             \x1b[36murl\x1b[0m=\"https://downloads.arduino.cc/libraries/github.com/firmata/Firmata-2.5.9.zip?query=upgrade-builtin\"\n")
+	require.Contains(t, string(stdout), `"url":"https://downloads.arduino.cc/libraries/github.com/firmata/Firmata-2.5.9.zip?query=upgrade-builtin"`)
 }
 
 func TestLibBundlesWhenLibWithTheSameNameIsInstalledGlobally(t *testing.T) {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fix an integration test.
The test checks a download URL for a dependency that has been updated.
Previously it downloaded version 3.3.1, but at the moment the new dependency is 3.4.0.
This fix makes the test independent from such changes.

## What is the current behavior?

## What is the new behavior?

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

## Other information
