### PR TITLE
[skip-changelog] Bump setup-protoc to v2

### DIFF
--- a/.github/workflows/check-protobuf-task.yml
+++ b/.github/workflows/check-protobuf-task.yml
@@ -77,7 +77,9 @@ jobs:
 
       - name: Check protocol buffers compile correctly
         if: runner.os == 'Linux'
-        run: task protoc:compile
+        run: |
+          task protoc:compile
+          git diff --color --exit-code
 
   check:
     needs: run-determination

--- a/.github/workflows/check-protobuf-task.yml
+++ b/.github/workflows/check-protobuf-task.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Go deps
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26.0
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 
       - name: Install Task
         uses: arduino/setup-task@v1

--- a/.github/workflows/check-protobuf-task.yml
+++ b/.github/workflows/check-protobuf-task.yml
@@ -59,9 +59,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install protoc compiler
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v2
         with:
-          version: v3.16.0
+          version: v21.12
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Go deps


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Bump the setup-protoc action. This will enable us to use the latest protobuf versions in the future

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
