### PR TITLE
Interpret "empty" gRPC Port object as no-port in upload

### DIFF
--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -195,7 +195,7 @@ func runProgramAction(pme *packagemanager.Explorer,
 	if burnBootloader && programmerID == "" {
 		return &arduino.MissingProgrammerError{}
 	}
-	if port == nil {
+	if port == nil || (port.Address == "" && port.Protocol == "") {
 		// For no-port uploads use "default" protocol
 		port = &rpc.Port{Protocol: "default"}
 	}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Makes the gRPC Upload command more relaxed in interpreting the "Port" object as a no port upload.

## What is the current behavior?

An empty gRPC Port (with `Address` and `Protocol` set to the empty string) will make the upload fail. The same upload request will work as expected if the gRPC Port is left `nil`/undefined.

## What is the new behavior?

An empty gRPC Port is treated the same as a `nil`/undefined Port.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information
