### PR TITLE
Return exit code 0 when a core is already up to date

### DIFF
--- a/internal/cli/core/upgrade.go
+++ b/internal/cli/core/upgrade.go
@@ -110,7 +110,7 @@ func Upgrade(inst *rpc.Instance, args []string, skipPostInstall bool) {
 		warningMissingIndex(response)
 		if err != nil {
 			if _, ok := err.(*arduino.PlatformAlreadyAtTheLatestVersionError); ok {
-				feedback.Fatal(err.Error(), feedback.Success)
+				feedback.Warning(err.Error())
 				continue
 			}
 
@@ -121,4 +121,19 @@ func Upgrade(inst *rpc.Instance, args []string, skipPostInstall bool) {
 	if hasBadArguments {
 		feedback.Fatal(tr("Some upgrades failed, please check the output for details."), feedback.ErrBadArgument)
 	}
+
+	feedback.PrintResult(&platformUpgradeResult{})
+}
+
+// This is needed so we can print warning messages in case users use --format json
+type platformUpgradeResult struct{}
+
+// Data implements feedback.Result.
+func (r *platformUpgradeResult) Data() interface{} {
+	return r
+}
+
+// String implements feedback.Result.
+func (r *platformUpgradeResult) String() string {
+	return ""
 }

--- a/internal/cli/core/upgrade.go
+++ b/internal/cli/core/upgrade.go
@@ -17,7 +17,6 @@ package core
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
@@ -110,7 +109,7 @@ func Upgrade(inst *rpc.Instance, args []string, skipPostInstall bool) {
 		response, err := core.PlatformUpgrade(context.Background(), r, feedback.ProgressBar(), feedback.TaskProgress())
 		warningMissingIndex(response)
 		if err != nil {
-			if errors.Is(err, &arduino.PlatformAlreadyAtTheLatestVersionError{}) {
+			if _, ok := err.(*arduino.PlatformAlreadyAtTheLatestVersionError); ok {
 				feedback.Print(err.Error())
 				continue
 			}

--- a/internal/cli/core/upgrade.go
+++ b/internal/cli/core/upgrade.go
@@ -110,7 +110,7 @@ func Upgrade(inst *rpc.Instance, args []string, skipPostInstall bool) {
 		warningMissingIndex(response)
 		if err != nil {
 			if _, ok := err.(*arduino.PlatformAlreadyAtTheLatestVersionError); ok {
-				feedback.Print(err.Error())
+				feedback.Fatal(err.Error(), feedback.Success)
 				continue
 			}
 

--- a/internal/cli/core/upgrade.go
+++ b/internal/cli/core/upgrade.go
@@ -17,6 +17,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -109,7 +110,8 @@ func Upgrade(inst *rpc.Instance, args []string, skipPostInstall bool) {
 		response, err := core.PlatformUpgrade(context.Background(), r, feedback.ProgressBar(), feedback.TaskProgress())
 		warningMissingIndex(response)
 		if err != nil {
-			if _, ok := err.(*arduino.PlatformAlreadyAtTheLatestVersionError); ok {
+			var alreadyAtLatestVersionErr *arduino.PlatformAlreadyAtTheLatestVersionError
+			if errors.As(err, &alreadyAtLatestVersionErr) {
 				feedback.Warning(err.Error())
 				continue
 			}

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -1041,8 +1041,8 @@ func TestCoreUpgradeWarningWithPackageInstalledButNotIndexed(t *testing.T) {
 		_, _, err = cli.Run("core", "install", "test:x86@1.0.0", "--additional-urls="+url)
 		require.NoError(t, err)
 		//upgrade without index fires a warning
-		_, jsonStderr, _ := cli.Run("core", "upgrade", "test:x86", "--format", "json")
-		requirejson.Query(t, jsonStderr, ".warnings[]", `"missing package index for test:x86, future updates cannot be guaranteed"`)
+		jsonStdout, _, _ := cli.Run("core", "upgrade", "test:x86", "--format", "json")
+		requirejson.Query(t, jsonStdout, ".warnings[]", `"missing package index for test:x86, future updates cannot be guaranteed"`)
 	})
 
 	// removing installed.json
@@ -1050,7 +1050,7 @@ func TestCoreUpgradeWarningWithPackageInstalledButNotIndexed(t *testing.T) {
 	require.NoError(t, os.Remove(installedJson.String()))
 
 	t.Run("missing both installed.json and additional-urls", func(t *testing.T) {
-		_, jsonStderr, _ := cli.Run("core", "upgrade", "test:x86", "--format", "json")
-		requirejson.Query(t, jsonStderr, ".warnings[]", `"missing package index for test:x86, future updates cannot be guaranteed"`)
+		jsonStdout, _, _ := cli.Run("core", "upgrade", "test:x86", "--format", "json")
+		requirejson.Query(t, jsonStdout, ".warnings[]", `"missing package index for test:x86, future updates cannot be guaranteed"`)
 	})
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Return exit code 0 if a platform is already at the latest version

## What is the current behavior?

Returns exit code 1.

## What is the new behavior?

Returns exit code 0.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
