### PR TITLE
Fix crash in upload if the upload tool platform is missing

### DIFF
--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -272,13 +272,18 @@ func runProgramAction(pme *packagemanager.Explorer,
 			Property: fmt.Sprintf("%s.tool.%s", action, port.Protocol), // TODO: Can be done better, maybe inline getToolID(...)
 			Value:    uploadToolID}
 	} else if len(split) == 2 {
+		p := pme.FindPlatform(&packagemanager.PlatformReference{
+			Package:              split[0],
+			PlatformArchitecture: boardPlatform.Platform.Architecture,
+		})
+		if p == nil {
+			return &arduino.PlatformNotFoundError{Platform: split[0] + ":" + boardPlatform.Platform.Architecture}
+		}
 		uploadToolID = split[1]
-		uploadToolPlatform = pme.GetInstalledPlatformRelease(
-			pme.FindPlatform(&packagemanager.PlatformReference{
-				Package:              split[0],
-				PlatformArchitecture: boardPlatform.Platform.Architecture,
-			}),
-		)
+		uploadToolPlatform = pme.GetInstalledPlatformRelease(p)
+		if uploadToolPlatform == nil {
+			return &arduino.PlatformNotFoundError{Platform: split[0] + ":" + boardPlatform.Platform.Architecture}
+		}
 	}
 
 	// Build configuration for upload


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fix a crash in upload if:
* The platform requires an upload tool from another (referenced) platform
* The referenced platform is missing

## What is the current behavior?

See https://github.com/arduino/arduino-cli/issues/2042 for more details:

```
$ arduino-cli compile -b arduino:avr:uno --upload arduino-cli/internal/integrationtest/testdata/bare_minimum
Sketch uses 444 bytes (1%) of program storage space. Maximum is 32256 bytes.
Global variables use 9 bytes (0%) of dynamic memory, leaving 2039 bytes for local variables. Maximum is 2048 bytes.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xaee351]

goroutine 1 [running]:
github.com/arduino/arduino-cli/arduino/cores/packagemanager.(*Explorer).GetInstalledPlatformRelease(0xc00076f600, 0xc0003ba9c0?)
        /home/megabug/Workspace/arduino-cli/arduino/cores/packagemanager/package_manager.go:576 +0x31
github.com/arduino/arduino-cli/commands/upload.runProgramAction(0xc00076f600, 0xc000721ce2?, {0x0, 0x0}, {0x0, 0x0}, {0x7ffcf7a16ea4, 0xf}, 0x40f5e8?, {0x0, ...}, ...)
        /home/megabug/Workspace/arduino-cli/commands/upload/upload.go:276 +0x97e
github.com/arduino/arduino-cli/commands/upload.Upload({0x17791f0?, 0x0?}, 0xc00029b040, {0x114bd00, 0xc00012b068}, {0x114bd00, 0xc00012b080})
        /home/megabug/Workspace/arduino-cli/commands/upload/upload.go:143 +0x445
github.com/arduino/arduino-cli/internal/cli/compile.runCompileCommand(0xc00038aa00?, {0xc0002599c0, 0x1, 0x4?})
        /home/megabug/Workspace/arduino-cli/internal/cli/compile/compile.go:268 +0x1287
github.com/spf13/cobra.(*Command).execute(0xc00038aa00, {0xc000259980, 0x4, 0x4})
        /home/megabug/Software/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:860 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002a9180)
        /home/megabug/Software/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).Execute(0x0?)
        /home/megabug/Software/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902 +0x19
main.main()
        /home/megabug/Workspace/arduino-cli/main.go:31 +0xea
```

## What is the new behavior?


```
arduino-cli compile -b arduino:avr:uno --upload /home/megabug/Workspace/arduino-cli/internal/integrationtest/testdata/bare_minimum
Sketch uses 444 bytes (1%) of program storage space. Maximum is 32256 bytes.
Global variables use 9 bytes (0%) of dynamic memory, leaving 2039 bytes for local variables. Maximum is 2048 bytes.
Error during Upload: Platform 'foo:avr' not found
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2042 
