### PR TITLE
[breaking] Check cross-platform compatibility of sketch names

### DIFF
--- a/commands/sketch/new.go
+++ b/commands/sketch/new.go
@@ -37,7 +37,7 @@ void loop() {
 
 // sketchNameMaxLength could be part of the regex, but it's intentionally left out for clearer error reporting
 var sketchNameMaxLength = 63
-var sketchNameValidationRegex = regexp.MustCompile(`^[0-9a-zA-Z_][0-9a-zA-Z_\.-]*$`)
+var sketchNameValidationRegex = regexp.MustCompile(`^[0-9a-zA-Z_](?:[0-9a-zA-Z_\.-]*[0-9a-zA-Z_-]|)$`)
 
 // NewSketch creates a new sketch via gRPC
 func NewSketch(ctx context.Context, req *rpc.NewSketchRequest) (*rpc.NewSketchResponse, error) {
@@ -80,7 +80,7 @@ func validateSketchName(name string) error {
 			sketchNameMaxLength))}
 	}
 	if !sketchNameValidationRegex.MatchString(name) {
-		return &arduino.CantCreateSketchError{Cause: errors.New(tr(`invalid sketch name "%[1]s": the first character must be alphanumeric or "_", the following ones can also contain "-" and ".".`,
+		return &arduino.CantCreateSketchError{Cause: errors.New(tr(`invalid sketch name "%[1]s": the first character must be alphanumeric or "_", the following ones can also contain "-" and ".". The last one cannot be ".".`,
 			name))}
 	}
 	return nil

--- a/commands/sketch/new.go
+++ b/commands/sketch/new.go
@@ -39,6 +39,9 @@ void loop() {
 var sketchNameMaxLength = 63
 var sketchNameValidationRegex = regexp.MustCompile(`^[0-9a-zA-Z_](?:[0-9a-zA-Z_\.-]*[0-9a-zA-Z_-]|)$`)
 
+var invalidNames = []string{"CON", "PRN", "AUX", "NUL", "COM0", "COM1", "COM2", "COM3", "COM4", "COM5",
+	"COM6", "COM7", "COM8", "COM9", "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}
+
 // NewSketch creates a new sketch via gRPC
 func NewSketch(ctx context.Context, req *rpc.NewSketchRequest) (*rpc.NewSketchResponse, error) {
 	var sketchesDir string
@@ -82,6 +85,11 @@ func validateSketchName(name string) error {
 	if !sketchNameValidationRegex.MatchString(name) {
 		return &arduino.CantCreateSketchError{Cause: errors.New(tr(`invalid sketch name "%[1]s": the first character must be alphanumeric or "_", the following ones can also contain "-" and ".". The last one cannot be ".".`,
 			name))}
+	}
+	for _, invalid := range invalidNames {
+		if name == invalid {
+			return &arduino.CantCreateSketchError{Cause: errors.New(tr(`sketch name cannot be the reserved name "%[1]s"`, invalid))}
+		}
 	}
 	return nil
 }

--- a/commands/sketch/new_test.go
+++ b/commands/sketch/new_test.go
@@ -91,3 +91,15 @@ func Test_SketchNameOk(t *testing.T) {
 		require.Nil(t, err)
 	}
 }
+
+func Test_SketchNameReserved(t *testing.T) {
+	invalidNames := []string{"CON", "PRN", "AUX", "NUL", "COM0", "COM1", "COM2", "COM3", "COM4", "COM5",
+		"COM6", "COM7", "COM8", "COM9", "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}
+	for _, name := range invalidNames {
+		_, err := NewSketch(context.Background(), &commands.NewSketchRequest{
+			SketchName: name,
+			SketchDir:  t.TempDir(),
+		})
+		require.EqualError(t, err, fmt.Sprintf(`Can't create sketch: sketch name cannot be the reserved name "%s"`, name))
+	}
+}

--- a/commands/sketch/new_test.go
+++ b/commands/sketch/new_test.go
@@ -30,6 +30,7 @@ func Test_SketchNameWrongPattern(t *testing.T) {
 		".hello",
 		"-hello",
 		"hello*",
+		"hello.",
 		"||||||||||||||",
 		",`hack[}attempt{];",
 	}
@@ -39,7 +40,7 @@ func Test_SketchNameWrongPattern(t *testing.T) {
 			SketchDir:  t.TempDir(),
 		})
 
-		require.EqualError(t, err, fmt.Sprintf(`Can't create sketch: invalid sketch name "%s": the first character must be alphanumeric or "_", the following ones can also contain "-" and ".".`,
+		require.EqualError(t, err, fmt.Sprintf(`Can't create sketch: invalid sketch name "%s": the first character must be alphanumeric or "_", the following ones can also contain "-" and ".". The last one cannot be ".".`,
 			name))
 	}
 }
@@ -78,7 +79,6 @@ func Test_SketchNameOk(t *testing.T) {
 		"h",
 		"h.ello",
 		"h..ello-world",
-		"h..ello-world.",
 		"hello_world__",
 		"_hello_world",
 		string(lengthLimitName),

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -4,6 +4,13 @@ Here you can find a list of migration guides to handle breaking changes between 
 
 ## 0.34.0
 
+### Updated sketch name specifications
+
+[Sketch name specifications](https://arduino.github.io/arduino-cli/dev/sketch-specification) have been updated to
+achieve cross-platform compatibility.
+
+Existing sketch names violating the new constraint need to be updated.
+
 ### golang API: `LoadSketch` function has been moved
 
 The function `github.com/arduino/arduino-cli/commands.LoadSketch` has been moved to package

--- a/docs/sketch-specification.md
+++ b/docs/sketch-specification.md
@@ -7,7 +7,9 @@ The programs that run on Arduino boards are called "sketches". This term was inh
 
 The sketch root folder name and code file names must start with a basic letter (`A`-`Z` or `a`-`z`), number (`0`-`9`)
 [<sup>1</sup>](#leading-number-note), or underscore (`_`) [<sup>2</sup>](#leading-underscore-note) followed by basic
-letters, numbers, underscores, dots (`.`) and dashes (`-`). The maximum length is 63 characters.
+letters, numbers, underscores, dots (`.`) and dashes (`-`). The maximum length is 63 characters. The sketch name cannot
+end with a dot (`.`) and cannot be a
+[reserved name](https://learn.microsoft.com/windows/win32/fileio/naming-a-file#naming-conventions).
 
 <a id="leading-number-note"></a> <sup>1</sup> Supported from Arduino IDE 1.8.4. <br />
 <a id="leading-underscore-note"></a> <sup>2</sup> Supported in all versions except Arduino IDE 2.0.4/Arduino CLI


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Documentation enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
Sketch names ending with a `.` can be used. [Reserved names](https://learn.microsoft.com/en-ca/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#naming-conventions) can be used as sketch names.
<!-- You can also link to an open issue here -->

## What is the new behavior?
It is no longer possible to name sketches in the above mentioned way.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
Yes
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->