### PR TITLE
[skip-changelog] Update expected `installed.json` after index changes

### DIFF
--- a/internal/integrationtest/testdata/installed.json
+++ b/internal/integrationtest/testdata/installed.json
@@ -123,2090 +123,103 @@
       ],
       "tools": [
         {
-          "name": "dfu-util",
-          "version": "0.10.0-arduino1",
+          "name": "windows-drivers",
+          "version": "1.6.9",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/drivers-arduino-windows-1.6.9.zip",
+              "archiveFileName": "drivers-arduino-windows-1.6.9.zip",
+              "size": "7071714",
+              "checksum": "SHA-256:10d456ab18d164d42545255db8bef4ac9e1bf660cc89acb7a0980b5a486654ac"
+            }
+          ]
+        },
+        {
+          "name": "windows-drivers",
+          "version": "1.8.0",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/drivers-arduino-windows-1.8.0.zip",
+              "archiveFileName": "drivers-arduino-windows-1.8.0.zip",
+              "size": "16302148",
+              "checksum": "SHA-256:60614b326ad6860ed0cb99eb4cb2cb69f9ba6ba3784396d5441fe3f99004f8ec"
+            }
+          ]
+        },
+        {
+          "name": "nrf5x-cl-tools",
+          "version": "9.3.1",
           "systems": [
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-osx.tar.bz2",
-              "archiveFileName": "dfu-util-0.10.0-arduino1-osx.tar.bz2",
-              "size": "73921",
-              "checksum": "SHA-256:7562d128036759605828d64b8d672d42445a8d95555c4b9ba339f73a1711a640"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-arm.tar.bz2",
-              "archiveFileName": "dfu-util-0.10.0-arduino1-arm.tar.bz2",
-              "size": "272153",
-              "checksum": "SHA-256:f1e550f40c235356b7fde1c59447bfbab28f768915d3c14bd858fe0576bfc5a9"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-arm64.tar.bz2",
-              "archiveFileName": "dfu-util-0.10.0-arduino1-arm64.tar.bz2",
-              "size": "277886",
-              "checksum": "SHA-256:ebfbd21d3030c500da1f83b9aae5b8c597bee04c3bde1ce0a51b41abeafc9614"
+              "url": "http://downloads.arduino.cc/arduino.org/nRF5x-Command-Line-Tools_9_3_1_OSX.tar.bz2",
+              "archiveFileName": "nRF5x-Command-Line-Tools_9_3_1_OSX.tar.bz2",
+              "size": "341674",
+              "checksum": "SHA-256:41e4580271b39459a7ef1b078d11ee08d8f4f23fab7ff03f3fe8c3bc986a0ed4"
             },
             {
               "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-linux64.tar.bz2",
-              "archiveFileName": "dfu-util-0.10.0-arduino1-linux64.tar.bz2",
-              "size": "77184",
-              "checksum": "SHA-256:13ef2ec591c1e8b0b7eb0a05da972ecd6695016e7a9607e332c7553899af9b4a"
+              "url": "http://downloads.arduino.cc/arduino.org/nRF5x-Command-Line-Tools_9_3_1_Linux-x86_64.tar.bz2",
+              "archiveFileName": "nRF5x-Command-Line-Tools_9_3_1_Linux-x86_64.tar.bz2",
+              "size": "167414",
+              "checksum": "SHA-256:4074fffe678d60968006a72edd182c6506b264472c9957bc3eaa39336bfcf972"
             },
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-linux32.tar.bz2",
-              "archiveFileName": "dfu-util-0.10.0-arduino1-linux32.tar.bz2",
-              "size": "81826",
-              "checksum": "SHA-256:43599ec60c000e9ef016970a496d6ab2cbbe5a8b7df9d06ef3114ecf83f9d123"
+              "url": "http://downloads.arduino.cc/arduino.org/nRF5x-Command-Line-Tools_9_3_1_Linux-i386.tar.bz2",
+              "archiveFileName": "nRF5x-Command-Line-Tools_9_3_1_Linux-i386.tar.bz2",
+              "size": "155680",
+              "checksum": "SHA-256:e880059b303e5aad3a8b34c83dfd8c22beee77ae2074fbd37511e3baa91464a5"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-windows.tar.bz2",
-              "archiveFileName": "dfu-util-0.10.0-arduino1-windows.tar.bz2",
-              "size": "464314",
-              "checksum": "SHA-256:90816b669273ae796d734a2459c46bb340d4790783fd7aa01eb40c0443f1a9b1"
+              "url": "http://downloads.arduino.cc/arduino.org/nRF5x-Command-Line-Tools_9_3_1_Win32.tar.bz2",
+              "archiveFileName": "nRF5x-Command-Line-Tools_9_3_1_Win32.tar.bz2",
+              "size": "812257",
+              "checksum": "SHA-256:a4467350e39314690cec2e96b80e7e3cab463c84eff9b81593ad57754d76ee00"
             }
           ]
         },
         {
-          "name": "dfu-util",
-          "version": "0.11.0-arduino1",
+          "name": "arduinoSTM32load",
+          "version": "2.0.0",
           "systems": [
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino1-osx.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino1-osx.tar.bz2",
-              "size": "72632",
-              "checksum": "SHA-256:4518156ef1f46655714f11c9c9e753b6dee24e975d2155b5887ee613be133831"
+              "url": "http://downloads.arduino.cc/arduino.org/arduinoSTM32load-2.0.0-darwin_amd64.tar.bz2",
+              "archiveFileName": "arduinoSTM32load-2.0.0-darwin_amd64.tar.bz2",
+              "size": "807514",
+              "checksum": "SHA-256:92fb9714091850febaa9d159501cbca5ba68d03020e5e2d4eff596154040bfaa"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino1-arm.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino1-arm.tar.bz2",
-              "size": "240667",
-              "checksum": "SHA-256:105ffe9287e7341b6ad017c1224b45a6fcf440fd8a1d1b796cf10e8c8e05e51d"
+              "url": "http://downloads.arduino.cc/arduino.org/arduinoSTM32load-2.0.0-linux_arm.tar.bz2",
+              "archiveFileName": "arduinoSTM32load-2.0.0-linux_arm.tar.bz2",
+              "size": "809480",
+              "checksum": "SHA-256:fc0d8058b57bda849e1ffc849f83f54b0b85f97954176db317da1c745c174e08"
             },
             {
               "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino1-linux64.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino1-linux64.tar.bz2",
-              "size": "76905",
-              "checksum": "SHA-256:dedd8ff3d21525957211a0f7ff320294542ea61e42431bd10f3d95200b07def0"
+              "url": "http://downloads.arduino.cc/arduino.org/arduinoSTM32load-2.0.0-linux_amd64.tar.bz2",
+              "archiveFileName": "arduinoSTM32load-2.0.0-linux_amd64.tar.bz2",
+              "size": "818885",
+              "checksum": "SHA-256:0ed5cf1ea05fe6c33567817c54daf9c296d058a3607c428e0b0bd9aad89b9809"
             },
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino1-linux32.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino1-linux32.tar.bz2",
-              "size": "76871",
-              "checksum": "SHA-256:cda70b9a3840b005f1070ac49e161df9c17bb5e9411897f38d4f5383104c864d"
+              "url": "http://downloads.arduino.cc/arduino.org/arduinoSTM32load-2.0.0-linux_386.tar.bz2",
+              "archiveFileName": "arduinoSTM32load-2.0.0-linux_386.tar.bz2",
+              "size": "814283",
+              "checksum": "SHA-256:fad50abaaca034e6d647d09b042291b761982aabfd42b6156411c86e4f873ca7"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino1-windows.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino1-windows.tar.bz2",
-              "size": "634135",
-              "checksum": "SHA-256:dad96adc633d1a415b68439298c75db8d66aff978aef1288977bc7797ae946f6"
-            }
-          ]
-        },
-        {
-          "name": "dfu-util",
-          "version": "0.11.0-arduino2",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-osx.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino2-osx.tar.bz2",
-              "size": "72590",
-              "checksum": "SHA-256:8a01eb2238962e42db6dc476a6c1ec204a8670b2f3c9f6784c69e6cb981fd938"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-arm.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino2-arm.tar.bz2",
-              "size": "285451",
-              "checksum": "SHA-256:63bbddbdab6889c925d6f9535c92f0ba5fbd58d4e5e03d32cb43b91ef44bf277"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-arm64.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino2-arm64.tar.bz2",
-              "size": "282570",
-              "checksum": "SHA-256:fc2fd50397b5e23d552424bf6fbdd38c970fd58b2d2ac11f2395c3e3b7228cee"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-linux64.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino2-linux64.tar.bz2",
-              "size": "76662",
-              "checksum": "SHA-256:bbfecff5e59c70f436777bd2ea4732708d34f0611634f386d29964692b87db2f"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-linux32.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino2-linux32.tar.bz2",
-              "size": "76696",
-              "checksum": "SHA-256:f6c39d312b0c70efc66c5439a3f95c08006eb7639c1205805175cc85a3725564"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-windows.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino2-windows.tar.bz2",
-              "size": "634198",
-              "checksum": "SHA-256:3ddc85d1dd0195bc88a45d7a1a82c8b4e1952923ef39f89e13645226f0294da8"
-            }
-          ]
-        },
-        {
-          "name": "dfu-util",
-          "version": "0.11.0-arduino3",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-osx.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino3-osx.tar.bz2",
-              "size": "79057",
-              "checksum": "SHA-256:81d88dae0ed068a7bdde14d7cd56c9b953a3aea87aaaf4bcbaf022ba7df47ad5"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-arm.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino3-arm.tar.bz2",
-              "size": "241168",
-              "checksum": "SHA-256:27fb1fc8ba19df08f1805236083c7199f59bdaaacacceead98fee0e817e48425"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-arm64.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino3-arm64.tar.bz2",
-              "size": "282961",
-              "checksum": "SHA-256:5f212524b6338d06bf833a2375f1012740e0a359c81ad1ff728222cc93a28586"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-linux64.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino3-linux64.tar.bz2",
-              "size": "78422",
-              "checksum": "SHA-256:6a72e62546d4ba1c0c05c00a1e4863b23ab99e1224e6325b458207822fbf0da4"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-linux32.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino3-linux32.tar.bz2",
-              "size": "82825",
-              "checksum": "SHA-256:d6e5bd3d1861ac01dc85e85ae44667346a18f56537a95fe63e9dc71b1adeac99"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-windows.tar.bz2",
-              "archiveFileName": "dfu-util-0.11.0-arduino3-windows.tar.bz2",
-              "size": "635719",
-              "checksum": "SHA-256:7dccfadc260c5b13f7267fcd9ed610571bc74f6f64a85c20541c9ae48a1833b3"
-            }
-          ]
-        },
-        {
-          "name": "dfu-util",
-          "version": "0.8.0-stm32-arduino1",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/arduino.org/dfu-util-0.8.0-stm32-arduino1-darwin_amd64.tar.bz2",
-              "archiveFileName": "dfu-util-0.8.0-stm32-arduino1-darwin_amd64.tar.bz2",
-              "size": "68381",
-              "checksum": "SHA-256:bb146803a4152ce2647d72b2cde68ff95eb3017c2460f24c4db922adac1fbd12"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/arduino.org/dfu-util-0.8.0-stm32-arduino1-linux_arm.tar.bz2",
-              "archiveFileName": "dfu-util-0.8.0-stm32-arduino1-linux_arm.tar.bz2",
-              "size": "213760",
-              "checksum": "SHA-256:607e6b0f2d2787ed7837f26da30b100131e3db207f84b8aca94a377db6e9ae50"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino.org/dfu-util-0.8.0-stm32-arduino1-linux_amd64.tar.bz2",
-              "archiveFileName": "dfu-util-0.8.0-stm32-arduino1-stm32-linux_amd64.tar.bz2",
-              "size": "68575",
-              "checksum": "SHA-256:e44287494ebd22f59fc79766a94e20306e59c6c799f5bb1cddeed80db95000d9"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino.org/dfu-util-0.8.0-stm32-arduino1-linux_386.tar.bz2",
-              "archiveFileName": "dfu-util-0.8.0-stm32-arduino1-linux_386.tar.bz2",
-              "size": "69097",
-              "checksum": "SHA-256:58131e35ad5d7053b281bc6176face7b117c5ad63331e43c6801f8ccd57f59a4"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/arduino.org/dfu-util-0.8.0-stm32-arduino1-windows_386.tar.bz2",
-              "archiveFileName": "dfu-util-0.8.0-stm32-arduino1-windows_386.tar.bz2",
-              "size": "159753",
-              "checksum": "SHA-256:25c2f84e1acf1f10fd2aa1afced441366d4545fd41eae56e64f0b990b4ce9f55"
-            }
-          ]
-        },
-        {
-          "name": "dfu-util",
-          "version": "0.9.0-arduino1",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino1-osx.tar.bz2",
-              "archiveFileName": "dfu-util-0.9.0-arduino1-osx.tar.bz2",
-              "size": "68361",
-              "checksum": "SHA-256:ea9216c627b7aa2d3a9bffab97df937e3c580cce66753c428dc697c854a35271"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino1-arm.tar.bz2",
-              "archiveFileName": "dfu-util-0.9.0-arduino1-arm.tar.bz2",
-              "size": "194826",
-              "checksum": "SHA-256:480637bf578e74b19753666a049f267d8ebcd9dfc8660d48f246bb76d5b806f9"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino1-linux64.tar.bz2",
-              "archiveFileName": "dfu-util-0.9.0-arduino1-linux64.tar.bz2",
-              "size": "66230",
-              "checksum": "SHA-256:e8a4d5477ab8c44d8528f35bc7dfafa5f3f04dace513906514aea31adc6fd3ba"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino1-linux32.tar.bz2",
-              "archiveFileName": "dfu-util-0.9.0-arduino1-linux32.tar.bz2",
-              "size": "62608",
-              "checksum": "SHA-256:17d69213914da04dadd6464d8adbcd3581dd930eb666b8f3336ab5383ce2127f"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino1-windows.tar.bz2",
-              "archiveFileName": "dfu-util-0.9.0-arduino1-windows.tar.bz2",
-              "size": "377537",
-              "checksum": "SHA-256:29be01b298348be8b822391be7147b71a969d47bd5457d5b24cfa5981dbce78e"
-            }
-          ]
-        },
-        {
-          "name": "dfu-util",
-          "version": "0.9.0-arduino2",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino2-osx.tar.bz2",
-              "archiveFileName": "dfu-util-0.9.0-arduino2-osx.tar.bz2",
-              "size": "65137",
-              "checksum": "SHA-256:00e87178b81d5721f334d4b688267f19f36eed1d9710a912c9e44bb1a748f766"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino2-arm.tar.bz2",
-              "archiveFileName": "dfu-util-0.9.0-arduino2-arm.tar.bz2",
-              "size": "198568",
-              "checksum": "SHA-256:b364a8fe1de697d7dd6c4135d341ddff6dbda7e33c707321c7dceab85dfc560b"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino2-linux64.tar.bz2",
-              "archiveFileName": "dfu-util-0.9.0-arduino2-linux64.tar.bz2",
-              "size": "70996",
-              "checksum": "SHA-256:628e01772007e622dff6af82220c27bcdf1d0726ba886bd2b36807601f66e4e8"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino2-linux32.tar.bz2",
-              "archiveFileName": "dfu-util-0.9.0-arduino2-linux32.tar.bz2",
-              "size": "71002",
-              "checksum": "SHA-256:7a6cec3d89c65119c52b6109cd92a9ec84bdf8a9d12083444d2c89e7ac16c84b"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino2-windows.tar.bz2",
-              "archiveFileName": "dfu-util-0.9.0-arduino2-windows.tar.bz2",
-              "size": "394993",
-              "checksum": "SHA-256:8ec0e66acdc41941b6e25545f8c12e7eb7ba01a0bafae0b4ab4c99a70deb2ea5"
-            }
-          ]
-        },
-        {
-          "name": "avr-gcc",
-          "version": "4.8.1-arduino2",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino2-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avr-gcc-4.8.1-arduino2-i386-apple-darwin11.tar.bz2",
-              "size": "24443285",
-              "checksum": "SHA-256:c19a7526235c364d7f62ec1a993d9b495973ba1813869ccf0241c65905896852"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.8.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "27152002",
-              "checksum": "SHA-256:24a931877bee5f36dc00a88877219a6d2f6a1fb7abb989fd04556b8432d2e14e"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.8.1-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "size": "25876628",
-              "checksum": "SHA-256:2d701b4efbc8cec62dc299cde01730c5eebcf23d7e4393db8cf7744a9bf1d3de"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino2-i686-mingw32.zip",
-              "archiveFileName": "avr-gcc-4.8.1-arduino2-i686-mingw32.zip",
-              "size": "46046691",
-              "checksum": "SHA-256:2eafb49fb803fa4d2c32d35e24c0b372fcd520ca0a790fa537a847179e382000"
-            }
-          ]
-        },
-        {
-          "name": "avr-gcc",
-          "version": "4.9.2-atmel3.5.3-arduino",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino-i386-apple-darwin11.tar.bz2",
-              "size": "27046965",
-              "checksum": "SHA-256:adeee70be27cc3ee0e4b9e844610d9c534c7b21dae24ec3fa49808c2f04958de"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino-armhf-pc-linux-gnu.tar.bz2",
-              "size": "27400001",
-              "checksum": "SHA-256:02dba9ee77694c23a4c304416a3808949c8faedf07f25a225a4189d850615ec6"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "29904544",
-              "checksum": "SHA-256:0711e885c0430859e7fea3831af8c69a0c25f92a90ecfda9281799a0acec7455"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino-i686-pc-linux-gnu.tar.bz2",
-              "size": "29077606",
-              "checksum": "SHA-256:fe0bb1d6369694779ceb671d457ccadbeafe855a11f6746b7db20055cea4df33"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino-i686-mingw32.zip",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino-i686-mingw32.zip",
-              "size": "43847566",
-              "checksum": "SHA-256:445ce3117e87be7e196809fbbea373976160689b6d4b43dbf185eb4c914d1469"
-            }
-          ]
-        },
-        {
-          "name": "avr-gcc",
-          "version": "5.4.0-atmel3.6.1-arduino2",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-armhf-pc-linux-gnu.tar.bz2",
-              "size": "31449123",
-              "checksum": "SHA-256:6741f95cc3182a8729cf9670eb13d8dc5a19e881639ca61e53a2d78346a4e99f"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-aarch64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-aarch64-pc-linux-gnu.tar.bz2",
-              "size": "33141295",
-              "checksum": "SHA-256:0fa9e4f2d6d09782dbc84dd91a302849cde2f192163cb9f29484c5f32785269a"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-i386-apple-darwin11.tar.bz2",
-              "size": "31894498",
-              "checksum": "SHA-256:abc50137543ba73e227b4d1b8510fff50a474bacd24f2c794f852904963849f8"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-w64-mingw32.zip",
-              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-w64-mingw32.zip",
-              "size": "45923772",
-              "checksum": "SHA-256:7eb5691a379b547798fae535b05d68bc02d3969f12d051b8a5a5f2f350ab0a7f"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "size": "33022916",
-              "checksum": "SHA-256:51f87e04f3cdaa73565c751051ac118e02904ad8478f1475b300e1bffcd5538f"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "33522375",
-              "checksum": "SHA-256:05422b0d73b10357c12ea938f02cf50529422b89a4722756e70024aed3e69185"
-            }
-          ]
-        },
-        {
-          "name": "avr-gcc",
-          "version": "7.3.0-atmel3.6.1-arduino5",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-arm-linux-gnueabihf.tar.bz2",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-arm-linux-gnueabihf.tar.bz2",
-              "size": "34462042",
-              "checksum": "SHA-256:f4acd5531c6b82c715e2edfa0aadb13fb718b4095b3ea1aa1f7fbde680069639"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-aarch64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-aarch64-pc-linux-gnu.tar.bz2",
-              "size": "39381972",
-              "checksum": "SHA-256:dd9c70190be370a44fb47dab1514de6d8852b861dfa527964b65c740d8d50c10"
-            },
-            {
-              "host": "x86_64-apple-darwin14",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-apple-darwin14.tar.bz2",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-apple-darwin14.tar.bz2",
-              "size": "38492678",
-              "checksum": "SHA-256:f48706317f04452544ab90e75bd1bb193f8af2cb1002f53aa702f27202c1b38f"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-i686-w64-mingw32.zip",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-i686-w64-mingw32.zip",
-              "size": "53727984",
-              "checksum": "SHA-256:6d4a5d089a36e5b5252befc73da204555b49e376ce7577ee19ca7f028b295830"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-i686-pc-linux-gnu.tar.bz2",
-              "size": "38710087",
-              "checksum": "SHA-256:2ff12739d7ed09688d6b3c2c126e8df69b5bda1a07ab558799f0e576571e0e1d"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "39114120",
-              "checksum": "SHA-256:3effed8ffa1978b6e4a46f1aa2acc629e440b4d77244f71f9b79a916025206fb"
-            }
-          ]
-        },
-        {
-          "name": "avr-gcc",
-          "version": "4.8.1-arduino3",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino3-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avr-gcc-4.8.1-arduino3-i386-apple-darwin11.tar.bz2",
-              "size": "24447175",
-              "checksum": "SHA-256:28e207c66b3dc405367d0c5e68ce3c278e5ec3abb0e4974e7927fe0f9a532c40"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino3-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.8.1-arduino3-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "30556996",
-              "checksum": "SHA-256:028340abec6eb3085b82404dfc7ed143e1bb05b2da961b539ddcdba4a6f65533"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino3-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.8.1-arduino3-i686-pc-linux-gnu.tar.bz2",
-              "size": "28768022",
-              "checksum": "SHA-256:37796548ba9653267568f959cd8c7ebfe5b4bce4599898cf9f876d64e616cb87"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino3-i686-mingw32.zip",
-              "archiveFileName": "avr-gcc-4.8.1-arduino3-i686-mingw32.zip",
-              "size": "46046917",
-              "checksum": "SHA-256:d6f0527793f9800f060408392a99eb290ed205730edbae43a1a25cbf6b6b588f"
-            }
-          ]
-        },
-        {
-          "name": "avr-gcc",
-          "version": "4.8.1-arduino5",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino5-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.8.1-arduino5-armhf-pc-linux-gnu.tar.bz2",
-              "size": "24403768",
-              "checksum": "SHA-256:c8ffcd2db7a651b48ab4ea19db4b34fbae3e7f0210a0f294592af2bdabf2154b"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino5-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avr-gcc-4.8.1-arduino5-i386-apple-darwin11.tar.bz2",
-              "size": "24437400",
-              "checksum": "SHA-256:111b3ef00d737d069eb237a8933406cbb928e4698689e24663cffef07688a901"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.8.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "27093036",
-              "checksum": "SHA-256:9054fcc174397a419ba56c4ce1bfcbcad275a6a080cc144905acc9b0351ee9cc"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino5-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.8.1-arduino5-i686-pc-linux-gnu.tar.bz2",
-              "size": "25882375",
-              "checksum": "SHA-256:7648b7f549b37191da0b0be53bae791b652f82ac3cb4e7877f85075aaf32141f"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino5-i686-mingw32.zip",
-              "archiveFileName": "avr-gcc-4.8.1-arduino5-i686-mingw32.zip",
-              "size": "46044779",
-              "checksum": "SHA-256:d4303226a7b41d3c445d901b5aa5903458def3fc7b7ff4ffef37cabeb37d424d"
-            }
-          ]
-        },
-        {
-          "name": "avr-gcc",
-          "version": "4.9.2-atmel3.5.3-arduino2",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino2-armhf-pc-linux-gnu.tar.bz2",
-              "size": "27400889",
-              "checksum": "SHA-256:77f300d519bc6b9a25df17b36cb303218e9a258c059b2f6bff8f71a0d8f96821"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino2-i386-apple-darwin11.tar.bz2",
-              "size": "27048070",
-              "checksum": "SHA-256:311258af188defe24a4b341e4e1f4dc93ca6c80516d3e3b55a2fc07a7050248b"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-i686-mingw32.zip",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino2-i686-mingw32.zip",
-              "size": "43847945",
-              "checksum": "SHA-256:f8e6ede8746c70be01ec79a30803277cd94360cc5b2e104762da0fbcf536fcc6"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "size": "29292729",
-              "checksum": "SHA-256:f108951e7c4dc90926d1fc76cc27549f6ea63c702a2bb7ff39647a19ae86ec68"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "29882960",
-              "checksum": "SHA-256:3903a6d1bb9fdd91727e504b5993d5501f119bcb7f99f7aee98a2101e5629188"
-            }
-          ]
-        },
-        {
-          "name": "avr-gcc",
-          "version": "4.9.2-atmel3.5.4-arduino2",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.4-arduino2-armhf-pc-linux-gnu.tar.bz2",
-              "size": "27764772",
-              "checksum": "SHA-256:ee36009e19bd238d1f6351cbc9aa5db69714761f67dec4c1d69d5d5d7758720c"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.4-arduino2-i386-apple-darwin11.tar.bz2",
-              "size": "28574644",
-              "checksum": "SHA-256:67b3ed3555eacf0b4fc6f62240773b9f0220171fe4de26bb8d711547fc884730"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-i686-mingw32.zip",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.4-arduino2-i686-mingw32.zip",
-              "size": "44386446",
-              "checksum": "SHA-256:6044551cd729d88ea6ffcccf10aad1934c5b164d61f4f5890b0e78524ffff853"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.4-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "size": "29723974",
-              "checksum": "SHA-256:63a9d4cebbac06fd5fa8f48a2e2ba7d513837dcddc97f560129b4e466af901b5"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.4-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "30374404",
-              "checksum": "SHA-256:19480217f1524d78467b83cd742f503182bbcc76b5440093261f146828aa588c"
-            }
-          ]
-        },
-        {
-          "name": "avr-gcc",
-          "version": "7.3.0-atmel3.6.1-arduino7",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-arm-linux-gnueabihf.tar.bz2",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-arm-linux-gnueabihf.tar.bz2",
-              "size": "34683056",
-              "checksum": "SHA-256:3903553d035da59e33cff9941b857c3cb379cb0638105dfdf69c97f0acc8e7b5"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-aarch64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-aarch64-pc-linux-gnu.tar.bz2",
-              "size": "38045723",
-              "checksum": "SHA-256:03d322b9df6da17289e9e7c6233c34a8535d9c645c19efc772ba19e56914f339"
-            },
-            {
-              "host": "x86_64-apple-darwin14",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-x86_64-apple-darwin14.tar.bz2",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-x86_64-apple-darwin14.tar.bz2",
-              "size": "36684546",
-              "checksum": "SHA-256:f6ed2346953fcf88df223469088633eb86de997fa27ece117fd1ef170d69c1f8"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-i686-w64-mingw32.zip",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-i686-w64-mingw32.zip",
-              "size": "52519412",
-              "checksum": "SHA-256:a54f64755fff4cb792a1495e5defdd789902a2a3503982e81b898299cf39800e"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-i686-pc-linux-gnu.tar.bz2",
-              "size": "37176991",
-              "checksum": "SHA-256:954bbffb33545bcdcd473af993da2980bf32e8461ff55a18e0eebc7b2ef69a4c"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "37630618",
-              "checksum": "SHA-256:bd8c37f6952a2130ac9ee32c53f6a660feb79bee8353c8e289eb60fdcefed91e"
-            }
-          ]
-        },
-        {
-          "name": "avrdude",
-          "version": "6.3.0-arduino8",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino8-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino8-armhf-pc-linux-gnu.tar.bz2",
-              "size": "644550",
-              "checksum": "SHA-256:25a6834ae48019fccf37024236a1f79fe21760414292a4f3fa058d937ceee1ce"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino8-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino8-i386-apple-darwin11.tar.bz2",
-              "size": "697268",
-              "checksum": "SHA-256:be8a33a7ec01bb7123279466ffa31371e0aa4fccefffcc23ce71810b59531947"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino8-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino8-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "711544",
-              "checksum": "SHA-256:85f38d02e2398d3b7f93da2ca8b830ee65bb73f66cc7a7b30c466d3cebf2da6e"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino8-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino8-i686-pc-linux-gnu.tar.bz2",
-              "size": "701718",
-              "checksum": "SHA-256:8e2e4bc71d22e9d11ed143763b97f3aa2d164cdeee678a9deaf5b36e245b2d20"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino8-i686-w64-mingw32.zip",
-              "archiveFileName": "avrdude-6.3.0-arduino8-i686-w64-mingw32.zip",
-              "size": "645996",
-              "checksum": "SHA-256:3a7592f6c33efd658b820c73d1058d3c868a297cbddb37da5644973c3b516d5e"
-            }
-          ]
-        },
-        {
-          "name": "avrdude",
-          "version": "6.3.0-arduino16",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino16-armhf-pc-linux-gnu.tar.bz2",
-              "size": "219642",
-              "checksum": "SHA-256:6fc443445440f0e2d95d70013ed075bceffc2a1babc1e7d4f1ae69c3fe268c57"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-aarch64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino16-aarch64-pc-linux-gnu.tar.bz2",
-              "size": "229997",
-              "checksum": "SHA-256:7a2726ab2fd18b910abc3d9dd33c4b40d18c34cf12c46f3367932e7fd87c0197"
-            },
-            {
-              "host": "x86_64-apple-darwin15",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino16-i386-apple-darwin11.tar.bz2",
-              "size": "279172",
-              "checksum": "SHA-256:f93dc12a4b30a335ab24b3c628e6cad0ebf2f8adfb7ef50f87c0fc17165b2156"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino16-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "254085",
-              "checksum": "SHA-256:57856d6e388d333d924afa3e2d5525161dbe0dc670e7caae2720e249606175a7"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino16-i686-pc-linux-gnu.tar.bz2",
-              "size": "244393",
-              "checksum": "SHA-256:bdf73358991243a9a8de11a42c80c4ec4b14c82f2222cb0c3c181f62656c41fb"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-i686-w64-mingw32.zip",
-              "archiveFileName": "avrdude-6.3.0-arduino16-i686-w64-mingw32.zip",
-              "size": "328456",
-              "checksum": "SHA-256:781c16a8bf813fa68fc0f47d427279053c9e098c3aed7165449ac4f0137304dd"
-            }
-          ]
-        },
-        {
-          "name": "avrdude",
-          "version": "6.3.0-arduino18",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino18-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino18-armhf-pc-linux-gnu.tar.bz2",
-              "size": "220677",
-              "checksum": "SHA-256:2e25c9e99c255d595a1072679a88ecddfa12c223b18510760bb867039f35efa5"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino18-aarch64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino18-aarch64-pc-linux-gnu.tar.bz2",
-              "size": "231047",
-              "checksum": "SHA-256:4f88bb50d2235182ed7aa9e0a1d08e4bb956378ac9569b8e1141e37ed314fb2d"
-            },
-            {
-              "host": "x86_64-apple-darwin12",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino18-x86_64-apple-darwin12.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino18-x86_64-apple-darwin12.tar.bz2",
-              "size": "280072",
-              "checksum": "SHA-256:df1dfd18e2e287c47232605cd4fa41751eb70df8c300aeb7a00a3a09b524a1b8"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino18-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino18-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "254460",
-              "checksum": "SHA-256:1ae46972b276b8a54c459f87c4ff326abdad0be2b1a293d73bf86e47765eddc3"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino18-i686-w64-mingw32.zip",
-              "archiveFileName": "avrdude-6.3.0-arduino18-i686-w64-mingw32.zip",
-              "size": "329515",
-              "checksum": "SHA-256:0781f4183e91a9783c2330035520144ab76b8f75c0a9f7a25877c063bc984c4d"
-            }
-          ]
-        },
-        {
-          "name": "avrdude",
-          "version": "6.0.1-arduino2",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avrdude-6.0.1-arduino2-i386-apple-darwin11.tar.bz2",
-              "size": "264965",
-              "checksum": "SHA-256:71117cce0096dad6c091e2c34eb0b9a3386d3aec7d863d2da733d9e5eac3a6b1"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.0.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "292541",
-              "checksum": "SHA-256:2489004d1d98177eaf69796760451f89224007c98b39ebb5577a9a34f51425f1"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.0.1-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "size": "283209",
-              "checksum": "SHA-256:6f633dd6270ad0d9ef19507bcbf8697b414a15208e4c0f71deec25ef89cdef3f"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-i686-mingw32.zip",
-              "archiveFileName": "avrdude-6.0.1-arduino2-i686-mingw32.zip",
-              "size": "241618",
-              "checksum": "SHA-256:6c5483800ba753c80893607e30cade8ab77b182808fcc5ea15fa3019c63d76ae"
-            }
-          ]
-        },
-        {
-          "name": "avrdude",
-          "version": "6.0.1-arduino3",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino3-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avrdude-6.0.1-arduino3-i386-apple-darwin11.tar.bz2",
-              "size": "264682",
-              "checksum": "SHA-256:df7cd4a76e45ab3767eb964f845f4d5e9d643df950ec32812923da1e9843d072"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino3-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.0.1-arduino3-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "748634",
-              "checksum": "SHA-256:bb7bff48f20a68e1fe559c3f3f644574df12ab5c98eb6a1491079f3c760434ad"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino3-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.0.1-arduino3-i686-pc-linux-gnu.tar.bz2",
-              "size": "495482",
-              "checksum": "SHA-256:96a0cfb83fe0452366159e3bf4e19ff10906a8957d1feafd3d98b49ab4b14405"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino3-i686-mingw32.zip",
-              "archiveFileName": "avrdude-6.0.1-arduino3-i686-mingw32.zip",
-              "size": "241619",
-              "checksum": "SHA-256:ea59bfc2ee85039c85318b2ba52c47ef0573513444a785b72f59b22586a950f9"
-            }
-          ]
-        },
-        {
-          "name": "avrdude",
-          "version": "6.3.0-arduino2",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino2-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino2-armhf-pc-linux-gnu.tar.bz2",
-              "size": "643484",
-              "checksum": "SHA-256:26af86137d8a872f64d217cb262734860b36fe26d6d34faf72e951042f187885"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino2-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino2-i386-apple-darwin11.tar.bz2",
-              "size": "653968",
-              "checksum": "SHA-256:32525ea3696c861030e1a6006a5f11971d1dad331e45bfa68dac35126476b04f"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "745081",
-              "checksum": "SHA-256:9635af5a35bdca11804c07582d7beec458140fb6e3308168c3deda18dc6790fa"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino2-i686-pc-linux-gnu.tar.bz2",
-              "size": "731802",
-              "checksum": "SHA-256:790b6cb610c48e73a2a0f65dcee9903d2fd7f1b0a1f75008a9a21f50a60c7251"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino2-i686-w64-mingw32.zip",
-              "archiveFileName": "avrdude-6.3.0-arduino2-i686-w64-mingw32.zip",
-              "size": "608496",
-              "checksum": "SHA-256:8eaf98ea41fbd4450483488ef31710cbcc43c0412dbc8e1e1b582feaab6eca30"
-            }
-          ]
-        },
-        {
-          "name": "avrdude",
-          "version": "6.3.0-arduino6",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino6-armhf-pc-linux-gnu.tar.bz2",
-              "size": "644600",
-              "checksum": "SHA-256:2426207423d58eb0e5fc4df9493418f1cb54ba3f328fdc7c3bb582f920b9cbe7"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino6-i386-apple-darwin11.tar.bz2",
-              "size": "696273",
-              "checksum": "SHA-256:d9a039c9e92d3dbb2011e75e6c044a1a4a2789e2fbf8386b1d580994811be084"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino6-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "746653",
-              "checksum": "SHA-256:97b4875cad6110c70101bb776f3ac37b64a2e73f036cd0b10afb6f4be96a6621"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino6-i686-pc-linux-gnu.tar.bz2",
-              "size": "733127",
-              "checksum": "SHA-256:5f4bc4b0957b1d34cec9908b7f84a7c297b894b39fe16a4992c284b24c00d6fb"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-i686-w64-mingw32.zip",
-              "archiveFileName": "avrdude-6.3.0-arduino6-i686-w64-mingw32.zip",
-              "size": "645859",
-              "checksum": "SHA-256:7468a1bcdfa459d175a095b102c0de28efc466accfb104305fbcad7832659ddc"
-            }
-          ]
-        },
-        {
-          "name": "avrdude",
-          "version": "6.0.1-arduino5",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino5-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.0.1-arduino5-armhf-pc-linux-gnu.tar.bz2",
-              "size": "267095",
-              "checksum": "SHA-256:23ea1341dbc117ec067f2eb1a498ad2bdd7d11fff0143c00b2e018c39804f6b4"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino5-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avrdude-6.0.1-arduino5-i386-apple-darwin11.tar.bz2",
-              "size": "264894",
-              "checksum": "SHA-256:41af8d3b0a586853c8317b4fb5163ca0db594a1870ddf680fd988c42166fc3e5"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.0.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "292629",
-              "checksum": "SHA-256:d826cca7383461f7e8adde686372cf900e9cb3afd639555cf2d6c645b283a476"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino5-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.0.1-arduino5-i686-pc-linux-gnu.tar.bz2",
-              "size": "283121",
-              "checksum": "SHA-256:5933d66927bce46ababa9b68a8b7f1d53f68c4f3ff7a5ce4b85d7cf4e6c6bfee"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino5-i686-mingw32.zip",
-              "archiveFileName": "avrdude-6.0.1-arduino5-i686-mingw32.zip",
-              "size": "241634",
-              "checksum": "SHA-256:41f667f1f6a0ab8df46b4ffacd023176dcdef331d6db3b74bddd37d18cca0a44"
-            }
-          ]
-        },
-        {
-          "name": "avrdude",
-          "version": "6.3.0-arduino9",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino9-armhf-pc-linux-gnu.tar.bz2",
-              "size": "644550",
-              "checksum": "SHA-256:25a6834ae48019fccf37024236a1f79fe21760414292a4f3fa058d937ceee1ce"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino9-i386-apple-darwin11.tar.bz2",
-              "size": "697309",
-              "checksum": "SHA-256:bfa06bc042dff252d3a8eded98da159484e75b46d2697da4d9446dcd2aea8465"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino9-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "711229",
-              "checksum": "SHA-256:c8cccb84e2fe49ee837b24f0a60a99e9c371dae26e84c5b0b22b6b6aab2f1f6a"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino9-i686-pc-linux-gnu.tar.bz2",
-              "size": "701590",
-              "checksum": "SHA-256:4235a2d58e3c3224c603d6c5f0610507ed6c48ebf4051fdcce9f77a7646e218b"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-i686-w64-mingw32.zip",
-              "archiveFileName": "avrdude-6.3.0-arduino9-i686-w64-mingw32.zip",
-              "size": "645974",
-              "checksum": "SHA-256:f3c5cfa8d0b3b0caee81c5b35fb6acff89c342ef609bf4266734c6266a256d4f"
-            }
-          ]
-        },
-        {
-          "name": "avrdude",
-          "version": "6.3.0-arduino14",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino14-armhf-pc-linux-gnu.tar.bz2",
-              "size": "219616",
-              "checksum": "SHA-256:d1a06275490d59a431c419788bbc53ffd5a79510dac1a35e63cf488621ba5589"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-aarch64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino14-aarch64-pc-linux-gnu.tar.bz2",
-              "size": "229688",
-              "checksum": "SHA-256:439f5de150695e3732dd598bb182dae6ec1e3a5cdb580f855d9b58e485e84e66"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino14-i386-apple-darwin12.tar.bz2",
-              "size": "256917",
-              "checksum": "SHA-256:47d03991522722ce92120c60c4118685b7861909d895f34575001137961e4a63"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino14-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "253366",
-              "checksum": "SHA-256:7986e8f3059353dc08f9234f7dbc98d9b2fa2242f046f02a8243a060f7358bfc"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino14-i686-pc-linux-gnu.tar.bz2",
-              "size": "244293",
-              "checksum": "SHA-256:4f100e3843c635064997df91d2a079ab15cd30d1d7fa227280abe6a7c3bc74ca"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-i686-w64-mingw32.zip",
-              "archiveFileName": "avrdude-6.3.0-arduino14-i686-w64-mingw32.zip",
-              "size": "328363",
-              "checksum": "SHA-256:69293e0de2eff8de89f553477795c25005f674a320bbba4b0222beb0194aa297"
-            }
-          ]
-        },
-        {
-          "name": "avrdude",
-          "version": "6.3.0-arduino17",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-armhf-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino17-armhf-pc-linux-gnu.tar.bz2",
-              "size": "219631",
-              "checksum": "SHA-256:2a8e68c5d803aa6f902ef219f177ec3a4c28275d85cbe272962ad2cd374f50d1"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-aarch64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino17-aarch64-pc-linux-gnu.tar.bz2",
-              "size": "229852",
-              "checksum": "SHA-256:6cf948f751acfe7b96684537f2291c766ec8b54b4f7dc95539864821456fa9fc"
-            },
-            {
-              "host": "x86_64-apple-darwin12",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-x86_64-apple-darwin12.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino17-x86_64-apple-darwin12.tar.bz2",
-              "size": "279045",
-              "checksum": "SHA-256:120cc9edaae699e7e9ac50b1b8eb0e7d51fdfa555bac54233c2511e6ee5418c9"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino17-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "254271",
-              "checksum": "SHA-256:accdfb920af2aabf4f7461d2ac73c0751760f525216dc4e7657427a78c60d13d"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-i686-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "avrdude-6.3.0-arduino17-i686-pc-linux-gnu.tar.bz2",
-              "size": "244550",
-              "checksum": "SHA-256:5c8cc6c17db9300e1451fe41cd7178b0442b4490ee6fdbc0aed9811aef96c05f"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-i686-w64-mingw32.zip",
-              "archiveFileName": "avrdude-6.3.0-arduino17-i686-w64-mingw32.zip",
-              "size": "328460",
-              "checksum": "SHA-256:e99188873c7c5ad8f8f906f068c33600e758b2e36cce3adbd518a21bd266749d"
-            }
-          ]
-        },
-        {
-          "name": "CMSIS",
-          "version": "4.0.0-atmel",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/CMSIS-4.0.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.0.0.tar.bz2",
-              "size": "17642623",
-              "checksum": "SHA-256:7d637d2d7a0c6bacc22065848a201db2fff124268e4a56868260d0f472b4bbb7"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/CMSIS-4.0.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.0.0.tar.bz2",
-              "size": "17642623",
-              "checksum": "SHA-256:7d637d2d7a0c6bacc22065848a201db2fff124268e4a56868260d0f472b4bbb7"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/CMSIS-4.0.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.0.0.tar.bz2",
-              "size": "17642623",
-              "checksum": "SHA-256:7d637d2d7a0c6bacc22065848a201db2fff124268e4a56868260d0f472b4bbb7"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/CMSIS-4.0.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.0.0.tar.bz2",
-              "size": "17642623",
-              "checksum": "SHA-256:7d637d2d7a0c6bacc22065848a201db2fff124268e4a56868260d0f472b4bbb7"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/CMSIS-4.0.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.0.0.tar.bz2",
-              "size": "17642623",
-              "checksum": "SHA-256:7d637d2d7a0c6bacc22065848a201db2fff124268e4a56868260d0f472b4bbb7"
-            }
-          ]
-        },
-        {
-          "name": "CMSIS",
-          "version": "4.5.0",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
-              "size": "31525196",
-              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
-              "size": "31525196",
-              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
-              "size": "31525196",
-              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
-              "size": "31525196",
-              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
-              "size": "31525196",
-              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
-              "size": "31525196",
-              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
-            },
-            {
-              "host": "all",
-              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
-              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
-              "size": "31525196",
-              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
-            }
-          ]
-        },
-        {
-          "name": "imgtool",
-          "version": "1.8.0-arduino.1",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_macOS_64bit.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-arduino.1_macOS_64bit.tar.gz",
-              "size": "8448535",
-              "checksum": "SHA-256:8002d8a017bbd994328f3ec7f0af007c1a5bc45d694860148870972fb3f3a5e8"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_ARMv6.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_ARMv6.tar.gz",
-              "size": "13477544",
-              "checksum": "SHA-256:bbd8136d9d67e2db81360df8d435a899f8b231247719b7313b7b2c920e85c4d7"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_ARM64.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_ARM64.tar.gz",
-              "size": "15650801",
-              "checksum": "SHA-256:fad64d46a2d10d225d21fa6cab1cbd4511cbe0028b67b18c460656bcc203538c"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_64bit.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_64bit.tar.gz",
-              "size": "15574228",
-              "checksum": "SHA-256:12c3c5b04bf53bea3baccf4072cbffaf9e9c4901a1a9ff77d611eb3c2db2ca1f"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_32bit.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_32bit.tar.gz",
-              "size": "13875969",
-              "checksum": "SHA-256:354343b2f6b91f463553ffd48bc4af3b91c897e4ac79ea43551982c9b3afeade"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Windows_32bit.zip",
-              "archiveFileName": "imgtool_1.8.0-arduino.1_Windows_32bit.zip",
-              "size": "6735777",
-              "checksum": "SHA-256:42d4fbf70a390c84a59a19db166b74d0fb231ff729d9c56775b4e7cc5055cef3"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Windows_64bit.zip",
-              "archiveFileName": "imgtool_1.8.0-arduino.1_Windows_64bit.zip",
-              "size": "8411018",
-              "checksum": "SHA-256:9c600c5ca22c50a6eb6b9d6a870d486710be4997060fe9cbacdabd968daacc87"
-            }
-          ]
-        },
-        {
-          "name": "imgtool",
-          "version": "1.8.0-arduino.2",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_macOS_64bit.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-arduino.2_macOS_64bit.tar.gz",
-              "size": "8454939",
-              "checksum": "SHA-256:d23daba045f46754bfa466f63199b3e17936de716a08502a369ab4a9c3615fda"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Linux_ARMv6.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-arduino.2_Linux_ARMv6.tar.gz",
-              "size": "13482271",
-              "checksum": "SHA-256:a215fc2fbd4f82194fdbd2fcb0e2f017859a68e915d4da031df824e1e7134b87"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Linux_ARM64.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-arduino.2_Linux_ARM64.tar.gz",
-              "size": "15655944",
-              "checksum": "SHA-256:cb0341f016e100833c0fd28c4215544d4056b195efebe523288bde9fed80445f"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Linux_64bit.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-arduino.2_Linux_64bit.tar.gz",
-              "size": "15579636",
-              "checksum": "SHA-256:062d9e3ac1066a7d3e345c9d105858aeff3e3b73e12bbb6c0c5d3e6761d52577"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Linux_32bit.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-arduino.2_Linux_32bit.tar.gz",
-              "size": "13881242",
-              "checksum": "SHA-256:4b58a23bc7c41268e113e25afba4dccaa477058fca94eea8749b315c7b7d2a8b"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Windows_32bit.zip",
-              "archiveFileName": "imgtool_1.8.0-arduino.2_Windows_32bit.zip",
-              "size": "6744516",
-              "checksum": "SHA-256:9e365727801229ba4775974f6c648711da1a06961bb9bef7546a11080ea25420"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Windows_64bit.zip",
-              "archiveFileName": "imgtool_1.8.0-arduino.2_Windows_64bit.zip",
-              "size": "8416009",
-              "checksum": "SHA-256:60d77da618b785345fc7ce2529bcb01c7195371b8e65a11abbd804c26ffd7df4"
-            }
-          ]
-        },
-        {
-          "name": "imgtool",
-          "version": "1.8.0-arduino",
-          "systems": [
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Linux_32bit.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-rc1_Linux_32bit.tar.gz",
-              "size": "13906205",
-              "checksum": "SHA-256:0b95b98c0e51a91512b3bfa10d3178315af1a1cd9e3b4982d0c9459ef84614b1"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Linux_64bit.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-rc1_Linux_64bit.tar.gz",
-              "size": "15591995",
-              "checksum": "SHA-256:92222eb8023fae0877da2e9d87dd2187fa9b82c0543330ab47a4a67bc0c89cae"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Windows_32bit.zip",
-              "archiveFileName": "imgtool_1.8.0-rc1_Windows_32bit.zip",
-              "size": "6736497",
-              "checksum": "SHA-256:1177275ca93ce6bfd3cc64f68837b9f6b8d8a1592a6fbcfa643b9ccf35b7879a"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Windows_64bit.zip",
-              "archiveFileName": "imgtool_1.8.0-rc1_Windows_64bit.zip",
-              "size": "8409007",
-              "checksum": "SHA-256:c51b62ff173887faa2d4e94e77777bac274ba898ae39bec0082b6327a011115b"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_macOS_64bit.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-rc1_macOS_64bit.tar.gz",
-              "size": "8425545",
-              "checksum": "SHA-256:6129c767c1b395c809b79aa2bd75fd0ce09544ff6d7ca20b330fac703efe3fc4"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Linux_ARMv6.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-rc1_Linux_ARMv6.tar.gz",
-              "size": "13500219",
-              "checksum": "SHA-256:dff39f8a884d4c5f98b5ac0ae075eaba35bf2d0b189c633c2723fc12170e7ea0"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Linux_ARM64.tar.gz",
-              "archiveFileName": "imgtool_1.8.0-rc1_Linux_ARM64.tar.gz",
-              "size": "15679158",
-              "checksum": "SHA-256:b893ac88bcf3f4da0af05fa31f8af43a2d29ef5ecef0bd4ba6fb66a0b2e360f1"
-            }
-          ]
-        },
-        {
-          "name": "bossac",
-          "version": "1.6-arduino",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.6-arduino-mingw32.tar.gz",
-              "archiveFileName": "bossac-1.6-arduino-mingw32.tar.gz",
-              "size": "222517",
-              "checksum": "SHA-256:b59d64d3f7a43c894d0fba2dd1241bbaeefedf8c902130a24d8ec63b08f9ff6a"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.6-arduino-i386-apple-darwin14.4.0.tar.gz",
-              "archiveFileName": "bossac-1.6-arduino-i386-apple-darwin14.4.0.tar.gz",
-              "size": "64538",
-              "checksum": "SHA-256:6b3b686a782b6587c64c85db80085c9089c5ea1b051e49e5af17b3c6109c8efa"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.6-arduino-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "bossac-1.6-arduino-x86_64-linux-gnu.tar.gz",
-              "size": "30649",
-              "checksum": "SHA-256:2ce7a54d609b4ce3b678147202b2556dd1ce5b318de48a018c676521b994c7a7"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.6-arduino-i486-linux-gnu.tar.gz",
-              "archiveFileName": "bossac-1.6-arduino-i486-linux-gnu.tar.gz",
-              "size": "30072",
-              "checksum": "SHA-256:5c320bf5cfdbf03e3f648642e6de325e459a061fcf96b2215cb955263f7467b2"
-            }
-          ]
-        },
-        {
-          "name": "bossac",
-          "version": "1.7.0-arduino3",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-windows.tar.gz",
-              "archiveFileName": "bossac-1.7.0-arduino3-windows.tar.gz",
-              "size": "3607421",
-              "checksum": "SHA-256:62745cc5a98c26949ec9041ef20420643c561ec43e99dae659debf44e6836526"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-osx.tar.gz",
-              "archiveFileName": "bossac-1.7.0-arduino3-osx.tar.gz",
-              "size": "75510",
-              "checksum": "SHA-256:adb3c14debd397d8135e9e970215c6972f0e592c7af7532fa15f9ce5e64b991f"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-linux64.tar.gz",
-              "archiveFileName": "bossac-1.7.0-arduino3-linux64.tar.gz",
-              "size": "207271",
-              "checksum": "SHA-256:1ae54999c1f97234a5c603eb99ad39313b11746a4ca517269a9285afa05f9100"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-linux32.tar.gz",
-              "archiveFileName": "bossac-1.7.0-arduino3-linux32.tar.gz",
-              "size": "193577",
-              "checksum": "SHA-256:4ac4354746d1a09258f49a43ef4d1baf030d81c022f8434774268b00f55d3ec3"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-linuxarm.tar.gz",
-              "archiveFileName": "bossac-1.7.0-arduino3-linuxarm.tar.gz",
-              "size": "193941",
-              "checksum": "SHA-256:626c6cc548046901143037b782bf019af1663bae0d78cf19181a876fb9abbb90"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-linuxaarch64.tar.gz",
-              "archiveFileName": "bossac-1.7.0-arduino3-linuxaarch64.tar.gz",
-              "size": "268365",
-              "checksum": "SHA-256:a098b2cc23e29f0dc468416210d097c4a808752cd5da1a7b9b8b7b931a04180b"
-            }
-          ]
-        },
-        {
-          "name": "bossac",
-          "version": "1.9.1-arduino1",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-windows.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino1-windows.tar.gz",
-              "size": "1260118",
-              "checksum": "SHA-256:fe2d6ef78ca711c78e104e258357ed06b09e95e9356dc72d8d2c9f6670af4b7a"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-osx.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino1-osx.tar.gz",
-              "size": "47835",
-              "checksum": "SHA-256:c356632f98d5bae9b4f5d3ad823a5ee89b23078c2b835e8ac39a208f4855b0e6"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-linux64.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino1-linux64.tar.gz",
-              "size": "399453",
-              "checksum": "SHA-256:d3d324a3503a8db825c01f3b38519e4d4824c4d0e42cb399a16c1e074f9a9a86"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-linux32.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino1-linux32.tar.gz",
-              "size": "384792",
-              "checksum": "SHA-256:eec622b8b5a8642af94ec23febfe14c928edd734f144db73b146bf6708d2057f"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-linuxarm.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino1-linuxarm.tar.gz",
-              "size": "361799",
-              "checksum": "SHA-256:b42061d2fa2dbd6910d0d295e024f2cff7bb44f3e2ecc0bc2fe71a1f31b0ecba"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-linuxaarch64.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino1-linuxaarch64.tar.gz",
-              "size": "442657",
-              "checksum": "SHA-256:b271013841e1e25ee55f241e8c50a56ed775d3b322844e1e3099231ba17f3868"
-            }
-          ]
-        },
-        {
-          "name": "bossac",
-          "version": "1.9.1-arduino2",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-windows.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino2-windows.tar.gz",
-              "size": "1260628",
-              "checksum": "SHA-256:5c994d04354f0db8e4bea136f49866d2ba537f0af74b2e78026f2d4fc75e3e39"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-osx.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino2-osx.tar.gz",
-              "size": "47870",
-              "checksum": "SHA-256:b7732129364a378676604db6579c9b8dab50dd965fb50d7a3afff1839c97ff80"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-linux64.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino2-linux64.tar.gz",
-              "size": "399532",
-              "checksum": "SHA-256:9eb549874391521999cee13dc823a2cfc8866b8246945339a281808d99c72d2c"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-linux32.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino2-linux32.tar.gz",
-              "size": "384951",
-              "checksum": "SHA-256:10d69f53f169f25afee2dd583dfd9dc803c10543e6c5260d106725cb0d174900"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-linuxarm.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino2-linuxarm.tar.gz",
-              "size": "361915",
-              "checksum": "SHA-256:c9539d161d23231b5beb1d09a71829744216c7f5bc2857a491999c3e567f5b19"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-linuxaarch64.tar.gz",
-              "archiveFileName": "bossac-1.9.1-arduino2-linuxaarch64.tar.gz",
-              "size": "442853",
-              "checksum": "SHA-256:c167fa0ea223966f4d21f5592da3888bcbfbae385be6c5c4e41f8abff35f5cb1"
-            }
-          ]
-        },
-        {
-          "name": "bossac",
-          "version": "1.3-arduino",
-          "systems": [
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.3a-arduino-i686-linux-gnu.tar.bz2",
-              "archiveFileName": "bossac-1.3a-arduino-i686-linux-gnu.tar.bz2",
-              "size": "147359",
-              "checksum": "SHA-256:d6d10362f40729a7877e43474fcf02ad82cf83321cc64ca931f5c82b2d25d24f"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.3a-arduino-x86_64-pc-linux-gnu.tar.bz2",
-              "archiveFileName": "bossac-1.3a-arduino-x86_64-pc-linux-gnu.tar.bz2",
-              "size": "26179",
-              "checksum": "SHA-256:c1daed033251296768fa8b63ad283e053da93427c0f3cd476a71a9188e18442c"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.3a-arduino-i686-mingw32.tar.bz2",
-              "archiveFileName": "bossac-1.3a-arduino-i686-mingw32.tar.bz2",
-              "size": "265647",
-              "checksum": "SHA-256:a37727622e0f86cb4f2856ad0209568a5d804234dba3dc0778829730d61a5ec7"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.3a-arduino-i386-apple-darwin11.tar.bz2",
-              "archiveFileName": "bossac-1.3a-arduino-i386-apple-darwin11.tar.bz2",
-              "size": "39475",
-              "checksum": "SHA-256:40770b225753e7a52bb165e8f37e6b760364f5c5e96048168d0178945bd96ad6"
-            }
-          ]
-        },
-        {
-          "name": "bossac",
-          "version": "1.5-arduino",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/bossac-1.5-arduino2-arm-linux-gnueabihf.tar.bz2",
-              "archiveFileName": "bossac-1.5-arduino2-arm-linux-gnueabihf.tar.bz2",
-              "size": "199550",
-              "checksum": "SHA-256:7b61b7814e5b57bcbd853439fc9cd3e98af4abfdd369bf039c6917f9599e44b9"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/bossac-1.5-arduino2-mingw32.tar.gz",
-              "archiveFileName": "bossac-1.5-arduino2-mingw32.tar.gz",
-              "size": "222283",
-              "checksum": "SHA-256:9d849a34f0b26c25c6a8c4d741cd749dea238cade73b57a3048f248c431d9cc9"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/bossac-1.5-arduino2-i386-apple-darwin14.3.0.tar.gz",
-              "archiveFileName": "bossac-1.5-arduino2-i386-apple-darwin14.3.0.tar.gz",
-              "size": "64120",
-              "checksum": "SHA-256:8f07e50a1f887cb254092034c6a4482d73209568cd83cb624d6625d66794f607"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/bossac-1.5-arduino2-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "bossac-1.5-arduino2-x86_64-linux-gnu.tar.gz",
-              "size": "30431",
-              "checksum": "SHA-256:42785329155dcb39872d4d30a2a9d31e0f0ce3ae7e34a3ed3d840cbc909c4657"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/bossac-1.5-arduino2-i486-linux-gnu.tar.gz",
-              "archiveFileName": "bossac-1.5-arduino2-i486-linux-gnu.tar.gz",
-              "size": "29783",
-              "checksum": "SHA-256:ac56e553bbd6d992fa5592ace90996806230ab582f2bf9f8590836fec9dabef6"
-            }
-          ]
-        },
-        {
-          "name": "bossac",
-          "version": "1.6.1-arduino",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/bossac-1.6.1-arduino-arm-linux-gnueabihf.tar.bz2",
-              "archiveFileName": "bossac-1.6.1-arduino-arm-linux-gnueabihf.tar.bz2",
-              "size": "201341",
-              "checksum": "SHA-256:8c4e63db982178919c824e7a35580dffc95c3426afa7285de3eb583982d4d391"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/bossac-1.6.1-arduino-mingw32.tar.gz",
-              "archiveFileName": "bossac-1.6.1-arduino-mingw32.tar.gz",
-              "size": "222918",
-              "checksum": "SHA-256:d59f43e2e83a337d04c4ae88b195a4ee175b8d87fff4c43144d23412a4a9513b"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/bossac-1.6.1-arduino-i386-apple-darwin14.5.0.tar.gz",
-              "archiveFileName": "bossac-1.6.1-arduino-i386-apple-darwin14.5.0.tar.gz",
-              "size": "64587",
-              "checksum": "SHA-256:2f80ef569a3fb19da60ab3489e49d8fe7d4699876acf30ff4938c632230a09aa"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/bossac-1.6.1-arduino-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "bossac-1.6.1-arduino-x86_64-linux-gnu.tar.gz",
-              "size": "30869",
-              "checksum": "SHA-256:b78afc66c00ccfdd69a08bd3959c260a0c64ccce78a71d5a1135ae4437ff40db"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/bossac-1.6.1-arduino-i486-linux-gnu.tar.gz",
-              "archiveFileName": "bossac-1.6.1-arduino-i486-linux-gnu.tar.gz",
-              "size": "30320",
-              "checksum": "SHA-256:1e211347569d75193b337296a10dd25b0ce04419e3d7dc644355178b6b514f92"
-            }
-          ]
-        },
-        {
-          "name": "bossac",
-          "version": "1.7.0",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-mingw32.tar.gz",
-              "archiveFileName": "bossac-1.7.0-mingw32.tar.gz",
-              "size": "243066",
-              "checksum": "SHA-256:9ef7d11b4fabca0adc17102a0290957d5cc26ce46b422c3a5344722c80acc7b2"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-i386-apple-darwin15.6.0.tar.gz",
-              "archiveFileName": "bossac-1.7.0-i386-apple-darwin15.6.0.tar.gz",
-              "size": "63822",
-              "checksum": "SHA-256:feac36ab38876c163dcf51bdbcfbed01554eede3d41c59a0e152e170fe5164d2"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "bossac-1.7.0-x86_64-linux-gnu.tar.gz",
-              "size": "31373",
-              "checksum": "SHA-256:9475c0c8596c1ba12dcbce60e48fef7559087fa8eccbea7bab732113f3c181ee"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-i686-linux-gnu.tar.gz",
-              "archiveFileName": "bossac-1.7.0-i686-linux-gnu.tar.gz",
-              "size": "31086",
-              "checksum": "SHA-256:17003b0bdc698d52eeb91b09c34aec501c6e0285b4aa88659ab7cc407a451a4d"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arm-linux-gnueabihf.tar.gz",
-              "archiveFileName": "bossac-1.7.0-arm-linux-gnueabihf.tar.gz",
-              "size": "27382",
-              "checksum": "SHA-256:09e46d0af61b2189caaac0bc6d4dd15cb22c167fdedc56ec98602dd5f10e68e0"
-            }
-          ]
-        },
-        {
-          "name": "bossac",
-          "version": "1.8.0-48-gb176eee",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.8-48-gb176eee-i686-w64-mingw32.tar.gz",
-              "archiveFileName": "bossac-1.8-48-gb176eee-i686-w64-mingw32.tar.gz",
-              "size": "91219",
-              "checksum": "SHA-256:4523a6897f3dfd673fe821c5cfbac8d6a12782e7a36b312b9ee7d41deec2a10a"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.8-48-gb176eee-i386-apple-darwin16.1.0.tar.gz",
-              "archiveFileName": "bossac-1.8-48-gb176eee-i386-apple-darwin16.1.0.tar.gz",
-              "size": "39150",
-              "checksum": "SHA-256:581ecc16021de36638ae14e9e064ffb4a1d532a11502f4252da8bcdf5ce1d649"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.8-48-gb176eee-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "bossac-1.8-48-gb176eee-x86_64-linux-gnu.tar.gz",
-              "size": "37798",
-              "checksum": "SHA-256:1347eec67f5b90b785abdf6c8a8aa59129d0c016de7ff9b5ac1690378eacca3c"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.8-48-gb176eee-i486-linux-gnu.tar.gz",
-              "archiveFileName": "bossac-1.8-48-gb176eee-i486-linux-gnu.tar.gz",
-              "size": "37374",
-              "checksum": "SHA-256:4c7492f876b8269aa9d8bcaad3aeda31acf1a0292383093b6d9f5f1d23fdafc3"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/bossac-1.8-48-gb176eee-arm-linux-gnueabihf.tar.gz",
-              "archiveFileName": "bossac-1.8-48-gb176eee-arm-linux-gnueabihf.tar.gz",
-              "size": "34825",
-              "checksum": "SHA-256:2001e4a592f3aefd22f213b1ddd6f5d8d5e74bd04080cf1b97c24cbaa81b10ed"
-            }
-          ]
-        },
-        {
-          "name": "CMSIS-Atmel",
-          "version": "1.0.0",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
-              "size": "1281654",
-              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
-              "size": "1281654",
-              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
-              "size": "1281654",
-              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
-              "size": "1281654",
-              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
-              "size": "1281654",
-              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
-            },
-            {
-              "host": "all",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
-              "size": "1281654",
-              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
-            }
-          ]
-        },
-        {
-          "name": "CMSIS-Atmel",
-          "version": "1.1.0",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
-              "size": "1659108",
-              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
-              "size": "1659108",
-              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
-              "size": "1659108",
-              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
-              "size": "1659108",
-              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
-              "size": "1659108",
-              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
-            },
-            {
-              "host": "all",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
-              "size": "1659108",
-              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
-            }
-          ]
-        },
-        {
-          "name": "CMSIS-Atmel",
-          "version": "1.2.0",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
-              "size": "2221805",
-              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
-              "size": "2221805",
-              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "https://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
-              "size": "2221805",
-              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "https://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
-              "size": "2221805",
-              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "https://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
-              "size": "2221805",
-              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "https://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
-              "size": "2221805",
-              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
-            },
-            {
-              "host": "all",
-              "url": "https://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
-              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
-              "size": "2221805",
-              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
-            }
-          ]
-        },
-        {
-          "name": "fwupdater",
-          "version": "0.0.7",
-          "systems": [
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-linux32.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.7-linux32.tar.bz2",
-              "size": "13077590",
-              "checksum": "SHA-256:05e26d5df253246cf68ba8a8f5f2de1032ac6f4d7af5310b8080ef6f54030fb4"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-linux64.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.7-linux64.tar.bz2",
-              "size": "13134534",
-              "checksum": "SHA-256:e8a36b7ae19060748b8b0540c9c0c9341d8d4c7a630441922a030223f767258d"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-windows.zip",
-              "archiveFileName": "FirmwareUpdater-0.0.7-windows.zip",
-              "size": "13337495",
-              "checksum": "SHA-256:e881dd8a4bbb35f7271157e8dd226c2e032ac1115106170b0aaf9c969817df86"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-osx.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.7-osx.tar.bz2",
-              "size": "13064291",
-              "checksum": "SHA-256:647ad713d68a1531ba56c88e5b3db9516cc0072ca1d401de5142d85ffcfd931a"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-linuxarm.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.7-linuxarm.tar.bz2",
-              "size": "12929770",
-              "checksum": "SHA-256:b6e09c07e816a35935585db07e07437023d44e66d1d2f05861708ea6ceff7629"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-linuxarm64.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.7-linuxarm64.tar.bz2",
-              "size": "12897349",
-              "checksum": "SHA-256:620f81148b13f70cdecbe59bbcbf605c7e0aae85f9cbee8ec48202f6018f23ce"
-            }
-          ]
-        },
-        {
-          "name": "fwupdater",
-          "version": "0.1.3",
-          "systems": [
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Linux_32bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.3_Linux_32bit.tar.bz2",
-              "size": "15794726",
-              "checksum": "SHA-256:22f72fee3a1682c30b0bf4579a1ecc2759a5063c2be9342dd3c46858db43d7ef"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Linux_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.3_Linux_64bit.tar.bz2",
-              "size": "15927812",
-              "checksum": "SHA-256:1f998f8f5d9ef9487beb00d2f434682cbcdc4b13337fd82271df8ad931121324"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Windows_32bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.3_Windows_32bit.zip",
-              "size": "16139436",
-              "checksum": "SHA-256:d23dd1ef5ea19b46633980b47964834d0718d11b375c64725b28d4e39660ff3c"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Windows_64bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.3_Windows_64bit.zip",
-              "size": "16189555",
-              "checksum": "SHA-256:fd6eb93b2737ae3a49800d4f42abd7fa925e985b043d3a418412f26dc61b3baa"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_macOS_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.3_macOS_64bit.tar.bz2",
-              "size": "15832036",
-              "checksum": "SHA-256:ba53f679baca0f5ab6bbd4991da89702437932d67ae6c589c4da6ced3a4dc66b"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Linux_ARM.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.3_Linux_ARM.tar.bz2",
-              "size": "15734716",
-              "checksum": "SHA-256:91a85be7d657b4f31f69aba7e1a0390234d4ede5d138474b3eef928119a21df4"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Linux_ARM64.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.3_Linux_ARM64.tar.bz2",
-              "size": "15557114",
-              "checksum": "SHA-256:7b2ebd25998c441b4a4da1cc5bf227285f0fd321b2107497d29910213d8ad039"
-            }
-          ]
-        },
-        {
-          "name": "fwupdater",
-          "version": "0.1.6",
-          "systems": [
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Linux_32bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.6_Linux_32bit.tar.bz2",
-              "size": "17458014",
-              "checksum": "SHA-256:67b413dd15afca65d327e45329b1c2e64614126ef1fae27a1323155bbdc74c20"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Linux_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.6_Linux_64bit.tar.bz2",
-              "size": "17433263",
-              "checksum": "SHA-256:e299bea991778a388e611c3e9a4b1f5a7d5cf1b121465f7a843570602d0b6f39"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Windows_32bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.6_Windows_32bit.zip",
-              "size": "16950481",
-              "checksum": "SHA-256:4be9f5208841150ffc0148feccd819d77c7fbb477f41597fc3198f633a09a8ac"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Windows_64bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.6_Windows_64bit.zip",
-              "size": "17079617",
-              "checksum": "SHA-256:2490cdceb24b17d8269d8c144172c02c37a81c2275ed395973d22f0017d53713"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_macOS_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.6_macOS_64bit.tar.bz2",
-              "size": "17000606",
-              "checksum": "SHA-256:2d4af33020a0291e54197b133de8f278a8d68c0272e0bc93953941fd06508694"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Linux_ARM.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.6_Linux_ARM.tar.bz2",
-              "size": "17147561",
-              "checksum": "SHA-256:1b392a5ec7d4b7f8fd052e0e249f85538fbcce790bc5a442980ce6be215b5872"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Linux_ARM64.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.6_Linux_ARM64.tar.bz2",
-              "size": "17186826",
-              "checksum": "SHA-256:538a24a8f7c6831477d39ae166695ed411eb29a6d5aec3b2bc69bc1ef7b4d7b1"
+              "url": "http://downloads.arduino.cc/arduino.org/arduinoSTM32load-2.0.0-windows_386.tar.bz2",
+              "archiveFileName": "arduinoSTM32load-2.0.0-windows_386.tar.bz2",
+              "size": "786335",
+              "checksum": "SHA-256:79467c0cde4b88c4884acb09445a2186af4e41f901eee56e99b5d89b7065d085"
             }
           ]
         },
@@ -2267,331 +280,104 @@
         },
         {
           "name": "fwupdater",
-          "version": "0.0.8",
+          "version": "0.1.12",
           "systems": [
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.8-linux32.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.8-linux32.tar.bz2",
-              "size": "20137214",
-              "checksum": "SHA-256:e1f43aa225e6e2ad1f2bccc07898ddb439e980905385a8d7e0615f804a69eee8"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Linux_32bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.12_Linux_32bit.tar.bz2",
+              "size": "26097546",
+              "checksum": "SHA-256:2fec2bdfd20ad4950bc9ba37108dc2a7c152f569174279c0697efe1f5a0db781"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.8-linux64.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.8-linux64.tar.bz2",
-              "size": "20167410",
-              "checksum": "SHA-256:423f67767d5b861a3c39ca6f6a18b2358a30b76bdc3d3d3d870e102b2b2271a8"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "https://downloads.arduino.cc/tools/FirmwareUpdater_0.0.8_Windows_64bit.zip",
-              "archiveFileName": "FirmwareUpdater_0.0.8_Windows_64bit.zip",
-              "size": "13645709",
-              "checksum": "SHA-256:c3386fdc440638186541f92f920462865308e0f5dde9f45e4dd1c35d2570b808"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Linux_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.12_Linux_64bit.tar.bz2",
+              "size": "26073327",
+              "checksum": "SHA-256:ce57d0afef30cb7d3513f5da326346c99d6bf4923bbc2200634086811f3fb31e"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://downloads.arduino.cc/tools/FirmwareUpdater_0.0.8_Windows_32bit.zip",
-              "archiveFileName": "FirmwareUpdater_0.0.8_Windows_32bit.zip",
-              "size": "13578670",
-              "checksum": "SHA-256:dc3ce2e824b2f8ab6ee4c7d2f836311450d60825db95cbb51eeb076a28a1e2af"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Windows_32bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.12_Windows_32bit.zip",
+              "size": "25743641",
+              "checksum": "SHA-256:558568b453caa1c821def8cc6d34555d0c910eb7e7e871de3ae1c39ae6f01bdd"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Windows_64bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.12_Windows_64bit.zip",
+              "size": "25851428",
+              "checksum": "SHA-256:ec16de33620985434280c92c3c322257b89bb67adf8fd4d5dd5f9467ea1e9e40"
             },
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.8-osx.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.8-osx.tar.bz2",
-              "size": "20091397",
-              "checksum": "SHA-256:635cbe786cd11ead26e5af0662991d8c3b647469f1874195eeb7f1dba5530b39"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_macOS_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.12_macOS_64bit.tar.bz2",
+              "size": "25792860",
+              "checksum": "SHA-256:a470361b57f86ddfcaecd274d844af51ee1d23a71cd6c26e30fcef2152d1a03f"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.8-linuxarm.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.8-linuxarm.tar.bz2",
-              "size": "19984154",
-              "checksum": "SHA-256:c027389528e9b04d622167943fe04badbd2f63923f08cc1b22935e5158b2545b"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Linux_ARM.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.12_Linux_ARM.tar.bz2",
+              "size": "25936245",
+              "checksum": "SHA-256:855fa0a9b942c3ee18906efc510bdfe30bf3334ff28ffbb476e648ff30033847"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.8-linuxarm64.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.8-linuxarm64.tar.bz2",
-              "size": "19952489",
-              "checksum": "SHA-256:b6846bb84034e6a8486ce3165dabeb9b32b4fd3804639cd6137a37a00d0157c8"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Linux_ARM64.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.12_Linux_ARM64.tar.bz2",
+              "size": "25967430",
+              "checksum": "SHA-256:691461e64fe075e9a79801347c2bd895fb72f8f2c45a7cd49056c6ad9efe8fc4"
             }
           ]
         },
         {
           "name": "fwupdater",
-          "version": "0.0.9",
+          "version": "0.0.6",
           "systems": [
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Linux_32bit.tar.bz2",
-              "archiveFileName": "FirmwareUpdater_0.0.9_Linux_32bit.tar.bz2",
-              "size": "13221786",
-              "checksum": "SHA-256:a45c536be798e6fc023044ee13911b9b567fb9d0b1c41c5cc9b722346f306425"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-linux32.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.6-linux32.tar.bz2",
+              "size": "7334059",
+              "checksum": "SHA-256:8c4e562a8e6fa3d916c4bf6bb24d7eec0df013d8cc45dff187e5c63086a92c11"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Linux_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUpdater_0.0.9_Linux_64bit.tar.bz2",
-              "size": "13255356",
-              "checksum": "SHA-256:89d08d4b75dae676bc6e982723f3b07ee5ab4c2fe6071fc97fe850697a0c5398"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Windows_32bit.zip",
-              "archiveFileName": "FirmwareUpdater_0.0.9_Windows_32bit.zip",
-              "size": "13589082",
-              "checksum": "SHA-256:523b2f09a38ef36dcd96558a31e072c5b244e511690326a03af9406eccda2650"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-linux64.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.6-linux64.tar.bz2",
+              "size": "7383853",
+              "checksum": "SHA-256:0e9132518acfe66e5a4e17ba4b6dd0c89dbd90cc0d9b4a54e007ac24d51fd36a"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Windows_64bit.zip",
-              "archiveFileName": "FirmwareUpdater_0.0.9_Windows_64bit.zip",
-              "size": "13658133",
-              "checksum": "SHA-256:51eacfcaba9279ef42050d15cf86d98e79511879a84a8e960a8994f6343f74a8"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-windows.zip",
+              "archiveFileName": "FirmwareUpdater-0.0.6-windows.zip",
+              "size": "7580663",
+              "checksum": "SHA-256:33a92661f43b8d025ca5f57be1116537ed153703067d9c86297619d58988feff"
             },
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_macOS_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUpdater_0.0.9_macOS_64bit.tar.bz2",
-              "size": "13202065",
-              "checksum": "SHA-256:26c0b8764a67f945037a461ead756bee0b453e383dee741548d03322327bd17d"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-osx.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.6-osx.tar.bz2",
+              "size": "7368819",
+              "checksum": "SHA-256:3584d7581ff2469bdfde9de6f57d87b2a0370de5c902e9df687b7322a5405018"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Linux_ARM.tar.bz2",
-              "archiveFileName": "FirmwareUpdater_0.0.9_Linux_ARM.tar.bz2",
-              "size": "13063437",
-              "checksum": "SHA-256:3cde04fa96479bb5342f07752b9cbabdf159f1dcbe7074b642a163ff2a363a28"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-linuxarm.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.6-linuxarm.tar.bz2",
+              "size": "7180391",
+              "checksum": "SHA-256:276f027e552eb620064b09591c7a7c79927c93c017428436c81f71bad666803c"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Linux_ARM64.tar.bz2",
-              "archiveFileName": "FirmwareUpdater_0.0.9_Linux_ARM64.tar.bz2",
-              "size": "13014703",
-              "checksum": "SHA-256:3a41fac33917c4b5d8f5e0720afa780b2250b2561dd6090ed5338d7ab147524f"
-            }
-          ]
-        },
-        {
-          "name": "fwupdater",
-          "version": "0.1.4",
-          "systems": [
-            {
-              "host": "i686-linux-gnu",
-              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Linux_32bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.4_Linux_32bit.tar.bz2",
-              "size": "17369582",
-              "checksum": "SHA-256:794192e4463191308687ca10d361f6e86d06b57384800ead82ff9f1c32e3462b"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Linux_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.4_Linux_64bit.tar.bz2",
-              "size": "17346963",
-              "checksum": "SHA-256:e7e5a7f3c3f1c363a4e1e3cce3bbd48faa806da9153ade19336c68adcbc80464"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Windows_32bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.4_Windows_32bit.zip",
-              "size": "16792636",
-              "checksum": "SHA-256:8bc96ea4a8e8232b7798feda9bd5e2e745c14ba7584b936a6588dcd44e69bcca"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Windows_64bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.4_Windows_64bit.zip",
-              "size": "16940370",
-              "checksum": "SHA-256:29b753610b9b285a31471fe35fa7938f54d461b773f3fcf4e5bff27ca72c20e8"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_macOS_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.4_macOS_64bit.tar.bz2",
-              "size": "16913255",
-              "checksum": "SHA-256:f4c5542c209e5b7f09b020c9714889d846e8e6a96d1e2ab6e22cdae8d3ad8ef4"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Linux_ARM.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.4_Linux_ARM.tar.bz2",
-              "size": "16992130",
-              "checksum": "SHA-256:93503377d29a84f63433a608f3a2320ef27ca7f4b54a5cef6857ad16aa464842"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Linux_ARM64.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.4_Linux_ARM64.tar.bz2",
-              "size": "17042502",
-              "checksum": "SHA-256:d68ddc8c78902f164f701d974d2b0deffdbe3a58bd4d62f0d2e10263c2292c0b"
-            }
-          ]
-        },
-        {
-          "name": "fwupdater",
-          "version": "0.1.8",
-          "systems": [
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Linux_32bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.8_Linux_32bit.tar.bz2",
-              "size": "22050201",
-              "checksum": "SHA-256:b4f2f7cc3ced6053b22ac252cff2105b24474bbff468149beb7161e4c42ddd44"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Linux_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.8_Linux_64bit.tar.bz2",
-              "size": "22026254",
-              "checksum": "SHA-256:af0b39ed9468554b69305ef195b32ce00564190d50d19b7c467b34e3b76dd9e3"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Windows_32bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.8_Windows_32bit.zip",
-              "size": "21595791",
-              "checksum": "SHA-256:f67fb4d74b518a06e0ae2109040a5df81def123287f47856ff64c67b32e2e801"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Windows_64bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.8_Windows_64bit.zip",
-              "size": "21918177",
-              "checksum": "SHA-256:3edc59cc39ef8e0a863f8619c92315494fdb5a3c9d7d165533fe89c10d0b8d3a"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_macOS_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.8_macOS_64bit.tar.bz2",
-              "size": "21661287",
-              "checksum": "SHA-256:7d9c1c6c44d21cc9c88fa429ccad122ee40101f6f8c77fb03643be8c674b7a46"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Linux_ARM.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.8_Linux_ARM.tar.bz2",
-              "size": "21801813",
-              "checksum": "SHA-256:221dfa1b928bf772d8f92039ae6c41b50d45bcf8447b00b55f5ca3df90e0346c"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Linux_ARM64.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.8_Linux_ARM64.tar.bz2",
-              "size": "21842771",
-              "checksum": "SHA-256:1518427a1f7862c10f21c87ffaf29550bba6cff0195bcd1954e683df4e60b8af"
-            }
-          ]
-        },
-        {
-          "name": "fwupdater",
-          "version": "0.1.9",
-          "systems": [
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Linux_32bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.9_Linux_32bit.tar.bz2",
-              "size": "24067265",
-              "checksum": "SHA-256:d49339643d6b834893488d32f87e56f9d320ef557520bb8ea52856cf19805e16"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Linux_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.9_Linux_64bit.tar.bz2",
-              "size": "24043342",
-              "checksum": "SHA-256:6097bc8eab1bedc0c8704b61a19556596d33ef6191548bc96d1744147de31a4a"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Windows_32bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.9_Windows_32bit.zip",
-              "size": "23702667",
-              "checksum": "SHA-256:c586a7f5752a8af22008ab6fd74c8f8ffad760169d702ba3df003636e505f922"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Windows_64bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.9_Windows_64bit.zip",
-              "size": "23847968",
-              "checksum": "SHA-256:a1e1622c48456f0eccef66e5c3a1bb012a7c5e64c45978d2ea729f66f0bc2083"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_macOS_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.9_macOS_64bit.tar.bz2",
-              "size": "23761216",
-              "checksum": "SHA-256:84042ff991829f9333d6f437c0b6aacf4e409b6af440dbbfad03f88d7a9358d5"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Linux_ARM.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.9_Linux_ARM.tar.bz2",
-              "size": "23894811",
-              "checksum": "SHA-256:9e4adf983d3a9b5882c33c0f1e06ef2db33194ec4f6e1a81841d718fa47d62b4"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Linux_ARM64.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.9_Linux_ARM64.tar.bz2",
-              "size": "23951209",
-              "checksum": "SHA-256:1878d10be00c1af98911cadeee03802bf23a4395d8f21dbbd9196741f3900d20"
-            }
-          ]
-        },
-        {
-          "name": "fwupdater",
-          "version": "0.1.10",
-          "systems": [
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Linux_32bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.10_Linux_32bit.tar.bz2",
-              "size": "24067265",
-              "checksum": "SHA-256:6d843ad2236e34c0fa7a0ce497bafdbb0870e6c00d181e9d16fc4a5b2d37e5b9"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Linux_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.10_Linux_64bit.tar.bz2",
-              "size": "24043342",
-              "checksum": "SHA-256:31b841a02ef001857e337733cac3d962abb8d3f66a0ae31bbb46d4673a8ed4cb"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Windows_32bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.10_Windows_32bit.zip",
-              "size": "23705443",
-              "checksum": "SHA-256:b1153781b68f1a564309d7f63ca9c389e94194c29be3ec3944f17c9c62dd7b61"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Windows_64bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.10_Windows_64bit.zip",
-              "size": "23847822",
-              "checksum": "SHA-256:0b8bb8cfcecff4965243507efaefcf679a5eb8f99748890c0d83fda5dc8a3a4b"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_macOS_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.10_macOS_64bit.tar.bz2",
-              "size": "23763971",
-              "checksum": "SHA-256:9bae4139f5da7a046c51bf20b12e2bc062618a654f601113bcf32217ac4611f9"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Linux_ARM.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.10_Linux_ARM.tar.bz2",
-              "size": "23897570",
-              "checksum": "SHA-256:da234dcb71445d17d504aff700948f0e3a1b16cc8acf4b517134fffe0cac79a7"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Linux_ARM64.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.10_Linux_ARM64.tar.bz2",
-              "size": "23953999",
-              "checksum": "SHA-256:8fb3edaf2b9439ec5326e489612cac30a0cf997ab350a98d465a50e1ef2e076c"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-linuxarm64.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.6-linuxarm64.tar.bz2",
+              "size": "7149332",
+              "checksum": "SHA-256:d6a2e72b4869c031b434380da6e6a8a4a6269f8ee6312a3d23e85ea133a37ae9"
             }
           ]
         },
@@ -2652,56 +438,166 @@
         },
         {
           "name": "fwupdater",
-          "version": "0.1.2",
+          "version": "0.1.4",
           "systems": [
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Linux_32bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.2_Linux_32bit.tar.bz2",
-              "size": "13222221",
-              "checksum": "SHA-256:973ce3cd2d604f8750c9b62dabccdf8689013f0380d62eee29f8d6427dd37e8e"
+              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Linux_32bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.4_Linux_32bit.tar.bz2",
+              "size": "17369582",
+              "checksum": "SHA-256:794192e4463191308687ca10d361f6e86d06b57384800ead82ff9f1c32e3462b"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Linux_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.2_Linux_64bit.tar.bz2",
-              "size": "13255805",
-              "checksum": "SHA-256:9303c50f051b459ba89a4b218bcb39c3348f469c55feb2c63ac53f7f12eb5048"
+              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Linux_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.4_Linux_64bit.tar.bz2",
+              "size": "17346963",
+              "checksum": "SHA-256:e7e5a7f3c3f1c363a4e1e3cce3bbd48faa806da9153ade19336c68adcbc80464"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Windows_32bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.2_Windows_32bit.zip",
-              "size": "13589237",
-              "checksum": "SHA-256:e3986ae565b658a4bcaf50c0592c5801166ade30255571154ad5729f9b8649eb"
+              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Windows_32bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.4_Windows_32bit.zip",
+              "size": "16792636",
+              "checksum": "SHA-256:8bc96ea4a8e8232b7798feda9bd5e2e745c14ba7584b936a6588dcd44e69bcca"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Windows_64bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.2_Windows_64bit.zip",
-              "size": "13657381",
-              "checksum": "SHA-256:a3094a4c9589812e2c9751ce324315de9011481575c53a772b3c4950cb0310d0"
+              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Windows_64bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.4_Windows_64bit.zip",
+              "size": "16940370",
+              "checksum": "SHA-256:29b753610b9b285a31471fe35fa7938f54d461b773f3fcf4e5bff27ca72c20e8"
             },
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_macOS_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.2_macOS_64bit.tar.bz2",
-              "size": "13201523",
-              "checksum": "SHA-256:01f952aa365ddbf2072e3181f95f1b0a82d9c85bd1707a4b913e7500f833ff5f"
+              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_macOS_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.4_macOS_64bit.tar.bz2",
+              "size": "16913255",
+              "checksum": "SHA-256:f4c5542c209e5b7f09b020c9714889d846e8e6a96d1e2ab6e22cdae8d3ad8ef4"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Linux_ARM.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.2_Linux_ARM.tar.bz2",
-              "size": "13063327",
-              "checksum": "SHA-256:824dec1d62c1a8b835e2692991b017ce21cd0c95287c9282ff9621620157b3d6"
+              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Linux_ARM.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.4_Linux_ARM.tar.bz2",
+              "size": "16992130",
+              "checksum": "SHA-256:93503377d29a84f63433a608f3a2320ef27ca7f4b54a5cef6857ad16aa464842"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Linux_ARM64.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.2_Linux_ARM64.tar.bz2",
-              "size": "13015184",
-              "checksum": "SHA-256:057243d5ee65b14772035a2402ac48cefb208e59102f75928b4004530227cd47"
+              "url": "https://downloads.arduino.cc/tools/FirmwareUploader_0.1.4_Linux_ARM64.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.4_Linux_ARM64.tar.bz2",
+              "size": "17042502",
+              "checksum": "SHA-256:d68ddc8c78902f164f701d974d2b0deffdbe3a58bd4d62f0d2e10263c2292c0b"
+            }
+          ]
+        },
+        {
+          "name": "fwupdater",
+          "version": "0.1.6",
+          "systems": [
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Linux_32bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.6_Linux_32bit.tar.bz2",
+              "size": "17458014",
+              "checksum": "SHA-256:67b413dd15afca65d327e45329b1c2e64614126ef1fae27a1323155bbdc74c20"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Linux_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.6_Linux_64bit.tar.bz2",
+              "size": "17433263",
+              "checksum": "SHA-256:e299bea991778a388e611c3e9a4b1f5a7d5cf1b121465f7a843570602d0b6f39"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Windows_32bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.6_Windows_32bit.zip",
+              "size": "16950481",
+              "checksum": "SHA-256:4be9f5208841150ffc0148feccd819d77c7fbb477f41597fc3198f633a09a8ac"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Windows_64bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.6_Windows_64bit.zip",
+              "size": "17079617",
+              "checksum": "SHA-256:2490cdceb24b17d8269d8c144172c02c37a81c2275ed395973d22f0017d53713"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_macOS_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.6_macOS_64bit.tar.bz2",
+              "size": "17000606",
+              "checksum": "SHA-256:2d4af33020a0291e54197b133de8f278a8d68c0272e0bc93953941fd06508694"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Linux_ARM.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.6_Linux_ARM.tar.bz2",
+              "size": "17147561",
+              "checksum": "SHA-256:1b392a5ec7d4b7f8fd052e0e249f85538fbcce790bc5a442980ce6be215b5872"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.6_Linux_ARM64.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.6_Linux_ARM64.tar.bz2",
+              "size": "17186826",
+              "checksum": "SHA-256:538a24a8f7c6831477d39ae166695ed411eb29a6d5aec3b2bc69bc1ef7b4d7b1"
+            }
+          ]
+        },
+        {
+          "name": "fwupdater",
+          "version": "0.1.10",
+          "systems": [
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Linux_32bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.10_Linux_32bit.tar.bz2",
+              "size": "24067265",
+              "checksum": "SHA-256:6d843ad2236e34c0fa7a0ce497bafdbb0870e6c00d181e9d16fc4a5b2d37e5b9"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Linux_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.10_Linux_64bit.tar.bz2",
+              "size": "24043342",
+              "checksum": "SHA-256:31b841a02ef001857e337733cac3d962abb8d3f66a0ae31bbb46d4673a8ed4cb"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Windows_32bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.10_Windows_32bit.zip",
+              "size": "23705443",
+              "checksum": "SHA-256:b1153781b68f1a564309d7f63ca9c389e94194c29be3ec3944f17c9c62dd7b61"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Windows_64bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.10_Windows_64bit.zip",
+              "size": "23847822",
+              "checksum": "SHA-256:0b8bb8cfcecff4965243507efaefcf679a5eb8f99748890c0d83fda5dc8a3a4b"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_macOS_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.10_macOS_64bit.tar.bz2",
+              "size": "23763971",
+              "checksum": "SHA-256:9bae4139f5da7a046c51bf20b12e2bc062618a654f601113bcf32217ac4611f9"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Linux_ARM.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.10_Linux_ARM.tar.bz2",
+              "size": "23897570",
+              "checksum": "SHA-256:da234dcb71445d17d504aff700948f0e3a1b16cc8acf4b517134fffe0cac79a7"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.10_Linux_ARM64.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.10_Linux_ARM64.tar.bz2",
+              "size": "23953999",
+              "checksum": "SHA-256:8fb3edaf2b9439ec5326e489612cac30a0cf997ab350a98d465a50e1ef2e076c"
             }
           ]
         },
@@ -2817,214 +713,379 @@
         },
         {
           "name": "fwupdater",
-          "version": "0.1.12",
+          "version": "0.0.7",
           "systems": [
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Linux_32bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.12_Linux_32bit.tar.bz2",
-              "size": "26097546",
-              "checksum": "SHA-256:2fec2bdfd20ad4950bc9ba37108dc2a7c152f569174279c0697efe1f5a0db781"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-linux32.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.7-linux32.tar.bz2",
+              "size": "13077590",
+              "checksum": "SHA-256:05e26d5df253246cf68ba8a8f5f2de1032ac6f4d7af5310b8080ef6f54030fb4"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Linux_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.12_Linux_64bit.tar.bz2",
-              "size": "26073327",
-              "checksum": "SHA-256:ce57d0afef30cb7d3513f5da326346c99d6bf4923bbc2200634086811f3fb31e"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-linux64.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.7-linux64.tar.bz2",
+              "size": "13134534",
+              "checksum": "SHA-256:e8a36b7ae19060748b8b0540c9c0c9341d8d4c7a630441922a030223f767258d"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Windows_32bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.12_Windows_32bit.zip",
-              "size": "25743641",
-              "checksum": "SHA-256:558568b453caa1c821def8cc6d34555d0c910eb7e7e871de3ae1c39ae6f01bdd"
-            },
-            {
-              "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Windows_64bit.zip",
-              "archiveFileName": "FirmwareUploader_0.1.12_Windows_64bit.zip",
-              "size": "25851428",
-              "checksum": "SHA-256:ec16de33620985434280c92c3c322257b89bb67adf8fd4d5dd5f9467ea1e9e40"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-windows.zip",
+              "archiveFileName": "FirmwareUpdater-0.0.7-windows.zip",
+              "size": "13337495",
+              "checksum": "SHA-256:e881dd8a4bbb35f7271157e8dd226c2e032ac1115106170b0aaf9c969817df86"
             },
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_macOS_64bit.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.12_macOS_64bit.tar.bz2",
-              "size": "25792860",
-              "checksum": "SHA-256:a470361b57f86ddfcaecd274d844af51ee1d23a71cd6c26e30fcef2152d1a03f"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-osx.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.7-osx.tar.bz2",
+              "size": "13064291",
+              "checksum": "SHA-256:647ad713d68a1531ba56c88e5b3db9516cc0072ca1d401de5142d85ffcfd931a"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Linux_ARM.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.12_Linux_ARM.tar.bz2",
-              "size": "25936245",
-              "checksum": "SHA-256:855fa0a9b942c3ee18906efc510bdfe30bf3334ff28ffbb476e648ff30033847"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-linuxarm.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.7-linuxarm.tar.bz2",
+              "size": "12929770",
+              "checksum": "SHA-256:b6e09c07e816a35935585db07e07437023d44e66d1d2f05861708ea6ceff7629"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.12_Linux_ARM64.tar.bz2",
-              "archiveFileName": "FirmwareUploader_0.1.12_Linux_ARM64.tar.bz2",
-              "size": "25967430",
-              "checksum": "SHA-256:691461e64fe075e9a79801347c2bd895fb72f8f2c45a7cd49056c6ad9efe8fc4"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.7-linuxarm64.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.7-linuxarm64.tar.bz2",
+              "size": "12897349",
+              "checksum": "SHA-256:620f81148b13f70cdecbe59bbcbf605c7e0aae85f9cbee8ec48202f6018f23ce"
             }
           ]
         },
         {
           "name": "fwupdater",
-          "version": "0.0.6",
+          "version": "0.0.8",
           "systems": [
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-linux32.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.6-linux32.tar.bz2",
-              "size": "7334059",
-              "checksum": "SHA-256:8c4e562a8e6fa3d916c4bf6bb24d7eec0df013d8cc45dff187e5c63086a92c11"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.8-linux32.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.8-linux32.tar.bz2",
+              "size": "20137214",
+              "checksum": "SHA-256:e1f43aa225e6e2ad1f2bccc07898ddb439e980905385a8d7e0615f804a69eee8"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-linux64.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.6-linux64.tar.bz2",
-              "size": "7383853",
-              "checksum": "SHA-256:0e9132518acfe66e5a4e17ba4b6dd0c89dbd90cc0d9b4a54e007ac24d51fd36a"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.8-linux64.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.8-linux64.tar.bz2",
+              "size": "20167410",
+              "checksum": "SHA-256:423f67767d5b861a3c39ca6f6a18b2358a30b76bdc3d3d3d870e102b2b2271a8"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "https://downloads.arduino.cc/tools/FirmwareUpdater_0.0.8_Windows_64bit.zip",
+              "archiveFileName": "FirmwareUpdater_0.0.8_Windows_64bit.zip",
+              "size": "13645709",
+              "checksum": "SHA-256:c3386fdc440638186541f92f920462865308e0f5dde9f45e4dd1c35d2570b808"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-windows.zip",
-              "archiveFileName": "FirmwareUpdater-0.0.6-windows.zip",
-              "size": "7580663",
-              "checksum": "SHA-256:33a92661f43b8d025ca5f57be1116537ed153703067d9c86297619d58988feff"
+              "url": "https://downloads.arduino.cc/tools/FirmwareUpdater_0.0.8_Windows_32bit.zip",
+              "archiveFileName": "FirmwareUpdater_0.0.8_Windows_32bit.zip",
+              "size": "13578670",
+              "checksum": "SHA-256:dc3ce2e824b2f8ab6ee4c7d2f836311450d60825db95cbb51eeb076a28a1e2af"
             },
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-osx.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.6-osx.tar.bz2",
-              "size": "7368819",
-              "checksum": "SHA-256:3584d7581ff2469bdfde9de6f57d87b2a0370de5c902e9df687b7322a5405018"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.8-osx.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.8-osx.tar.bz2",
+              "size": "20091397",
+              "checksum": "SHA-256:635cbe786cd11ead26e5af0662991d8c3b647469f1874195eeb7f1dba5530b39"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-linuxarm.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.6-linuxarm.tar.bz2",
-              "size": "7180391",
-              "checksum": "SHA-256:276f027e552eb620064b09591c7a7c79927c93c017428436c81f71bad666803c"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.8-linuxarm.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.8-linuxarm.tar.bz2",
+              "size": "19984154",
+              "checksum": "SHA-256:c027389528e9b04d622167943fe04badbd2f63923f08cc1b22935e5158b2545b"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.6-linuxarm64.tar.bz2",
-              "archiveFileName": "FirmwareUpdater-0.0.6-linuxarm64.tar.bz2",
-              "size": "7149332",
-              "checksum": "SHA-256:d6a2e72b4869c031b434380da6e6a8a4a6269f8ee6312a3d23e85ea133a37ae9"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater-0.0.8-linuxarm64.tar.bz2",
+              "archiveFileName": "FirmwareUpdater-0.0.8-linuxarm64.tar.bz2",
+              "size": "19952489",
+              "checksum": "SHA-256:b6846bb84034e6a8486ce3165dabeb9b32b4fd3804639cd6137a37a00d0157c8"
             }
           ]
         },
         {
-          "name": "arduino-fwuploader",
-          "version": "2.0.1",
+          "name": "fwupdater",
+          "version": "0.0.9",
           "systems": [
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Linux_32bit.tar.gz",
-              "archiveFileName": "arduino-fwuploader_2.0.1_Linux_32bit.tar.gz",
-              "size": "6592200",
-              "checksum": "SHA-256:c1df11f9096955ceca5ae0fb0d16394408c373a72e603034f96ddbd48bc6af0a"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Linux_32bit.tar.bz2",
+              "archiveFileName": "FirmwareUpdater_0.0.9_Linux_32bit.tar.bz2",
+              "size": "13221786",
+              "checksum": "SHA-256:a45c536be798e6fc023044ee13911b9b567fb9d0b1c41c5cc9b722346f306425"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Linux_64bit.tar.gz",
-              "archiveFileName": "arduino-fwuploader_2.0.1_Linux_64bit.tar.gz",
-              "size": "6787210",
-              "checksum": "SHA-256:fd7408d52c4b187e00ac60a2ebc37150ab680989a992168fcab524caa0e4519b"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Windows_32bit.zip",
-              "archiveFileName": "arduino-fwuploader_2.0.1_Windows_32bit.zip",
-              "size": "6790043",
-              "checksum": "SHA-256:7d99c03d4b8a127b6f4acf40e89fe0fbd4c3bb7fe11d2b4c89ca9200e8993f73"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Linux_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUpdater_0.0.9_Linux_64bit.tar.bz2",
+              "size": "13255356",
+              "checksum": "SHA-256:89d08d4b75dae676bc6e982723f3b07ee5ab4c2fe6071fc97fe850697a0c5398"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Windows_64bit.zip",
-              "archiveFileName": "arduino-fwuploader_2.0.1_Windows_64bit.zip",
-              "size": "6885151",
-              "checksum": "SHA-256:94f120eb2d5172e9afc03e3cd04d80e5e5312927065cd53c3fef3926b4e3e398"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Windows_32bit.zip",
+              "archiveFileName": "FirmwareUpdater_0.0.9_Windows_32bit.zip",
+              "size": "13589082",
+              "checksum": "SHA-256:523b2f09a38ef36dcd96558a31e072c5b244e511690326a03af9406eccda2650"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Windows_64bit.zip",
+              "archiveFileName": "FirmwareUpdater_0.0.9_Windows_64bit.zip",
+              "size": "13658133",
+              "checksum": "SHA-256:51eacfcaba9279ef42050d15cf86d98e79511879a84a8e960a8994f6343f74a8"
             },
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_macOS_64bit.tar.gz",
-              "archiveFileName": "arduino-fwuploader_2.0.1_macOS_64bit.tar.gz",
-              "size": "6802383",
-              "checksum": "SHA-256:11b907d0ff0be73f9b7ef3a9b90b1265fc416c22aee10d724354668168550fb1"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_macOS_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUpdater_0.0.9_macOS_64bit.tar.bz2",
+              "size": "13202065",
+              "checksum": "SHA-256:26c0b8764a67f945037a461ead756bee0b453e383dee741548d03322327bd17d"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Linux_ARM.tar.gz",
-              "archiveFileName": "arduino-fwuploader_2.0.1_Linux_ARM.tar.gz",
-              "size": "6296962",
-              "checksum": "SHA-256:de2759ff0cc560e651658f9d7cebebada9bb246281e9370d3362ce0a08353ff6"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Linux_ARM.tar.bz2",
+              "archiveFileName": "FirmwareUpdater_0.0.9_Linux_ARM.tar.bz2",
+              "size": "13063437",
+              "checksum": "SHA-256:3cde04fa96479bb5342f07752b9cbabdf159f1dcbe7074b642a163ff2a363a28"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Linux_ARM64.tar.gz",
-              "archiveFileName": "arduino-fwuploader_2.0.1_Linux_ARM64.tar.gz",
-              "size": "6311327",
-              "checksum": "SHA-256:ab280543697379be604a59f3db4694e80d5a85fee61b7073dba8b2df31989404"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUpdater_0.0.9_Linux_ARM64.tar.bz2",
+              "archiveFileName": "FirmwareUpdater_0.0.9_Linux_ARM64.tar.bz2",
+              "size": "13014703",
+              "checksum": "SHA-256:3a41fac33917c4b5d8f5e0720afa780b2250b2561dd6090ed5338d7ab147524f"
             }
           ]
         },
         {
-          "name": "arduino-fwuploader",
-          "version": "2.1.0",
+          "name": "fwupdater",
+          "version": "0.1.2",
           "systems": [
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Linux_32bit.tar.gz",
-              "archiveFileName": "arduino-fwuploader_2.1.0_Linux_32bit.tar.gz",
-              "size": "6592713",
-              "checksum": "SHA-256:fe9a8ac10841ba9855aee79b487b0c3620930e25fceedc635d90996cc4f8745a"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Linux_32bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.2_Linux_32bit.tar.bz2",
+              "size": "13222221",
+              "checksum": "SHA-256:973ce3cd2d604f8750c9b62dabccdf8689013f0380d62eee29f8d6427dd37e8e"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Linux_64bit.tar.gz",
-              "archiveFileName": "arduino-fwuploader_2.1.0_Linux_64bit.tar.gz",
-              "size": "6909998",
-              "checksum": "SHA-256:7b375b7cc1618027c609e76e97c77cc2036e7c7a95e10db743261e2f397f04db"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Linux_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.2_Linux_64bit.tar.bz2",
+              "size": "13255805",
+              "checksum": "SHA-256:9303c50f051b459ba89a4b218bcb39c3348f469c55feb2c63ac53f7f12eb5048"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Windows_32bit.zip",
-              "archiveFileName": "arduino-fwuploader_2.1.0_Windows_32bit.zip",
-              "size": "6770325",
-              "checksum": "SHA-256:70c3f58074aa04bfe0392f504a24c39f196b85d93fdd41accf75f5e9eda58441"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Windows_32bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.2_Windows_32bit.zip",
+              "size": "13589237",
+              "checksum": "SHA-256:e3986ae565b658a4bcaf50c0592c5801166ade30255571154ad5729f9b8649eb"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Windows_64bit.zip",
-              "archiveFileName": "arduino-fwuploader_2.1.0_Windows_64bit.zip",
-              "size": "6994066",
-              "checksum": "SHA-256:8c2f7b1b76502323fc2fb0eb43375a2d88509ddf084b6a9836a138f0fb4d1c9b"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Windows_64bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.2_Windows_64bit.zip",
+              "size": "13657381",
+              "checksum": "SHA-256:a3094a4c9589812e2c9751ce324315de9011481575c53a772b3c4950cb0310d0"
             },
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_macOS_64bit.tar.gz",
-              "archiveFileName": "arduino-fwuploader_2.1.0_macOS_64bit.tar.gz",
-              "size": "6926299",
-              "checksum": "SHA-256:6979551a7a84417ec7f5f04fa6b75bec89c12d3891f061c1843cec43957d4d9a"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_macOS_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.2_macOS_64bit.tar.bz2",
+              "size": "13201523",
+              "checksum": "SHA-256:01f952aa365ddbf2072e3181f95f1b0a82d9c85bd1707a4b913e7500f833ff5f"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Linux_ARM.tar.gz",
-              "archiveFileName": "arduino-fwuploader_2.1.0_Linux_ARM.tar.gz",
-              "size": "6317910",
-              "checksum": "SHA-256:3b707df47b8b33a8fc9756838999c77e4605b79b8b2acadb4162e6a9d7aa9e79"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Linux_ARM.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.2_Linux_ARM.tar.bz2",
+              "size": "13063327",
+              "checksum": "SHA-256:824dec1d62c1a8b835e2692991b017ce21cd0c95287c9282ff9621620157b3d6"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Linux_ARM64.tar.gz",
-              "archiveFileName": "arduino-fwuploader_2.1.0_Linux_ARM64.tar.gz",
-              "size": "6374511",
-              "checksum": "SHA-256:ac32bf7c2b28e71fcfb06ea485775b43712bbd63f07eee4bbcd0ea197c1b475e"
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.2_Linux_ARM64.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.2_Linux_ARM64.tar.bz2",
+              "size": "13015184",
+              "checksum": "SHA-256:057243d5ee65b14772035a2402ac48cefb208e59102f75928b4004530227cd47"
+            }
+          ]
+        },
+        {
+          "name": "fwupdater",
+          "version": "0.1.3",
+          "systems": [
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Linux_32bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.3_Linux_32bit.tar.bz2",
+              "size": "15794726",
+              "checksum": "SHA-256:22f72fee3a1682c30b0bf4579a1ecc2759a5063c2be9342dd3c46858db43d7ef"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Linux_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.3_Linux_64bit.tar.bz2",
+              "size": "15927812",
+              "checksum": "SHA-256:1f998f8f5d9ef9487beb00d2f434682cbcdc4b13337fd82271df8ad931121324"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Windows_32bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.3_Windows_32bit.zip",
+              "size": "16139436",
+              "checksum": "SHA-256:d23dd1ef5ea19b46633980b47964834d0718d11b375c64725b28d4e39660ff3c"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Windows_64bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.3_Windows_64bit.zip",
+              "size": "16189555",
+              "checksum": "SHA-256:fd6eb93b2737ae3a49800d4f42abd7fa925e985b043d3a418412f26dc61b3baa"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_macOS_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.3_macOS_64bit.tar.bz2",
+              "size": "15832036",
+              "checksum": "SHA-256:ba53f679baca0f5ab6bbd4991da89702437932d67ae6c589c4da6ced3a4dc66b"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Linux_ARM.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.3_Linux_ARM.tar.bz2",
+              "size": "15734716",
+              "checksum": "SHA-256:91a85be7d657b4f31f69aba7e1a0390234d4ede5d138474b3eef928119a21df4"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.3_Linux_ARM64.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.3_Linux_ARM64.tar.bz2",
+              "size": "15557114",
+              "checksum": "SHA-256:7b2ebd25998c441b4a4da1cc5bf227285f0fd321b2107497d29910213d8ad039"
+            }
+          ]
+        },
+        {
+          "name": "fwupdater",
+          "version": "0.1.8",
+          "systems": [
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Linux_32bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.8_Linux_32bit.tar.bz2",
+              "size": "22050201",
+              "checksum": "SHA-256:b4f2f7cc3ced6053b22ac252cff2105b24474bbff468149beb7161e4c42ddd44"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Linux_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.8_Linux_64bit.tar.bz2",
+              "size": "22026254",
+              "checksum": "SHA-256:af0b39ed9468554b69305ef195b32ce00564190d50d19b7c467b34e3b76dd9e3"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Windows_32bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.8_Windows_32bit.zip",
+              "size": "21595791",
+              "checksum": "SHA-256:f67fb4d74b518a06e0ae2109040a5df81def123287f47856ff64c67b32e2e801"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Windows_64bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.8_Windows_64bit.zip",
+              "size": "21918177",
+              "checksum": "SHA-256:3edc59cc39ef8e0a863f8619c92315494fdb5a3c9d7d165533fe89c10d0b8d3a"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_macOS_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.8_macOS_64bit.tar.bz2",
+              "size": "21661287",
+              "checksum": "SHA-256:7d9c1c6c44d21cc9c88fa429ccad122ee40101f6f8c77fb03643be8c674b7a46"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Linux_ARM.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.8_Linux_ARM.tar.bz2",
+              "size": "21801813",
+              "checksum": "SHA-256:221dfa1b928bf772d8f92039ae6c41b50d45bcf8447b00b55f5ca3df90e0346c"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.8_Linux_ARM64.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.8_Linux_ARM64.tar.bz2",
+              "size": "21842771",
+              "checksum": "SHA-256:1518427a1f7862c10f21c87ffaf29550bba6cff0195bcd1954e683df4e60b8af"
+            }
+          ]
+        },
+        {
+          "name": "fwupdater",
+          "version": "0.1.9",
+          "systems": [
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Linux_32bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.9_Linux_32bit.tar.bz2",
+              "size": "24067265",
+              "checksum": "SHA-256:d49339643d6b834893488d32f87e56f9d320ef557520bb8ea52856cf19805e16"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Linux_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.9_Linux_64bit.tar.bz2",
+              "size": "24043342",
+              "checksum": "SHA-256:6097bc8eab1bedc0c8704b61a19556596d33ef6191548bc96d1744147de31a4a"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Windows_32bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.9_Windows_32bit.zip",
+              "size": "23702667",
+              "checksum": "SHA-256:c586a7f5752a8af22008ab6fd74c8f8ffad760169d702ba3df003636e505f922"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Windows_64bit.zip",
+              "archiveFileName": "FirmwareUploader_0.1.9_Windows_64bit.zip",
+              "size": "23847968",
+              "checksum": "SHA-256:a1e1622c48456f0eccef66e5c3a1bb012a7c5e64c45978d2ea729f66f0bc2083"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_macOS_64bit.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.9_macOS_64bit.tar.bz2",
+              "size": "23761216",
+              "checksum": "SHA-256:84042ff991829f9333d6f437c0b6aacf4e409b6af440dbbfad03f88d7a9358d5"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Linux_ARM.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.9_Linux_ARM.tar.bz2",
+              "size": "23894811",
+              "checksum": "SHA-256:9e4adf983d3a9b5882c33c0f1e06ef2db33194ec4f6e1a81841d718fa47d62b4"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/FirmwareUploader_0.1.9_Linux_ARM64.tar.bz2",
+              "archiveFileName": "FirmwareUploader_0.1.9_Linux_ARM64.tar.bz2",
+              "size": "23951209",
+              "checksum": "SHA-256:1878d10be00c1af98911cadeee03802bf23a4395d8f21dbbd9196741f3900d20"
             }
           ]
         },
@@ -3146,418 +1207,112 @@
           ]
         },
         {
-          "name": "rp2040tools",
-          "version": "1.0.2",
+          "name": "arduino-fwuploader",
+          "version": "2.0.1",
           "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-darwin_amd64.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.2-darwin_amd64.tar.bz2",
-              "size": "1665895",
-              "checksum": "SHA-256:039e0ddb7a407c5c20c3ef6def8d7cc2abdc7a4fc6dcb039abb3b41c4791f69f"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-linux_arm.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.2-linux_arm.tar.bz2",
-              "size": "5438204",
-              "checksum": "SHA-256:8981155a50bac8c7e3621f22b8e9c87f7d6aace4e28dddb03f41d704301da94d"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-linux_arm64.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.2-linux_arm64.tar.bz2",
-              "size": "5650185",
-              "checksum": "SHA-256:4f102352d702fc89757c119cd46c231b998f9900956183b0f7874994dc3965d5"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-linux_amd64.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.2-linux_amd64.tar.bz2",
-              "size": "4180308",
-              "checksum": "SHA-256:f6faafdfdf3cb780b884fe7d092679963e95f88ea78a9ed38312c511045d15c7"
-            },
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-linux_386.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.2-linux_386.tar.bz2",
-              "size": "4423488",
-              "checksum": "SHA-256:9af1aaf46402ab27d60a6b5d28da5ab8807f3099d78ee6e681bf7a36911ee690"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-windows_386.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.2-windows_386.tar.bz2",
-              "size": "2493234",
-              "checksum": "SHA-256:8aa684c431b1194d9af4958b116a0a96e4ebf6c90764f9f3420db0515dc6e2c7"
-            }
-          ]
-        },
-        {
-          "name": "rp2040tools",
-          "version": "1.0.5",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-darwin_amd64.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.5-darwin_amd64.tar.bz2",
-              "size": "1735713",
-              "checksum": "SHA-256:be2aa4c61206420f9aeac753deba6b365b40ccb2785536fbf8f16dc2ee3520b7"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-linux_arm.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.5-linux_arm.tar.bz2",
-              "size": "8729125",
-              "checksum": "SHA-256:621a9553c8f1f3a5fcd96540f1994799795dbc74ceaba79f64224665a67ca6ea"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-linux_arm64.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.5-linux_arm64.tar.bz2",
-              "size": "9069986",
-              "checksum": "SHA-256:951c8834c3fa740e0c6fd15a484d6c6f6be4e461baf410e568ef0e47c1500b8f"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-linux_amd64.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.5-linux_amd64.tar.bz2",
-              "size": "6138070",
-              "checksum": "SHA-256:6cb2554a28450e30265beeb64361d0d2ab822fc9daa9d5bd0c7963ae51e80526"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-linux_386.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.5-linux_386.tar.bz2",
-              "size": "6645102",
-              "checksum": "SHA-256:83d9adcbb7a42689b87a4fc968dad458d3770fbae364542e1f7e35da07eba71f"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-windows_386.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.5-windows_386.tar.bz2",
-              "size": "3180797",
-              "checksum": "SHA-256:698b5193f7f8efa0ecc01e75b505ec6c815ba7d59568babb2661d3871674db53"
-            }
-          ]
-        },
-        {
-          "name": "rp2040tools",
-          "version": "1.0.6",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-darwin_amd64.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.6-darwin_amd64.tar.bz2",
-              "size": "1717967",
-              "checksum": "SHA-256:4e32aa4b8f36db40a17bfbdfd34d80da91710e30c3887732bf0c0bf0b02840a7"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-linux_arm.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.6-linux_arm.tar.bz2",
-              "size": "8702508",
-              "checksum": "SHA-256:084a29accf0014bc79723fbb40057b95299c7ae63876f74494a077c987014cc3"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-linux_arm64.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.6-linux_arm64.tar.bz2",
-              "size": "9037783",
-              "checksum": "SHA-256:1a2a6cb1abf1f7b8198d494c8d8e838700297d748877be8232e02aaa5ca8d0df"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-linux_amd64.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.6-linux_amd64.tar.bz2",
-              "size": "6108121",
-              "checksum": "SHA-256:6e2ea818db1ff57f2d8e1e3010fbc5bdb5f28ff44f5a68900cae41d7d709f738"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-linux_386.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.6-linux_386.tar.bz2",
-              "size": "6604083",
-              "checksum": "SHA-256:ef339e2e0f5c7d5464b9911b612c634767daba39a6be977a1ffa41c95b9827a1"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-windows_386.tar.bz2",
-              "archiveFileName": "rp2040tools-1.0.6-windows_386.tar.bz2",
-              "size": "3145329",
-              "checksum": "SHA-256:26a5daebba68c2348dade33716a6e379ded89895ef0e49df1332964a724f6170"
-            }
-          ]
-        },
-        {
-          "name": "windows-drivers",
-          "version": "1.6.9",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/drivers-arduino-windows-1.6.9.zip",
-              "archiveFileName": "drivers-arduino-windows-1.6.9.zip",
-              "size": "7071714",
-              "checksum": "SHA-256:10d456ab18d164d42545255db8bef4ac9e1bf660cc89acb7a0980b5a486654ac"
-            }
-          ]
-        },
-        {
-          "name": "windows-drivers",
-          "version": "1.8.0",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/drivers-arduino-windows-1.8.0.zip",
-              "archiveFileName": "drivers-arduino-windows-1.8.0.zip",
-              "size": "16302148",
-              "checksum": "SHA-256:60614b326ad6860ed0cb99eb4cb2cb69f9ba6ba3784396d5441fe3f99004f8ec"
-            }
-          ]
-        },
-        {
-          "name": "adb",
-          "version": "32.0.0",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/android/platform-tools_r32.0.0-darwin.zip",
-              "archiveFileName": "platform-tools_r32.0.0-darwin.zip",
-              "size": "19439685",
-              "checksum": "SHA-256:29f0163a8f5c2cea7b3bedf3ccaa9374513a2cd653f436b0debdb7c4974ba525"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/android/adb_r32.0.0-linux64.tar.bz2",
-              "archiveFileName": "adb_r32.0.0-linux64.tar.bz2",
-              "size": "3171335",
-              "checksum": "SHA-256:a14c748d59a46145e053ed10404395db8ca5ac2ac5980a331771efc20be16d8d"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/android/adb_r32.0.0-linux-aarch64.tar.bz2",
-              "archiveFileName": "adb_r32.0.0-linux-aarch64.tar.bz2",
-              "size": "2520745",
-              "checksum": "SHA-256:684b27537fbedfce5f4b310e7a0706c7274ef467bf8d227d1512ef6f4a5597fe"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/android/platform-tools_r32.0.0-windows.zip",
-              "archiveFileName": "platform-tools_r32.0.0-windows.zip",
-              "size": "12033552",
-              "checksum": "SHA-256:41f4c7512b32cbb3f8c624c20b56326abb692a6f169b03b4b63b6c5a6fdbb08c"
-            }
-          ]
-        },
-        {
-          "name": "arduinoSTM32load",
-          "version": "2.0.0",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/arduino.org/arduinoSTM32load-2.0.0-darwin_amd64.tar.bz2",
-              "archiveFileName": "arduinoSTM32load-2.0.0-darwin_amd64.tar.bz2",
-              "size": "807514",
-              "checksum": "SHA-256:92fb9714091850febaa9d159501cbca5ba68d03020e5e2d4eff596154040bfaa"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/arduino.org/arduinoSTM32load-2.0.0-linux_arm.tar.bz2",
-              "archiveFileName": "arduinoSTM32load-2.0.0-linux_arm.tar.bz2",
-              "size": "809480",
-              "checksum": "SHA-256:fc0d8058b57bda849e1ffc849f83f54b0b85f97954176db317da1c745c174e08"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino.org/arduinoSTM32load-2.0.0-linux_amd64.tar.bz2",
-              "archiveFileName": "arduinoSTM32load-2.0.0-linux_amd64.tar.bz2",
-              "size": "818885",
-              "checksum": "SHA-256:0ed5cf1ea05fe6c33567817c54daf9c296d058a3607c428e0b0bd9aad89b9809"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino.org/arduinoSTM32load-2.0.0-linux_386.tar.bz2",
-              "archiveFileName": "arduinoSTM32load-2.0.0-linux_386.tar.bz2",
-              "size": "814283",
-              "checksum": "SHA-256:fad50abaaca034e6d647d09b042291b761982aabfd42b6156411c86e4f873ca7"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/arduino.org/arduinoSTM32load-2.0.0-windows_386.tar.bz2",
-              "archiveFileName": "arduinoSTM32load-2.0.0-windows_386.tar.bz2",
-              "size": "786335",
-              "checksum": "SHA-256:79467c0cde4b88c4884acb09445a2186af4e41f901eee56e99b5d89b7065d085"
-            }
-          ]
-        },
-        {
-          "name": "nrf5x-cl-tools",
-          "version": "9.3.1",
-          "systems": [
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/arduino.org/nRF5x-Command-Line-Tools_9_3_1_OSX.tar.bz2",
-              "archiveFileName": "nRF5x-Command-Line-Tools_9_3_1_OSX.tar.bz2",
-              "size": "341674",
-              "checksum": "SHA-256:41e4580271b39459a7ef1b078d11ee08d8f4f23fab7ff03f3fe8c3bc986a0ed4"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino.org/nRF5x-Command-Line-Tools_9_3_1_Linux-x86_64.tar.bz2",
-              "archiveFileName": "nRF5x-Command-Line-Tools_9_3_1_Linux-x86_64.tar.bz2",
-              "size": "167414",
-              "checksum": "SHA-256:4074fffe678d60968006a72edd182c6506b264472c9957bc3eaa39336bfcf972"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino.org/nRF5x-Command-Line-Tools_9_3_1_Linux-i386.tar.bz2",
-              "archiveFileName": "nRF5x-Command-Line-Tools_9_3_1_Linux-i386.tar.bz2",
-              "size": "155680",
-              "checksum": "SHA-256:e880059b303e5aad3a8b34c83dfd8c22beee77ae2074fbd37511e3baa91464a5"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/arduino.org/nRF5x-Command-Line-Tools_9_3_1_Win32.tar.bz2",
-              "archiveFileName": "nRF5x-Command-Line-Tools_9_3_1_Win32.tar.bz2",
-              "size": "812257",
-              "checksum": "SHA-256:a4467350e39314690cec2e96b80e7e3cab463c84eff9b81593ad57754d76ee00"
-            }
-          ]
-        },
-        {
-          "name": "arm-none-eabi-gcc",
-          "version": "4.8.3-2014q1",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
-              "size": "44423906",
-              "checksum": "SHA-256:ebe96b34c4f434667cab0187b881ed585e7c7eb990fe6b69be3c81ec7e11e845"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-windows.tar.gz",
-              "archiveFileName": "gcc-arm-none-eabi-4.8.3-2014q1-windows.tar.gz",
-              "size": "84537449",
-              "checksum": "SHA-256:fd8c111c861144f932728e00abd3f7d1107e186eb9cd6083a54c7236ea78b7c2"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-mac.tar.gz",
-              "archiveFileName": "gcc-arm-none-eabi-4.8.3-2014q1-mac.tar.gz",
-              "size": "52518522",
-              "checksum": "SHA-256:3598acf21600f17a8e4a4e8e193dc422b894dc09384759b270b2ece5facb59c2"
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Linux_32bit.tar.gz",
+              "archiveFileName": "arduino-fwuploader_2.0.1_Linux_32bit.tar.gz",
+              "size": "6592200",
+              "checksum": "SHA-256:c1df11f9096955ceca5ae0fb0d16394408c373a72e603034f96ddbd48bc6af0a"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-linux64.tar.gz",
-              "archiveFileName": "gcc-arm-none-eabi-4.8.3-2014q1-linux64.tar.gz",
-              "size": "51395093",
-              "checksum": "SHA-256:d23f6626148396d6ec42a5b4d928955a703e0757829195fa71a939e5b86eecf6"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-linux32.tar.gz",
-              "archiveFileName": "gcc-arm-none-eabi-4.8.3-2014q1-linux32.tar.gz",
-              "size": "51029223",
-              "checksum": "SHA-256:ba1994235f69c526c564f65343f22ddbc9822b2ea8c5ee07dd79d89f6ace2498"
-            }
-          ]
-        },
-        {
-          "name": "arm-none-eabi-gcc",
-          "version": "7-2017q4",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
-              "size": "96613739",
-              "checksum": "SHA-256:34180943d95f759c66444a40b032f7dd9159a562670fc334f049567de140c51b"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
-              "size": "99558726",
-              "checksum": "SHA-256:6fb5752fb4d11012bd0a1ceb93a19d0641ff7cf29d289b3e6b86b99768e66f76"
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Linux_64bit.tar.gz",
+              "archiveFileName": "arduino-fwuploader_2.0.1_Linux_64bit.tar.gz",
+              "size": "6787210",
+              "checksum": "SHA-256:fd7408d52c4b187e00ac60a2ebc37150ab680989a992168fcab524caa0e4519b"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-win32-arduino1.zip",
-              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-win32-arduino1.zip",
-              "size": "131761924",
-              "checksum": "SHA-256:96dd0091856f4d2eb21046eba571321feecf7d50b9c156f708b2a8b683903382"
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Windows_32bit.zip",
+              "archiveFileName": "arduino-fwuploader_2.0.1_Windows_32bit.zip",
+              "size": "6790043",
+              "checksum": "SHA-256:7d99c03d4b8a127b6f4acf40e89fe0fbd4c3bb7fe11d2b4c89ca9200e8993f73"
             },
             {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-mac.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-mac.tar.bz2",
-              "size": "104550003",
-              "checksum": "SHA-256:89b776c7cf0591c810b5b60067e4dc113b5b71bc50084a536e71b894a97fdccb"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-linux64.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-linux64.tar.bz2",
-              "size": "99857645",
-              "checksum": "SHA-256:96a029e2ae130a1210eaa69e309ea40463028eab18ba19c1086e4c2dafe69a6a"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
-              "size": "97427309",
-              "checksum": "SHA-256:090a0bc2b1956bc49392dff924a6c30fa57c88130097b1972204d67a45ce3cf3"
-            }
-          ]
-        },
-        {
-          "name": "arduinoOTA",
-          "version": "1.3.0",
-          "systems": [
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_386.tar.bz2",
-              "archiveFileName": "arduinoOTA-1.3.0-linux_386.tar.bz2",
-              "size": "2633516",
-              "checksum": "SHA-256:3e7f59d6fbc7a724598303f0d3289d0c4fd137a8973437980658379a024887b2"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_amd64.tar.bz2",
-              "archiveFileName": "arduinoOTA-1.3.0-linux_amd64.tar.bz2",
-              "size": "2716248",
-              "checksum": "SHA-256:aa45ee2441ffc3a122daec5802941d1fa2ac47adf5c5c481b5e0daa4dc259ffa"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_arm.tar.bz2",
-              "archiveFileName": "arduinoOTA-1.3.0-linux_arm.tar.bz2",
-              "size": "2567435",
-              "checksum": "SHA-256:1888587409b56aef4ba0ab0e6703b3dccba7cc3a022756ba9b908247e5d5a656"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_arm64.tar.bz2",
-              "archiveFileName": "arduinoOTA-1.3.0-linux_arm64.tar.bz2",
-              "size": "2472427",
-              "checksum": "SHA-256:835ed8f37cffac37e979d1b0f6041559592d3d98be52f0e8611b76c4858e4113"
+              "host": "x86_64-mingw32",
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Windows_64bit.zip",
+              "archiveFileName": "arduino-fwuploader_2.0.1_Windows_64bit.zip",
+              "size": "6885151",
+              "checksum": "SHA-256:94f120eb2d5172e9afc03e3cd04d80e5e5312927065cd53c3fef3926b4e3e398"
             },
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-darwin_amd64.tar.bz2",
-              "archiveFileName": "arduinoOTA-1.3.0-darwin_amd64.tar.bz2",
-              "size": "2766116",
-              "checksum": "SHA-256:d5d0f82ff829c0e434d12a2ee640a6fbd78f893ab37782edbb8b5bf2359d119e"
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_macOS_64bit.tar.gz",
+              "archiveFileName": "arduino-fwuploader_2.0.1_macOS_64bit.tar.gz",
+              "size": "6802383",
+              "checksum": "SHA-256:11b907d0ff0be73f9b7ef3a9b90b1265fc416c22aee10d724354668168550fb1"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Linux_ARM.tar.gz",
+              "archiveFileName": "arduino-fwuploader_2.0.1_Linux_ARM.tar.gz",
+              "size": "6296962",
+              "checksum": "SHA-256:de2759ff0cc560e651658f9d7cebebada9bb246281e9370d3362ce0a08353ff6"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.0.1_Linux_ARM64.tar.gz",
+              "archiveFileName": "arduino-fwuploader_2.0.1_Linux_ARM64.tar.gz",
+              "size": "6311327",
+              "checksum": "SHA-256:ab280543697379be604a59f3db4694e80d5a85fee61b7073dba8b2df31989404"
+            }
+          ]
+        },
+        {
+          "name": "arduino-fwuploader",
+          "version": "2.1.0",
+          "systems": [
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Linux_32bit.tar.gz",
+              "archiveFileName": "arduino-fwuploader_2.1.0_Linux_32bit.tar.gz",
+              "size": "6592713",
+              "checksum": "SHA-256:fe9a8ac10841ba9855aee79b487b0c3620930e25fceedc635d90996cc4f8745a"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Linux_64bit.tar.gz",
+              "archiveFileName": "arduino-fwuploader_2.1.0_Linux_64bit.tar.gz",
+              "size": "6909998",
+              "checksum": "SHA-256:7b375b7cc1618027c609e76e97c77cc2036e7c7a95e10db743261e2f397f04db"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-windows_386.zip",
-              "archiveFileName": "arduinoOTA-1.3.0-windows_386.zip",
-              "size": "2768948",
-              "checksum": "SHA-256:051943844eee442460d2c709edefadca184287fffd2b6c100dd53aa742aa05f6"
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Windows_32bit.zip",
+              "archiveFileName": "arduino-fwuploader_2.1.0_Windows_32bit.zip",
+              "size": "6770325",
+              "checksum": "SHA-256:70c3f58074aa04bfe0392f504a24c39f196b85d93fdd41accf75f5e9eda58441"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Windows_64bit.zip",
+              "archiveFileName": "arduino-fwuploader_2.1.0_Windows_64bit.zip",
+              "size": "6994066",
+              "checksum": "SHA-256:8c2f7b1b76502323fc2fb0eb43375a2d88509ddf084b6a9836a138f0fb4d1c9b"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_macOS_64bit.tar.gz",
+              "archiveFileName": "arduino-fwuploader_2.1.0_macOS_64bit.tar.gz",
+              "size": "6926299",
+              "checksum": "SHA-256:6979551a7a84417ec7f5f04fa6b75bec89c12d3891f061c1843cec43957d4d9a"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Linux_ARM.tar.gz",
+              "archiveFileName": "arduino-fwuploader_2.1.0_Linux_ARM.tar.gz",
+              "size": "6317910",
+              "checksum": "SHA-256:3b707df47b8b33a8fc9756838999c77e4605b79b8b2acadb4162e6a9d7aa9e79"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.1.0_Linux_ARM64.tar.gz",
+              "archiveFileName": "arduino-fwuploader_2.1.0_Linux_ARM64.tar.gz",
+              "size": "6374511",
+              "checksum": "SHA-256:ac32bf7c2b28e71fcfb06ea485775b43712bbd63f07eee4bbcd0ea197c1b475e"
             }
           ]
         },
@@ -3788,98 +1543,1077 @@
           ]
         },
         {
-          "name": "openocd",
-          "version": "0.10.0-arduino13",
+          "name": "arduinoOTA",
+          "version": "1.3.0",
           "systems": [
             {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-aarch64-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino13-static-aarch64-linux-gnu.tar.bz2",
-              "size": "1820630",
-              "checksum": "SHA-256:47ae7a1a7961ac9daef001b011505b38777baac3c02dd7e673f62601df841427"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-arm-linux-gnueabihf.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino13-static-arm-linux-gnueabihf.tar.bz2",
-              "size": "1896478",
-              "checksum": "SHA-256:4dd38b701019ad2fbb58173a3bc6c58effd39501a4a8266256dfe169e7516655"
-            },
-            {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino13-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
-              "size": "1883854",
-              "checksum": "SHA-256:788093504b25d2b9b772657215254ba178ed37773364ce240de68281efe40bd5"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-i686-w64-mingw32.zip",
-              "archiveFileName": "openocd-0.10.0-arduino13-static-i686-w64-mingw32.zip",
-              "size": "2334654",
-              "checksum": "SHA-256:2f3b87c644569f47780b16b071cd0929a64a8899ec769f4ca7480d20d5503365"
-            },
-            {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-x86_64-apple-darwin13.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino13-static-x86_64-apple-darwin13.tar.bz2",
-              "size": "1767137",
-              "checksum": "SHA-256:0f3f6e5e03355ffbbc84c4b4750e63c9315b7638c56d63df1b7795968208e6ba"
+              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_386.tar.bz2",
+              "archiveFileName": "arduinoOTA-1.3.0-linux_386.tar.bz2",
+              "size": "2633516",
+              "checksum": "SHA-256:3e7f59d6fbc7a724598303f0d3289d0c4fd137a8973437980658379a024887b2"
             },
             {
               "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino13-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
-              "size": "1955043",
-              "checksum": "SHA-256:e4b2ffbc9a29be21c32c6921c2e7c0ee39c664c4faca28a5f839c1df32d3bd24"
+              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_amd64.tar.bz2",
+              "archiveFileName": "arduinoOTA-1.3.0-linux_amd64.tar.bz2",
+              "size": "2716248",
+              "checksum": "SHA-256:aa45ee2441ffc3a122daec5802941d1fa2ac47adf5c5c481b5e0daa4dc259ffa"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_arm.tar.bz2",
+              "archiveFileName": "arduinoOTA-1.3.0-linux_arm.tar.bz2",
+              "size": "2567435",
+              "checksum": "SHA-256:1888587409b56aef4ba0ab0e6703b3dccba7cc3a022756ba9b908247e5d5a656"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_arm64.tar.bz2",
+              "archiveFileName": "arduinoOTA-1.3.0-linux_arm64.tar.bz2",
+              "size": "2472427",
+              "checksum": "SHA-256:835ed8f37cffac37e979d1b0f6041559592d3d98be52f0e8611b76c4858e4113"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-darwin_amd64.tar.bz2",
+              "archiveFileName": "arduinoOTA-1.3.0-darwin_amd64.tar.bz2",
+              "size": "2766116",
+              "checksum": "SHA-256:d5d0f82ff829c0e434d12a2ee640a6fbd78f893ab37782edbb8b5bf2359d119e"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-windows_386.zip",
+              "archiveFileName": "arduinoOTA-1.3.0-windows_386.zip",
+              "size": "2768948",
+              "checksum": "SHA-256:051943844eee442460d2c709edefadca184287fffd2b6c100dd53aa742aa05f6"
             }
           ]
         },
         {
-          "name": "openocd",
-          "version": "0.11.0-arduino2",
+          "name": "CMSIS",
+          "version": "4.0.0-atmel",
           "systems": [
             {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-aarch64-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.11.0-arduino2-static-aarch64-linux-gnu.tar.bz2",
-              "size": "1902818",
-              "checksum": "SHA-256:a1aa7f1435a61eafb72ee90722f2496d6a34a7a0f085d0315c2613e4a548b824"
-            },
-            {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-arm-linux-gnueabihf.tar.bz2",
-              "archiveFileName": "openocd-0.11.0-arduino2-static-arm-linux-gnueabihf.tar.bz2",
-              "size": "1986716",
-              "checksum": "SHA-256:57041130160be086e69387cceb4616eefc9819a0ef75de1f7c11aea57fb92699"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.11.0-arduino2-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
-              "size": "1971364",
-              "checksum": "SHA-256:6f4a8b77c8076aa18afb8438472526dff8c0d161a3ca68d0326163b59fcab663"
+              "url": "http://downloads.arduino.cc/CMSIS-4.0.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.0.0.tar.bz2",
+              "size": "17642623",
+              "checksum": "SHA-256:7d637d2d7a0c6bacc22065848a201db2fff124268e4a56868260d0f472b4bbb7"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-i686-w64-mingw32.zip",
-              "archiveFileName": "openocd-0.11.0-arduino2-static-i686-w64-mingw32.zip",
-              "size": "2460087",
-              "checksum": "SHA-256:631010980f12b1e750c4c67ce012b31c5953caabf4d30607d806e3d2b717d4b8"
+              "url": "http://downloads.arduino.cc/CMSIS-4.0.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.0.0.tar.bz2",
+              "size": "17642623",
+              "checksum": "SHA-256:7d637d2d7a0c6bacc22065848a201db2fff124268e4a56868260d0f472b4bbb7"
             },
             {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/CMSIS-4.0.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.0.0.tar.bz2",
+              "size": "17642623",
+              "checksum": "SHA-256:7d637d2d7a0c6bacc22065848a201db2fff124268e4a56868260d0f472b4bbb7"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/CMSIS-4.0.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.0.0.tar.bz2",
+              "size": "17642623",
+              "checksum": "SHA-256:7d637d2d7a0c6bacc22065848a201db2fff124268e4a56868260d0f472b4bbb7"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/CMSIS-4.0.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.0.0.tar.bz2",
+              "size": "17642623",
+              "checksum": "SHA-256:7d637d2d7a0c6bacc22065848a201db2fff124268e4a56868260d0f472b4bbb7"
+            }
+          ]
+        },
+        {
+          "name": "CMSIS",
+          "version": "4.5.0",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
+              "size": "31525196",
+              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
+              "size": "31525196",
+              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
+              "size": "31525196",
+              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
+              "size": "31525196",
+              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
+              "size": "31525196",
+              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
+              "size": "31525196",
+              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
+            },
+            {
+              "host": "all",
+              "url": "http://downloads.arduino.cc/CMSIS-4.5.0.tar.bz2",
+              "archiveFileName": "CMSIS-4.5.0.tar.bz2",
+              "size": "31525196",
+              "checksum": "SHA-256:cd8f7eae9fc7c8b4a1b5e40b89b9666d33953b47d3d2eb81844f5af729fa224d"
+            }
+          ]
+        },
+        {
+          "name": "CMSIS-Atmel",
+          "version": "1.0.0",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
+              "size": "1281654",
+              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
+              "size": "1281654",
+              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
+              "size": "1281654",
+              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
+              "size": "1281654",
+              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
+              "size": "1281654",
+              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
+            },
+            {
+              "host": "all",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.0.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.0.0.tar.bz2",
+              "size": "1281654",
+              "checksum": "SHA-256:b3c954570a2f8d9821c372e0864f5f0b86cfbeab8114ce95821f5c49758c7256"
+            }
+          ]
+        },
+        {
+          "name": "CMSIS-Atmel",
+          "version": "1.1.0",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
+              "size": "1659108",
+              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
+              "size": "1659108",
+              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
+              "size": "1659108",
+              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
+              "size": "1659108",
+              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
+              "size": "1659108",
+              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
+            },
+            {
+              "host": "all",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.1.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.1.0.tar.bz2",
+              "size": "1659108",
+              "checksum": "SHA-256:3ea5ec0451f42dc2b97f869b027a9cf696241cfc927cfc48d74ccc7b396ba41b"
+            }
+          ]
+        },
+        {
+          "name": "CMSIS-Atmel",
+          "version": "1.2.0",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
+              "size": "2221805",
+              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
+              "size": "2221805",
+              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "https://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
+              "size": "2221805",
+              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "https://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
+              "size": "2221805",
+              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "https://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
+              "size": "2221805",
+              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "https://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
+              "size": "2221805",
+              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
+            },
+            {
+              "host": "all",
+              "url": "https://downloads.arduino.cc/CMSIS-Atmel-1.2.0.tar.bz2",
+              "archiveFileName": "CMSIS-Atmel-1.2.0.tar.bz2",
+              "size": "2221805",
+              "checksum": "SHA-256:5e02670be7e36be9691d059bee0b04ee8b249404687531f33893922d116b19a5"
+            }
+          ]
+        },
+        {
+          "name": "dfu-util",
+          "version": "0.11.0-arduino2",
+          "systems": [
+            {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-x86_64-apple-darwin13.tar.bz2",
-              "archiveFileName": "openocd-0.11.0-arduino2-static-x86_64-apple-darwin13.tar.bz2",
-              "size": "1893150",
-              "checksum": "SHA-256:280e7234eba84e830e92d791ebc685286f71d2bc1d3347f93605ef170d54fef4"
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-osx.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino2-osx.tar.bz2",
+              "size": "72590",
+              "checksum": "SHA-256:8a01eb2238962e42db6dc476a6c1ec204a8670b2f3c9f6784c69e6cb981fd938"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-arm.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino2-arm.tar.bz2",
+              "size": "285451",
+              "checksum": "SHA-256:63bbddbdab6889c925d6f9535c92f0ba5fbd58d4e5e03d32cb43b91ef44bf277"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-arm64.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino2-arm64.tar.bz2",
+              "size": "282570",
+              "checksum": "SHA-256:fc2fd50397b5e23d552424bf6fbdd38c970fd58b2d2ac11f2395c3e3b7228cee"
             },
             {
               "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.11.0-arduino2-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
-              "size": "2052080",
-              "checksum": "SHA-256:4d19b6e3906de1434ec86841e0e3138235714c655d45f037c0fabfa5e5c0681b"
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-linux64.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino2-linux64.tar.bz2",
+              "size": "76662",
+              "checksum": "SHA-256:bbfecff5e59c70f436777bd2ea4732708d34f0611634f386d29964692b87db2f"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-linux32.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino2-linux32.tar.bz2",
+              "size": "76696",
+              "checksum": "SHA-256:f6c39d312b0c70efc66c5439a3f95c08006eb7639c1205805175cc85a3725564"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino2-windows.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino2-windows.tar.bz2",
+              "size": "634198",
+              "checksum": "SHA-256:3ddc85d1dd0195bc88a45d7a1a82c8b4e1952923ef39f89e13645226f0294da8"
+            }
+          ]
+        },
+        {
+          "name": "dfu-util",
+          "version": "0.11.0-arduino3",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-osx.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino3-osx.tar.bz2",
+              "size": "79057",
+              "checksum": "SHA-256:81d88dae0ed068a7bdde14d7cd56c9b953a3aea87aaaf4bcbaf022ba7df47ad5"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-arm.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino3-arm.tar.bz2",
+              "size": "241168",
+              "checksum": "SHA-256:27fb1fc8ba19df08f1805236083c7199f59bdaaacacceead98fee0e817e48425"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-arm64.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino3-arm64.tar.bz2",
+              "size": "282961",
+              "checksum": "SHA-256:5f212524b6338d06bf833a2375f1012740e0a359c81ad1ff728222cc93a28586"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-linux64.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino3-linux64.tar.bz2",
+              "size": "78422",
+              "checksum": "SHA-256:6a72e62546d4ba1c0c05c00a1e4863b23ab99e1224e6325b458207822fbf0da4"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-linux32.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino3-linux32.tar.bz2",
+              "size": "82825",
+              "checksum": "SHA-256:d6e5bd3d1861ac01dc85e85ae44667346a18f56537a95fe63e9dc71b1adeac99"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino3-windows.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino3-windows.tar.bz2",
+              "size": "635719",
+              "checksum": "SHA-256:7dccfadc260c5b13f7267fcd9ed610571bc74f6f64a85c20541c9ae48a1833b3"
+            }
+          ]
+        },
+        {
+          "name": "dfu-util",
+          "version": "0.11.0-arduino5",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-darwin_amd64.tar.gz",
+              "archiveFileName": "dfu-util-0.11-arduino5-darwin_amd64.tar.gz",
+              "size": "72429",
+              "checksum": "SHA-256:9e576c6e44f54b1e921a43ea77bcc08ec99e0e4e0905f4b9acf9ab2c979f0a22"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-linux_arm.tar.gz",
+              "archiveFileName": "dfu-util-0.11-arduino5-linux_arm.tar.gz",
+              "size": "2512819",
+              "checksum": "SHA-256:acd4bd283fd408515279a44dd830499ad37b0767e8f2fde5c27e878ded909dc3"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-linux_arm64.tar.gz",
+              "archiveFileName": "dfu-util-0.11-arduino5-linux_arm64.tar.gz",
+              "size": "2607592",
+              "checksum": "SHA-256:b3f46a65da0c2fed2449dc5a3351c3c74953a868aa7f8d99ba2bb8c418344fe9"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-linux_amd64.tar.gz",
+              "archiveFileName": "dfu-util-0.11-arduino5-linux_amd64.tar.gz",
+              "size": "2283425",
+              "checksum": "SHA-256:96c64c278561af806b585c123c85748926ad02b1aedc07e5578ca9bee2be0d2a"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-linux_386.tar.gz",
+              "archiveFileName": "dfu-util-0.11-arduino5-linux_386.tar.gz",
+              "size": "2524406",
+              "checksum": "SHA-256:9a707692261e5710ed79a6d8a4031ffd0bfe1e585216569934346e9b2d68d0c2"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-windows_386.tar.gz",
+              "archiveFileName": "dfu-util-0.11-arduino5-windows_386.tar.gz",
+              "size": "571340",
+              "checksum": "SHA-256:6451e16bf77600fe2436c8708ab4b75077c49997cf8bedf03221d9d6726bb641"
+            }
+          ]
+        },
+        {
+          "name": "dfu-util",
+          "version": "0.8.0-stm32-arduino1",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/arduino.org/dfu-util-0.8.0-stm32-arduino1-darwin_amd64.tar.bz2",
+              "archiveFileName": "dfu-util-0.8.0-stm32-arduino1-darwin_amd64.tar.bz2",
+              "size": "68381",
+              "checksum": "SHA-256:bb146803a4152ce2647d72b2cde68ff95eb3017c2460f24c4db922adac1fbd12"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/arduino.org/dfu-util-0.8.0-stm32-arduino1-linux_arm.tar.bz2",
+              "archiveFileName": "dfu-util-0.8.0-stm32-arduino1-linux_arm.tar.bz2",
+              "size": "213760",
+              "checksum": "SHA-256:607e6b0f2d2787ed7837f26da30b100131e3db207f84b8aca94a377db6e9ae50"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/arduino.org/dfu-util-0.8.0-stm32-arduino1-linux_amd64.tar.bz2",
+              "archiveFileName": "dfu-util-0.8.0-stm32-arduino1-stm32-linux_amd64.tar.bz2",
+              "size": "68575",
+              "checksum": "SHA-256:e44287494ebd22f59fc79766a94e20306e59c6c799f5bb1cddeed80db95000d9"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/arduino.org/dfu-util-0.8.0-stm32-arduino1-linux_386.tar.bz2",
+              "archiveFileName": "dfu-util-0.8.0-stm32-arduino1-linux_386.tar.bz2",
+              "size": "69097",
+              "checksum": "SHA-256:58131e35ad5d7053b281bc6176face7b117c5ad63331e43c6801f8ccd57f59a4"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/arduino.org/dfu-util-0.8.0-stm32-arduino1-windows_386.tar.bz2",
+              "archiveFileName": "dfu-util-0.8.0-stm32-arduino1-windows_386.tar.bz2",
+              "size": "159753",
+              "checksum": "SHA-256:25c2f84e1acf1f10fd2aa1afced441366d4545fd41eae56e64f0b990b4ce9f55"
+            }
+          ]
+        },
+        {
+          "name": "dfu-util",
+          "version": "0.9.0-arduino1",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino1-osx.tar.bz2",
+              "archiveFileName": "dfu-util-0.9.0-arduino1-osx.tar.bz2",
+              "size": "68361",
+              "checksum": "SHA-256:ea9216c627b7aa2d3a9bffab97df937e3c580cce66753c428dc697c854a35271"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino1-arm.tar.bz2",
+              "archiveFileName": "dfu-util-0.9.0-arduino1-arm.tar.bz2",
+              "size": "194826",
+              "checksum": "SHA-256:480637bf578e74b19753666a049f267d8ebcd9dfc8660d48f246bb76d5b806f9"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino1-linux64.tar.bz2",
+              "archiveFileName": "dfu-util-0.9.0-arduino1-linux64.tar.bz2",
+              "size": "66230",
+              "checksum": "SHA-256:e8a4d5477ab8c44d8528f35bc7dfafa5f3f04dace513906514aea31adc6fd3ba"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino1-linux32.tar.bz2",
+              "archiveFileName": "dfu-util-0.9.0-arduino1-linux32.tar.bz2",
+              "size": "62608",
+              "checksum": "SHA-256:17d69213914da04dadd6464d8adbcd3581dd930eb666b8f3336ab5383ce2127f"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino1-windows.tar.bz2",
+              "archiveFileName": "dfu-util-0.9.0-arduino1-windows.tar.bz2",
+              "size": "377537",
+              "checksum": "SHA-256:29be01b298348be8b822391be7147b71a969d47bd5457d5b24cfa5981dbce78e"
+            }
+          ]
+        },
+        {
+          "name": "dfu-util",
+          "version": "0.9.0-arduino2",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino2-osx.tar.bz2",
+              "archiveFileName": "dfu-util-0.9.0-arduino2-osx.tar.bz2",
+              "size": "65137",
+              "checksum": "SHA-256:00e87178b81d5721f334d4b688267f19f36eed1d9710a912c9e44bb1a748f766"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino2-arm.tar.bz2",
+              "archiveFileName": "dfu-util-0.9.0-arduino2-arm.tar.bz2",
+              "size": "198568",
+              "checksum": "SHA-256:b364a8fe1de697d7dd6c4135d341ddff6dbda7e33c707321c7dceab85dfc560b"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino2-linux64.tar.bz2",
+              "archiveFileName": "dfu-util-0.9.0-arduino2-linux64.tar.bz2",
+              "size": "70996",
+              "checksum": "SHA-256:628e01772007e622dff6af82220c27bcdf1d0726ba886bd2b36807601f66e4e8"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino2-linux32.tar.bz2",
+              "archiveFileName": "dfu-util-0.9.0-arduino2-linux32.tar.bz2",
+              "size": "71002",
+              "checksum": "SHA-256:7a6cec3d89c65119c52b6109cd92a9ec84bdf8a9d12083444d2c89e7ac16c84b"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.9.0-arduino2-windows.tar.bz2",
+              "archiveFileName": "dfu-util-0.9.0-arduino2-windows.tar.bz2",
+              "size": "394993",
+              "checksum": "SHA-256:8ec0e66acdc41941b6e25545f8c12e7eb7ba01a0bafae0b4ab4c99a70deb2ea5"
+            }
+          ]
+        },
+        {
+          "name": "dfu-util",
+          "version": "0.10.0-arduino1",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-osx.tar.bz2",
+              "archiveFileName": "dfu-util-0.10.0-arduino1-osx.tar.bz2",
+              "size": "73921",
+              "checksum": "SHA-256:7562d128036759605828d64b8d672d42445a8d95555c4b9ba339f73a1711a640"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-arm.tar.bz2",
+              "archiveFileName": "dfu-util-0.10.0-arduino1-arm.tar.bz2",
+              "size": "272153",
+              "checksum": "SHA-256:f1e550f40c235356b7fde1c59447bfbab28f768915d3c14bd858fe0576bfc5a9"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-arm64.tar.bz2",
+              "archiveFileName": "dfu-util-0.10.0-arduino1-arm64.tar.bz2",
+              "size": "277886",
+              "checksum": "SHA-256:ebfbd21d3030c500da1f83b9aae5b8c597bee04c3bde1ce0a51b41abeafc9614"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-linux64.tar.bz2",
+              "archiveFileName": "dfu-util-0.10.0-arduino1-linux64.tar.bz2",
+              "size": "77184",
+              "checksum": "SHA-256:13ef2ec591c1e8b0b7eb0a05da972ecd6695016e7a9607e332c7553899af9b4a"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-linux32.tar.bz2",
+              "archiveFileName": "dfu-util-0.10.0-arduino1-linux32.tar.bz2",
+              "size": "81826",
+              "checksum": "SHA-256:43599ec60c000e9ef016970a496d6ab2cbbe5a8b7df9d06ef3114ecf83f9d123"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.10.0-arduino1-windows.tar.bz2",
+              "archiveFileName": "dfu-util-0.10.0-arduino1-windows.tar.bz2",
+              "size": "464314",
+              "checksum": "SHA-256:90816b669273ae796d734a2459c46bb340d4790783fd7aa01eb40c0443f1a9b1"
+            }
+          ]
+        },
+        {
+          "name": "dfu-util",
+          "version": "0.11.0-arduino1",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino1-osx.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino1-osx.tar.bz2",
+              "size": "72632",
+              "checksum": "SHA-256:4518156ef1f46655714f11c9c9e753b6dee24e975d2155b5887ee613be133831"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino1-arm.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino1-arm.tar.bz2",
+              "size": "240667",
+              "checksum": "SHA-256:105ffe9287e7341b6ad017c1224b45a6fcf440fd8a1d1b796cf10e8c8e05e51d"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino1-linux64.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino1-linux64.tar.bz2",
+              "size": "76905",
+              "checksum": "SHA-256:dedd8ff3d21525957211a0f7ff320294542ea61e42431bd10f3d95200b07def0"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino1-linux32.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino1-linux32.tar.bz2",
+              "size": "76871",
+              "checksum": "SHA-256:cda70b9a3840b005f1070ac49e161df9c17bb5e9411897f38d4f5383104c864d"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/dfu-util-0.11.0-arduino1-windows.tar.bz2",
+              "archiveFileName": "dfu-util-0.11.0-arduino1-windows.tar.bz2",
+              "size": "634135",
+              "checksum": "SHA-256:dad96adc633d1a415b68439298c75db8d66aff978aef1288977bc7797ae946f6"
+            }
+          ]
+        },
+        {
+          "name": "bossac",
+          "version": "1.5-arduino",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/bossac-1.5-arduino2-arm-linux-gnueabihf.tar.bz2",
+              "archiveFileName": "bossac-1.5-arduino2-arm-linux-gnueabihf.tar.bz2",
+              "size": "199550",
+              "checksum": "SHA-256:7b61b7814e5b57bcbd853439fc9cd3e98af4abfdd369bf039c6917f9599e44b9"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/bossac-1.5-arduino2-mingw32.tar.gz",
+              "archiveFileName": "bossac-1.5-arduino2-mingw32.tar.gz",
+              "size": "222283",
+              "checksum": "SHA-256:9d849a34f0b26c25c6a8c4d741cd749dea238cade73b57a3048f248c431d9cc9"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/bossac-1.5-arduino2-i386-apple-darwin14.3.0.tar.gz",
+              "archiveFileName": "bossac-1.5-arduino2-i386-apple-darwin14.3.0.tar.gz",
+              "size": "64120",
+              "checksum": "SHA-256:8f07e50a1f887cb254092034c6a4482d73209568cd83cb624d6625d66794f607"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/bossac-1.5-arduino2-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "bossac-1.5-arduino2-x86_64-linux-gnu.tar.gz",
+              "size": "30431",
+              "checksum": "SHA-256:42785329155dcb39872d4d30a2a9d31e0f0ce3ae7e34a3ed3d840cbc909c4657"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/bossac-1.5-arduino2-i486-linux-gnu.tar.gz",
+              "archiveFileName": "bossac-1.5-arduino2-i486-linux-gnu.tar.gz",
+              "size": "29783",
+              "checksum": "SHA-256:ac56e553bbd6d992fa5592ace90996806230ab582f2bf9f8590836fec9dabef6"
+            }
+          ]
+        },
+        {
+          "name": "bossac",
+          "version": "1.6-arduino",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.6-arduino-mingw32.tar.gz",
+              "archiveFileName": "bossac-1.6-arduino-mingw32.tar.gz",
+              "size": "222517",
+              "checksum": "SHA-256:b59d64d3f7a43c894d0fba2dd1241bbaeefedf8c902130a24d8ec63b08f9ff6a"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.6-arduino-i386-apple-darwin14.4.0.tar.gz",
+              "archiveFileName": "bossac-1.6-arduino-i386-apple-darwin14.4.0.tar.gz",
+              "size": "64538",
+              "checksum": "SHA-256:6b3b686a782b6587c64c85db80085c9089c5ea1b051e49e5af17b3c6109c8efa"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.6-arduino-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "bossac-1.6-arduino-x86_64-linux-gnu.tar.gz",
+              "size": "30649",
+              "checksum": "SHA-256:2ce7a54d609b4ce3b678147202b2556dd1ce5b318de48a018c676521b994c7a7"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.6-arduino-i486-linux-gnu.tar.gz",
+              "archiveFileName": "bossac-1.6-arduino-i486-linux-gnu.tar.gz",
+              "size": "30072",
+              "checksum": "SHA-256:5c320bf5cfdbf03e3f648642e6de325e459a061fcf96b2215cb955263f7467b2"
+            }
+          ]
+        },
+        {
+          "name": "bossac",
+          "version": "1.7.0-arduino3",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-windows.tar.gz",
+              "archiveFileName": "bossac-1.7.0-arduino3-windows.tar.gz",
+              "size": "3607421",
+              "checksum": "SHA-256:62745cc5a98c26949ec9041ef20420643c561ec43e99dae659debf44e6836526"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-osx.tar.gz",
+              "archiveFileName": "bossac-1.7.0-arduino3-osx.tar.gz",
+              "size": "75510",
+              "checksum": "SHA-256:adb3c14debd397d8135e9e970215c6972f0e592c7af7532fa15f9ce5e64b991f"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-linux64.tar.gz",
+              "archiveFileName": "bossac-1.7.0-arduino3-linux64.tar.gz",
+              "size": "207271",
+              "checksum": "SHA-256:1ae54999c1f97234a5c603eb99ad39313b11746a4ca517269a9285afa05f9100"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-linux32.tar.gz",
+              "archiveFileName": "bossac-1.7.0-arduino3-linux32.tar.gz",
+              "size": "193577",
+              "checksum": "SHA-256:4ac4354746d1a09258f49a43ef4d1baf030d81c022f8434774268b00f55d3ec3"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-linuxarm.tar.gz",
+              "archiveFileName": "bossac-1.7.0-arduino3-linuxarm.tar.gz",
+              "size": "193941",
+              "checksum": "SHA-256:626c6cc548046901143037b782bf019af1663bae0d78cf19181a876fb9abbb90"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-linuxaarch64.tar.gz",
+              "archiveFileName": "bossac-1.7.0-arduino3-linuxaarch64.tar.gz",
+              "size": "268365",
+              "checksum": "SHA-256:a098b2cc23e29f0dc468416210d097c4a808752cd5da1a7b9b8b7b931a04180b"
+            }
+          ]
+        },
+        {
+          "name": "bossac",
+          "version": "1.9.1-arduino1",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-windows.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino1-windows.tar.gz",
+              "size": "1260118",
+              "checksum": "SHA-256:fe2d6ef78ca711c78e104e258357ed06b09e95e9356dc72d8d2c9f6670af4b7a"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-osx.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino1-osx.tar.gz",
+              "size": "47835",
+              "checksum": "SHA-256:c356632f98d5bae9b4f5d3ad823a5ee89b23078c2b835e8ac39a208f4855b0e6"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-linux64.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino1-linux64.tar.gz",
+              "size": "399453",
+              "checksum": "SHA-256:d3d324a3503a8db825c01f3b38519e4d4824c4d0e42cb399a16c1e074f9a9a86"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-linux32.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino1-linux32.tar.gz",
+              "size": "384792",
+              "checksum": "SHA-256:eec622b8b5a8642af94ec23febfe14c928edd734f144db73b146bf6708d2057f"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-linuxarm.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino1-linuxarm.tar.gz",
+              "size": "361799",
+              "checksum": "SHA-256:b42061d2fa2dbd6910d0d295e024f2cff7bb44f3e2ecc0bc2fe71a1f31b0ecba"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino1-linuxaarch64.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino1-linuxaarch64.tar.gz",
+              "size": "442657",
+              "checksum": "SHA-256:b271013841e1e25ee55f241e8c50a56ed775d3b322844e1e3099231ba17f3868"
+            }
+          ]
+        },
+        {
+          "name": "bossac",
+          "version": "1.9.1-arduino2",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-windows.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino2-windows.tar.gz",
+              "size": "1260628",
+              "checksum": "SHA-256:5c994d04354f0db8e4bea136f49866d2ba537f0af74b2e78026f2d4fc75e3e39"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-osx.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino2-osx.tar.gz",
+              "size": "47870",
+              "checksum": "SHA-256:b7732129364a378676604db6579c9b8dab50dd965fb50d7a3afff1839c97ff80"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-linux64.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino2-linux64.tar.gz",
+              "size": "399532",
+              "checksum": "SHA-256:9eb549874391521999cee13dc823a2cfc8866b8246945339a281808d99c72d2c"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-linux32.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino2-linux32.tar.gz",
+              "size": "384951",
+              "checksum": "SHA-256:10d69f53f169f25afee2dd583dfd9dc803c10543e6c5260d106725cb0d174900"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-linuxarm.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino2-linuxarm.tar.gz",
+              "size": "361915",
+              "checksum": "SHA-256:c9539d161d23231b5beb1d09a71829744216c7f5bc2857a491999c3e567f5b19"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino2-linuxaarch64.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino2-linuxaarch64.tar.gz",
+              "size": "442853",
+              "checksum": "SHA-256:c167fa0ea223966f4d21f5592da3888bcbfbae385be6c5c4e41f8abff35f5cb1"
+            }
+          ]
+        },
+        {
+          "name": "bossac",
+          "version": "1.3-arduino",
+          "systems": [
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.3a-arduino-i686-linux-gnu.tar.bz2",
+              "archiveFileName": "bossac-1.3a-arduino-i686-linux-gnu.tar.bz2",
+              "size": "147359",
+              "checksum": "SHA-256:d6d10362f40729a7877e43474fcf02ad82cf83321cc64ca931f5c82b2d25d24f"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.3a-arduino-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "bossac-1.3a-arduino-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "26179",
+              "checksum": "SHA-256:c1daed033251296768fa8b63ad283e053da93427c0f3cd476a71a9188e18442c"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.3a-arduino-i686-mingw32.tar.bz2",
+              "archiveFileName": "bossac-1.3a-arduino-i686-mingw32.tar.bz2",
+              "size": "265647",
+              "checksum": "SHA-256:a37727622e0f86cb4f2856ad0209568a5d804234dba3dc0778829730d61a5ec7"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.3a-arduino-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "bossac-1.3a-arduino-i386-apple-darwin11.tar.bz2",
+              "size": "39475",
+              "checksum": "SHA-256:40770b225753e7a52bb165e8f37e6b760364f5c5e96048168d0178945bd96ad6"
+            }
+          ]
+        },
+        {
+          "name": "bossac",
+          "version": "1.6.1-arduino",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/bossac-1.6.1-arduino-arm-linux-gnueabihf.tar.bz2",
+              "archiveFileName": "bossac-1.6.1-arduino-arm-linux-gnueabihf.tar.bz2",
+              "size": "201341",
+              "checksum": "SHA-256:8c4e63db982178919c824e7a35580dffc95c3426afa7285de3eb583982d4d391"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/bossac-1.6.1-arduino-mingw32.tar.gz",
+              "archiveFileName": "bossac-1.6.1-arduino-mingw32.tar.gz",
+              "size": "222918",
+              "checksum": "SHA-256:d59f43e2e83a337d04c4ae88b195a4ee175b8d87fff4c43144d23412a4a9513b"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/bossac-1.6.1-arduino-i386-apple-darwin14.5.0.tar.gz",
+              "archiveFileName": "bossac-1.6.1-arduino-i386-apple-darwin14.5.0.tar.gz",
+              "size": "64587",
+              "checksum": "SHA-256:2f80ef569a3fb19da60ab3489e49d8fe7d4699876acf30ff4938c632230a09aa"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/bossac-1.6.1-arduino-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "bossac-1.6.1-arduino-x86_64-linux-gnu.tar.gz",
+              "size": "30869",
+              "checksum": "SHA-256:b78afc66c00ccfdd69a08bd3959c260a0c64ccce78a71d5a1135ae4437ff40db"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/bossac-1.6.1-arduino-i486-linux-gnu.tar.gz",
+              "archiveFileName": "bossac-1.6.1-arduino-i486-linux-gnu.tar.gz",
+              "size": "30320",
+              "checksum": "SHA-256:1e211347569d75193b337296a10dd25b0ce04419e3d7dc644355178b6b514f92"
+            }
+          ]
+        },
+        {
+          "name": "bossac",
+          "version": "1.7.0",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-mingw32.tar.gz",
+              "archiveFileName": "bossac-1.7.0-mingw32.tar.gz",
+              "size": "243066",
+              "checksum": "SHA-256:9ef7d11b4fabca0adc17102a0290957d5cc26ce46b422c3a5344722c80acc7b2"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-i386-apple-darwin15.6.0.tar.gz",
+              "archiveFileName": "bossac-1.7.0-i386-apple-darwin15.6.0.tar.gz",
+              "size": "63822",
+              "checksum": "SHA-256:feac36ab38876c163dcf51bdbcfbed01554eede3d41c59a0e152e170fe5164d2"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "bossac-1.7.0-x86_64-linux-gnu.tar.gz",
+              "size": "31373",
+              "checksum": "SHA-256:9475c0c8596c1ba12dcbce60e48fef7559087fa8eccbea7bab732113f3c181ee"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-i686-linux-gnu.tar.gz",
+              "archiveFileName": "bossac-1.7.0-i686-linux-gnu.tar.gz",
+              "size": "31086",
+              "checksum": "SHA-256:17003b0bdc698d52eeb91b09c34aec501c6e0285b4aa88659ab7cc407a451a4d"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.7.0-arm-linux-gnueabihf.tar.gz",
+              "archiveFileName": "bossac-1.7.0-arm-linux-gnueabihf.tar.gz",
+              "size": "27382",
+              "checksum": "SHA-256:09e46d0af61b2189caaac0bc6d4dd15cb22c167fdedc56ec98602dd5f10e68e0"
+            }
+          ]
+        },
+        {
+          "name": "bossac",
+          "version": "1.8.0-48-gb176eee",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.8-48-gb176eee-i686-w64-mingw32.tar.gz",
+              "archiveFileName": "bossac-1.8-48-gb176eee-i686-w64-mingw32.tar.gz",
+              "size": "91219",
+              "checksum": "SHA-256:4523a6897f3dfd673fe821c5cfbac8d6a12782e7a36b312b9ee7d41deec2a10a"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.8-48-gb176eee-i386-apple-darwin16.1.0.tar.gz",
+              "archiveFileName": "bossac-1.8-48-gb176eee-i386-apple-darwin16.1.0.tar.gz",
+              "size": "39150",
+              "checksum": "SHA-256:581ecc16021de36638ae14e9e064ffb4a1d532a11502f4252da8bcdf5ce1d649"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.8-48-gb176eee-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "bossac-1.8-48-gb176eee-x86_64-linux-gnu.tar.gz",
+              "size": "37798",
+              "checksum": "SHA-256:1347eec67f5b90b785abdf6c8a8aa59129d0c016de7ff9b5ac1690378eacca3c"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.8-48-gb176eee-i486-linux-gnu.tar.gz",
+              "archiveFileName": "bossac-1.8-48-gb176eee-i486-linux-gnu.tar.gz",
+              "size": "37374",
+              "checksum": "SHA-256:4c7492f876b8269aa9d8bcaad3aeda31acf1a0292383093b6d9f5f1d23fdafc3"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.8-48-gb176eee-arm-linux-gnueabihf.tar.gz",
+              "archiveFileName": "bossac-1.8-48-gb176eee-arm-linux-gnueabihf.tar.gz",
+              "size": "34825",
+              "checksum": "SHA-256:2001e4a592f3aefd22f213b1ddd6f5d8d5e74bd04080cf1b97c24cbaa81b10ed"
+            }
+          ]
+        },
+        {
+          "name": "bossac",
+          "version": "1.9.1-arduino5",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino5-osx.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino5-osx.tar.gz",
+              "size": "47862",
+              "checksum": "SHA-256:c76eae00874a44265029b452303fb355e9ffa006e7ba214ca7ae01b1416867da"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino5-linuxaarch64.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino5-linuxaarch64.tar.gz",
+              "size": "442901",
+              "checksum": "SHA-256:f91dbbe90d57dd8074cd9b0ca7a2f5d41ee71bdf15e9bfd68bf2048a08e4a286"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino5-linuxarm.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino5-linuxarm.tar.gz",
+              "size": "362365",
+              "checksum": "SHA-256:a0680ac5067ca8134f28fd7f86320d4c3099c782cefecd2e9b1edfde57f5947b"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino5-linux64.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino5-linux64.tar.gz",
+              "size": "399674",
+              "checksum": "SHA-256:ef80d247c431db2686a3e6728cb4897b708b92cd67687100c125684f3c12fc80"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino5-linux32.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino5-linux32.tar.gz",
+              "size": "385086",
+              "checksum": "SHA-256:d9c7ddab312bfc330ed7a98916ffa2c7a9c44798863ce1f4467fb240abc1830a"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/bossac-1.9.1-arduino5-windows.tar.gz",
+              "archiveFileName": "bossac-1.9.1-arduino5-windows.tar.gz",
+              "size": "1260650",
+              "checksum": "SHA-256:99e1982cf29600152e1c89b3389c1b4ce853201491ed52a12b4a327200cc6af0"
             }
           ]
         },
@@ -4015,90 +2749,145 @@
         },
         {
           "name": "openocd",
-          "version": "0.10.0-arduino9",
+          "version": "0.10.0-arduino12",
           "systems": [
             {
               "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-aarch64-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino9-static-aarch64-linux-gnu.tar.bz2",
-              "size": "1714657",
-              "checksum": "SHA-256:b814b16b52cef21eacf456cc7a89d7b5d4cb1385bfb8fb82963b7d8151824d93"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-aarch64-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino12-static-aarch64-linux-gnu.tar.bz2",
+              "size": "1778706",
+              "checksum": "SHA-256:86e15186a44b87c00f5ddd9c05849d2ec107783dd18a5ac984ce2a71e34084ed"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-arm-linux-gnueabihf.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino9-static-arm-linux-gnueabihf.tar.bz2",
-              "size": "1778177",
-              "checksum": "SHA-256:f0443e771f5e3a779949498d3c9bfffd1dd27cdf0ad7136a2db5e80447a7175a"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-arm-linux-gnueabihf.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino12-static-arm-linux-gnueabihf.tar.bz2",
+              "size": "1855234",
+              "checksum": "SHA-256:5c6ca6189f61894ee77b29bc342f96cd14e4d7627fabeb2a8d2e2c534316cc38"
             },
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino9-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
-              "size": "1782958",
-              "checksum": "SHA-256:a22872918df899cb808f9286141d42438ae5611156c143cfb692069f52a2bddd"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino12-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
+              "size": "1844359",
+              "checksum": "SHA-256:4938742d3fec62941187666b8ded44d8f6c7a404920ff49d97fca484b9fd08af"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-i686-w64-mingw32.zip",
-              "archiveFileName": "openocd-0.10.0-arduino9-static-i686-w64-mingw32.zip",
-              "size": "2190484",
-              "checksum": "SHA-256:f53f9a2b7f48a2ebc00ea9196bf559d15987d3779bcea4118ebec8925da5a1f6"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-i686-w64-mingw32.zip",
+              "archiveFileName": "openocd-0.10.0-arduino12-static-i686-w64-mingw32.zip",
+              "size": "2276602",
+              "checksum": "SHA-256:1e23c0f1f809725db3e1f8d1e1f460a37fb7b2cf95e93c6e328e527501ab084c"
             },
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-x86_64-apple-darwin13.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino9-static-x86_64-apple-darwin13.tar.bz2",
-              "size": "1655311",
-              "checksum": "SHA-256:6d47f97919f317bb6e5f1f903127604271d66d149f4625f29b8e0eb5f6c94c64"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-x86_64-apple-darwin13.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino12-static-x86_64-apple-darwin13.tar.bz2",
+              "size": "1723600",
+              "checksum": "SHA-256:b40d135449401870302bec073326d6f1df79da38d9dd21326314a5a90189a06e"
             },
             {
               "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino9-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
-              "size": "1844365",
-              "checksum": "SHA-256:f624552b5ba56aa78d0c1a0e5d18cf2b5694db2ed44080968e22aa1af8f23c1b"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino12-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
+              "size": "1918845",
+              "checksum": "SHA-256:bc48be10916f69f3a4b050f04babc14ee99dad1fc5da55ce606077991edab1d0"
             }
           ]
         },
         {
           "name": "openocd",
-          "version": "0.10.0-arduino1-static",
+          "version": "0.10.0-arduino13",
           "systems": [
             {
-              "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/arduino.org/OpenOCD-0.10.0-nrf52-osx-static.tar.gz",
-              "archiveFileName": "OpenOCD-0.10.0-nrf52-osx-static.tar.gz",
-              "size": "1529841",
-              "checksum": "SHA-256:46bd02c1d42c5d94c4936e4d4a0ff29697b621840be9a6f882e316203122049d"
-            },
-            {
-              "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino.org/OpenOCD-0.10.0-nrf52-linux64-static.tar.gz",
-              "archiveFileName": "OpenOCD-0.10.0-nrf52-linux64-static.tar.gz",
-              "size": "1777984",
-              "checksum": "SHA-256:1c9ae77930dd7377d8c13f84abe7307b67fdcd6da74cc1ce269a79e138e7a00a"
-            },
-            {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino.org/OpenOCD-0.10.0-nrf52-linux32-static.tar.gz",
-              "archiveFileName": "OpenOCD-0.10.0-nrf52-linux32-static.tar.gz",
-              "size": "1713236",
-              "checksum": "SHA-256:777371df34828810e1bea623b0f7c98f28fedf30fd3bc8e7d8f0a5745fb4e258"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/arduino.org/OpenOCD-0.10.0-nrf52-win32-static.zip",
-              "archiveFileName": "OpenOCD-0.10.0-nrf52-win32-static.zip",
-              "size": "1773642",
-              "checksum": "SHA-256:9371b25d000bd589c058a5bf10720617adb91fd8b8a21d2e887cf45eaa2df93c"
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-aarch64-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino13-static-aarch64-linux-gnu.tar.bz2",
+              "size": "1820630",
+              "checksum": "SHA-256:47ae7a1a7961ac9daef001b011505b38777baac3c02dd7e673f62601df841427"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/arduino.org/OpenOCD-0.10.0-nrf52-arm-static.tar.gz",
-              "archiveFileName": "OpenOCD-0.10.0-nrf52-arm-static.tar.gz",
-              "size": "1526863",
-              "checksum": "SHA-256:b5172422077f87ff05b76ff40034979678c9c640e9d08cee15ce55e40dd8c929"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-arm-linux-gnueabihf.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino13-static-arm-linux-gnueabihf.tar.bz2",
+              "size": "1896478",
+              "checksum": "SHA-256:4dd38b701019ad2fbb58173a3bc6c58effd39501a4a8266256dfe169e7516655"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino13-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
+              "size": "1883854",
+              "checksum": "SHA-256:788093504b25d2b9b772657215254ba178ed37773364ce240de68281efe40bd5"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-i686-w64-mingw32.zip",
+              "archiveFileName": "openocd-0.10.0-arduino13-static-i686-w64-mingw32.zip",
+              "size": "2334654",
+              "checksum": "SHA-256:2f3b87c644569f47780b16b071cd0929a64a8899ec769f4ca7480d20d5503365"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-x86_64-apple-darwin13.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino13-static-x86_64-apple-darwin13.tar.bz2",
+              "size": "1767137",
+              "checksum": "SHA-256:0f3f6e5e03355ffbbc84c4b4750e63c9315b7638c56d63df1b7795968208e6ba"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino13-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino13-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
+              "size": "1955043",
+              "checksum": "SHA-256:e4b2ffbc9a29be21c32c6921c2e7c0ee39c664c4faca28a5f839c1df32d3bd24"
+            }
+          ]
+        },
+        {
+          "name": "openocd",
+          "version": "0.11.0-arduino2",
+          "systems": [
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-aarch64-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.11.0-arduino2-static-aarch64-linux-gnu.tar.bz2",
+              "size": "1902818",
+              "checksum": "SHA-256:a1aa7f1435a61eafb72ee90722f2496d6a34a7a0f085d0315c2613e4a548b824"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-arm-linux-gnueabihf.tar.bz2",
+              "archiveFileName": "openocd-0.11.0-arduino2-static-arm-linux-gnueabihf.tar.bz2",
+              "size": "1986716",
+              "checksum": "SHA-256:57041130160be086e69387cceb4616eefc9819a0ef75de1f7c11aea57fb92699"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.11.0-arduino2-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
+              "size": "1971364",
+              "checksum": "SHA-256:6f4a8b77c8076aa18afb8438472526dff8c0d161a3ca68d0326163b59fcab663"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-i686-w64-mingw32.zip",
+              "archiveFileName": "openocd-0.11.0-arduino2-static-i686-w64-mingw32.zip",
+              "size": "2460087",
+              "checksum": "SHA-256:631010980f12b1e750c4c67ce012b31c5953caabf4d30607d806e3d2b717d4b8"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-x86_64-apple-darwin13.tar.bz2",
+              "archiveFileName": "openocd-0.11.0-arduino2-static-x86_64-apple-darwin13.tar.bz2",
+              "size": "1893150",
+              "checksum": "SHA-256:280e7234eba84e830e92d791ebc685286f71d2bc1d3347f93605ef170d54fef4"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.11.0-arduino2-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.11.0-arduino2-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
+              "size": "2052080",
+              "checksum": "SHA-256:4d19b6e3906de1434ec86841e0e3138235714c655d45f037c0fabfa5e5c0681b"
             }
           ]
         },
@@ -4193,49 +2982,49 @@
         },
         {
           "name": "openocd",
-          "version": "0.10.0-arduino12",
+          "version": "0.10.0-arduino9",
           "systems": [
             {
               "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-aarch64-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino12-static-aarch64-linux-gnu.tar.bz2",
-              "size": "1778706",
-              "checksum": "SHA-256:86e15186a44b87c00f5ddd9c05849d2ec107783dd18a5ac984ce2a71e34084ed"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-aarch64-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino9-static-aarch64-linux-gnu.tar.bz2",
+              "size": "1714657",
+              "checksum": "SHA-256:b814b16b52cef21eacf456cc7a89d7b5d4cb1385bfb8fb82963b7d8151824d93"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-arm-linux-gnueabihf.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino12-static-arm-linux-gnueabihf.tar.bz2",
-              "size": "1855234",
-              "checksum": "SHA-256:5c6ca6189f61894ee77b29bc342f96cd14e4d7627fabeb2a8d2e2c534316cc38"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-arm-linux-gnueabihf.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino9-static-arm-linux-gnueabihf.tar.bz2",
+              "size": "1778177",
+              "checksum": "SHA-256:f0443e771f5e3a779949498d3c9bfffd1dd27cdf0ad7136a2db5e80447a7175a"
             },
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino12-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
-              "size": "1844359",
-              "checksum": "SHA-256:4938742d3fec62941187666b8ded44d8f6c7a404920ff49d97fca484b9fd08af"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino9-static-i686-ubuntu12.04-linux-gnu.tar.bz2",
+              "size": "1782958",
+              "checksum": "SHA-256:a22872918df899cb808f9286141d42438ae5611156c143cfb692069f52a2bddd"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-i686-w64-mingw32.zip",
-              "archiveFileName": "openocd-0.10.0-arduino12-static-i686-w64-mingw32.zip",
-              "size": "2276602",
-              "checksum": "SHA-256:1e23c0f1f809725db3e1f8d1e1f460a37fb7b2cf95e93c6e328e527501ab084c"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-i686-w64-mingw32.zip",
+              "archiveFileName": "openocd-0.10.0-arduino9-static-i686-w64-mingw32.zip",
+              "size": "2190484",
+              "checksum": "SHA-256:f53f9a2b7f48a2ebc00ea9196bf559d15987d3779bcea4118ebec8925da5a1f6"
             },
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-x86_64-apple-darwin13.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino12-static-x86_64-apple-darwin13.tar.bz2",
-              "size": "1723600",
-              "checksum": "SHA-256:b40d135449401870302bec073326d6f1df79da38d9dd21326314a5a90189a06e"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-x86_64-apple-darwin13.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino9-static-x86_64-apple-darwin13.tar.bz2",
+              "size": "1655311",
+              "checksum": "SHA-256:6d47f97919f317bb6e5f1f903127604271d66d149f4625f29b8e0eb5f6c94c64"
             },
             {
               "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino12-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
-              "archiveFileName": "openocd-0.10.0-arduino12-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
-              "size": "1918845",
-              "checksum": "SHA-256:bc48be10916f69f3a4b050f04babc14ee99dad1fc5da55ce606077991edab1d0"
+              "url": "http://downloads.arduino.cc/tools/openocd-0.10.0-arduino9-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.10.0-arduino9-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
+              "size": "1844365",
+              "checksum": "SHA-256:f624552b5ba56aa78d0c1a0e5d18cf2b5694db2ed44080968e22aa1af8f23c1b"
             }
           ]
         },
@@ -4284,6 +3073,1313 @@
               "archiveFileName": "openocd-0.11.0-arduino1-static-x86_64-ubuntu12.04-linux-gnu.tar.bz2",
               "size": "2023084",
               "checksum": "SHA-256:beb45bb95e43d2d592ee62342e6fdfbb15b87c20c96177b8f6bbc2a57cddbeb1"
+            }
+          ]
+        },
+        {
+          "name": "openocd",
+          "version": "0.10.0-arduino1-static",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/arduino.org/OpenOCD-0.10.0-nrf52-osx-static.tar.gz",
+              "archiveFileName": "OpenOCD-0.10.0-nrf52-osx-static.tar.gz",
+              "size": "1529841",
+              "checksum": "SHA-256:46bd02c1d42c5d94c4936e4d4a0ff29697b621840be9a6f882e316203122049d"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/arduino.org/OpenOCD-0.10.0-nrf52-linux64-static.tar.gz",
+              "archiveFileName": "OpenOCD-0.10.0-nrf52-linux64-static.tar.gz",
+              "size": "1777984",
+              "checksum": "SHA-256:1c9ae77930dd7377d8c13f84abe7307b67fdcd6da74cc1ce269a79e138e7a00a"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/arduino.org/OpenOCD-0.10.0-nrf52-linux32-static.tar.gz",
+              "archiveFileName": "OpenOCD-0.10.0-nrf52-linux32-static.tar.gz",
+              "size": "1713236",
+              "checksum": "SHA-256:777371df34828810e1bea623b0f7c98f28fedf30fd3bc8e7d8f0a5745fb4e258"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/arduino.org/OpenOCD-0.10.0-nrf52-win32-static.zip",
+              "archiveFileName": "OpenOCD-0.10.0-nrf52-win32-static.zip",
+              "size": "1773642",
+              "checksum": "SHA-256:9371b25d000bd589c058a5bf10720617adb91fd8b8a21d2e887cf45eaa2df93c"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/arduino.org/OpenOCD-0.10.0-nrf52-arm-static.tar.gz",
+              "archiveFileName": "OpenOCD-0.10.0-nrf52-arm-static.tar.gz",
+              "size": "1526863",
+              "checksum": "SHA-256:b5172422077f87ff05b76ff40034979678c9c640e9d08cee15ce55e40dd8c929"
+            }
+          ]
+        },
+        {
+          "name": "adb",
+          "version": "32.0.0",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/android/platform-tools_r32.0.0-darwin.zip",
+              "archiveFileName": "platform-tools_r32.0.0-darwin.zip",
+              "size": "19439685",
+              "checksum": "SHA-256:29f0163a8f5c2cea7b3bedf3ccaa9374513a2cd653f436b0debdb7c4974ba525"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/android/adb_r32.0.0-linux64.tar.bz2",
+              "archiveFileName": "adb_r32.0.0-linux64.tar.bz2",
+              "size": "3171335",
+              "checksum": "SHA-256:a14c748d59a46145e053ed10404395db8ca5ac2ac5980a331771efc20be16d8d"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/android/adb_r32.0.0-linux-aarch64.tar.bz2",
+              "archiveFileName": "adb_r32.0.0-linux-aarch64.tar.bz2",
+              "size": "2520745",
+              "checksum": "SHA-256:684b27537fbedfce5f4b310e7a0706c7274ef467bf8d227d1512ef6f4a5597fe"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/android/platform-tools_r32.0.0-windows.zip",
+              "archiveFileName": "platform-tools_r32.0.0-windows.zip",
+              "size": "12033552",
+              "checksum": "SHA-256:41f4c7512b32cbb3f8c624c20b56326abb692a6f169b03b4b63b6c5a6fdbb08c"
+            }
+          ]
+        },
+        {
+          "name": "imgtool",
+          "version": "1.8.0-arduino",
+          "systems": [
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Linux_32bit.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-rc1_Linux_32bit.tar.gz",
+              "size": "13906205",
+              "checksum": "SHA-256:0b95b98c0e51a91512b3bfa10d3178315af1a1cd9e3b4982d0c9459ef84614b1"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Linux_64bit.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-rc1_Linux_64bit.tar.gz",
+              "size": "15591995",
+              "checksum": "SHA-256:92222eb8023fae0877da2e9d87dd2187fa9b82c0543330ab47a4a67bc0c89cae"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Windows_32bit.zip",
+              "archiveFileName": "imgtool_1.8.0-rc1_Windows_32bit.zip",
+              "size": "6736497",
+              "checksum": "SHA-256:1177275ca93ce6bfd3cc64f68837b9f6b8d8a1592a6fbcfa643b9ccf35b7879a"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Windows_64bit.zip",
+              "archiveFileName": "imgtool_1.8.0-rc1_Windows_64bit.zip",
+              "size": "8409007",
+              "checksum": "SHA-256:c51b62ff173887faa2d4e94e77777bac274ba898ae39bec0082b6327a011115b"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_macOS_64bit.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-rc1_macOS_64bit.tar.gz",
+              "size": "8425545",
+              "checksum": "SHA-256:6129c767c1b395c809b79aa2bd75fd0ce09544ff6d7ca20b330fac703efe3fc4"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Linux_ARMv6.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-rc1_Linux_ARMv6.tar.gz",
+              "size": "13500219",
+              "checksum": "SHA-256:dff39f8a884d4c5f98b5ac0ae075eaba35bf2d0b189c633c2723fc12170e7ea0"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/imgtool_1.8.0-rc1_Linux_ARM64.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-rc1_Linux_ARM64.tar.gz",
+              "size": "15679158",
+              "checksum": "SHA-256:b893ac88bcf3f4da0af05fa31f8af43a2d29ef5ecef0bd4ba6fb66a0b2e360f1"
+            }
+          ]
+        },
+        {
+          "name": "imgtool",
+          "version": "1.8.0-arduino.1",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_macOS_64bit.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-arduino.1_macOS_64bit.tar.gz",
+              "size": "8448535",
+              "checksum": "SHA-256:8002d8a017bbd994328f3ec7f0af007c1a5bc45d694860148870972fb3f3a5e8"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_ARMv6.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_ARMv6.tar.gz",
+              "size": "13477544",
+              "checksum": "SHA-256:bbd8136d9d67e2db81360df8d435a899f8b231247719b7313b7b2c920e85c4d7"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_ARM64.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_ARM64.tar.gz",
+              "size": "15650801",
+              "checksum": "SHA-256:fad64d46a2d10d225d21fa6cab1cbd4511cbe0028b67b18c460656bcc203538c"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_64bit.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_64bit.tar.gz",
+              "size": "15574228",
+              "checksum": "SHA-256:12c3c5b04bf53bea3baccf4072cbffaf9e9c4901a1a9ff77d611eb3c2db2ca1f"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_32bit.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_32bit.tar.gz",
+              "size": "13875969",
+              "checksum": "SHA-256:354343b2f6b91f463553ffd48bc4af3b91c897e4ac79ea43551982c9b3afeade"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Windows_32bit.zip",
+              "archiveFileName": "imgtool_1.8.0-arduino.1_Windows_32bit.zip",
+              "size": "6735777",
+              "checksum": "SHA-256:42d4fbf70a390c84a59a19db166b74d0fb231ff729d9c56775b4e7cc5055cef3"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Windows_64bit.zip",
+              "archiveFileName": "imgtool_1.8.0-arduino.1_Windows_64bit.zip",
+              "size": "8411018",
+              "checksum": "SHA-256:9c600c5ca22c50a6eb6b9d6a870d486710be4997060fe9cbacdabd968daacc87"
+            }
+          ]
+        },
+        {
+          "name": "imgtool",
+          "version": "1.8.0-arduino.2",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_macOS_64bit.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-arduino.2_macOS_64bit.tar.gz",
+              "size": "8454939",
+              "checksum": "SHA-256:d23daba045f46754bfa466f63199b3e17936de716a08502a369ab4a9c3615fda"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Linux_ARMv6.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-arduino.2_Linux_ARMv6.tar.gz",
+              "size": "13482271",
+              "checksum": "SHA-256:a215fc2fbd4f82194fdbd2fcb0e2f017859a68e915d4da031df824e1e7134b87"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Linux_ARM64.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-arduino.2_Linux_ARM64.tar.gz",
+              "size": "15655944",
+              "checksum": "SHA-256:cb0341f016e100833c0fd28c4215544d4056b195efebe523288bde9fed80445f"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Linux_64bit.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-arduino.2_Linux_64bit.tar.gz",
+              "size": "15579636",
+              "checksum": "SHA-256:062d9e3ac1066a7d3e345c9d105858aeff3e3b73e12bbb6c0c5d3e6761d52577"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Linux_32bit.tar.gz",
+              "archiveFileName": "imgtool_1.8.0-arduino.2_Linux_32bit.tar.gz",
+              "size": "13881242",
+              "checksum": "SHA-256:4b58a23bc7c41268e113e25afba4dccaa477058fca94eea8749b315c7b7d2a8b"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Windows_32bit.zip",
+              "archiveFileName": "imgtool_1.8.0-arduino.2_Windows_32bit.zip",
+              "size": "6744516",
+              "checksum": "SHA-256:9e365727801229ba4775974f6c648711da1a06961bb9bef7546a11080ea25420"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.2_Windows_64bit.zip",
+              "archiveFileName": "imgtool_1.8.0-arduino.2_Windows_64bit.zip",
+              "size": "8416009",
+              "checksum": "SHA-256:60d77da618b785345fc7ce2529bcb01c7195371b8e65a11abbd804c26ffd7df4"
+            }
+          ]
+        },
+        {
+          "name": "arm-none-eabi-gcc",
+          "version": "4.8.3-2014q1",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
+              "size": "44423906",
+              "checksum": "SHA-256:ebe96b34c4f434667cab0187b881ed585e7c7eb990fe6b69be3c81ec7e11e845"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-windows.tar.gz",
+              "archiveFileName": "gcc-arm-none-eabi-4.8.3-2014q1-windows.tar.gz",
+              "size": "84537449",
+              "checksum": "SHA-256:fd8c111c861144f932728e00abd3f7d1107e186eb9cd6083a54c7236ea78b7c2"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-mac.tar.gz",
+              "archiveFileName": "gcc-arm-none-eabi-4.8.3-2014q1-mac.tar.gz",
+              "size": "52518522",
+              "checksum": "SHA-256:3598acf21600f17a8e4a4e8e193dc422b894dc09384759b270b2ece5facb59c2"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-linux64.tar.gz",
+              "archiveFileName": "gcc-arm-none-eabi-4.8.3-2014q1-linux64.tar.gz",
+              "size": "51395093",
+              "checksum": "SHA-256:d23f6626148396d6ec42a5b4d928955a703e0757829195fa71a939e5b86eecf6"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-linux32.tar.gz",
+              "archiveFileName": "gcc-arm-none-eabi-4.8.3-2014q1-linux32.tar.gz",
+              "size": "51029223",
+              "checksum": "SHA-256:ba1994235f69c526c564f65343f22ddbc9822b2ea8c5ee07dd79d89f6ace2498"
+            }
+          ]
+        },
+        {
+          "name": "arm-none-eabi-gcc",
+          "version": "7-2017q4",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
+              "size": "96613739",
+              "checksum": "SHA-256:34180943d95f759c66444a40b032f7dd9159a562670fc334f049567de140c51b"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
+              "size": "99558726",
+              "checksum": "SHA-256:6fb5752fb4d11012bd0a1ceb93a19d0641ff7cf29d289b3e6b86b99768e66f76"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-win32-arduino1.zip",
+              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-win32-arduino1.zip",
+              "size": "131761924",
+              "checksum": "SHA-256:96dd0091856f4d2eb21046eba571321feecf7d50b9c156f708b2a8b683903382"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-mac.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-mac.tar.bz2",
+              "size": "104550003",
+              "checksum": "SHA-256:89b776c7cf0591c810b5b60067e4dc113b5b71bc50084a536e71b894a97fdccb"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-linux64.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-linux64.tar.bz2",
+              "size": "99857645",
+              "checksum": "SHA-256:96a029e2ae130a1210eaa69e309ea40463028eab18ba19c1086e4c2dafe69a6a"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
+              "size": "97427309",
+              "checksum": "SHA-256:090a0bc2b1956bc49392dff924a6c30fa57c88130097b1972204d67a45ce3cf3"
+            }
+          ]
+        },
+        {
+          "name": "avr-gcc",
+          "version": "4.8.1-arduino5",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino5-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.8.1-arduino5-armhf-pc-linux-gnu.tar.bz2",
+              "size": "24403768",
+              "checksum": "SHA-256:c8ffcd2db7a651b48ab4ea19db4b34fbae3e7f0210a0f294592af2bdabf2154b"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino5-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avr-gcc-4.8.1-arduino5-i386-apple-darwin11.tar.bz2",
+              "size": "24437400",
+              "checksum": "SHA-256:111b3ef00d737d069eb237a8933406cbb928e4698689e24663cffef07688a901"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.8.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "27093036",
+              "checksum": "SHA-256:9054fcc174397a419ba56c4ce1bfcbcad275a6a080cc144905acc9b0351ee9cc"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino5-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.8.1-arduino5-i686-pc-linux-gnu.tar.bz2",
+              "size": "25882375",
+              "checksum": "SHA-256:7648b7f549b37191da0b0be53bae791b652f82ac3cb4e7877f85075aaf32141f"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino5-i686-mingw32.zip",
+              "archiveFileName": "avr-gcc-4.8.1-arduino5-i686-mingw32.zip",
+              "size": "46044779",
+              "checksum": "SHA-256:d4303226a7b41d3c445d901b5aa5903458def3fc7b7ff4ffef37cabeb37d424d"
+            }
+          ]
+        },
+        {
+          "name": "avr-gcc",
+          "version": "4.9.2-atmel3.5.3-arduino",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino-i386-apple-darwin11.tar.bz2",
+              "size": "27046965",
+              "checksum": "SHA-256:adeee70be27cc3ee0e4b9e844610d9c534c7b21dae24ec3fa49808c2f04958de"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino-armhf-pc-linux-gnu.tar.bz2",
+              "size": "27400001",
+              "checksum": "SHA-256:02dba9ee77694c23a4c304416a3808949c8faedf07f25a225a4189d850615ec6"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "29904544",
+              "checksum": "SHA-256:0711e885c0430859e7fea3831af8c69a0c25f92a90ecfda9281799a0acec7455"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino-i686-pc-linux-gnu.tar.bz2",
+              "size": "29077606",
+              "checksum": "SHA-256:fe0bb1d6369694779ceb671d457ccadbeafe855a11f6746b7db20055cea4df33"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino-i686-mingw32.zip",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino-i686-mingw32.zip",
+              "size": "43847566",
+              "checksum": "SHA-256:445ce3117e87be7e196809fbbea373976160689b6d4b43dbf185eb4c914d1469"
+            }
+          ]
+        },
+        {
+          "name": "avr-gcc",
+          "version": "7.3.0-atmel3.6.1-arduino5",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-arm-linux-gnueabihf.tar.bz2",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-arm-linux-gnueabihf.tar.bz2",
+              "size": "34462042",
+              "checksum": "SHA-256:f4acd5531c6b82c715e2edfa0aadb13fb718b4095b3ea1aa1f7fbde680069639"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-aarch64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-aarch64-pc-linux-gnu.tar.bz2",
+              "size": "39381972",
+              "checksum": "SHA-256:dd9c70190be370a44fb47dab1514de6d8852b861dfa527964b65c740d8d50c10"
+            },
+            {
+              "host": "x86_64-apple-darwin14",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-apple-darwin14.tar.bz2",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-apple-darwin14.tar.bz2",
+              "size": "38492678",
+              "checksum": "SHA-256:f48706317f04452544ab90e75bd1bb193f8af2cb1002f53aa702f27202c1b38f"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-i686-w64-mingw32.zip",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-i686-w64-mingw32.zip",
+              "size": "53727984",
+              "checksum": "SHA-256:6d4a5d089a36e5b5252befc73da204555b49e376ce7577ee19ca7f028b295830"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-i686-pc-linux-gnu.tar.bz2",
+              "size": "38710087",
+              "checksum": "SHA-256:2ff12739d7ed09688d6b3c2c126e8df69b5bda1a07ab558799f0e576571e0e1d"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "39114120",
+              "checksum": "SHA-256:3effed8ffa1978b6e4a46f1aa2acc629e440b4d77244f71f9b79a916025206fb"
+            }
+          ]
+        },
+        {
+          "name": "avr-gcc",
+          "version": "7.3.0-atmel3.6.1-arduino7",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-arm-linux-gnueabihf.tar.bz2",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-arm-linux-gnueabihf.tar.bz2",
+              "size": "34683056",
+              "checksum": "SHA-256:3903553d035da59e33cff9941b857c3cb379cb0638105dfdf69c97f0acc8e7b5"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-aarch64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-aarch64-pc-linux-gnu.tar.bz2",
+              "size": "38045723",
+              "checksum": "SHA-256:03d322b9df6da17289e9e7c6233c34a8535d9c645c19efc772ba19e56914f339"
+            },
+            {
+              "host": "x86_64-apple-darwin14",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-x86_64-apple-darwin14.tar.bz2",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-x86_64-apple-darwin14.tar.bz2",
+              "size": "36684546",
+              "checksum": "SHA-256:f6ed2346953fcf88df223469088633eb86de997fa27ece117fd1ef170d69c1f8"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-i686-w64-mingw32.zip",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-i686-w64-mingw32.zip",
+              "size": "52519412",
+              "checksum": "SHA-256:a54f64755fff4cb792a1495e5defdd789902a2a3503982e81b898299cf39800e"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-i686-pc-linux-gnu.tar.bz2",
+              "size": "37176991",
+              "checksum": "SHA-256:954bbffb33545bcdcd473af993da2980bf32e8461ff55a18e0eebc7b2ef69a4c"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-arduino7-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "37630618",
+              "checksum": "SHA-256:bd8c37f6952a2130ac9ee32c53f6a660feb79bee8353c8e289eb60fdcefed91e"
+            }
+          ]
+        },
+        {
+          "name": "avr-gcc",
+          "version": "5.4.0-atmel3.6.1-arduino2",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-armhf-pc-linux-gnu.tar.bz2",
+              "size": "31449123",
+              "checksum": "SHA-256:6741f95cc3182a8729cf9670eb13d8dc5a19e881639ca61e53a2d78346a4e99f"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-aarch64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-aarch64-pc-linux-gnu.tar.bz2",
+              "size": "33141295",
+              "checksum": "SHA-256:0fa9e4f2d6d09782dbc84dd91a302849cde2f192163cb9f29484c5f32785269a"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-i386-apple-darwin11.tar.bz2",
+              "size": "31894498",
+              "checksum": "SHA-256:abc50137543ba73e227b4d1b8510fff50a474bacd24f2c794f852904963849f8"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-w64-mingw32.zip",
+              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-w64-mingw32.zip",
+              "size": "45923772",
+              "checksum": "SHA-256:7eb5691a379b547798fae535b05d68bc02d3969f12d051b8a5a5f2f350ab0a7f"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "size": "33022916",
+              "checksum": "SHA-256:51f87e04f3cdaa73565c751051ac118e02904ad8478f1475b300e1bffcd5538f"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-5.4.0-atmel3.6.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-5.4.0-atmel3.6.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "33522375",
+              "checksum": "SHA-256:05422b0d73b10357c12ea938f02cf50529422b89a4722756e70024aed3e69185"
+            }
+          ]
+        },
+        {
+          "name": "avr-gcc",
+          "version": "4.8.1-arduino2",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino2-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avr-gcc-4.8.1-arduino2-i386-apple-darwin11.tar.bz2",
+              "size": "24443285",
+              "checksum": "SHA-256:c19a7526235c364d7f62ec1a993d9b495973ba1813869ccf0241c65905896852"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.8.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "27152002",
+              "checksum": "SHA-256:24a931877bee5f36dc00a88877219a6d2f6a1fb7abb989fd04556b8432d2e14e"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.8.1-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "size": "25876628",
+              "checksum": "SHA-256:2d701b4efbc8cec62dc299cde01730c5eebcf23d7e4393db8cf7744a9bf1d3de"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino2-i686-mingw32.zip",
+              "archiveFileName": "avr-gcc-4.8.1-arduino2-i686-mingw32.zip",
+              "size": "46046691",
+              "checksum": "SHA-256:2eafb49fb803fa4d2c32d35e24c0b372fcd520ca0a790fa537a847179e382000"
+            }
+          ]
+        },
+        {
+          "name": "avr-gcc",
+          "version": "4.8.1-arduino3",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino3-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avr-gcc-4.8.1-arduino3-i386-apple-darwin11.tar.bz2",
+              "size": "24447175",
+              "checksum": "SHA-256:28e207c66b3dc405367d0c5e68ce3c278e5ec3abb0e4974e7927fe0f9a532c40"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino3-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.8.1-arduino3-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "30556996",
+              "checksum": "SHA-256:028340abec6eb3085b82404dfc7ed143e1bb05b2da961b539ddcdba4a6f65533"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino3-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.8.1-arduino3-i686-pc-linux-gnu.tar.bz2",
+              "size": "28768022",
+              "checksum": "SHA-256:37796548ba9653267568f959cd8c7ebfe5b4bce4599898cf9f876d64e616cb87"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino3-i686-mingw32.zip",
+              "archiveFileName": "avr-gcc-4.8.1-arduino3-i686-mingw32.zip",
+              "size": "46046917",
+              "checksum": "SHA-256:d6f0527793f9800f060408392a99eb290ed205730edbae43a1a25cbf6b6b588f"
+            }
+          ]
+        },
+        {
+          "name": "avr-gcc",
+          "version": "4.9.2-atmel3.5.3-arduino2",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino2-armhf-pc-linux-gnu.tar.bz2",
+              "size": "27400889",
+              "checksum": "SHA-256:77f300d519bc6b9a25df17b36cb303218e9a258c059b2f6bff8f71a0d8f96821"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino2-i386-apple-darwin11.tar.bz2",
+              "size": "27048070",
+              "checksum": "SHA-256:311258af188defe24a4b341e4e1f4dc93ca6c80516d3e3b55a2fc07a7050248b"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-i686-mingw32.zip",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino2-i686-mingw32.zip",
+              "size": "43847945",
+              "checksum": "SHA-256:f8e6ede8746c70be01ec79a30803277cd94360cc5b2e104762da0fbcf536fcc6"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "size": "29292729",
+              "checksum": "SHA-256:f108951e7c4dc90926d1fc76cc27549f6ea63c702a2bb7ff39647a19ae86ec68"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.3-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.3-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "29882960",
+              "checksum": "SHA-256:3903a6d1bb9fdd91727e504b5993d5501f119bcb7f99f7aee98a2101e5629188"
+            }
+          ]
+        },
+        {
+          "name": "avr-gcc",
+          "version": "4.9.2-atmel3.5.4-arduino2",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.4-arduino2-armhf-pc-linux-gnu.tar.bz2",
+              "size": "27764772",
+              "checksum": "SHA-256:ee36009e19bd238d1f6351cbc9aa5db69714761f67dec4c1d69d5d5d7758720c"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.4-arduino2-i386-apple-darwin11.tar.bz2",
+              "size": "28574644",
+              "checksum": "SHA-256:67b3ed3555eacf0b4fc6f62240773b9f0220171fe4de26bb8d711547fc884730"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-i686-mingw32.zip",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.4-arduino2-i686-mingw32.zip",
+              "size": "44386446",
+              "checksum": "SHA-256:6044551cd729d88ea6ffcccf10aad1934c5b164d61f4f5890b0e78524ffff853"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.4-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "size": "29723974",
+              "checksum": "SHA-256:63a9d4cebbac06fd5fa8f48a2e2ba7d513837dcddc97f560129b4e466af901b5"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avr-gcc-4.9.2-atmel3.5.4-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "30374404",
+              "checksum": "SHA-256:19480217f1524d78467b83cd742f503182bbcc76b5440093261f146828aa588c"
+            }
+          ]
+        },
+        {
+          "name": "avrdude",
+          "version": "6.3.0-arduino16",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino16-armhf-pc-linux-gnu.tar.bz2",
+              "size": "219642",
+              "checksum": "SHA-256:6fc443445440f0e2d95d70013ed075bceffc2a1babc1e7d4f1ae69c3fe268c57"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-aarch64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino16-aarch64-pc-linux-gnu.tar.bz2",
+              "size": "229997",
+              "checksum": "SHA-256:7a2726ab2fd18b910abc3d9dd33c4b40d18c34cf12c46f3367932e7fd87c0197"
+            },
+            {
+              "host": "x86_64-apple-darwin15",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino16-i386-apple-darwin11.tar.bz2",
+              "size": "279172",
+              "checksum": "SHA-256:f93dc12a4b30a335ab24b3c628e6cad0ebf2f8adfb7ef50f87c0fc17165b2156"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino16-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "254085",
+              "checksum": "SHA-256:57856d6e388d333d924afa3e2d5525161dbe0dc670e7caae2720e249606175a7"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino16-i686-pc-linux-gnu.tar.bz2",
+              "size": "244393",
+              "checksum": "SHA-256:bdf73358991243a9a8de11a42c80c4ec4b14c82f2222cb0c3c181f62656c41fb"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino16-i686-w64-mingw32.zip",
+              "archiveFileName": "avrdude-6.3.0-arduino16-i686-w64-mingw32.zip",
+              "size": "328456",
+              "checksum": "SHA-256:781c16a8bf813fa68fc0f47d427279053c9e098c3aed7165449ac4f0137304dd"
+            }
+          ]
+        },
+        {
+          "name": "avrdude",
+          "version": "6.0.1-arduino3",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino3-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avrdude-6.0.1-arduino3-i386-apple-darwin11.tar.bz2",
+              "size": "264682",
+              "checksum": "SHA-256:df7cd4a76e45ab3767eb964f845f4d5e9d643df950ec32812923da1e9843d072"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino3-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.0.1-arduino3-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "748634",
+              "checksum": "SHA-256:bb7bff48f20a68e1fe559c3f3f644574df12ab5c98eb6a1491079f3c760434ad"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino3-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.0.1-arduino3-i686-pc-linux-gnu.tar.bz2",
+              "size": "495482",
+              "checksum": "SHA-256:96a0cfb83fe0452366159e3bf4e19ff10906a8957d1feafd3d98b49ab4b14405"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino3-i686-mingw32.zip",
+              "archiveFileName": "avrdude-6.0.1-arduino3-i686-mingw32.zip",
+              "size": "241619",
+              "checksum": "SHA-256:ea59bfc2ee85039c85318b2ba52c47ef0573513444a785b72f59b22586a950f9"
+            }
+          ]
+        },
+        {
+          "name": "avrdude",
+          "version": "6.3.0-arduino8",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino8-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino8-armhf-pc-linux-gnu.tar.bz2",
+              "size": "644550",
+              "checksum": "SHA-256:25a6834ae48019fccf37024236a1f79fe21760414292a4f3fa058d937ceee1ce"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino8-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino8-i386-apple-darwin11.tar.bz2",
+              "size": "697268",
+              "checksum": "SHA-256:be8a33a7ec01bb7123279466ffa31371e0aa4fccefffcc23ce71810b59531947"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino8-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino8-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "711544",
+              "checksum": "SHA-256:85f38d02e2398d3b7f93da2ca8b830ee65bb73f66cc7a7b30c466d3cebf2da6e"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino8-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino8-i686-pc-linux-gnu.tar.bz2",
+              "size": "701718",
+              "checksum": "SHA-256:8e2e4bc71d22e9d11ed143763b97f3aa2d164cdeee678a9deaf5b36e245b2d20"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino8-i686-w64-mingw32.zip",
+              "archiveFileName": "avrdude-6.3.0-arduino8-i686-w64-mingw32.zip",
+              "size": "645996",
+              "checksum": "SHA-256:3a7592f6c33efd658b820c73d1058d3c868a297cbddb37da5644973c3b516d5e"
+            }
+          ]
+        },
+        {
+          "name": "avrdude",
+          "version": "6.3.0-arduino9",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino9-armhf-pc-linux-gnu.tar.bz2",
+              "size": "644550",
+              "checksum": "SHA-256:25a6834ae48019fccf37024236a1f79fe21760414292a4f3fa058d937ceee1ce"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino9-i386-apple-darwin11.tar.bz2",
+              "size": "697309",
+              "checksum": "SHA-256:bfa06bc042dff252d3a8eded98da159484e75b46d2697da4d9446dcd2aea8465"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino9-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "711229",
+              "checksum": "SHA-256:c8cccb84e2fe49ee837b24f0a60a99e9c371dae26e84c5b0b22b6b6aab2f1f6a"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino9-i686-pc-linux-gnu.tar.bz2",
+              "size": "701590",
+              "checksum": "SHA-256:4235a2d58e3c3224c603d6c5f0610507ed6c48ebf4051fdcce9f77a7646e218b"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-i686-w64-mingw32.zip",
+              "archiveFileName": "avrdude-6.3.0-arduino9-i686-w64-mingw32.zip",
+              "size": "645974",
+              "checksum": "SHA-256:f3c5cfa8d0b3b0caee81c5b35fb6acff89c342ef609bf4266734c6266a256d4f"
+            }
+          ]
+        },
+        {
+          "name": "avrdude",
+          "version": "6.3.0-arduino14",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino14-armhf-pc-linux-gnu.tar.bz2",
+              "size": "219616",
+              "checksum": "SHA-256:d1a06275490d59a431c419788bbc53ffd5a79510dac1a35e63cf488621ba5589"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-aarch64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino14-aarch64-pc-linux-gnu.tar.bz2",
+              "size": "229688",
+              "checksum": "SHA-256:439f5de150695e3732dd598bb182dae6ec1e3a5cdb580f855d9b58e485e84e66"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino14-i386-apple-darwin12.tar.bz2",
+              "size": "256917",
+              "checksum": "SHA-256:47d03991522722ce92120c60c4118685b7861909d895f34575001137961e4a63"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino14-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "253366",
+              "checksum": "SHA-256:7986e8f3059353dc08f9234f7dbc98d9b2fa2242f046f02a8243a060f7358bfc"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino14-i686-pc-linux-gnu.tar.bz2",
+              "size": "244293",
+              "checksum": "SHA-256:4f100e3843c635064997df91d2a079ab15cd30d1d7fa227280abe6a7c3bc74ca"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino14-i686-w64-mingw32.zip",
+              "archiveFileName": "avrdude-6.3.0-arduino14-i686-w64-mingw32.zip",
+              "size": "328363",
+              "checksum": "SHA-256:69293e0de2eff8de89f553477795c25005f674a320bbba4b0222beb0194aa297"
+            }
+          ]
+        },
+        {
+          "name": "avrdude",
+          "version": "6.3.0-arduino17",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino17-armhf-pc-linux-gnu.tar.bz2",
+              "size": "219631",
+              "checksum": "SHA-256:2a8e68c5d803aa6f902ef219f177ec3a4c28275d85cbe272962ad2cd374f50d1"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-aarch64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino17-aarch64-pc-linux-gnu.tar.bz2",
+              "size": "229852",
+              "checksum": "SHA-256:6cf948f751acfe7b96684537f2291c766ec8b54b4f7dc95539864821456fa9fc"
+            },
+            {
+              "host": "x86_64-apple-darwin12",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-x86_64-apple-darwin12.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino17-x86_64-apple-darwin12.tar.bz2",
+              "size": "279045",
+              "checksum": "SHA-256:120cc9edaae699e7e9ac50b1b8eb0e7d51fdfa555bac54233c2511e6ee5418c9"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino17-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "254271",
+              "checksum": "SHA-256:accdfb920af2aabf4f7461d2ac73c0751760f525216dc4e7657427a78c60d13d"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino17-i686-pc-linux-gnu.tar.bz2",
+              "size": "244550",
+              "checksum": "SHA-256:5c8cc6c17db9300e1451fe41cd7178b0442b4490ee6fdbc0aed9811aef96c05f"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-i686-w64-mingw32.zip",
+              "archiveFileName": "avrdude-6.3.0-arduino17-i686-w64-mingw32.zip",
+              "size": "328460",
+              "checksum": "SHA-256:e99188873c7c5ad8f8f906f068c33600e758b2e36cce3adbd518a21bd266749d"
+            }
+          ]
+        },
+        {
+          "name": "avrdude",
+          "version": "6.3.0-arduino18",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino18-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino18-armhf-pc-linux-gnu.tar.bz2",
+              "size": "220677",
+              "checksum": "SHA-256:2e25c9e99c255d595a1072679a88ecddfa12c223b18510760bb867039f35efa5"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino18-aarch64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino18-aarch64-pc-linux-gnu.tar.bz2",
+              "size": "231047",
+              "checksum": "SHA-256:4f88bb50d2235182ed7aa9e0a1d08e4bb956378ac9569b8e1141e37ed314fb2d"
+            },
+            {
+              "host": "x86_64-apple-darwin12",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino18-x86_64-apple-darwin12.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino18-x86_64-apple-darwin12.tar.bz2",
+              "size": "280072",
+              "checksum": "SHA-256:df1dfd18e2e287c47232605cd4fa41751eb70df8c300aeb7a00a3a09b524a1b8"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino18-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino18-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "254460",
+              "checksum": "SHA-256:1ae46972b276b8a54c459f87c4ff326abdad0be2b1a293d73bf86e47765eddc3"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino18-i686-w64-mingw32.zip",
+              "archiveFileName": "avrdude-6.3.0-arduino18-i686-w64-mingw32.zip",
+              "size": "329515",
+              "checksum": "SHA-256:0781f4183e91a9783c2330035520144ab76b8f75c0a9f7a25877c063bc984c4d"
+            }
+          ]
+        },
+        {
+          "name": "avrdude",
+          "version": "6.0.1-arduino2",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avrdude-6.0.1-arduino2-i386-apple-darwin11.tar.bz2",
+              "size": "264965",
+              "checksum": "SHA-256:71117cce0096dad6c091e2c34eb0b9a3386d3aec7d863d2da733d9e5eac3a6b1"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.0.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "292541",
+              "checksum": "SHA-256:2489004d1d98177eaf69796760451f89224007c98b39ebb5577a9a34f51425f1"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.0.1-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "size": "283209",
+              "checksum": "SHA-256:6f633dd6270ad0d9ef19507bcbf8697b414a15208e4c0f71deec25ef89cdef3f"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-i686-mingw32.zip",
+              "archiveFileName": "avrdude-6.0.1-arduino2-i686-mingw32.zip",
+              "size": "241618",
+              "checksum": "SHA-256:6c5483800ba753c80893607e30cade8ab77b182808fcc5ea15fa3019c63d76ae"
+            }
+          ]
+        },
+        {
+          "name": "avrdude",
+          "version": "6.0.1-arduino5",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino5-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.0.1-arduino5-armhf-pc-linux-gnu.tar.bz2",
+              "size": "267095",
+              "checksum": "SHA-256:23ea1341dbc117ec067f2eb1a498ad2bdd7d11fff0143c00b2e018c39804f6b4"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino5-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avrdude-6.0.1-arduino5-i386-apple-darwin11.tar.bz2",
+              "size": "264894",
+              "checksum": "SHA-256:41af8d3b0a586853c8317b4fb5163ca0db594a1870ddf680fd988c42166fc3e5"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.0.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "292629",
+              "checksum": "SHA-256:d826cca7383461f7e8adde686372cf900e9cb3afd639555cf2d6c645b283a476"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino5-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.0.1-arduino5-i686-pc-linux-gnu.tar.bz2",
+              "size": "283121",
+              "checksum": "SHA-256:5933d66927bce46ababa9b68a8b7f1d53f68c4f3ff7a5ce4b85d7cf4e6c6bfee"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino5-i686-mingw32.zip",
+              "archiveFileName": "avrdude-6.0.1-arduino5-i686-mingw32.zip",
+              "size": "241634",
+              "checksum": "SHA-256:41f667f1f6a0ab8df46b4ffacd023176dcdef331d6db3b74bddd37d18cca0a44"
+            }
+          ]
+        },
+        {
+          "name": "avrdude",
+          "version": "6.3.0-arduino2",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino2-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino2-armhf-pc-linux-gnu.tar.bz2",
+              "size": "643484",
+              "checksum": "SHA-256:26af86137d8a872f64d217cb262734860b36fe26d6d34faf72e951042f187885"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino2-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino2-i386-apple-darwin11.tar.bz2",
+              "size": "653968",
+              "checksum": "SHA-256:32525ea3696c861030e1a6006a5f11971d1dad331e45bfa68dac35126476b04f"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino2-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "745081",
+              "checksum": "SHA-256:9635af5a35bdca11804c07582d7beec458140fb6e3308168c3deda18dc6790fa"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino2-i686-pc-linux-gnu.tar.bz2",
+              "size": "731802",
+              "checksum": "SHA-256:790b6cb610c48e73a2a0f65dcee9903d2fd7f1b0a1f75008a9a21f50a60c7251"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino2-i686-w64-mingw32.zip",
+              "archiveFileName": "avrdude-6.3.0-arduino2-i686-w64-mingw32.zip",
+              "size": "608496",
+              "checksum": "SHA-256:8eaf98ea41fbd4450483488ef31710cbcc43c0412dbc8e1e1b582feaab6eca30"
+            }
+          ]
+        },
+        {
+          "name": "avrdude",
+          "version": "6.3.0-arduino6",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-armhf-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino6-armhf-pc-linux-gnu.tar.bz2",
+              "size": "644600",
+              "checksum": "SHA-256:2426207423d58eb0e5fc4df9493418f1cb54ba3f328fdc7c3bb582f920b9cbe7"
+            },
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-i386-apple-darwin11.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino6-i386-apple-darwin11.tar.bz2",
+              "size": "696273",
+              "checksum": "SHA-256:d9a039c9e92d3dbb2011e75e6c044a1a4a2789e2fbf8386b1d580994811be084"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-x86_64-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino6-x86_64-pc-linux-gnu.tar.bz2",
+              "size": "746653",
+              "checksum": "SHA-256:97b4875cad6110c70101bb776f3ac37b64a2e73f036cd0b10afb6f4be96a6621"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-i686-pc-linux-gnu.tar.bz2",
+              "archiveFileName": "avrdude-6.3.0-arduino6-i686-pc-linux-gnu.tar.bz2",
+              "size": "733127",
+              "checksum": "SHA-256:5f4bc4b0957b1d34cec9908b7f84a7c297b894b39fe16a4992c284b24c00d6fb"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/avrdude-6.3.0-arduino6-i686-w64-mingw32.zip",
+              "archiveFileName": "avrdude-6.3.0-arduino6-i686-w64-mingw32.zip",
+              "size": "645859",
+              "checksum": "SHA-256:7468a1bcdfa459d175a095b102c0de28efc466accfb104305fbcad7832659ddc"
+            }
+          ]
+        },
+        {
+          "name": "rp2040tools",
+          "version": "1.0.2",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-darwin_amd64.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.2-darwin_amd64.tar.bz2",
+              "size": "1665895",
+              "checksum": "SHA-256:039e0ddb7a407c5c20c3ef6def8d7cc2abdc7a4fc6dcb039abb3b41c4791f69f"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-linux_arm.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.2-linux_arm.tar.bz2",
+              "size": "5438204",
+              "checksum": "SHA-256:8981155a50bac8c7e3621f22b8e9c87f7d6aace4e28dddb03f41d704301da94d"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-linux_arm64.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.2-linux_arm64.tar.bz2",
+              "size": "5650185",
+              "checksum": "SHA-256:4f102352d702fc89757c119cd46c231b998f9900956183b0f7874994dc3965d5"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-linux_amd64.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.2-linux_amd64.tar.bz2",
+              "size": "4180308",
+              "checksum": "SHA-256:f6faafdfdf3cb780b884fe7d092679963e95f88ea78a9ed38312c511045d15c7"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-linux_386.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.2-linux_386.tar.bz2",
+              "size": "4423488",
+              "checksum": "SHA-256:9af1aaf46402ab27d60a6b5d28da5ab8807f3099d78ee6e681bf7a36911ee690"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.2-windows_386.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.2-windows_386.tar.bz2",
+              "size": "2493234",
+              "checksum": "SHA-256:8aa684c431b1194d9af4958b116a0a96e4ebf6c90764f9f3420db0515dc6e2c7"
+            }
+          ]
+        },
+        {
+          "name": "rp2040tools",
+          "version": "1.0.5",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-darwin_amd64.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.5-darwin_amd64.tar.bz2",
+              "size": "1735713",
+              "checksum": "SHA-256:be2aa4c61206420f9aeac753deba6b365b40ccb2785536fbf8f16dc2ee3520b7"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-linux_arm.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.5-linux_arm.tar.bz2",
+              "size": "8729125",
+              "checksum": "SHA-256:621a9553c8f1f3a5fcd96540f1994799795dbc74ceaba79f64224665a67ca6ea"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-linux_arm64.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.5-linux_arm64.tar.bz2",
+              "size": "9069986",
+              "checksum": "SHA-256:951c8834c3fa740e0c6fd15a484d6c6f6be4e461baf410e568ef0e47c1500b8f"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-linux_amd64.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.5-linux_amd64.tar.bz2",
+              "size": "6138070",
+              "checksum": "SHA-256:6cb2554a28450e30265beeb64361d0d2ab822fc9daa9d5bd0c7963ae51e80526"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-linux_386.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.5-linux_386.tar.bz2",
+              "size": "6645102",
+              "checksum": "SHA-256:83d9adcbb7a42689b87a4fc968dad458d3770fbae364542e1f7e35da07eba71f"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.5-windows_386.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.5-windows_386.tar.bz2",
+              "size": "3180797",
+              "checksum": "SHA-256:698b5193f7f8efa0ecc01e75b505ec6c815ba7d59568babb2661d3871674db53"
+            }
+          ]
+        },
+        {
+          "name": "rp2040tools",
+          "version": "1.0.6",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-darwin_amd64.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.6-darwin_amd64.tar.bz2",
+              "size": "1717967",
+              "checksum": "SHA-256:4e32aa4b8f36db40a17bfbdfd34d80da91710e30c3887732bf0c0bf0b02840a7"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-linux_arm.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.6-linux_arm.tar.bz2",
+              "size": "8702508",
+              "checksum": "SHA-256:084a29accf0014bc79723fbb40057b95299c7ae63876f74494a077c987014cc3"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-linux_arm64.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.6-linux_arm64.tar.bz2",
+              "size": "9037783",
+              "checksum": "SHA-256:1a2a6cb1abf1f7b8198d494c8d8e838700297d748877be8232e02aaa5ca8d0df"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-linux_amd64.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.6-linux_amd64.tar.bz2",
+              "size": "6108121",
+              "checksum": "SHA-256:6e2ea818db1ff57f2d8e1e3010fbc5bdb5f28ff44f5a68900cae41d7d709f738"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-linux_386.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.6-linux_386.tar.bz2",
+              "size": "6604083",
+              "checksum": "SHA-256:ef339e2e0f5c7d5464b9911b612c634767daba39a6be977a1ffa41c95b9827a1"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/rp2040tools-1.0.6-windows_386.tar.bz2",
+              "archiveFileName": "rp2040tools-1.0.6-windows_386.tar.bz2",
+              "size": "3145329",
+              "checksum": "SHA-256:26a5daebba68c2348dade33716a6e379ded89895ef0e49df1332964a724f6170"
             }
           ]
         }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Infrastructure imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the new behavior?
Expected `installed.json` used in integration tests is up-to-date.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
