### PR TITLE
[breaking] Align `board list --watch` and `board list` json output

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -4,6 +4,58 @@ Here you can find a list of migration guides to handle breaking changes between 
 
 ## 0.34.0
 
+### `board list --watch` command JSON output has changed
+
+`board list --watch` command JSON output changed from:
+
+```
+{
+  "type": "add",
+  "address": "COM3",
+  "label": "COM3",
+  "protocol": "serial",
+  "protocol_label": "Serial Port (USB)",
+  "hardwareId": "93B0245008567CB2",
+  "properties": {
+    "pid": "0x005E",
+    "serialNumber": "93B0245008567CB2",
+    "vid": "0x2341"
+  },
+  "boards": [
+    {
+      "name": "Arduino Nano RP2040 Connect",
+      "fqbn": "arduino:mbed_nano:nanorp2040connect"
+    }
+  ]
+}
+```
+
+to:
+
+```
+{
+  "eventType": "add",
+  "matching_boards": [
+    {
+      "name": "Arduino Nano RP2040 Connect",
+      "fqbn": "arduino:mbed_nano:nanorp2040connect"
+    }
+  ],
+  "port": {
+    "address": "COM3",
+    "label": "COM3",
+    "protocol": "serial",
+    "protocol_label": "Serial Port (USB)",
+    "properties": {
+      "pid": "0x005E",
+      "serialNumber": "93B0245008567CB2",
+      "vid": "0x2341"
+    },
+    "hardware_id": "93B0245008567CB2"
+  }
+}
+```
+
 ### Updated sketch name specifications
 
 [Sketch name specifications](https://arduino.github.io/arduino-cli/dev/sketch-specification) have been updated to

--- a/internal/cli/board/list.go
+++ b/internal/cli/board/list.go
@@ -99,15 +99,10 @@ func watchList(inst *rpc.Instance) {
 
 	for event := range eventsChan {
 		feedback.PrintResult(watchEvent{
-			Type:          event.EventType,
-			Label:         event.Port.Port.Label,
-			Address:       event.Port.Port.Address,
-			Protocol:      event.Port.Port.Protocol,
-			ProtocolLabel: event.Port.Port.ProtocolLabel,
-			HardwareID:    event.Port.Port.HardwareId,
-			Properties:    event.Port.Port.Properties,
-			Boards:        event.Port.MatchingBoards,
-			Error:         event.Error,
+			Type:   event.EventType,
+			Boards: event.Port.MatchingBoards,
+			Port:   event.Port.Port,
+			Error:  event.Error,
 		})
 	}
 }
@@ -176,15 +171,10 @@ func (dr result) String() string {
 }
 
 type watchEvent struct {
-	Type          string               `json:"type"`
-	Address       string               `json:"address,omitempty"`
-	Label         string               `json:"label,omitempty"`
-	Protocol      string               `json:"protocol,omitempty"`
-	ProtocolLabel string               `json:"protocol_label,omitempty"`
-	HardwareID    string               `json:"hardwareId,omitempty"`
-	Properties    map[string]string    `json:"properties"`
-	Boards        []*rpc.BoardListItem `json:"boards,omitempty"`
-	Error         string               `json:"error,omitempty"`
+	Type   string               `json:"eventType"`
+	Boards []*rpc.BoardListItem `json:"matching_boards,omitempty"`
+	Port   *rpc.Port            `json:"port,omitempty"`
+	Error  string               `json:"error,omitempty"`
 }
 
 func (dr watchEvent) Data() interface{} {
@@ -199,11 +189,11 @@ func (dr watchEvent) String() string {
 		"remove": tr("Disconnected"),
 	}[dr.Type]
 
-	address := fmt.Sprintf("%s://%s", dr.Protocol, dr.Address)
-	if dr.Protocol == "serial" || dr.Protocol == "" {
-		address = dr.Address
+	address := fmt.Sprintf("%s://%s", dr.Port.Protocol, dr.Port.Address)
+	if dr.Port.Protocol == "serial" || dr.Port.Protocol == "" {
+		address = dr.Port.Address
 	}
-	protocol := dr.ProtocolLabel
+	protocol := dr.Port.ProtocolLabel
 	if boards := dr.Boards; len(boards) > 0 {
 		sort.Slice(boards, func(i, j int) bool {
 			x, y := boards[i], boards[j]


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
The json output of the two commands is different.
<!-- You can also link to an open issue here -->

## What is the new behavior?
The output of `board list --watch` has changed to align to `board list`. The changes are:

- `matching_boards` replaced `boards`
- `address`, `label`, `protocl` and others have been grouped under `port`
- `eventType` replaced `type`

These are the json outputs now:
```
$ ./arduino-cli.exe board list --watch --format json
{
  "eventType": "add",
  "matching_boards": [
    {
      "name": "Arduino Nano RP2040 Connect",
      "fqbn": "arduino:mbed_nano:nanorp2040connect"
    }
  ],
  "port": {
    "address": "COM3",
    "label": "COM3",
    "protocol": "serial",
    "protocol_label": "Serial Port (USB)",
    "properties": {
      "pid": "0x005E",
      "serialNumber": "93B0245008567CB2",
      "vid": "0x2341"
    },
    "hardware_id": "93B0245008567CB2"
  }
}
```
```
$ ./arduino-cli.exe board list --format json
[
  {
    "matching_boards": [
      {
        "name": "Arduino Nano RP2040 Connect",
        "fqbn": "arduino:mbed_nano:nanorp2040connect"
      }
    ],
    "port": {
      "address": "COM3",
      "label": "COM3",
      "protocol": "serial",
      "protocol_label": "Serial Port (USB)",
      "properties": {
        "pid": "0x005E",
        "serialNumber": "93B0245008567CB2",
        "vid": "0x2341"
      },
      "hardware_id": "93B0245008567CB2"
    }
  }
]
```
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
Yes
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->