### PR TITLE
Improve cli exit codes

### DIFF
--- a/internal/cli/compile/compile.go
+++ b/internal/cli/compile/compile.go
@@ -166,7 +166,7 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 
 	sk, err := sketch.LoadSketch(context.Background(), &rpc.LoadSketchRequest{SketchPath: sketchPath.String()})
 	if err != nil {
-		feedback.FatalError(err, feedback.ErrGeneric)
+		feedback.FatalError(err, feedback.ErrSketchError)
 	}
 	fqbn, port := arguments.CalculateFQBNAndPort(&portArgs, &fqbnArg, inst, sk.GetDefaultFqbn(), sk.GetDefaultPort(), sk.GetDefaultProtocol())
 
@@ -269,7 +269,7 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 		}
 
 		if err := upload.Upload(context.Background(), uploadRequest, stdOut, stdErr); err != nil {
-			feedback.Fatal(tr("Error during Upload: %v", err), feedback.ErrGeneric)
+			feedback.Fatal(tr("Error during Upload: %v", err), feedback.ErrBoardUpload)
 		}
 	}
 
@@ -366,7 +366,7 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 				}
 			}
 		}
-		feedback.FatalResult(res, feedback.ErrGeneric)
+		feedback.FatalResult(res, feedback.ErrCompilation)
 	}
 	feedback.PrintResult(res)
 }

--- a/internal/cli/feedback/errorcodes.go
+++ b/internal/cli/feedback/errorcodes.go
@@ -42,4 +42,13 @@ const (
 
 	// ErrBadArgument is returned when the arguments are not valid (7)
 	ErrBadArgument
+
+	// ErrSketchError is return when the occurs some error in the sketch package (8)
+	ErrSketchError
+
+	// ErrCompilation is returned when the compiler throw some errors (9)
+	ErrCompilation
+
+	// ErrBoardUpload is returned when the upload to board fails (10)
+	ErrBoardUpload
 )

--- a/internal/cli/upload/upload.go
+++ b/internal/cli/upload/upload.go
@@ -92,7 +92,7 @@ func runUploadCommand(command *cobra.Command, args []string) {
 
 	sk, err := sketch.New(sketchPath)
 	if err != nil && importDir == "" && importFile == "" {
-		feedback.Fatal(tr("Error during Upload: %v", err), feedback.ErrGeneric)
+		feedback.Fatal(tr("Error during Upload: %v", err), feedback.ErrSketchError)
 	}
 
 	instance, profile := instance.CreateAndInitWithProfile(profileArg.Get(), sketchPath)
@@ -136,7 +136,7 @@ func runUploadCommand(command *cobra.Command, args []string) {
 				msg += tr("Platform %s is not found in any known index\nMaybe you need to add a 3rd party URL?", platformErr.Platform)
 			}
 		}
-		feedback.Fatal(msg, feedback.ErrGeneric)
+		feedback.Fatal(msg, feedback.ErrBoardUpload)
 	}
 
 	fields := map[string]string{}
@@ -169,7 +169,7 @@ func runUploadCommand(command *cobra.Command, args []string) {
 		UserFields: fields,
 	}
 	if err := upload.Upload(context.Background(), req, stdOut, stdErr); err != nil {
-		feedback.FatalError(err, feedback.ErrGeneric)
+		feedback.FatalError(err, feedback.ErrBoardUpload)
 	}
 	feedback.PrintResult(stdIOResult())
 }

--- a/internal/integrationtest/assert/assert.go
+++ b/internal/integrationtest/assert/assert.go
@@ -1,0 +1,30 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2023 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package assert
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/arduino/arduino-cli/internal/cli/feedback"
+	"github.com/stretchr/testify/require"
+)
+
+func CmdExitCode(t *testing.T, expected feedback.ExitCode, err error) {
+	var cmdErr *exec.ExitError
+	require.ErrorAs(t, err, &cmdErr)
+	require.Equal(t, expected, feedback.ExitCode(cmdErr.ExitCode()))
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

It adds different cmd exit codes.

## What is the current behavior?

Right now almost every error exit code is identified with the number 1

## What is the new behavior?

The new behavior expands the exit code numbers to distinguish better what kind of error we had. This is especially useful in commands like `compile` that perform various operations and it's not clear if it is something related to the compilation itself or other components it's using like sketches file problems or upload issues.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts, or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

I've experimented a bit at trying to throw very precise exit codes for every error we had, but it becomes way too unmanageable (plus we have limited exit code numbers available in UNIX systems) 
The tradeoff is having one exit code that expresses an error happening in a specific component. For example, if the compile commands use sketch, upload, and compile components and one of them fails we can return their associated exit codes.

Open points:
- Do we like this kind of handling?
- Should we return these enhanced exit codes only for commands that use different components, and it's not straightforward to understand what caused the problem? I see no value in creating a specific exit code for commands like `core install`, `core upgrade`, or `board details` as their logic uses only their dedicated component. 

I'll leave this PR open for feedback, especially from @kittaakos 