### PR TITLE
Set installed property for installed platform when core search is executed 

### DIFF
--- a/commands/core/search.go
+++ b/commands/core/search.go
@@ -85,6 +85,9 @@ func PlatformSearch(req *rpc.PlatformSearchRequest) (*rpc.PlatformSearchResponse
 	out := make([]*rpc.Platform, len(res))
 	for i, platformRelease := range res {
 		out[i] = commands.PlatformReleaseToRPC(platformRelease)
+		if platformRelease.IsInstalled() {
+			out[i].Installed = platformRelease.Version.String()
+		}
 	}
 	// Sort result alphabetically and put deprecated platforms at the bottom
 	sort.Slice(

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -68,9 +68,13 @@ func TestCoreSearch(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, len(strings.Split(string(out), "\n")), 2)
 
+	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.6")
+	require.NoError(t, err)
 	out, _, err = cli.Run("core", "search", "avr", "--format", "json")
 	require.NoError(t, err)
 	requirejson.NotEmpty(t, out)
+	// Verify that "installed" is set
+	requirejson.Contains(t, out, `[{installed: "1.8.6"}]`)
 
 	// additional URL
 	out, _, err = cli.Run("core", "search", "test_core", "--format", "json", "--additional-urls="+url.String())


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Code enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
The installed property is never set.
```
./arduino-cli core install arduino:avr --format json
```
```
./arduino-cli core search "" --format json | jq '.[]  | select(.id == "arduino:avr") | .installed'
null
```
<!-- You can also link to an open issue here -->

## What is the new behavior?
The installed property is set if the platform is installed.
```
./arduino-cli core install arduino:avr --format json
```
```
./arduino-cli core search "" --format json | jq '.[]  | select(.id == "arduino:avr") | .installed'
"1.8.6"
```
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
