### PR TITLE
Report `is_hidden` field in board identification

### DIFF
--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -159,6 +159,7 @@ func identify(pme *packagemanager.Explorer, port *discovery.Port) ([]*rpc.BoardL
 		boards = append(boards, &rpc.BoardListItem{
 			Name:     board.Name(),
 			Fqbn:     fqbn.String(),
+			IsHidden: board.IsHidden(),
 			Platform: platform,
 		})
 	}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Populates the `is_hidden` field when the board is detected.

## What is the current behavior?

`board list` do not report hidden field:

## What is the new behavior?

`board list` do report hidden field:

```
[
  {
    "matching_boards": [
      {
        "name": "Arduino Uno R4 WiFi",
        "fqbn": "arduino:renesas_portenta:unor4wifi",
        "is_hidden": true
      },
      {
        "name": "Arduino Uno R4 WiFi",
        "fqbn": "arduino:renesas_uno:unor4wifi"
      }
    ],
    "port": {
      "address": "/dev/ttyACM0",
      "label": "/dev/ttyACM0",
      "protocol": "serial",
      "protocol_label": "Serial Port (USB)",
      "properties": {
        "pid": "0x1002",
        "serialNumber": "DC5475C30184",
        "vid": "0x2341"
      },
      "hardware_id": "DC5475C30184"
    }
  },
  {
    "port": {
      "address": "/dev/ttyS4",
      "label": "/dev/ttyS4",
      "protocol": "serial",
      "protocol_label": "Serial Port"
    }
  }
]
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

At the moment this is only reported as metadata in JSON / gRPC responses, it has no direct effect on the `board list` command. A board filtering based on the `is_hidden` value may be implemented later.
