### PR TITLE
When launching `core list` with no installed platforms show table headers

### DIFF
--- a/internal/cli/core/list.go
+++ b/internal/cli/core/list.go
@@ -82,6 +82,9 @@ func (ir installedResult) Data() interface{} {
 }
 
 func (ir installedResult) String() string {
+	if len(ir.platforms) == 0 {
+		return tr("No platforms installed.")
+	}
 	t := table.New()
 	t.SetHeader(tr("ID"), tr("Installed"), tr("Latest"), tr("Name"))
 	for _, p := range ir.platforms {

--- a/internal/cli/core/list.go
+++ b/internal/cli/core/list.go
@@ -82,10 +82,6 @@ func (ir installedResult) Data() interface{} {
 }
 
 func (ir installedResult) String() string {
-	if ir.platforms == nil || len(ir.platforms) == 0 {
-		return ""
-	}
-
 	t := table.New()
 	t.SetHeader(tr("ID"), tr("Installed"), tr("Latest"), tr("Name"))
 	for _, p := range ir.platforms {

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -1069,5 +1069,5 @@ func TestCoreListWhenNoPlatformAreInstalled(t *testing.T) {
 
 	stdout, _, err = cli.Run("core", "list")
 	require.NoError(t, err)
-	require.Equal(t, "ID Installed Latest Name\n\n", string(stdout))
+	require.Equal(t, "No platforms installed.\n", string(stdout))
 }

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -1058,3 +1058,16 @@ func TestCoreUpgradeWarningWithPackageInstalledButNotIndexed(t *testing.T) {
 		requirejson.Query(t, jsonStdout, ".warnings[]", `"missing package index for test:x86, future updates cannot be guaranteed"`)
 	})
 }
+
+func TestCoreListWhenNoPlatformAreInstalled(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	stdout, _, err := cli.Run("core", "list", "--format", "json")
+	require.NoError(t, err)
+	requirejson.Empty(t, stdout)
+
+	stdout, _, err = cli.Run("core", "list")
+	require.NoError(t, err)
+	require.Equal(t, "ID Installed Latest Name\n\n", string(stdout))
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

`core list` command now prints the table headers in the stdout when no platforms are installed

## What is the current behavior?

Empty stdout. The only case we show something is when we set the json format flag it returns `[]`

## What is the new behavior?

The new behavior if no platforms are installed prints only the table headers.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

The other option we have is to show something like this:
```bash
$ arduino-cli core list
No platforms installed.
```