### PR TITLE
[skip-changelog] Add `output.no_color` to configuration docs

### DIFF
--- a/configuration/configuration.schema.json
+++ b/configuration/configuration.schema.json
@@ -135,6 +135,16 @@
       },
       "type": "object"
     },
+    "output": {
+      "description": "settings related to text output.",
+      "properties": {
+        "no_color": {
+          "description": "ANSI color escape codes are added by default to the output. Set to `true` to disable colored text output.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "sketch": {
       "description": "configuration options relating to [Arduino sketches][sketch specification].",
       "properties": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,9 @@
 - `metrics` - settings related to the collection of data used for continued improvement of Arduino CLI.
   - `addr` - TCP port used for metrics communication.
   - `enabled` - controls the use of metrics.
+- `output` - settings related to text output.
+  - `no_color` - ANSI color escape codes are added by default to the output. Set to `true` to disable colored text
+    output.
 - `sketch` - configuration options relating to [Arduino sketches][sketch specification].
   - `always_export_binaries` - set to `true` to make [`arduino-cli compile`][arduino-cli compile] always save binaries
     to the sketch folder. This is the equivalent of using the [`--export-binaries`][arduino-cli compile options] flag.


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [x] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Documentation enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the new behavior?
An explanation for the configuration key `output.no_color` has been added to the docs.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
