### PR TITLE
[skip-changelog] Add explanation on how to change the monitor configuration to FAQ

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -25,6 +25,17 @@ by this command is very limited and you may want to look for other tools if you 
 There are many excellent serial terminals to chose from. On Linux or macOS, you may already have [screen][screen]
 installed. On Windows, a good choice for command line usage is Plink, included with [PuTTY][putty].
 
+## How to change monitor configuration?
+
+[Configuration parameters][configuration parameters] of the monitor can be obtained by executing the following command:
+
+`$ arduino-cli monitor -p <port> --describe`
+
+These parameters can be modified by passing a list of `<key>=<desiredValue>` pairs to the `--config` flag. For example,
+when using a serial port, the monitor baud rate can be set to 4800 with the following command:
+
+`$ arduino-cli monitor -p <port> --config baudrate=4800`
+
 ## Additional assistance
 
 If your question wasn't answered, feel free to ask on [Arduino CLI's forum board][1].
@@ -35,3 +46,4 @@ If your question wasn't answered, feel free to ask on [Arduino CLI's forum board
 [screen]: https://www.gnu.org/software/screen/manual/screen.html
 [putty]: https://www.chiark.greenend.org.uk/~sgtatham/putty/
 [monitor command]: commands/arduino-cli_monitor.md
+[configuration parameters]: pluggable-monitor-specification.md#describe-command


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Documentation enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the new behavior?
An explanation on how to change monitor configuration parameters using `monitor -c` has been added to the FAQ.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
