### PR TITLE
Explain usage of `monitor --config` in command help

### DIFF
--- a/internal/cli/monitor/monitor.go
+++ b/internal/cli/monitor/monitor.go
@@ -59,7 +59,7 @@ func NewCommand() *cobra.Command {
 	}
 	portArgs.AddToCommand(monitorCommand)
 	monitorCommand.Flags().BoolVar(&describe, "describe", false, tr("Show all the settings of the communication port."))
-	monitorCommand.Flags().StringSliceVarP(&configs, "config", "c", []string{}, tr("Configuration of the port."))
+	monitorCommand.Flags().StringSliceVarP(&configs, "config", "c", []string{}, tr("Configure communication port settings. The format is <ID>=<value>[,<ID>=<value>]..."))
 	monitorCommand.Flags().BoolVarP(&quiet, "quiet", "q", false, tr("Run in silent mode, show only monitor input and output."))
 	fqbn.AddToCommand(monitorCommand)
 	monitorCommand.MarkFlagRequired("port")


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The [`--config`](https://arduino.github.io/arduino-cli/dev/commands/arduino-cli_monitor/#options) flag of the [`arduino-cli monitor`](https://arduino.github.io/arduino-cli/dev/commands/arduino-cli_monitor/) command is used to configure the communication port used by the monitor.

Previously the command line help did not provide any guidance for the usage of this flag, which might lead the users to wonder (https://github.com/arduino/arduino-cli/issues/2070):

- How can the configuration options available for use via the flag be determined?
- What is the format for the configuration option argument?

The information is provided [in the FAQ page](https://arduino.github.io/arduino-cli/dev/FAQ/#how-to-change-monitor-configuration) of the documentation (https://github.com/arduino/arduino-cli/pull/2247), but that is not as convenient a source of information as the command line help and the user may not even be aware of its existence.

## What is the new behavior?

Adjust the command help to provide the user with the missing information by:

- Creating a conceptual linkage between the `--config` and `--describe` flags by using the "communication port settings" terminology in the references of both.
- Documenting the argument format.

In addition to the comma-separated list format I documented here, an alternative usage of passing multiple `--config` flags is also supported. I chose the former because I felt that the descriptions of the latter in either [command line notation](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html) (e.g., `[--config <ID>=<value>]...`) or in prose (e.g., "The format is \<ID\>=\<value\>. Can be used multiple times for multiple settings.") were less clear.


## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.