### PR TITLE
Add `--log` global flag as alias for `--verbose/-v`

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -104,6 +104,8 @@ func createCliCommandTree(cmd *cobra.Command) {
 	cmd.AddCommand(feedback.NewCommand())
 
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, tr("Print the logs on the standard output."))
+	cmd.Flag("verbose").Hidden = true
+	cmd.PersistentFlags().BoolVar(&verbose, "log", false, tr("Print the logs on the standard output."))
 	validLogLevels := []string{"trace", "debug", "info", "warn", "error", "fatal", "panic"}
 	cmd.PersistentFlags().String("log-level", "", tr("Messages with this level and above will be logged. Valid levels are: %s", strings.Join(validLogLevels, ", ")))
 	cmd.RegisterFlagCompletionFunc("log-level", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Adds a `--log` global flag and hides the old `-v`.
This change allows to print logs with commands that have their own `-v` flag overridden (`compile` and `upload`).

## What is the current behavior?

```
$ arduino-cli
[...]
      --log-file string           Path to the file where logs will be written.
      --log-format string         The output format for the logs, can be: text, json
      --log-level string          Messages with this level and above will be logged. Valid levels are: trace, debug, info, warn, error, fatal, panic
      --no-color                  Disable colored output.
  -v, --verbose                   Print the logs on the standard output.

$ arduino-cli compile -b arduino:avr:uno -v
[...there is no way to display log with compile command...]

$ arduino-cli upload -b arduino:avr:uno -p /dev/ttyACM0 -v
[...there is no way to display log with upload command...]
```

## What is the new behavior?

```
$ arduino-cli
[...]
      --log                       Print the logs on the standard output.
      --log-file string           Path to the file where logs will be written.
      --log-format string         The output format for the logs, can be: text, json
      --log-level string          Messages with this level and above will be logged. Valid levels are: trace, debug, info, warn, error, fatal, panic
      --no-color                  Disable colored output.

Use "arduino-cli [command] --help" for more information about a command.

$ arduino-cli compile -b arduino:avr:uno -v --log
[...run verbose compile and print logs together...]

$ arduino-cli upload -b arduino:avr:uno -p /dev/ttyACM0 -v
[...run verbose upload and print logs together...]
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

The old `-v` flag is not removed but just hidden, everything will continue to work as before.

## Other information

