### PR TITLE
Fixed loading of Library given a non-absolute path

### DIFF
--- a/arduino/libraries/libraries_test.go
+++ b/arduino/libraries/libraries_test.go
@@ -54,12 +54,16 @@ func TestLibLayoutAndLocationJSONUnMarshaler(t *testing.T) {
 
 func TestLibrariesLoader(t *testing.T) {
 	{
-		lib, err := Load(paths.New("testdata", "TestLib"), User)
+		libPath := paths.New("testdata", "TestLib")
+		lib, err := Load(libPath, User)
 		require.NoError(t, err)
 		require.Equal(t, "TestLib", lib.Name)
 		require.Equal(t, "1.0.3", lib.Version.String())
 		require.False(t, lib.IsLegacy)
 		require.False(t, lib.InDevelopment)
+		absPath, err := libPath.Abs()
+		require.NoError(t, err)
+		require.Equal(t, lib.InstallDir.String(), absPath.String())
 	}
 	{
 		lib, err := Load(paths.New("testdata", "TestLibInDev"), User)

--- a/arduino/libraries/loader.go
+++ b/arduino/libraries/loader.go
@@ -28,6 +28,13 @@ import (
 
 // Load loads a library from the given LibraryLocation
 func Load(libDir *paths.Path, location LibraryLocation) (*Library, error) {
+	if !libDir.IsAbs() {
+		if abs, err := libDir.Abs(); err == nil {
+			libDir = abs
+		} else {
+			return nil, err
+		}
+	}
 	if libDir.Join("library.properties").Exist() {
 		return makeNewLibrary(libDir, location)
 	}


### PR DESCRIPTION
Givin a relative path is not ideal, but at least allows the CLI to compile the sketch correctly.

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This PR makes the `Library` loader a bit more resilient by allowing relative paths as input.
Using relative paths may lead to other problems, but at least this change allows the CLI to not bail out with weird errors.

## What is the current behavior?

If a relative path is given (via `directories` configuration in `arduino-cli.yaml`) in some cases the path composition during compile fails. See #2180 for an example.

## What is the new behavior?

The compilation succeeds.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2180
