### PR TITLE
regression: hide include-not-found errors during library discovery

### DIFF
--- a/internal/integrationtest/compile_3/testdata/using_Wire/using_Wire.ino
+++ b/internal/integrationtest/compile_3/testdata/using_Wire/using_Wire.ino
@@ -1,0 +1,4 @@
+#include <Wire.h>
+
+void setup() {}
+void loop() {}

--- a/legacy/builder/container_find_includes.go
+++ b/legacy/builder/container_find_includes.go
@@ -374,7 +374,6 @@ func findIncludesUntilDone(ctx *types.Context, cache *includeCache, sourceFileQu
 			preprocStdout, preprocStderr, preprocErr = preprocessor.GCC(sourcePath, targetFilePath, includeFolders, ctx.BuildProperties)
 			if ctx.Verbose {
 				ctx.WriteStdout(preprocStdout)
-				ctx.WriteStdout(preprocStderr)
 			}
 			// Unwrap error and see if it is an ExitError.
 			_, isExitErr := errors.Cause(preprocErr).(*exec.ExitError)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This regression was made during a refactoring of the Arduino preprocessor. In particular the wrong change was part of this commit: https://github.com/arduino/arduino-cli/commit/0585435f8b1d05e0117606f69bea42d3f3dfec79#diff-65ff16cbee816c0f443157444d99bcc144beee06c3329aec891894c8aeda7b27L372-R378

```diff
-                       preproc_stderr, preproc_err = GCCPreprocRunner(ctx, sourcePath, targetFilePath, includes)
+                       var preproc_stdout []byte
+                       preproc_stdout, preproc_stderr, preproc_err = preprocessor.GCC(sourcePath, targetFilePath, includes, ctx.BuildProperties)
+                       if ctx.Verbose {
+                               ctx.WriteStdout(preproc_stdout)
+                               ctx.WriteStdout(preproc_stderr)
+                       }
```

Previously GCCPreprocRunner, in verbose mode would show ONLY the stdout of the process, the "refactored" code wrongly added also stderr to the output.

For reference, this is the old GCCPreprocRunner implementation: https://github.com/arduino/arduino-cli/commit/0585435f8b1d05e0117606f69bea42d3f3dfec79#diff-371f93465ca5a66f01cbe876348f67990750091d27a827781c8633456b93ef3bL36

```diff
-func GCCPreprocRunner(ctx *types.Context, sourceFilePath *paths.Path, targetFilePath *paths.Path, includes paths.PathList) ([]byte, error) {
-       cmd, err := prepareGCCPreprocRecipeProperties(ctx, sourceFilePath, targetFilePath, includes)
-       if err != nil {
-               return nil, err
-       }
-       _, stderr, err := utils.ExecCommand(ctx, cmd, utils.ShowIfVerbose /* stdout */, utils.Capture /* stderr */)
-       return stderr, err
-}
```

This PR fixes the regression.

## What is the current behavior?

Include not found errors are shown during library discovery in verbose compile. See #2263 for details.

## What is the new behavior?

The spurious errors are not displayed anymore.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

The regression has been introduced in #2194. 
Fix #2263 
