### PR TITLE
regression: Fix property expansion of "recipe.preproc.macros"

### DIFF
--- a/arduino/builder/preprocessor/gcc.go
+++ b/arduino/builder/preprocessor/gcc.go
@@ -59,6 +59,7 @@ func GCC(sourceFilePath *paths.Path, targetFilePath *paths.Path, includes paths.
 	}
 
 	commandLine := gccBuildProperties.ExpandPropsInString(pattern)
+	commandLine = properties.DeleteUnexpandedPropsFromString(commandLine)
 	args, err := properties.SplitQuotedString(commandLine, `"'`, false)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Previously the undefined template placeholders in `recipe.preproc.macros` were silently replaced by the empty string. This changed after a refactoring in 0585435f8b1d05e0117606f69bea42d3f3dfec79.

Previously it was:

https://github.com/arduino/arduino-cli/commit/0585435f8b1d05e0117606f69bea42d3f3dfec79#diff-371f93465ca5a66f01cbe876348f67990750091d27a827781c8633456b93ef3bL62
```diff
-       cmd, err := builder_utils.PrepareCommandForRecipe(buildProperties, "recipe.preproc.macros", true, ctx.PackageManager.GetEnvVarsForSpawnedProcess())
```

The `true` parameter in the call to `builder_utils.PrepareCommandForRecipe` is the parameter `removeUnsetProperties`.

This behavior has not been ported over after the "refactoring": https://github.com/arduino/arduino-cli/commit/0585435f8b1d05e0117606f69bea42d3f3dfec79#diff-733dda6759fe968eb8a8d7305c37c7a320a8df52764ca0cba8e88a6f1d077eb5R44-R65

```diff
+       const gccPreprocRecipeProperty = "recipe.preproc.macros"
+       if gccBuildProperties.Get(gccPreprocRecipeProperty) == "" {
+               // autogenerate preprocess macros recipe from compile recipe
+               preprocPattern := gccBuildProperties.Get("recipe.cpp.o.pattern")
+               // add {preproc.macros.flags} to {compiler.cpp.flags}
+               preprocPattern = strings.Replace(preprocPattern, "{compiler.cpp.flags}", "{compiler.cpp.flags} {preproc.macros.flags}", 1)
+               // replace "{object_file}" with "{preprocessed_file_path}"
+               preprocPattern = strings.Replace(preprocPattern, "{object_file}", "{preprocessed_file_path}", 1)
+
+               gccBuildProperties.Set(gccPreprocRecipeProperty, preprocPattern)
+       }
+
+       pattern := gccBuildProperties.Get(gccPreprocRecipeProperty)
+       if pattern == "" {
+               return nil, nil, errors.Errorf(tr("%s pattern is missing"), gccPreprocRecipeProperty)
+       }
+
+       commandLine := gccBuildProperties.ExpandPropsInString(pattern)
+       args, err := properties.SplitQuotedString(commandLine, `"'`, false)
+       if err != nil {
+               return nil, nil, err
+       }
```

that is completely missing the call to `properties.DeleteUnexpandedPropsFromString`.

## What is the current behavior?

The old behavior for property expansion of "recipe.preproc.macros" is not preserved. See #2267 for details.

## What is the new behavior?

The old behavior for property expansion of "recipe.preproc.macros" is restored.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

The regression has been introduced in #2194. 
Fix #2261 
