### PR TITLE
Added vscode config to fix bogus protoc compiler import errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /debug
 /arduino-cli*
 /main
-/.vscode/
 /cmd/formatter/debug.test
 /arduino-cli.yaml
 /wiki

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "protoc": {
+        "options": [
+            "--proto_path=rpc"
+        ]
+    }
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Adds a config file for `vscode` to fix bogus compiler import errors.

## What is the current behavior?

![image](https://github.com/arduino/arduino-cli/assets/423515/16e3ab75-0a2f-4e30-8f59-1b6a638b4804)

## What is the new behavior?

![image](https://github.com/arduino/arduino-cli/assets/423515/080630ca-8d7b-4d67-820a-dda2b8c3466e)

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

## Other information
