### PR TITLE
Upload port detector improvements

### DIFF
--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -527,7 +527,7 @@ func detectUploadPort(
 	result f.Future[*discovery.Port],
 ) {
 	log := logrus.WithField("task", "port_detection")
-	log.Tracef("Detecting new board port after upload")
+	log.Debugf("Detecting new board port after upload")
 
 	candidate := uploadPort.Clone()
 	defer func() {
@@ -543,11 +543,11 @@ func detectUploadPort(
 				return
 			}
 			if candidate != nil && ev.Type == "remove" && ev.Port.Equals(candidate) {
-				log.WithField("event", ev).Trace("User-specified port has been disconnected, forcing wait for upload port")
+				log.WithField("event", ev).Debug("User-specified port has been disconnected, forcing wait for upload port")
 				waitForUploadPort = true
 				candidate = nil
 			} else {
-				log.WithField("event", ev).Trace("Ignored watcher event before upload")
+				log.WithField("event", ev).Debug("Ignored watcher event before upload")
 			}
 			continue
 		case <-uploadCtx.Done():
@@ -569,17 +569,17 @@ func detectUploadPort(
 				return
 			}
 			if candidate != nil && ev.Type == "remove" && candidate.Equals(ev.Port) {
-				log.WithField("event", ev).Trace("Candidate port is no longer available")
+				log.WithField("event", ev).Debug("Candidate port is no longer available")
 				candidate = nil
 				if !waitForUploadPort {
 					waitForUploadPort = true
 					timeout = time.After(5 * time.Second)
-					log.Trace("User-specified port has been disconnected, now waiting for upload port, timeout extended by 5 seconds")
+					log.Debug("User-specified port has been disconnected, now waiting for upload port, timeout extended by 5 seconds")
 				}
 				continue
 			}
 			if ev.Type != "add" {
-				log.WithField("event", ev).Trace("Ignored non-add event")
+				log.WithField("event", ev).Debug("Ignored non-add event")
 				continue
 			}
 
@@ -602,21 +602,21 @@ func detectUploadPort(
 			evPortPriority := portPriority(ev.Port)
 			candidatePriority := portPriority(candidate)
 			if evPortPriority <= candidatePriority {
-				log.WithField("event", ev).Tracef("New upload port candidate is worse than the current one (prio=%d)", evPortPriority)
+				log.WithField("event", ev).Debugf("New upload port candidate is worse than the current one (prio=%d)", evPortPriority)
 				continue
 			}
-			log.WithField("event", ev).Tracef("Found new upload port candidate (prio=%d)", evPortPriority)
+			log.WithField("event", ev).Debugf("Found new upload port candidate (prio=%d)", evPortPriority)
 			candidate = ev.Port
 
 			// If the current candidate have the desired HW-ID return it quickly.
 			if candidate.HardwareID == ev.Port.HardwareID {
 				timeout = time.After(time.Second)
-				log.Trace("New candidate port match the desired HW ID, timeout reduced to 1 second.")
+				log.Debug("New candidate port match the desired HW ID, timeout reduced to 1 second.")
 				continue
 			}
 
 		case <-timeout:
-			log.WithField("selected_port", candidate).Trace("Timeout waiting for candidate port")
+			log.WithField("selected_port", candidate).Debug("Timeout waiting for candidate port")
 			return
 		}
 	}

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -575,9 +575,6 @@ func detectUploadPort(
 					waitForUploadPort = true
 					timeout = time.After(5 * time.Second)
 					log.Debug("User-specified port has been disconnected, now waiting for upload port, timeout extended by 5 seconds")
-				} else {
-					timeout = time.After(time.Second)
-					log.Debug("Candidate port has been disconnected, timeout extended by 1 second")
 				}
 				continue
 			}

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -575,6 +575,9 @@ func detectUploadPort(
 					waitForUploadPort = true
 					timeout = time.After(5 * time.Second)
 					log.Debug("User-specified port has been disconnected, now waiting for upload port, timeout extended by 5 seconds")
+				} else {
+					timeout = time.After(time.Second)
+					log.Debug("Candidate port has been disconnected, timeout extended by 1 second")
 				}
 				continue
 			}

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -514,7 +514,8 @@ func runProgramAction(pme *packagemanager.Explorer,
 
 	updatedPort := updatedUploadPort.Await()
 	if updatedPort == nil {
-		return nil, nil
+		// If the algorithms can not detect the new port, fallback to the user-provided port.
+		return userPort, nil
 	}
 	return updatedPort.ToRPC(), nil
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This patch takes into account the port connection/disconnection that may happen after the upload.
This case was already handled, but this patch slightly increased the timeout to allow the port re-enumeration.

Moreover, I've added a fallback: if the algorithm is unable to find a port, it will return the user-provided port for the upload.

## What is the current behavior?

No upload port detected:
```
./arduino-cli upload -b arduino:mbed_nano:nano33ble -p /dev/cu.usbmodem5 ~/Documents/Arduino/minimal --format json
{
  "stdout": "Device       : nRF52840-QIAA\nVersion      : Arduino Bootloader (SAM-BA extended) 2.0 [Arduino:IKXYZ]\nAddress      : 0x0\nPages        : 256\nPage Size    : 4096 bytes\nTotal Size   : 1024KB\nPlanes       : 1\nLock Regions : 0\nLocked       : none\nSecurity     : false\nErase flash\n\nDone in 0.001 seconds\nWrite 84088 bytes to flash (21 pages)\n\r[                              ] 0% (0/21 pages)\r[=                             ] 4% (1/21 pages)\r[==                            ] 9% (2/21 pages)\r[====                          ] 14% (3/21 pages)\r[=====                         ] 19% (4/21 pages)\r[=======                       ] 23% (5/21 pages)\r[========                      ] 28% (6/21 pages)\r[==========                    ] 33% (7/21 pages)\r[===========                   ] 38% (8/21 pages)\r[============                  ] 42% (9/21 pages)\r[==============                ] 47% (10/21 pages)\r[===============               ] 52% (11/21 pages)\r[=================             ] 57% (12/21 pages)\r[==================            ] 61% (13/21 pages)\r[====================          ] 66% (14/21 pages)\r[=====================         ] 71% (15/21 pages)\r[======================        ] 76% (16/21 pages)\r[========================      ] 80% (17/21 pages)\r[=========================     ] 85% (18/21 pages)\r[===========================   ] 90% (19/21 pages)\r[============================  ] 95% (20/21 pages)\r[==============================] 100% (21/21 pages)\nDone in 3.335 seconds\n",
  "stderr": ""
}
```
See #2287  for details.

## What is the new behavior?

It should always detect the port, BTW I'm unable to reproduce it so I'll wait for @kittaakos confirmation :-)

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2287 
