### PR TITLE
Text output: removed trailing spaces for right-padding of tables

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -18,6 +18,7 @@ package table
 import (
 	"fmt"
 	"math"
+	"strings"
 )
 
 // ColumnWidthMode is used to configure columns type
@@ -127,6 +128,7 @@ func (t *Table) Render() string {
 
 	res := ""
 	for _, row := range t.rows {
+		line := ""
 		for x, cell := range row.cells {
 			selectedWidth := widths[x]
 			if x < len(t.columnsWidthMode) {
@@ -143,9 +145,10 @@ func (t *Table) Render() string {
 			if x > 0 {
 				line += " "
 			}
-			res += cell.Pad(selectedWidth)
+			line += cell.Pad(selectedWidth)
 		}
-		res += "\n"
+
+		res += strings.TrimRight(line, " ") + "\n"
 	}
 	return res
 }

--- a/table/table.go
+++ b/table/table.go
@@ -127,7 +127,6 @@ func (t *Table) Render() string {
 
 	res := ""
 	for _, row := range t.rows {
-		separator := ""
 		for x, cell := range row.cells {
 			selectedWidth := widths[x]
 			if x < len(t.columnsWidthMode) {
@@ -141,9 +140,10 @@ func (t *Table) Render() string {
 			if selectedWidth < minimum[x] {
 				selectedWidth = minimum[x]
 			}
-			res += separator
+			if x > 0 {
+				line += " "
+			}
 			res += cell.Pad(selectedWidth)
-			separator = " "
 		}
 		res += "\n"
 	}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Remove the right-padding of tables of the CLI.

## What is the current behavior?

See #2289:

> Here is an example of what the current behavior looks like, with = replacing spaces to make it clearer.
>
> ```
> Sketch=uses=58120=bytes=(11%)=of=program=storage=space.=Maximum=is=507904=bytes.
> 
> Used=library===============Version=Path==================================================
> CAN=Adafruit=Fork==========1.2.1===/home/trb/Arduino/libraries/arduino-CAN-master========
> LibPrintf==================1.2.13==/home/trb/Arduino/libraries/LibPrintf=================
> Adafruit=SleepyDog=Library=1.6.4===/home/trb/Arduino/libraries/Adafruit_SleepyDog_Library
> ```

## What is the new behavior?

No trailing spaces.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2289
