### PR TITLE
[skip-changelog] Use gRPC function call to avoid accessing `arduino/cores` package directly

### DIFF
--- a/internal/cli/arguments/completion.go
+++ b/internal/cli/arguments/completion.go
@@ -18,11 +18,11 @@ package arguments
 import (
 	"context"
 
-	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/commands/core"
 	"github.com/arduino/arduino-cli/commands/lib"
+	"github.com/arduino/arduino-cli/commands/upload"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
@@ -103,10 +103,12 @@ func GetInstalledProgrammers() []string {
 
 	installedProgrammers := make(map[string]string)
 	for _, board := range list.Boards {
-		fqbn, _ := cores.ParseFQBN(board.Fqbn)
-		_, boardPlatform, _, _, _, _ := pme.ResolveFQBN(fqbn)
-		for programmerID, programmer := range boardPlatform.Programmers {
-			installedProgrammers[programmerID] = programmer.Name
+		programmers, _ := upload.ListProgrammersAvailableForUpload(context.Background(), &rpc.ListProgrammersAvailableForUploadRequest{
+			Instance: inst,
+			Fqbn:     board.Fqbn,
+		})
+		for _, programmer := range programmers.GetProgrammers() {
+			installedProgrammers[programmer.GetId()] = programmer.GetName()
 		}
 	}
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

No changes, the code is reorganized to avoid accessing `arduino/cores` package directly.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information
Related to https://github.com/arduino/arduino-cli/issues/1948
<!-- Any additional information that could help the review process -->
