### PR TITLE
[skip-changelog] Use `LoadSketch` in upload function and return `rpc.Port` in `GetPort`

### DIFF
--- a/internal/cli/arguments/fqbn.go
+++ b/internal/cli/arguments/fqbn.go
@@ -89,5 +89,5 @@ func CalculateFQBNAndPort(portArgs *Port, fqbnArg *Fqbn, instance *rpc.Instance,
 	if err != nil {
 		feedback.Fatal(tr("Error getting port metadata: %v", err), feedback.ErrGeneric)
 	}
-	return fqbn, port.ToRPC()
+	return fqbn, port
 }

--- a/internal/cli/arguments/port.go
+++ b/internal/cli/arguments/port.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/arduino/arduino-cli/arduino"
-	"github.com/arduino/arduino-cli/arduino/discovery"
 	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
@@ -70,8 +69,7 @@ func (p *Port) GetPortAddressAndProtocol(instance *rpc.Instance, defaultAddress,
 
 // GetPort returns the Port obtained by parsing command line arguments.
 // The extra metadata for the ports is obtained using the pluggable discoveries.
-func (p *Port) GetPort(instance *rpc.Instance, defaultAddress, defaultProtocol string) (*discovery.Port, error) {
-	// TODO: REMOVE discovery from here (use board.List instead)
+func (p *Port) GetPort(instance *rpc.Instance, defaultAddress, defaultProtocol string) (*rpc.Port, error) {
 
 	address := p.address
 	protocol := p.protocol
@@ -84,7 +82,7 @@ func (p *Port) GetPort(instance *rpc.Instance, defaultAddress, defaultProtocol s
 		// the attached board without specifying explictly a port.
 		// Tools that work this way must be specified using the property
 		// "BOARD_ID.upload.tool.default" in the platform's boards.txt.
-		return &discovery.Port{
+		return &rpc.Port{
 			Protocol: "default",
 		}, nil
 	}
@@ -113,13 +111,13 @@ func (p *Port) GetPort(instance *rpc.Instance, defaultAddress, defaultProtocol s
 			}
 			port := portEvent.Port
 			if (protocol == "" || protocol == port.Protocol) && address == port.Address {
-				return port, nil
+				return port.ToRPC(), nil
 			}
 
 		case <-deadline:
 			// No matching port found
 			if protocol == "" {
-				return &discovery.Port{
+				return &rpc.Port{
 					Address:  address,
 					Protocol: "serial",
 				}, nil

--- a/internal/cli/burnbootloader/burnbootloader.go
+++ b/internal/cli/burnbootloader/burnbootloader.go
@@ -76,7 +76,7 @@ func runBootloaderCommand(command *cobra.Command, args []string) {
 	if _, err := upload.BurnBootloader(context.Background(), &rpc.BurnBootloaderRequest{
 		Instance:   instance,
 		Fqbn:       fqbn.String(),
-		Port:       discoveryPort.ToRPC(),
+		Port:       discoveryPort,
 		Verbose:    verbose,
 		Verify:     verify,
 		Programmer: programmer.String(),


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
No changes, the gRPC interface is used to avoid accessing `arduino` package directly.
<!-- Bug fix, feature, docs update, ... -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information
Related to #1948 
<!-- Any additional information that could help the review process -->
