### PR TITLE
add "config get" command to print settings values

### DIFF
--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -37,6 +37,7 @@ func NewCommand() *cobra.Command {
 	configCommand.AddCommand(initAddCommand())
 	configCommand.AddCommand(initDeleteCommand())
 	configCommand.AddCommand(initDumpCommand())
+	configCommand.AddCommand(initGetCommand())
 	configCommand.AddCommand(initInitCommand())
 	configCommand.AddCommand(initRemoveCommand())
 	configCommand.AddCommand(initSetCommand())

--- a/internal/cli/config/get.go
+++ b/internal/cli/config/get.go
@@ -17,7 +17,6 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 
 	"github.com/arduino/arduino-cli/commands/daemon"
@@ -26,6 +25,7 @@ import (
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func initGetCommand() *cobra.Command {
@@ -77,5 +77,10 @@ func (gr getResult) Data() interface{} {
 }
 
 func (gr getResult) String() string {
-	return fmt.Sprintf("%v", gr.resp)
+	gs, err := yaml.Marshal(gr.resp)
+	if err != nil {
+		// Should never happen
+		panic(tr("unable to marshal config to YAML: %v", err))
+	}
+	return string(gs)
 }

--- a/internal/cli/config/get.go
+++ b/internal/cli/config/get.go
@@ -53,12 +53,13 @@ func runGetCommand(cmd *cobra.Command, args []string) {
 	for _, toGet := range args {
 		resp, err := svc.SettingsGetValue(cmd.Context(), &rpc.SettingsGetValueRequest{Key: toGet})
 		if err != nil {
-			feedback.Fatal(tr("Cannot get the key %[1]s: %[2]v", toGet, err), feedback.ErrGeneric)
+			feedback.Fatal(tr("Cannot get the configuration key %[1]s: %[2]v", toGet, err), feedback.ErrGeneric)
 		}
 		var result getResult
 		err = json.Unmarshal([]byte(resp.GetJsonData()), &result.resp)
 		if err != nil {
-			feedback.Fatal(tr("Cannot parse JSON for key %[1]s: %[2]v", toGet, err), feedback.ErrGeneric)
+			// Should never happen...
+			panic(fmt.Sprintf("Cannot parse JSON for key %[1]s: %[2]v", toGet, err))
 		}
 		feedback.PrintResult(result)
 	}

--- a/internal/cli/config/get.go
+++ b/internal/cli/config/get.go
@@ -19,11 +19,11 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/arduino/arduino-cli/configuration"
+	"github.com/arduino/arduino-cli/internal/cli/configuration"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func initGetCommand() *cobra.Command {

--- a/internal/cli/config/get.go
+++ b/internal/cli/config/get.go
@@ -17,6 +17,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/arduino/arduino-cli/commands/daemon"

--- a/internal/cli/config/get.go
+++ b/internal/cli/config/get.go
@@ -47,7 +47,7 @@ func initGetCommand() *cobra.Command {
 func runGetCommand(cmd *cobra.Command, args []string) {
 	logrus.Info("Executing `arduino-cli config get`")
 
-        svc := daemon.ArduinoCoreServerImpl{}
+	svc := daemon.ArduinoCoreServerImpl{}
 	for _, toGet := range args {
 		resp, err := svc.SettingsGetValue(cmd.Context(), &rpc.SettingsGetValueRequest{Key: toGet})
 		if err != nil {
@@ -61,7 +61,7 @@ func runGetCommand(cmd *cobra.Command, args []string) {
 // create a dedicated feedback.Result implementation to safely handle
 // any changes to the configuration.Settings struct.
 type getResult struct {
-	key string
+	key  string
 	data interface{}
 }
 

--- a/internal/cli/config/get.go
+++ b/internal/cli/config/get.go
@@ -1,0 +1,88 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package config
+
+import (
+	"os"
+	"reflect"
+
+	"github.com/arduino/arduino-cli/configuration"
+	"github.com/arduino/arduino-cli/internal/cli/feedback"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func initGetCommand() *cobra.Command {
+	getCommand := &cobra.Command{
+		Use:   "get",
+		Short: tr("Gets a setting value."),
+		Long:  tr("Gets a setting value."),
+		Example: "" +
+			"  " + os.Args[0] + " config get logging.level\n" +
+			"  " + os.Args[0] + " config get logging.file\n" +
+			"  " + os.Args[0] + " config get sketch.always_export_binaries\n" +
+			"  " + os.Args[0] + " config get board_manager.additional_urls",
+		Args: cobra.MinimumNArgs(1),
+		Run:  runGetCommand,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return configuration.Settings.AllKeys(), cobra.ShellCompDirectiveDefault
+		},
+	}
+	return getCommand
+}
+
+func runGetCommand(cmd *cobra.Command, args []string) {
+	logrus.Info("Executing `arduino-cli config get`")
+	key := args[0]
+	kind := validateKey(key)
+
+	if kind != reflect.Slice && len(args) > 1 {
+		feedback.Fatal(tr("Can't get multiple key values"), feedback.ErrGeneric)
+	}
+
+	var value interface{}
+	switch kind {
+	case reflect.Slice:
+		value = configuration.Settings.GetStringSlice(key)
+	case reflect.String:
+		value = configuration.Settings.GetString(key)
+	case reflect.Bool:
+		value = configuration.Settings.GetBool(key)
+	}
+
+	feedback.PrintResult(getResult{value})
+}
+
+// output from this command may require special formatting.
+// create a dedicated feedback.Result implementation to safely handle
+// any changes to the configuration.Settings struct.
+type getResult struct {
+	data interface{}
+}
+
+func (gr getResult) Data() interface{} {
+	return gr.data
+}
+
+func (gr getResult) String() string {
+	gs, err := yaml.Marshal(gr.data)
+	if err != nil {
+		// Should never happen
+		panic(tr("unable to marshal config to YAML: %v", err))
+	}
+	return string(gs)
+}

--- a/internal/integrationtest/config/config_test.go
+++ b/internal/integrationtest/config/config_test.go
@@ -834,31 +834,17 @@ func TestGet(t *testing.T) {
 	// Get simple key value
 	stdout, _, err = cli.Run("config", "get", "daemon.port", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	require.Equal(t, `"50051"`, stdout)
+	requirejson.Contains(t, stdout, `"50051"`)
 
 	// Get structured key value
 	stdout, _, err = cli.Run("config", "get", "daemon", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	require.Equal(t, `{"port":"50051"}`, stdout)
-
-	// Get multiple key values
-	stdout, _, err = cli.Run("config", "get", "logging.format", "logging.level", "--format", "json", "--config-file", "arduino-cli.yaml")
-	require.NoError(t, err)
-	require.Equal(t, `"text"`+"\n"+`"info"`, stdout)
+	requirejson.Contains(t, stdout, `{"port":"50051"}`)
 
 	// Get undefined key
-	stdout, _, err = cli.Run("config", "get", "foo", "--format", "json", "--config-file", "arduino-cli.yaml")
-	require.Empty(t, stdout)
-	require.Contains(t, err, "Cannot get key foo")
-
-	// Set undefined key
-	_, _, err = cli.Run("config", "set", "foo", "bar", "--config-file", "arduino-cli.yaml")
-	require.NoError(t, err)
-
-	// Get previously-undefined key
-	stdout, _, err = cli.Run("config", "get", "foo", "--format", "json", "--config-file", "arduino-cli.yaml")
-	require.NoError(t, err)
-	require.Equal(t, `"bar"`, stdout)
+	_, stderr, err := cli.Run("config", "get", "foo", "--format", "json", "--config-file", "arduino-cli.yaml")
+	require.Error(t, err)
+	requirejson.Contains(t, stderr, `{"error":"Cannot get the key foo: key not found in settings"}`)
 }
 
 func TestInitializationOrderOfConfigThroughFlagAndEnv(t *testing.T) {

--- a/internal/integrationtest/config/config_test.go
+++ b/internal/integrationtest/config/config_test.go
@@ -844,7 +844,7 @@ func TestGet(t *testing.T) {
 	// Get multiple key values
 	stdout, _, err = cli.Run("config", "get", "logging.format", "logging.level", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	require.Equal(t,`"text"` + "\n" + `"info"`, stdout)
+	require.Equal(t, `"text"`+"\n"+`"info"`, stdout)
 
 	// Get undefined key
 	stdout, _, err = cli.Run("config", "get", "foo", "--format", "json", "--config-file", "arduino-cli.yaml")

--- a/internal/integrationtest/config/config_test.go
+++ b/internal/integrationtest/config/config_test.go
@@ -818,6 +818,49 @@ func TestDelete(t *testing.T) {
 	require.NotContains(t, configLines, "board_manager")
 }
 
+func TestGet(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	// Create a config file
+	_, _, err := cli.Run("config", "init", "--dest-dir", ".")
+	require.NoError(t, err)
+
+	// Verifies default state
+	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
+	require.NoError(t, err)
+	requirejson.Query(t, stdout, ".config | .daemon | .port", `"50051"`)
+
+	// Get simple key value
+	stdout, _, err = cli.Run("config", "get", "daemon.port", "--format", "json", "--config-file", "arduino-cli.yaml")
+	require.NoError(t, err)
+	require.Equal(t, `"50051"`, stdout)
+
+	// Get structured key value
+	stdout, _, err = cli.Run("config", "get", "daemon", "--format", "json", "--config-file", "arduino-cli.yaml")
+	require.NoError(t, err)
+	require.Equal(t, `{"port":"50051"}`, stdout)
+
+	// Get multiple key values
+	stdout, _, err = cli.Run("config", "get", "logging.format", "logging.level", "--format", "json", "--config-file", "arduino-cli.yaml")
+	require.NoError(t, err)
+	require.Equal(t,`"text"` + "\n" + `"info"`, stdout)
+
+	// Get undefined key
+	stdout, _, err = cli.Run("config", "get", "foo", "--format", "json", "--config-file", "arduino-cli.yaml")
+	require.Empty(t, stdout)
+	require.Contains(t, err, "Cannot get key foo")
+
+	// Set undefined key
+	_, _, err = cli.Run("config", "set", "foo", "bar", "--config-file", "arduino-cli.yaml")
+	require.NoError(t, err)
+
+	// Get previously-undefined key
+	stdout, _, err = cli.Run("config", "get", "foo", "--format", "json", "--config-file", "arduino-cli.yaml")
+	require.NoError(t, err)
+	require.Equal(t, `"bar"`, stdout)
+}
+
 func TestInitializationOrderOfConfigThroughFlagAndEnv(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()

--- a/internal/integrationtest/config/config_test.go
+++ b/internal/integrationtest/config/config_test.go
@@ -844,7 +844,7 @@ func TestGet(t *testing.T) {
 	// Get undefined key
 	_, stderr, err := cli.Run("config", "get", "foo", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.Error(t, err)
-	requirejson.Contains(t, stderr, `{"error":"Cannot get the key foo: key not found in settings"}`)
+	requirejson.Contains(t, stderr, `{"error":"Cannot get the configuration key foo: key not found in settings"}`)
 }
 
 func TestInitializationOrderOfConfigThroughFlagAndEnv(t *testing.T) {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] ~`UPGRADING.md` has been updated with a migration guide (for breaking changes)~
- [ ] ~`configuration.schema.json` updated if new parameters are added.~

## What kind of change does this PR introduce?

Feature addition

## What is the current behavior?

There are `config` commands to `add`/`set` individual settings, but retrieving settings requires the user to `dump` all settings and parse the output with either JSON/YAML to retrieve an individual.

## What is the new behavior?

With the addition of a `config get` command, the user can retrieve individual configuration settings without having to parse JSON/YAML.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

Not a breaking change

## Other information

None