### PR TITLE
Fixed weird error message in `core install` if invalid platform is spcified

### DIFF
--- a/arduino/errors.go
+++ b/arduino/errors.go
@@ -837,11 +837,8 @@ type MultiplePlatformsError struct {
 }
 
 func (e *MultiplePlatformsError) Error() string {
-	return tr("Found %d platform for reference \"%s\":\n%s",
-		len(e.Platforms),
-		e.UserPlatform,
-		strings.Join(e.Platforms, "\n"),
-	)
+	return tr("Found %d platforms matching \"%s\": %s",
+		len(e.Platforms), e.UserPlatform, strings.Join(e.Platforms, ", "))
 }
 
 // ToRPCStatus converts the error into a *status.Status

--- a/internal/cli/arguments/reference.go
+++ b/internal/cli/arguments/reference.go
@@ -116,11 +116,13 @@ func ParseReference(arg string) (*Reference, error) {
 	}
 	// replace the returned Reference only if only one occurrence is found,
 	// otherwise return an error to the user because we don't know on which platform operate
-	if len(foundPlatforms) == 1 {
-		ret.PackageName = toks[0]
-		ret.Architecture = toks[1]
-	} else {
+	if len(foundPlatforms) == 0 {
+		return nil, &arduino.PlatformNotFoundError{Platform: arg}
+	}
+	if len(foundPlatforms) > 1 {
 		return nil, &arduino.MultiplePlatformsError{Platforms: foundPlatforms, UserPlatform: arg}
 	}
+	ret.PackageName = toks[0]
+	ret.Architecture = toks[1]
 	return ret, nil
 }

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -883,7 +883,7 @@ func TestCoreDownloadMultiplePlatforms(t *testing.T) {
 	// The cli should not allow it since optimizing the casing results in finding two cores
 	_, stderr, err := cli.Run("core", "upgrade", "Packager:Arch")
 	require.Error(t, err)
-	require.Contains(t, string(stderr), "Invalid argument passed: Found 2 platform for reference")
+	require.Contains(t, string(stderr), "Invalid argument passed: Found 2 platforms matching")
 }
 
 func TestCoreWithMissingCustomBoardOptionsIsLoaded(t *testing.T) {


### PR DESCRIPTION

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fixed an error message.

## What is the current behavior?

```
$ arduino-cli core install asdasd:asdasd
Invalid argument passed: Found 0 platform for reference "asdasd:asdasd":
```

## What is the new behavior?

```
$ arduino-cli core install asdasd:asdasd
Invalid argument passed: Platform 'asdasd:asdasd' not found
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
