### PR TITLE
Improve signature check on library_index.json

### DIFF
--- a/arduino/resources/index.go
+++ b/arduino/resources/index.go
@@ -17,6 +17,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"path"
 	"strings"
@@ -33,8 +34,9 @@ import (
 
 // IndexResource is a reference to an index file URL with an optional signature.
 type IndexResource struct {
-	URL          *url.URL
-	SignatureURL *url.URL
+	URL                          *url.URL
+	SignatureURL                 *url.URL
+	EnforceSignatureVerification bool
 }
 
 // IndexFileName returns the index file name as it is saved in data dir (package_xxx_index.json).
@@ -139,6 +141,10 @@ func (res *IndexResource) Download(destDir *paths.Path, downloadCB rpc.DownloadP
 			return &arduino.PermissionDeniedError{Message: tr("Error verifying signature"), Cause: err}
 		} else if !valid {
 			return &arduino.SignatureVerificationFailedError{File: res.URL.String()}
+		}
+	} else {
+		if res.EnforceSignatureVerification {
+			return &arduino.PermissionDeniedError{Message: tr("Error verifying signature"), Cause: errors.New(tr("missing signature"))}
 		}
 	}
 

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -511,7 +511,8 @@ func UpdateLibrariesIndex(ctx context.Context, req *rpc.UpdateLibrariesIndexRequ
 	defer tmp.RemoveAll()
 
 	indexResource := resources.IndexResource{
-		URL: librariesmanager.LibraryIndexWithSignatureArchiveURL,
+		URL:                          librariesmanager.LibraryIndexWithSignatureArchiveURL,
+		EnforceSignatureVerification: true,
 	}
 	if err := indexResource.Download(lm.IndexFile.Parent(), downloadCB); err != nil {
 		return err


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

There are some cases where the signature check is skipped when upgrading indexes. This PR ensures that the signature check is enforced for the library_index.json.

## What is the current behavior?

If the "bundle index+signature" `library_index.tar.bz2` does not contain the signature, then the signature check is silently sipped.

## What is the new behavior?

If the "bundle index+signature" `library_index.tar.bz2` does not contain the signature, then the index upgrade fails.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

<!-- Any additional information that could help the review process -->
