### PR TITLE
Get default port address and protocol from sketch profile using `monitor -s <sketchPath>`

### DIFF
--- a/internal/cli/arguments/port.go
+++ b/internal/cli/arguments/port.go
@@ -155,3 +155,8 @@ func (p *Port) DetectFQBN(inst *rpc.Instance) (string, *rpc.Port) {
 	}
 	return "", nil
 }
+
+// IsPortFlagSet returns true if the port address is provided
+func (p *Port) IsPortFlagSet() bool {
+	return p.address != ""
+}

--- a/internal/cli/arguments/sketch.go
+++ b/internal/cli/arguments/sketch.go
@@ -25,7 +25,7 @@ import (
 // InitSketchPath returns an instance of paths.Path pointing to sketchPath.
 // If sketchPath is an empty string returns the current working directory.
 // In both cases it warns the user if he's using deprecated files
-func InitSketchPath(path string) (sketchPath *paths.Path) {
+func InitSketchPath(path string, printWarnings bool) (sketchPath *paths.Path) {
 	if path != "" {
 		sketchPath = paths.New(path)
 	} else {
@@ -36,8 +36,10 @@ func InitSketchPath(path string) (sketchPath *paths.Path) {
 		logrus.Infof("Reading sketch from dir: %s", wd)
 		sketchPath = wd
 	}
-	if msg := sk.WarnDeprecatedFiles(sketchPath); msg != "" {
-		feedback.Warning(msg)
+	if printWarnings {
+		if msg := sk.WarnDeprecatedFiles(sketchPath); msg != "" {
+			feedback.Warning(msg)
+		}
 	}
 	return sketchPath
 }

--- a/internal/cli/board/attach.go
+++ b/internal/cli/board/attach.go
@@ -53,7 +53,7 @@ func initAttachCommand() *cobra.Command {
 }
 
 func runAttachCommand(path string, port *arguments.Port, fqbn string) {
-	sketchPath := arguments.InitSketchPath(path)
+	sketchPath := arguments.InitSketchPath(path, true)
 
 	portAddress, portProtocol, _ := port.GetPortAddressAndProtocol(nil, "", "")
 	newDefaults, err := sketch.SetSketchDefaults(context.Background(), &rpc.SetSketchDefaultsRequest{

--- a/internal/cli/compile/compile.go
+++ b/internal/cli/compile/compile.go
@@ -157,7 +157,7 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 		path = args[0]
 	}
 
-	sketchPath := arguments.InitSketchPath(path)
+	sketchPath := arguments.InitSketchPath(path, true)
 
 	sk, err := sketch.LoadSketch(context.Background(), &rpc.LoadSketchRequest{SketchPath: sketchPath.String()})
 	if err != nil {

--- a/internal/cli/debug/debug.go
+++ b/internal/cli/debug/debug.go
@@ -74,7 +74,7 @@ func runDebugCommand(command *cobra.Command, args []string) {
 		path = args[0]
 	}
 
-	sketchPath := arguments.InitSketchPath(path)
+	sketchPath := arguments.InitSketchPath(path, true)
 	sk, err := sketch.LoadSketch(context.Background(), &rpc.LoadSketchRequest{SketchPath: sketchPath.String()})
 	if err != nil {
 		feedback.FatalError(err, feedback.ErrGeneric)

--- a/internal/cli/monitor/monitor.go
+++ b/internal/cli/monitor/monitor.go
@@ -98,6 +98,11 @@ func runMonitorCmd(
 		defaultPort, defaultProtocol string
 	)
 
+	// Flags takes maximum precedence over sketch.yaml
+	// If {--port --fqbn --profile} are set we ignore the profile.
+	// If both {--port --profile} are set we read the fqbn in the following order: profile -> default_fqbn -> discovery
+	// If only --port is set we read the fqbn in the following order: default_fqbn -> discovery
+	// If only --fqbn is set we read the port in the following order: default_port
 	sketchPath := arguments.InitSketchPath(sketchPathArg)
 	sketch, err := sk.LoadSketch(context.Background(), &rpc.LoadSketchRequest{SketchPath: sketchPath.String()})
 	if err != nil && !portArgs.IsPortFlagSet() {
@@ -108,6 +113,8 @@ func runMonitorCmd(
 	}
 	if sketch != nil {
 		defaultPort, defaultProtocol = sketch.GetDefaultPort(), sketch.GetDefaultProtocol()
+	}
+	if fqbnArg.String() == "" {
 		if profileArg.Get() == "" {
 			inst, profile = instance.CreateAndInitWithProfile(sketch.GetDefaultProfile().GetName(), sketchPath)
 		} else {

--- a/internal/cli/monitor/monitor.go
+++ b/internal/cli/monitor/monitor.go
@@ -67,11 +67,7 @@ func NewCommand() *cobra.Command {
 			if len(args) > 0 {
 				sketchPath = args[0]
 			}
-			var portProvidedFromFlag bool
-			if p := cmd.Flags().Lookup("port"); p != nil && p.Changed {
-				portProvidedFromFlag = true
-			}
-			runMonitorCmd(&portArgs, &fqbnArg, &profileArg, sketchPath, configs, describe, timestamp, quiet, raw, portProvidedFromFlag)
+			runMonitorCmd(&portArgs, &fqbnArg, &profileArg, sketchPath, configs, describe, timestamp, quiet, raw)
 		},
 	}
 	portArgs.AddToCommand(monitorCommand)
@@ -87,7 +83,7 @@ func NewCommand() *cobra.Command {
 
 func runMonitorCmd(
 	portArgs *arguments.Port, fqbnArg *arguments.Fqbn, profileArg *arguments.Profile, sketchPathArg string,
-	configs []string, describe, timestamp, quiet, raw bool, portProvidedFromFlag bool,
+	configs []string, describe, timestamp, quiet, raw bool,
 ) {
 	logrus.Info("Executing `arduino-cli monitor`")
 
@@ -101,7 +97,7 @@ func runMonitorCmd(
 		defaultPort, defaultProtocol string
 	)
 
-	if !portProvidedFromFlag {
+	if !portArgs.IsPortFlagSet() {
 		sketchPath := arguments.InitSketchPath(sketchPathArg)
 		sketch, err := sk.LoadSketch(context.Background(), &rpc.LoadSketchRequest{SketchPath: sketchPath.String()})
 		if err != nil {

--- a/internal/cli/monitor/monitor.go
+++ b/internal/cli/monitor/monitor.go
@@ -103,7 +103,7 @@ func runMonitorCmd(
 	// If both {--port --profile} are set we read the fqbn in the following order: profile -> default_fqbn -> discovery
 	// If only --port is set we read the fqbn in the following order: default_fqbn -> discovery
 	// If only --fqbn is set we read the port in the following order: default_port
-	sketchPath := arguments.InitSketchPath(sketchPathArg)
+	sketchPath := arguments.InitSketchPath(sketchPathArg, false)
 	sketch, err := sk.LoadSketch(context.Background(), &rpc.LoadSketchRequest{SketchPath: sketchPath.String()})
 	if err != nil && !portArgs.IsPortFlagSet() {
 		feedback.Fatal(

--- a/internal/cli/upload/upload.go
+++ b/internal/cli/upload/upload.go
@@ -89,7 +89,7 @@ func runUploadCommand(args []string, uploadFieldsArgs map[string]string) {
 	if len(args) > 0 {
 		path = args[0]
 	}
-	sketchPath := arguments.InitSketchPath(path)
+	sketchPath := arguments.InitSketchPath(path, true)
 
 	if msg := sk.WarnDeprecatedFiles(sketchPath); importDir == "" && importFile == "" && msg != "" {
 		feedback.Warning(msg)

--- a/internal/integrationtest/monitor/monitor_test.go
+++ b/internal/integrationtest/monitor/monitor_test.go
@@ -21,8 +21,15 @@ import (
 	"testing"
 
 	"github.com/arduino/arduino-cli/internal/integrationtest"
+	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
 )
+
+// returns a reader that tells the mocked monitor to exit
+func quitMonitor() io.Reader {
+	// tells mocked monitor to exit
+	return bytes.NewBufferString("QUIT\n")
+}
 
 func TestMonitorConfigFlags(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
@@ -38,14 +45,8 @@ func TestMonitorConfigFlags(t *testing.T) {
 	cli.InstallMockedSerialDiscovery(t)
 	cli.InstallMockedSerialMonitor(t)
 
-	// Test monitor command
-	quit := func() io.Reader {
-		// tells mocked monitor to exit
-		return bytes.NewBufferString("QUIT\n")
-	}
-
 	t.Run("NoArgs", func(t *testing.T) {
-		stdout, _, err := cli.RunWithCustomInput(quit(), "monitor", "-p", "/dev/ttyARG", "--raw")
+		stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARG", "--raw")
 		require.NoError(t, err)
 		require.Contains(t, string(stdout), "Opened port: /dev/ttyARG")
 		require.Contains(t, string(stdout), "Configuration baudrate = 9600")
@@ -54,7 +55,7 @@ func TestMonitorConfigFlags(t *testing.T) {
 	})
 
 	t.Run("BaudConfig", func(t *testing.T) {
-		stdout, _, err := cli.RunWithCustomInput(quit(), "monitor", "-p", "/dev/ttyARG", "-c", "baudrate=115200", "--raw")
+		stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARG", "-c", "baudrate=115200", "--raw")
 		require.NoError(t, err)
 		require.Contains(t, string(stdout), "Opened port: /dev/ttyARG")
 		require.Contains(t, string(stdout), "Configuration baudrate = 115200")
@@ -64,7 +65,7 @@ func TestMonitorConfigFlags(t *testing.T) {
 	})
 
 	t.Run("BaudAndParitfyConfig", func(t *testing.T) {
-		stdout, _, err := cli.RunWithCustomInput(quit(), "monitor", "-p", "/dev/ttyARG",
+		stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARG",
 			"-c", "baudrate=115200", "-c", "parity=even", "--raw")
 		require.NoError(t, err)
 		require.Contains(t, string(stdout), "Opened port: /dev/ttyARG")
@@ -75,16 +76,181 @@ func TestMonitorConfigFlags(t *testing.T) {
 	})
 
 	t.Run("InvalidConfigKey", func(t *testing.T) {
-		_, stderr, err := cli.RunWithCustomInput(quit(), "monitor", "-p", "/dev/ttyARG",
+		_, stderr, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARG",
 			"-c", "baud=115200", "-c", "parity=even", "--raw")
 		require.Error(t, err)
 		require.Contains(t, string(stderr), "invalid port configuration: baud=115200")
 	})
 
 	t.Run("InvalidConfigValue", func(t *testing.T) {
-		_, stderr, err := cli.RunWithCustomInput(quit(), "monitor", "-p", "/dev/ttyARG",
+		_, stderr, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARG",
 			"-c", "parity=9600", "--raw")
 		require.Error(t, err)
 		require.Contains(t, string(stderr), "invalid port configuration value for parity: 9600")
+	})
+}
+
+func TestMonitorCommandFlagsAndDefaultPortFQBNSelection(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	// Install AVR platform
+	_, _, err := cli.Run("core", "install", "arduino:avr@1.8.6")
+	require.NoError(t, err)
+
+	// Patch the Yun board to require special RTS/DTR serial configuration
+	f, err := cli.DataDir().Join("packages", "arduino", "hardware", "avr", "1.8.6", "boards.txt").Append()
+	require.NoError(t, err)
+	_, err = f.WriteString(`
+uno.serial.disableRTS=true
+uno.serial.disableDTR=false
+yun.serial.disableRTS=true
+yun.serial.disableDTR=true
+`)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Install mocked discovery and monitor for testing
+	cli.InstallMockedSerialDiscovery(t)
+	cli.InstallMockedSerialMonitor(t)
+
+	// Create test sketches
+	getSketchPath := func(sketch string) string {
+		p, err := paths.New("testdata", sketch).Abs()
+		require.NoError(t, err)
+		require.True(t, p.IsDir())
+		return p.String()
+	}
+	sketch := getSketchPath("SketchWithNoProfiles")
+	sketchWithPort := getSketchPath("SketchWithDefaultPort")
+	sketchWithFQBN := getSketchPath("SketchWithDefaultFQBN")
+	sketchWithPortAndFQBN := getSketchPath("SketchWithDefaultPortAndFQBN")
+
+	t.Run("NoFlags", func(t *testing.T) {
+		t.Run("NoDefaultPortNoDefaultFQBN", func(t *testing.T) {
+			_, stderr, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "--raw", sketch)
+			require.Error(t, err)
+			require.Contains(t, string(stderr), "No monitor available for the port protocol default")
+		})
+
+		t.Run("WithDefaultPort", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "--raw", sketchWithPort)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyDEF")
+			require.Contains(t, string(stdout), "Configuration rts = on")
+			require.Contains(t, string(stdout), "Configuration dtr = on")
+		})
+
+		t.Run("WithDefaultFQBN", func(t *testing.T) {
+			_, stderr, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "--raw", sketchWithFQBN)
+			require.Error(t, err)
+			require.Contains(t, string(stderr), "No monitor available for the port protocol default")
+		})
+
+		t.Run("WithDefaultPortAndQBN", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "--raw", sketchWithPortAndFQBN)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyDEF")
+			require.Contains(t, string(stdout), "Configuration rts = off")
+			require.Contains(t, string(stdout), "Configuration dtr = off")
+		})
+	})
+
+	t.Run("WithPortFlag", func(t *testing.T) {
+		t.Run("NoDefaultPortNoDefaultFQBN", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARGS", "--raw", sketch)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyARGS")
+			require.Contains(t, string(stdout), "Configuration rts = on")
+			require.Contains(t, string(stdout), "Configuration dtr = on")
+		})
+
+		t.Run("WithDefaultPort", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARGS", "--raw", sketchWithPort)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyARGS")
+			require.Contains(t, string(stdout), "Configuration rts = on")
+			require.Contains(t, string(stdout), "Configuration dtr = on")
+		})
+
+		t.Run("WithDefaultFQBN", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARGS", "--raw", sketchWithFQBN)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyARGS")
+			require.Contains(t, string(stdout), "Configuration rts = off")
+			require.Contains(t, string(stdout), "Configuration dtr = off")
+		})
+
+		t.Run("WithDefaultPortAndQBN", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARGS", "--raw", sketchWithPortAndFQBN)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyARGS")
+			require.Contains(t, string(stdout), "Configuration rts = off")
+			require.Contains(t, string(stdout), "Configuration dtr = off")
+		})
+	})
+
+	t.Run("WithFQBNFlag", func(t *testing.T) {
+		t.Run("NoDefaultPortNoDefaultFQBN", func(t *testing.T) {
+			_, stderr, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-b", "arduino:avr:uno", "--raw", sketch)
+			require.Error(t, err)
+			require.Contains(t, string(stderr), "No monitor available for the port protocol default")
+		})
+
+		t.Run("WithDefaultPort", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-b", "arduino:avr:uno", "--raw", sketchWithPort)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyDEF")
+			require.Contains(t, string(stdout), "Configuration rts = off")
+			require.Contains(t, string(stdout), "Configuration dtr = on")
+		})
+
+		t.Run("WithDefaultFQBN", func(t *testing.T) {
+			_, stderr, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-b", "arduino:avr:uno", "--raw", sketchWithFQBN)
+			require.Error(t, err)
+			require.Contains(t, string(stderr), "No monitor available for the port protocol default")
+		})
+
+		t.Run("WithDefaultPortAndQBN", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-b", "arduino:avr:uno", "--raw", sketchWithPortAndFQBN)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyDEF")
+			require.Contains(t, string(stdout), "Configuration rts = off")
+			require.Contains(t, string(stdout), "Configuration dtr = on")
+		})
+	})
+
+	t.Run("WithPortAndFQBNFlags", func(t *testing.T) {
+		t.Run("NoDefaultPortNoDefaultFQBN", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARGS", "-b", "arduino:avr:uno", "--raw", sketch)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyARGS")
+			require.Contains(t, string(stdout), "Configuration rts = off")
+			require.Contains(t, string(stdout), "Configuration dtr = on")
+		})
+
+		t.Run("WithDefaultPort", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARGS", "-b", "arduino:avr:uno", "--raw", sketchWithPort)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyARGS")
+			require.Contains(t, string(stdout), "Configuration rts = off")
+			require.Contains(t, string(stdout), "Configuration dtr = on")
+		})
+
+		t.Run("WithDefaultFQBN", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARGS", "-b", "arduino:avr:uno", "--raw", sketchWithFQBN)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyARGS")
+			require.Contains(t, string(stdout), "Configuration rts = off")
+			require.Contains(t, string(stdout), "Configuration dtr = on")
+		})
+
+		t.Run("WithDefaultPortAndQBN", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARGS", "-b", "arduino:avr:uno", "--raw", sketchWithPortAndFQBN)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyARGS")
+			require.Contains(t, string(stdout), "Configuration rts = off")
+			require.Contains(t, string(stdout), "Configuration dtr = on")
+		})
 	})
 }

--- a/internal/integrationtest/monitor/monitor_test.go
+++ b/internal/integrationtest/monitor/monitor_test.go
@@ -154,6 +154,13 @@ yun.serial.disableDTR=true
 			require.Contains(t, string(stdout), "Configuration rts = off")
 			require.Contains(t, string(stdout), "Configuration dtr = off")
 		})
+
+		t.Run("FQBNFromSpecificProfile", func(t *testing.T) {
+			// The only way to assert we're picking up the fqbn specified from the profile is to provide a wrong value
+			_, stderr, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "--raw", "--profile", "profile1", sketchWithPortAndFQBN)
+			require.Error(t, err)
+			require.Contains(t, string(stderr), "not an FQBN: broken_fqbn")
+		})
 	})
 
 	t.Run("WithPortFlag", func(t *testing.T) {
@@ -188,6 +195,13 @@ yun.serial.disableDTR=true
 			require.Contains(t, string(stdout), "Configuration rts = off")
 			require.Contains(t, string(stdout), "Configuration dtr = off")
 		})
+
+		t.Run("FQBNFromSpecificProfile", func(t *testing.T) {
+			// The only way to assert we're picking up the fqbn specified from the profile is to provide a wrong value
+			_, stderr, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARGS", "--raw", "--profile", "profile1", sketchWithPortAndFQBN)
+			require.Error(t, err)
+			require.Contains(t, string(stderr), "not an FQBN: broken_fqbn")
+		})
 	})
 
 	t.Run("WithFQBNFlag", func(t *testing.T) {
@@ -213,6 +227,14 @@ yun.serial.disableDTR=true
 
 		t.Run("WithDefaultPortAndQBN", func(t *testing.T) {
 			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-b", "arduino:avr:uno", "--raw", sketchWithPortAndFQBN)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyDEF")
+			require.Contains(t, string(stdout), "Configuration rts = off")
+			require.Contains(t, string(stdout), "Configuration dtr = on")
+		})
+
+		t.Run("IgnoreProfile", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-b", "arduino:avr:uno", "--raw", "--profile", "profile1", sketchWithPortAndFQBN)
 			require.NoError(t, err)
 			require.Contains(t, string(stdout), "Opened port: /dev/ttyDEF")
 			require.Contains(t, string(stdout), "Configuration rts = off")
@@ -247,6 +269,14 @@ yun.serial.disableDTR=true
 
 		t.Run("WithDefaultPortAndQBN", func(t *testing.T) {
 			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARGS", "-b", "arduino:avr:uno", "--raw", sketchWithPortAndFQBN)
+			require.NoError(t, err)
+			require.Contains(t, string(stdout), "Opened port: /dev/ttyARGS")
+			require.Contains(t, string(stdout), "Configuration rts = off")
+			require.Contains(t, string(stdout), "Configuration dtr = on")
+		})
+
+		t.Run("IgnoreProfile", func(t *testing.T) {
+			stdout, _, err := cli.RunWithCustomInput(quitMonitor(), "monitor", "-p", "/dev/ttyARGS", "-b", "arduino:avr:uno", "--raw", "--profile", "profile1", sketchWithPortAndFQBN)
 			require.NoError(t, err)
 			require.Contains(t, string(stdout), "Opened port: /dev/ttyARGS")
 			require.Contains(t, string(stdout), "Configuration rts = off")

--- a/internal/integrationtest/monitor/testdata/SketchWithDefaultFQBN/SketchWithDefaultFQBN.ino
+++ b/internal/integrationtest/monitor/testdata/SketchWithDefaultFQBN/SketchWithDefaultFQBN.ino
@@ -1,0 +1,3 @@
+
+void setup() {}
+void loop() {}

--- a/internal/integrationtest/monitor/testdata/SketchWithDefaultFQBN/sketch.yaml
+++ b/internal/integrationtest/monitor/testdata/SketchWithDefaultFQBN/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: arduino:avr:yun

--- a/internal/integrationtest/monitor/testdata/SketchWithDefaultPort/SketchWithDefaultPort.ino
+++ b/internal/integrationtest/monitor/testdata/SketchWithDefaultPort/SketchWithDefaultPort.ino
@@ -1,0 +1,3 @@
+
+void setup() {}
+void loop() {}

--- a/internal/integrationtest/monitor/testdata/SketchWithDefaultPort/sketch.yaml
+++ b/internal/integrationtest/monitor/testdata/SketchWithDefaultPort/sketch.yaml
@@ -1,0 +1,1 @@
+default_port: /dev/ttyDEF

--- a/internal/integrationtest/monitor/testdata/SketchWithDefaultPortAndFQBN/SketchWithDefaultPortAndFQBN.ino
+++ b/internal/integrationtest/monitor/testdata/SketchWithDefaultPortAndFQBN/SketchWithDefaultPortAndFQBN.ino
@@ -1,0 +1,3 @@
+
+void setup() {}
+void loop() {}

--- a/internal/integrationtest/monitor/testdata/SketchWithDefaultPortAndFQBN/sketch.yaml
+++ b/internal/integrationtest/monitor/testdata/SketchWithDefaultPortAndFQBN/sketch.yaml
@@ -1,0 +1,2 @@
+default_port: /dev/ttyDEF
+default_fqbn: arduino:avr:yun

--- a/internal/integrationtest/monitor/testdata/SketchWithDefaultPortAndFQBN/sketch.yaml
+++ b/internal/integrationtest/monitor/testdata/SketchWithDefaultPortAndFQBN/sketch.yaml
@@ -1,2 +1,5 @@
 default_port: /dev/ttyDEF
 default_fqbn: arduino:avr:yun
+profiles:
+  profile1:
+    fqbn: "broken_fqbn"

--- a/internal/integrationtest/monitor/testdata/SketchWithNoProfiles/SketchWithNoProfiles.ino
+++ b/internal/integrationtest/monitor/testdata/SketchWithNoProfiles/SketchWithNoProfiles.ino
@@ -1,0 +1,3 @@
+
+void setup() {}
+void loop() {}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
 Code enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
It is not possible to retrieve port address and protocol information from a sketch profile. `monitor` cannot run if `-p <port>` is not specified.
<!-- You can also link to an open issue here -->

## What is the new behavior?
Default port address and protocol can be retrieved from the sketch profile using the `-s <sketchPath>` flag. `-p <port>` and `-l <protocol>` have priority over the information stored in the profile.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
