### PR TITLE
refactor: Made `command` functions to access PackageManager unavailable from public API

### DIFF
--- a/commands/board/details.go
+++ b/commands/board/details.go
@@ -21,14 +21,14 @@ import (
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/utils"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
 // Details returns all details for a board including tools and HW identifiers.
 // This command basically gather al the information and translates it into the required grpc struct properties
 func Details(ctx context.Context, req *rpc.BoardDetailsRequest) (*rpc.BoardDetailsResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/board/details.go
+++ b/commands/board/details.go
@@ -28,7 +28,7 @@ import (
 // Details returns all details for a board including tools and HW identifiers.
 // This command basically gather al the information and translates it into the required grpc struct properties
 func Details(ctx context.Context, req *rpc.BoardDetailsRequest) (*rpc.BoardDetailsResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -31,7 +31,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/arduino/discovery"
 	"github.com/arduino/arduino-cli/arduino/httpclient"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/internal/inventory"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-properties-orderedmap"
@@ -203,7 +203,7 @@ func identify(pme *packagemanager.Explorer, port *discovery.Port) ([]*rpc.BoardL
 // In case of errors partial results from discoveries that didn't fail
 // are returned.
 func List(req *rpc.BoardListRequest) (r []*rpc.DetectedPort, discoveryStartErrors []error, e error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, nil, &arduino.InvalidInstanceError{}
 	}
@@ -258,7 +258,7 @@ func hasMatchingBoard(b *rpc.DetectedPort, fqbnFilter *cores.FQBN) bool {
 
 // Watch returns a channel that receives boards connection and disconnection events.
 func Watch(ctx context.Context, req *rpc.BoardListWatchRequest) (<-chan *rpc.BoardListWatchResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/board/list.go
+++ b/commands/board/list.go
@@ -203,7 +203,7 @@ func identify(pme *packagemanager.Explorer, port *discovery.Port) ([]*rpc.BoardL
 // In case of errors partial results from discoveries that didn't fail
 // are returned.
 func List(req *rpc.BoardListRequest) (r []*rpc.DetectedPort, discoveryStartErrors []error, e error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, nil, &arduino.InvalidInstanceError{}
 	}
@@ -258,7 +258,7 @@ func hasMatchingBoard(b *rpc.DetectedPort, fqbnFilter *cores.FQBN) bool {
 
 // Watch returns a channel that receives boards connection and disconnection events.
 func Watch(ctx context.Context, req *rpc.BoardListWatchRequest) (<-chan *rpc.BoardListWatchResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/board/listall.go
+++ b/commands/board/listall.go
@@ -29,7 +29,7 @@ import (
 
 // ListAll FIXMEDOC
 func ListAll(ctx context.Context, req *rpc.BoardListAllRequest) (*rpc.BoardListAllResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/board/listall.go
+++ b/commands/board/listall.go
@@ -23,13 +23,13 @@ import (
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/utils"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
 // ListAll FIXMEDOC
 func ListAll(ctx context.Context, req *rpc.BoardListAllRequest) (*rpc.BoardListAllResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/board/search.go
+++ b/commands/board/search.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/utils"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
@@ -31,7 +31,7 @@ import (
 // installed. Note that platforms that are not installed don't include boards' FQBNs.
 // If no search argument is used all boards are returned.
 func Search(ctx context.Context, req *rpc.BoardSearchRequest) (*rpc.BoardSearchResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/board/search.go
+++ b/commands/board/search.go
@@ -31,7 +31,7 @@ import (
 // installed. Note that platforms that are not installed don't include boards' FQBNs.
 // If no search argument is used all boards are returned.
 func Search(ctx context.Context, req *rpc.BoardSearchRequest) (*rpc.BoardSearchResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -30,7 +30,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/sketch"
 	"github.com/arduino/arduino-cli/arduino/utils"
 	"github.com/arduino/arduino-cli/buildcache"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/configuration"
 	"github.com/arduino/arduino-cli/i18n"
 	"github.com/arduino/arduino-cli/internal/inventory"
@@ -57,13 +57,13 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 		exportBinaries = reqExportBinaries.Value
 	}
 
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}
 	defer release()
 
-	lm := commands.GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -57,13 +57,13 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 		exportBinaries = reqExportBinaries.Value
 	}
 
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}
 	defer release()
 
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/core/download.go
+++ b/commands/core/download.go
@@ -21,6 +21,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/i18n"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
@@ -29,7 +30,7 @@ var tr = i18n.Tr
 
 // PlatformDownload FIXMEDOC
 func PlatformDownload(ctx context.Context, req *rpc.PlatformDownloadRequest, downloadCB rpc.DownloadProgressCB) (*rpc.PlatformDownloadResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/core/download.go
+++ b/commands/core/download.go
@@ -29,7 +29,7 @@ var tr = i18n.Tr
 
 // PlatformDownload FIXMEDOC
 func PlatformDownload(ctx context.Context, req *rpc.PlatformDownloadRequest, downloadCB rpc.DownloadProgressCB) (*rpc.PlatformDownloadResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/core/install.go
+++ b/commands/core/install.go
@@ -28,7 +28,7 @@ import (
 // PlatformInstall FIXMEDOC
 func PlatformInstall(ctx context.Context, req *rpc.PlatformInstallRequest, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) (*rpc.PlatformInstallResponse, error) {
 	install := func() error {
-		pme, release := commands.GetPackageManagerExplorer(req)
+		pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 		if pme == nil {
 			return &arduino.InvalidInstanceError{}
 		}

--- a/commands/core/install.go
+++ b/commands/core/install.go
@@ -22,13 +22,14 @@ import (
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
 // PlatformInstall FIXMEDOC
 func PlatformInstall(ctx context.Context, req *rpc.PlatformInstallRequest, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) (*rpc.PlatformInstallResponse, error) {
 	install := func() error {
-		pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+		pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 		if pme == nil {
 			return &arduino.InvalidInstanceError{}
 		}

--- a/commands/core/list.go
+++ b/commands/core/list.go
@@ -28,7 +28,7 @@ import (
 // PlatformList returns a list of installed platforms, optionally filtered by
 // those requiring an update.
 func PlatformList(req *rpc.PlatformListRequest) (*rpc.PlatformListResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/core/list.go
+++ b/commands/core/list.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
 // PlatformList returns a list of installed platforms, optionally filtered by
 // those requiring an update.
 func PlatformList(req *rpc.PlatformListRequest) (*rpc.PlatformListResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/core/search.go
+++ b/commands/core/search.go
@@ -29,7 +29,7 @@ import (
 
 // PlatformSearch FIXMEDOC
 func PlatformSearch(req *rpc.PlatformSearchRequest) (*rpc.PlatformSearchResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/core/search.go
+++ b/commands/core/search.go
@@ -24,12 +24,13 @@ import (
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/utils"
 	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
 // PlatformSearch FIXMEDOC
 func PlatformSearch(req *rpc.PlatformSearchRequest) (*rpc.PlatformSearchResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/core/uninstall.go
+++ b/commands/core/uninstall.go
@@ -21,6 +21,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
@@ -37,7 +38,7 @@ func PlatformUninstall(ctx context.Context, req *rpc.PlatformUninstallRequest, t
 
 // platformUninstall is the implementation of platform unistaller
 func platformUninstall(ctx context.Context, req *rpc.PlatformUninstallRequest, taskCB rpc.TaskProgressCB) error {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return &arduino.InvalidInstanceError{}
 	}

--- a/commands/core/uninstall.go
+++ b/commands/core/uninstall.go
@@ -37,7 +37,7 @@ func PlatformUninstall(ctx context.Context, req *rpc.PlatformUninstallRequest, t
 
 // platformUninstall is the implementation of platform unistaller
 func platformUninstall(ctx context.Context, req *rpc.PlatformUninstallRequest, taskCB rpc.TaskProgressCB) error {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return &arduino.InvalidInstanceError{}
 	}

--- a/commands/core/upgrade.go
+++ b/commands/core/upgrade.go
@@ -18,18 +18,18 @@ package core
 import (
 	"context"
 
-	"github.com/arduino/arduino-cli/arduino/cores"
-
 	"github.com/arduino/arduino-cli/arduino"
+	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
 // PlatformUpgrade FIXMEDOC
 func PlatformUpgrade(ctx context.Context, req *rpc.PlatformUpgradeRequest, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) (*rpc.PlatformUpgradeResponse, error) {
 	upgrade := func() (*cores.PlatformRelease, error) {
-		pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+		pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 		if pme == nil {
 			return nil, &arduino.InvalidInstanceError{}
 		}

--- a/commands/core/upgrade.go
+++ b/commands/core/upgrade.go
@@ -29,7 +29,7 @@ import (
 // PlatformUpgrade FIXMEDOC
 func PlatformUpgrade(ctx context.Context, req *rpc.PlatformUpgradeRequest, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) (*rpc.PlatformUpgradeResponse, error) {
 	upgrade := func() (*cores.PlatformRelease, error) {
-		pme, release := commands.GetPackageManagerExplorer(req)
+		pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 		if pme == nil {
 			return nil, &arduino.InvalidInstanceError{}
 		}

--- a/commands/debug/debug.go
+++ b/commands/debug/debug.go
@@ -45,7 +45,7 @@ var tr = i18n.Tr
 func Debug(ctx context.Context, req *rpc.GetDebugConfigRequest, inStream io.Reader, out io.Writer, interrupt <-chan os.Signal) (*rpc.DebugResponse, error) {
 
 	// Get debugging command line to run debugger
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/debug/debug.go
+++ b/commands/debug/debug.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/executils"
 	"github.com/arduino/arduino-cli/i18n"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
@@ -45,7 +45,7 @@ var tr = i18n.Tr
 func Debug(ctx context.Context, req *rpc.GetDebugConfigRequest, inStream io.Reader, out io.Writer, interrupt <-chan os.Signal) (*rpc.DebugResponse, error) {
 
 	// Get debugging command line to run debugger
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/debug/debug_info.go
+++ b/commands/debug/debug_info.go
@@ -25,7 +25,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/arduino/sketch"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
@@ -35,7 +35,7 @@ import (
 
 // GetDebugConfig returns metadata to start debugging with the specified board
 func GetDebugConfig(ctx context.Context, req *rpc.GetDebugConfigRequest) (*rpc.GetDebugConfigResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/debug/debug_info.go
+++ b/commands/debug/debug_info.go
@@ -35,7 +35,7 @@ import (
 
 // GetDebugConfig returns metadata to start debugging with the specified board
 func GetDebugConfig(ctx context.Context, req *rpc.GetDebugConfigRequest) (*rpc.GetDebugConfigResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -102,8 +102,8 @@ func (c *coreInstancesContainer) RemoveID(id int32) bool {
 // GetPackageManager returns a PackageManager. If the package manager is not found
 // (because the instance is invalid or has been destroyed), nil is returned.
 // Deprecated: use GetPackageManagerExplorer instead.
-func GetPackageManager(instance rpc.InstanceCommand) *packagemanager.PackageManager {
-	i := instances.GetInstance(instance.GetInstance().GetId())
+func GetPackageManager(instance *rpc.Instance) *packagemanager.PackageManager {
+	i := instances.GetInstance(instance.GetId())
 	if i == nil {
 		return nil
 	}
@@ -113,7 +113,7 @@ func GetPackageManager(instance rpc.InstanceCommand) *packagemanager.PackageMana
 // GetPackageManagerExplorer returns a new package manager Explorer. The
 // explorer holds a read lock on the underlying PackageManager and it should
 // be released by calling the returned "release" function.
-func GetPackageManagerExplorer(req rpc.InstanceCommand) (explorer *packagemanager.Explorer, release func()) {
+func GetPackageManagerExplorer(req *rpc.Instance) (explorer *packagemanager.Explorer, release func()) {
 	pm := GetPackageManager(req)
 	if pm == nil {
 		return nil, nil
@@ -122,8 +122,8 @@ func GetPackageManagerExplorer(req rpc.InstanceCommand) (explorer *packagemanage
 }
 
 // GetLibraryManager returns the library manager for the given instance.
-func GetLibraryManager(req rpc.InstanceCommand) *librariesmanager.LibrariesManager {
-	i := instances.GetInstance(req.GetInstance().GetId())
+func GetLibraryManager(req *rpc.Instance) *librariesmanager.LibrariesManager {
+	i := instances.GetInstance(req.GetId())
 	if i == nil {
 		return nil
 	}
@@ -494,7 +494,7 @@ func Destroy(ctx context.Context, req *rpc.DestroyRequest) (*rpc.DestroyResponse
 // UpdateLibrariesIndex updates the library_index.json
 func UpdateLibrariesIndex(ctx context.Context, req *rpc.UpdateLibrariesIndexRequest, downloadCB rpc.DownloadProgressCB) error {
 	logrus.Info("Updating libraries index")
-	lm := GetLibraryManager(req)
+	lm := GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return &arduino.InvalidInstanceError{}
 	}

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/cores"
@@ -34,10 +33,10 @@ import (
 	"github.com/arduino/arduino-cli/arduino/resources"
 	"github.com/arduino/arduino-cli/arduino/sketch"
 	"github.com/arduino/arduino-cli/arduino/utils"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/configuration"
 	"github.com/arduino/arduino-cli/i18n"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
-	"github.com/arduino/arduino-cli/version"
 	paths "github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
@@ -45,90 +44,6 @@ import (
 )
 
 var tr = i18n.Tr
-
-// CoreInstance is an instance of the Arduino Core Services. The user can
-// instantiate as many as needed by providing a different configuration
-// for each one.
-type CoreInstance struct {
-	pm *packagemanager.PackageManager
-	lm *librariesmanager.LibrariesManager
-}
-
-// coreInstancesContainer has methods to add an remove instances atomically.
-type coreInstancesContainer struct {
-	instances      map[int32]*CoreInstance
-	instancesCount int32
-	instancesMux   sync.Mutex
-}
-
-// instances contains all the running Arduino Core Services instances
-var instances = &coreInstancesContainer{
-	instances:      map[int32]*CoreInstance{},
-	instancesCount: 1,
-}
-
-// GetInstance returns a CoreInstance for the given ID, or nil if ID
-// doesn't exist
-func (c *coreInstancesContainer) GetInstance(id int32) *CoreInstance {
-	c.instancesMux.Lock()
-	defer c.instancesMux.Unlock()
-	return c.instances[id]
-}
-
-// AddAndAssignID saves the CoreInstance and assigns a unique ID to
-// retrieve it later
-func (c *coreInstancesContainer) AddAndAssignID(i *CoreInstance) int32 {
-	c.instancesMux.Lock()
-	defer c.instancesMux.Unlock()
-	id := c.instancesCount
-	c.instances[id] = i
-	c.instancesCount++
-	return id
-}
-
-// RemoveID removes the CoreInstance referenced by id. Returns true
-// if the operation is successful, or false if the CoreInstance does
-// not exist
-func (c *coreInstancesContainer) RemoveID(id int32) bool {
-	c.instancesMux.Lock()
-	defer c.instancesMux.Unlock()
-	if _, ok := c.instances[id]; !ok {
-		return false
-	}
-	delete(c.instances, id)
-	return true
-}
-
-// GetPackageManager returns a PackageManager. If the package manager is not found
-// (because the instance is invalid or has been destroyed), nil is returned.
-// Deprecated: use GetPackageManagerExplorer instead.
-func GetPackageManager(instance *rpc.Instance) *packagemanager.PackageManager {
-	i := instances.GetInstance(instance.GetId())
-	if i == nil {
-		return nil
-	}
-	return i.pm
-}
-
-// GetPackageManagerExplorer returns a new package manager Explorer. The
-// explorer holds a read lock on the underlying PackageManager and it should
-// be released by calling the returned "release" function.
-func GetPackageManagerExplorer(req *rpc.Instance) (explorer *packagemanager.Explorer, release func()) {
-	pm := GetPackageManager(req)
-	if pm == nil {
-		return nil, nil
-	}
-	return pm.NewExplorer()
-}
-
-// GetLibraryManager returns the library manager for the given instance.
-func GetLibraryManager(req *rpc.Instance) *librariesmanager.LibrariesManager {
-	i := instances.GetInstance(req.GetId())
-	if i == nil {
-		return nil
-	}
-	return i.lm
-}
 
 func installTool(pm *packagemanager.PackageManager, tool *cores.ToolRelease, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) error {
 	pme, release := pm.NewExplorer()
@@ -146,50 +61,11 @@ func installTool(pm *packagemanager.PackageManager, tool *cores.ToolRelease, dow
 
 // Create a new CoreInstance ready to be initialized, supporting directories are also created.
 func Create(req *rpc.CreateRequest, extraUserAgent ...string) (*rpc.CreateResponse, error) {
-	instance := &CoreInstance{}
-
-	// Setup downloads directory
-	downloadsDir := configuration.DownloadsDir(configuration.Settings)
-	if downloadsDir.NotExist() {
-		err := downloadsDir.MkdirAll()
-		if err != nil {
-			return nil, &arduino.PermissionDeniedError{Message: tr("Failed to create downloads directory"), Cause: err}
-		}
+	inst, err := instances.Create(extraUserAgent...)
+	if err != nil {
+		return nil, err
 	}
-
-	// Setup data directory
-	dataDir := configuration.DataDir(configuration.Settings)
-	packagesDir := configuration.PackagesDir(configuration.Settings)
-	if packagesDir.NotExist() {
-		err := packagesDir.MkdirAll()
-		if err != nil {
-			return nil, &arduino.PermissionDeniedError{Message: tr("Failed to create data directory"), Cause: err}
-		}
-	}
-
-	// Create package manager
-	userAgent := "arduino-cli/" + version.VersionInfo.VersionString
-	for _, ua := range extraUserAgent {
-		userAgent += " " + ua
-	}
-	instance.pm = packagemanager.NewBuilder(
-		dataDir,
-		configuration.PackagesDir(configuration.Settings),
-		downloadsDir,
-		dataDir.Join("tmp"),
-		userAgent,
-	).Build()
-	instance.lm = librariesmanager.NewLibraryManager(
-		dataDir,
-		downloadsDir,
-	)
-
-	// Save instance
-	instanceID := instances.AddAndAssignID(instance)
-
-	return &rpc.CreateResponse{
-		Instance: &rpc.Instance{Id: instanceID},
-	}, nil
+	return &rpc.CreateResponse{Instance: inst}, nil
 }
 
 // Init loads installed libraries and Platforms in CoreInstance with specified ID,
@@ -205,8 +81,8 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 	if reqInst == nil {
 		return &arduino.InvalidInstanceError{}
 	}
-	instance := instances.GetInstance(reqInst.GetId())
-	if instance == nil {
+	instance := req.GetInstance()
+	if !instances.IsValid(instance) {
 		return &arduino.InvalidInstanceError{}
 	}
 
@@ -295,7 +171,7 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 		// after reinitializing an instance after installing or uninstalling a core.
 		// If this is not done the information of the uninstall core is kept in memory,
 		// even if it should not.
-		pmb, commitPackageManager := instance.pm.NewBuilder()
+		pmb, commitPackageManager := instances.GetPackageManager(instance).NewBuilder()
 
 		// Load packages index
 		for _, URL := range allPackageIndexUrls {
@@ -390,7 +266,7 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 		commitPackageManager()
 	}
 
-	pme, release := instance.pm.NewExplorer()
+	pme, release := instances.GetPackageManagerExplorer(instance)
 	defer release()
 
 	for _, err := range pme.LoadDiscoveries() {
@@ -403,7 +279,7 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 		pme.IndexDir,
 		pme.DownloadDir,
 	)
-	instance.lm = lm
+	_ = instances.SetLibraryManager(instance, lm) // should never fail
 
 	// Load libraries
 	for _, pack := range pme.GetPackages() {
@@ -485,7 +361,7 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 
 // Destroy FIXMEDOC
 func Destroy(ctx context.Context, req *rpc.DestroyRequest) (*rpc.DestroyResponse, error) {
-	if ok := instances.RemoveID(req.GetInstance().GetId()); !ok {
+	if ok := instances.Delete(req.GetInstance()); !ok {
 		return nil, &arduino.InvalidInstanceError{}
 	}
 	return &rpc.DestroyResponse{}, nil
@@ -494,7 +370,7 @@ func Destroy(ctx context.Context, req *rpc.DestroyRequest) (*rpc.DestroyResponse
 // UpdateLibrariesIndex updates the library_index.json
 func UpdateLibrariesIndex(ctx context.Context, req *rpc.UpdateLibrariesIndexRequest, downloadCB rpc.DownloadProgressCB) error {
 	logrus.Info("Updating libraries index")
-	lm := GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return &arduino.InvalidInstanceError{}
 	}
@@ -523,7 +399,7 @@ func UpdateLibrariesIndex(ctx context.Context, req *rpc.UpdateLibrariesIndexRequ
 
 // UpdateIndex FIXMEDOC
 func UpdateIndex(ctx context.Context, req *rpc.UpdateIndexRequest, downloadCB rpc.DownloadProgressCB) error {
-	if instances.GetInstance(req.GetInstance().GetId()) == nil {
+	if !instances.IsValid(req.GetInstance()) {
 		return &arduino.InvalidInstanceError{}
 	}
 

--- a/commands/internal/instances/instances.go
+++ b/commands/internal/instances/instances.go
@@ -1,0 +1,170 @@
+package instances
+
+import (
+	"sync"
+
+	"github.com/arduino/arduino-cli/arduino"
+	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
+	"github.com/arduino/arduino-cli/arduino/libraries/librariesmanager"
+	"github.com/arduino/arduino-cli/configuration"
+	"github.com/arduino/arduino-cli/i18n"
+	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
+	"github.com/arduino/arduino-cli/version"
+)
+
+var tr = i18n.Tr
+
+// CoreInstance is an instance of the Arduino Core Services. The user can
+// instantiate as many as needed by providing a different configuration
+// for each one.
+type CoreInstance struct {
+	pm *packagemanager.PackageManager
+	lm *librariesmanager.LibrariesManager
+}
+
+// coreInstancesContainer has methods to add an remove instances atomically.
+type coreInstancesContainer struct {
+	instances      map[int32]*CoreInstance
+	instancesCount int32
+	instancesMux   sync.Mutex
+}
+
+// instances contains all the running Arduino Core Services instances
+var instances = &coreInstancesContainer{
+	instances:      map[int32]*CoreInstance{},
+	instancesCount: 1,
+}
+
+// GetInstance returns a CoreInstance for the given ID, or nil if ID
+// doesn't exist
+func (c *coreInstancesContainer) GetInstance(id int32) *CoreInstance {
+	c.instancesMux.Lock()
+	defer c.instancesMux.Unlock()
+	return c.instances[id]
+}
+
+// AddAndAssignID saves the CoreInstance and assigns a unique ID to
+// retrieve it later
+func (c *coreInstancesContainer) AddAndAssignID(i *CoreInstance) int32 {
+	c.instancesMux.Lock()
+	defer c.instancesMux.Unlock()
+	id := c.instancesCount
+	c.instances[id] = i
+	c.instancesCount++
+	return id
+}
+
+// RemoveID removes the CoreInstance referenced by id. Returns true
+// if the operation is successful, or false if the CoreInstance does
+// not exist
+func (c *coreInstancesContainer) RemoveID(id int32) bool {
+	c.instancesMux.Lock()
+	defer c.instancesMux.Unlock()
+	if _, ok := c.instances[id]; !ok {
+		return false
+	}
+	delete(c.instances, id)
+	return true
+}
+
+// GetPackageManager returns a PackageManager. If the package manager is not found
+// (because the instance is invalid or has been destroyed), nil is returned.
+// Deprecated: use GetPackageManagerExplorer instead.
+func GetPackageManager(instance *rpc.Instance) *packagemanager.PackageManager {
+	i := instances.GetInstance(instance.GetId())
+	if i == nil {
+		return nil
+	}
+	return i.pm
+}
+
+// GetPackageManagerExplorer returns a new package manager Explorer. The
+// explorer holds a read lock on the underlying PackageManager and it should
+// be released by calling the returned "release" function.
+func GetPackageManagerExplorer(req *rpc.Instance) (explorer *packagemanager.Explorer, release func()) {
+	pm := GetPackageManager(req)
+	if pm == nil {
+		return nil, nil
+	}
+	return pm.NewExplorer()
+}
+
+// GetLibraryManager returns the library manager for the given instance.
+func GetLibraryManager(req *rpc.Instance) *librariesmanager.LibrariesManager {
+	i := instances.GetInstance(req.GetId())
+	if i == nil {
+		return nil
+	}
+	return i.lm
+}
+
+// SetLibraryManager sets the library manager for the given instance.
+func SetLibraryManager(inst *rpc.Instance, lm *librariesmanager.LibrariesManager) bool {
+	coreInstance := instances.GetInstance(inst.GetId())
+	if coreInstance == nil {
+		return false
+	}
+	coreInstance.lm = lm
+	return true
+}
+
+// Create a new *rpc.Instance ready to be initialized, supporting directories are also created.
+func Create(extraUserAgent ...string) (*rpc.Instance, error) {
+	instance := &CoreInstance{}
+
+	// Setup downloads directory
+	downloadsDir := configuration.DownloadsDir(configuration.Settings)
+	if downloadsDir.NotExist() {
+		err := downloadsDir.MkdirAll()
+		if err != nil {
+			return nil, &arduino.PermissionDeniedError{Message: tr("Failed to create downloads directory"), Cause: err}
+		}
+	}
+
+	// Setup data directory
+	dataDir := configuration.DataDir(configuration.Settings)
+	packagesDir := configuration.PackagesDir(configuration.Settings)
+	if packagesDir.NotExist() {
+		err := packagesDir.MkdirAll()
+		if err != nil {
+			return nil, &arduino.PermissionDeniedError{Message: tr("Failed to create data directory"), Cause: err}
+		}
+	}
+
+	// Create package manager
+	userAgent := "arduino-cli/" + version.VersionInfo.VersionString
+	for _, ua := range extraUserAgent {
+		userAgent += " " + ua
+	}
+	instance.pm = packagemanager.NewBuilder(
+		dataDir,
+		configuration.PackagesDir(configuration.Settings),
+		downloadsDir,
+		dataDir.Join("tmp"),
+		userAgent,
+	).Build()
+	instance.lm = librariesmanager.NewLibraryManager(
+		dataDir,
+		downloadsDir,
+	)
+
+	// Save instance
+	instanceID := instances.AddAndAssignID(instance)
+	return &rpc.Instance{Id: instanceID}, nil
+}
+
+// IsValid returns true if the given instance is valid.
+func IsValid(inst *rpc.Instance) bool {
+	if inst == nil {
+		return false
+	}
+	return instances.GetInstance(inst.GetId()) != nil
+}
+
+// Delete removes an instance.
+func Delete(inst *rpc.Instance) bool {
+	if inst == nil {
+		return false
+	}
+	return instances.RemoveID(inst.GetId())
+}

--- a/commands/internal/instances/instances.go
+++ b/commands/internal/instances/instances.go
@@ -14,30 +14,30 @@ import (
 
 var tr = i18n.Tr
 
-// CoreInstance is an instance of the Arduino Core Services. The user can
+// coreInstance is an instance of the Arduino Core Services. The user can
 // instantiate as many as needed by providing a different configuration
 // for each one.
-type CoreInstance struct {
+type coreInstance struct {
 	pm *packagemanager.PackageManager
 	lm *librariesmanager.LibrariesManager
 }
 
 // coreInstancesContainer has methods to add an remove instances atomically.
 type coreInstancesContainer struct {
-	instances      map[int32]*CoreInstance
+	instances      map[int32]*coreInstance
 	instancesCount int32
 	instancesMux   sync.Mutex
 }
 
 // instances contains all the running Arduino Core Services instances
 var instances = &coreInstancesContainer{
-	instances:      map[int32]*CoreInstance{},
+	instances:      map[int32]*coreInstance{},
 	instancesCount: 1,
 }
 
 // GetInstance returns a CoreInstance for the given ID, or nil if ID
 // doesn't exist
-func (c *coreInstancesContainer) GetInstance(id int32) *CoreInstance {
+func (c *coreInstancesContainer) GetInstance(id int32) *coreInstance {
 	c.instancesMux.Lock()
 	defer c.instancesMux.Unlock()
 	return c.instances[id]
@@ -45,7 +45,7 @@ func (c *coreInstancesContainer) GetInstance(id int32) *CoreInstance {
 
 // AddAndAssignID saves the CoreInstance and assigns a unique ID to
 // retrieve it later
-func (c *coreInstancesContainer) AddAndAssignID(i *CoreInstance) int32 {
+func (c *coreInstancesContainer) AddAndAssignID(i *coreInstance) int32 {
 	c.instancesMux.Lock()
 	defer c.instancesMux.Unlock()
 	id := c.instancesCount
@@ -110,7 +110,7 @@ func SetLibraryManager(inst *rpc.Instance, lm *librariesmanager.LibrariesManager
 
 // Create a new *rpc.Instance ready to be initialized, supporting directories are also created.
 func Create(extraUserAgent ...string) (*rpc.Instance, error) {
-	instance := &CoreInstance{}
+	instance := &coreInstance{}
 
 	// Setup downloads directory
 	downloadsDir := configuration.DownloadsDir(configuration.Settings)

--- a/commands/lib/download.go
+++ b/commands/lib/download.go
@@ -22,7 +22,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/httpclient"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesindex"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesmanager"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/i18n"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/sirupsen/logrus"
@@ -35,7 +35,7 @@ var tr = i18n.Tr
 func LibraryDownload(ctx context.Context, req *rpc.LibraryDownloadRequest, downloadCB rpc.DownloadProgressCB) (*rpc.LibraryDownloadResponse, error) {
 	logrus.Info("Executing `arduino-cli lib download`")
 
-	lm := commands.GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/lib/download.go
+++ b/commands/lib/download.go
@@ -35,7 +35,7 @@ var tr = i18n.Tr
 func LibraryDownload(ctx context.Context, req *rpc.LibraryDownloadRequest, downloadCB rpc.DownloadProgressCB) (*rpc.LibraryDownloadResponse, error) {
 	logrus.Info("Executing `arduino-cli lib download`")
 
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/lib/install.go
+++ b/commands/lib/install.go
@@ -32,7 +32,7 @@ import (
 
 // LibraryInstall resolves the library dependencies, then downloads and installs the libraries into the install location.
 func LibraryInstall(ctx context.Context, req *rpc.LibraryInstallRequest, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return &arduino.InvalidInstanceError{}
 	}
@@ -143,7 +143,7 @@ func installLibrary(lm *librariesmanager.LibrariesManager, libRelease *libraries
 
 // ZipLibraryInstall FIXMEDOC
 func ZipLibraryInstall(ctx context.Context, req *rpc.ZipLibraryInstallRequest, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance())
 	if err := lm.InstallZipLib(ctx, paths.New(req.Path), req.Overwrite); err != nil {
 		return &arduino.FailedLibraryInstallError{Cause: err}
 	}
@@ -153,7 +153,7 @@ func ZipLibraryInstall(ctx context.Context, req *rpc.ZipLibraryInstallRequest, t
 
 // GitLibraryInstall FIXMEDOC
 func GitLibraryInstall(ctx context.Context, req *rpc.GitLibraryInstallRequest, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance())
 	if err := lm.InstallGitLib(req.Url, req.Overwrite); err != nil {
 		return &arduino.FailedLibraryInstallError{Cause: err}
 	}

--- a/commands/lib/install.go
+++ b/commands/lib/install.go
@@ -25,6 +25,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesindex"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesmanager"
 	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
@@ -32,7 +33,7 @@ import (
 
 // LibraryInstall resolves the library dependencies, then downloads and installs the libraries into the install location.
 func LibraryInstall(ctx context.Context, req *rpc.LibraryInstallRequest, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return &arduino.InvalidInstanceError{}
 	}
@@ -143,7 +144,7 @@ func installLibrary(lm *librariesmanager.LibrariesManager, libRelease *libraries
 
 // ZipLibraryInstall FIXMEDOC
 func ZipLibraryInstall(ctx context.Context, req *rpc.ZipLibraryInstallRequest, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	if err := lm.InstallZipLib(ctx, paths.New(req.Path), req.Overwrite); err != nil {
 		return &arduino.FailedLibraryInstallError{Cause: err}
 	}
@@ -153,7 +154,7 @@ func ZipLibraryInstall(ctx context.Context, req *rpc.ZipLibraryInstallRequest, t
 
 // GitLibraryInstall FIXMEDOC
 func GitLibraryInstall(ctx context.Context, req *rpc.GitLibraryInstallRequest, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	if err := lm.InstallGitLib(req.Url, req.Overwrite); err != nil {
 		return &arduino.FailedLibraryInstallError{Cause: err}
 	}

--- a/commands/lib/list.go
+++ b/commands/lib/list.go
@@ -36,13 +36,13 @@ type installedLib struct {
 
 // LibraryList FIXMEDOC
 func LibraryList(ctx context.Context, req *rpc.LibraryListRequest) (*rpc.LibraryListResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}
 	defer release()
 
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/lib/list.go
+++ b/commands/lib/list.go
@@ -25,7 +25,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesindex"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesmanager"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesresolver"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
@@ -36,13 +36,13 @@ type installedLib struct {
 
 // LibraryList FIXMEDOC
 func LibraryList(ctx context.Context, req *rpc.LibraryListRequest) (*rpc.LibraryListResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}
 	defer release()
 
-	lm := commands.GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/lib/resolve_deps.go
+++ b/commands/lib/resolve_deps.go
@@ -22,13 +22,13 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/libraries"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
 // LibraryResolveDependencies FIXMEDOC
 func LibraryResolveDependencies(ctx context.Context, req *rpc.LibraryResolveDependenciesRequest) (*rpc.LibraryResolveDependenciesResponse, error) {
-	lm := commands.GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/lib/resolve_deps.go
+++ b/commands/lib/resolve_deps.go
@@ -28,7 +28,7 @@ import (
 
 // LibraryResolveDependencies FIXMEDOC
 func LibraryResolveDependencies(ctx context.Context, req *rpc.LibraryResolveDependenciesRequest) (*rpc.LibraryResolveDependenciesResponse, error) {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/lib/search.go
+++ b/commands/lib/search.go
@@ -24,14 +24,14 @@ import (
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesindex"
 	"github.com/arduino/arduino-cli/arduino/libraries/librariesmanager"
 	"github.com/arduino/arduino-cli/arduino/utils"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	semver "go.bug.st/relaxed-semver"
 )
 
 // LibrarySearch FIXMEDOC
 func LibrarySearch(ctx context.Context, req *rpc.LibrarySearchRequest) (*rpc.LibrarySearchResponse, error) {
-	lm := commands.GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/lib/search.go
+++ b/commands/lib/search.go
@@ -31,7 +31,7 @@ import (
 
 // LibrarySearch FIXMEDOC
 func LibrarySearch(ctx context.Context, req *rpc.LibrarySearchRequest) (*rpc.LibrarySearchResponse, error) {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/lib/uninstall.go
+++ b/commands/lib/uninstall.go
@@ -20,14 +20,14 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/libraries"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-paths-helper"
 )
 
 // LibraryUninstall FIXMEDOC
 func LibraryUninstall(ctx context.Context, req *rpc.LibraryUninstallRequest, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	ref, err := createLibIndexReference(lm, req)
 	if err != nil {
 		return &arduino.InvalidLibraryError{Cause: err}

--- a/commands/lib/uninstall.go
+++ b/commands/lib/uninstall.go
@@ -27,7 +27,7 @@ import (
 
 // LibraryUninstall FIXMEDOC
 func LibraryUninstall(ctx context.Context, req *rpc.LibraryUninstallRequest, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance())
 	ref, err := createLibIndexReference(lm, req)
 	if err != nil {
 		return &arduino.InvalidLibraryError{Cause: err}

--- a/commands/lib/upgrade.go
+++ b/commands/lib/upgrade.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
 // LibraryUpgradeAll upgrades all the available libraries
 func LibraryUpgradeAll(req *rpc.LibraryUpgradeAllRequest, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return &arduino.InvalidInstanceError{}
 	}
@@ -43,7 +44,7 @@ func LibraryUpgradeAll(req *rpc.LibraryUpgradeAllRequest, downloadCB rpc.Downloa
 
 // LibraryUpgrade upgrades a library
 func LibraryUpgrade(ctx context.Context, req *rpc.LibraryUpgradeRequest, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req.GetInstance())
+	lm := instances.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return &arduino.InvalidInstanceError{}
 	}

--- a/commands/lib/upgrade.go
+++ b/commands/lib/upgrade.go
@@ -25,7 +25,7 @@ import (
 
 // LibraryUpgradeAll upgrades all the available libraries
 func LibraryUpgradeAll(req *rpc.LibraryUpgradeAllRequest, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return &arduino.InvalidInstanceError{}
 	}
@@ -43,7 +43,7 @@ func LibraryUpgradeAll(req *rpc.LibraryUpgradeAllRequest, downloadCB rpc.Downloa
 
 // LibraryUpgrade upgrades a library
 func LibraryUpgrade(ctx context.Context, req *rpc.LibraryUpgradeRequest, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB) error {
-	lm := commands.GetLibraryManager(req)
+	lm := commands.GetLibraryManager(req.GetInstance())
 	if lm == nil {
 		return &arduino.InvalidInstanceError{}
 	}

--- a/commands/monitor/monitor.go
+++ b/commands/monitor/monitor.go
@@ -24,7 +24,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/cores"
 	"github.com/arduino/arduino-cli/arduino/cores/packagemanager"
 	pluggableMonitor "github.com/arduino/arduino-cli/arduino/monitor"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/i18n"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-properties-orderedmap"
@@ -61,7 +61,7 @@ func (p *PortProxy) Close() error {
 // Monitor opens a communication port. It returns a PortProxy to communicate with the port and a PortDescriptor
 // that describes the available configuration settings.
 func Monitor(ctx context.Context, req *rpc.MonitorRequest) (*PortProxy, *pluggableMonitor.PortDescriptor, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/monitor/monitor.go
+++ b/commands/monitor/monitor.go
@@ -61,7 +61,7 @@ func (p *PortProxy) Close() error {
 // Monitor opens a communication port. It returns a PortProxy to communicate with the port and a PortDescriptor
 // that describes the available configuration settings.
 func Monitor(ctx context.Context, req *rpc.MonitorRequest) (*PortProxy, *pluggableMonitor.PortDescriptor, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/monitor/settings.go
+++ b/commands/monitor/settings.go
@@ -20,13 +20,13 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino"
 	pluggableMonitor "github.com/arduino/arduino-cli/arduino/monitor"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
 // EnumerateMonitorPortSettings returns a description of the configuration settings of a monitor port
 func EnumerateMonitorPortSettings(ctx context.Context, req *rpc.EnumerateMonitorPortSettingsRequest) (*rpc.EnumerateMonitorPortSettingsResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/monitor/settings.go
+++ b/commands/monitor/settings.go
@@ -26,7 +26,7 @@ import (
 
 // EnumerateMonitorPortSettings returns a description of the configuration settings of a monitor port
 func EnumerateMonitorPortSettings(ctx context.Context, req *rpc.EnumerateMonitorPortSettingsRequest) (*rpc.EnumerateMonitorPortSettingsResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/upload/burnbootloader.go
+++ b/commands/upload/burnbootloader.go
@@ -33,7 +33,7 @@ func BurnBootloader(ctx context.Context, req *rpc.BurnBootloaderRequest, outStre
 		WithField("programmer", req.GetProgrammer()).
 		Trace("BurnBootloader started", req.GetFqbn())
 
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/upload/burnbootloader.go
+++ b/commands/upload/burnbootloader.go
@@ -20,7 +20,7 @@ import (
 	"io"
 
 	"github.com/arduino/arduino-cli/arduino"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -33,7 +33,7 @@ func BurnBootloader(ctx context.Context, req *rpc.BurnBootloaderRequest, outStre
 		WithField("programmer", req.GetProgrammer()).
 		Trace("BurnBootloader started", req.GetFqbn())
 
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/upload/programmers_list.go
+++ b/commands/upload/programmers_list.go
@@ -20,13 +20,13 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/arduino/cores"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
 // ListProgrammersAvailableForUpload FIXMEDOC
 func ListProgrammersAvailableForUpload(ctx context.Context, req *rpc.ListProgrammersAvailableForUploadRequest) (*rpc.ListProgrammersAvailableForUploadResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/upload/programmers_list.go
+++ b/commands/upload/programmers_list.go
@@ -26,7 +26,7 @@ import (
 
 // ListProgrammersAvailableForUpload FIXMEDOC
 func ListProgrammersAvailableForUpload(ctx context.Context, req *rpc.ListProgrammersAvailableForUploadRequest) (*rpc.ListProgrammersAvailableForUploadResponse, error) {
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -30,7 +30,7 @@ import (
 	"github.com/arduino/arduino-cli/arduino/globals"
 	"github.com/arduino/arduino-cli/arduino/serialutils"
 	"github.com/arduino/arduino-cli/arduino/sketch"
-	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/executils"
 	"github.com/arduino/arduino-cli/i18n"
 	f "github.com/arduino/arduino-cli/internal/algorithms"
@@ -50,7 +50,7 @@ func SupportedUserFields(ctx context.Context, req *rpc.SupportedUserFieldsReques
 		return nil, &arduino.MissingPortProtocolError{}
 	}
 
-	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, release := instances.GetPackageManagerExplorer(req.GetInstance())
 	defer release()
 
 	if pme == nil {
@@ -137,7 +137,7 @@ func Upload(ctx context.Context, req *rpc.UploadRequest, outStream io.Writer, er
 		return nil, &arduino.CantOpenSketchError{Cause: err}
 	}
 
-	pme, pmeRelease := commands.GetPackageManagerExplorer(req.GetInstance())
+	pme, pmeRelease := instances.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -50,7 +50,7 @@ func SupportedUserFields(ctx context.Context, req *rpc.SupportedUserFieldsReques
 		return nil, &arduino.MissingPortProtocolError{}
 	}
 
-	pme, release := commands.GetPackageManagerExplorer(req)
+	pme, release := commands.GetPackageManagerExplorer(req.GetInstance())
 	defer release()
 
 	if pme == nil {
@@ -137,7 +137,7 @@ func Upload(ctx context.Context, req *rpc.UploadRequest, outStream io.Writer, er
 		return nil, &arduino.CantOpenSketchError{Cause: err}
 	}
 
-	pme, pmeRelease := commands.GetPackageManagerExplorer(req)
+	pme, pmeRelease := commands.GetPackageManagerExplorer(req.GetInstance())
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/internal/cli/arguments/completion.go
+++ b/internal/cli/arguments/completion.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/commands/core"
-	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/commands/lib"
 	"github.com/arduino/arduino-cli/commands/upload"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
@@ -50,13 +49,6 @@ func GetInstalledBoards() []string {
 // It returns a list of protocols available based on the installed boards
 func GetInstalledProtocols() []string {
 	inst := instance.CreateAndInit()
-
-	// FIXME: We must not access PackageManager directly here but use one of the commands.* functions
-	pme, release := instances.GetPackageManagerExplorer(inst)
-	if pme == nil {
-		return nil // should never happen...
-	}
-	defer release()
 
 	boards := pme.InstalledBoards()
 
@@ -93,13 +85,6 @@ func GetInstalledProgrammers() []string {
 		IncludeHiddenBoards: false,
 	}
 	list, _ := board.ListAll(context.Background(), listAllReq)
-
-	// FIXME: We must not access PackageManager directly here but use one of the commands.* functions
-	pme, release := instances.GetPackageManagerExplorer(inst)
-	if pme == nil {
-		return nil // should never happen...
-	}
-	defer release()
 
 	installedProgrammers := make(map[string]string)
 	for _, board := range list.Boards {

--- a/internal/cli/arguments/completion.go
+++ b/internal/cli/arguments/completion.go
@@ -45,34 +45,6 @@ func GetInstalledBoards() []string {
 	return res
 }
 
-// GetInstalledProtocols is an helper function useful to autocomplete.
-// It returns a list of protocols available based on the installed boards
-func GetInstalledProtocols() []string {
-	inst := instance.CreateAndInit()
-
-	boards := pme.InstalledBoards()
-
-	installedProtocols := make(map[string]struct{})
-	for _, board := range boards {
-		for _, protocol := range board.Properties.SubTree("upload.tool").FirstLevelKeys() {
-			if protocol == "default" {
-				// default is used as fallback when trying to upload to a board
-				// using a protocol not defined for it, it's useless showing it
-				// in autocompletion
-				continue
-			}
-			installedProtocols[protocol] = struct{}{}
-		}
-	}
-	res := make([]string, len(installedProtocols))
-	i := 0
-	for k := range installedProtocols {
-		res[i] = k
-		i++
-	}
-	return res
-}
-
 // GetInstalledProgrammers is an helper function useful to autocomplete.
 // It returns a list of programmers available based on the installed boards
 func GetInstalledProgrammers() []string {
@@ -188,19 +160,19 @@ func GetInstallableLibs() []string {
 	return res
 }
 
-// GetConnectedBoards is an helper function useful to autocomplete.
-// It returns a list of boards which are currently connected
-// Obviously it does not suggests network ports because of the timeout
-func GetConnectedBoards() []string {
+// GetAvailablePorts is an helper function useful to autocomplete.
+// It returns a list of upload port of the boards which are currently connected.
+// It will not suggests network ports because the timeout is not set.
+func GetAvailablePorts() []*rpc.Port {
 	inst := instance.CreateAndInit()
 
 	list, _, _ := board.List(&rpc.BoardListRequest{
 		Instance: inst,
 	})
-	var res []string
+	var res []*rpc.Port
 	// transform the data structure for the completion
 	for _, i := range list {
-		res = append(res, i.Port.Address)
+		res = append(res, i.Port)
 	}
 	return res
 }

--- a/internal/cli/arguments/completion.go
+++ b/internal/cli/arguments/completion.go
@@ -18,9 +18,9 @@ package arguments
 import (
 	"context"
 
-	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/commands/core"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/commands/lib"
 	"github.com/arduino/arduino-cli/commands/upload"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
@@ -52,7 +52,7 @@ func GetInstalledProtocols() []string {
 	inst := instance.CreateAndInit()
 
 	// FIXME: We must not access PackageManager directly here but use one of the commands.* functions
-	pme, release := commands.GetPackageManagerExplorer(inst)
+	pme, release := instances.GetPackageManagerExplorer(inst)
 	if pme == nil {
 		return nil // should never happen...
 	}
@@ -95,7 +95,7 @@ func GetInstalledProgrammers() []string {
 	list, _ := board.ListAll(context.Background(), listAllReq)
 
 	// FIXME: We must not access PackageManager directly here but use one of the commands.* functions
-	pme, release := commands.GetPackageManagerExplorer(inst)
+	pme, release := instances.GetPackageManagerExplorer(inst)
 	if pme == nil {
 		return nil // should never happen...
 	}

--- a/internal/cli/arguments/completion.go
+++ b/internal/cli/arguments/completion.go
@@ -52,7 +52,7 @@ func GetInstalledProtocols() []string {
 	inst := instance.CreateAndInit()
 
 	// FIXME: We must not access PackageManager directly here but use one of the commands.* functions
-	pme, release := commands.GetPackageManagerExplorer(&rpc.BoardListAllRequest{Instance: inst})
+	pme, release := commands.GetPackageManagerExplorer(inst)
 	if pme == nil {
 		return nil // should never happen...
 	}
@@ -95,7 +95,7 @@ func GetInstalledProgrammers() []string {
 	list, _ := board.ListAll(context.Background(), listAllReq)
 
 	// FIXME: We must not access PackageManager directly here but use one of the commands.* functions
-	pme, release := commands.GetPackageManagerExplorer(listAllReq)
+	pme, release := commands.GetPackageManagerExplorer(inst)
 	if pme == nil {
 		return nil // should never happen...
 	}

--- a/internal/cli/arguments/port.go
+++ b/internal/cli/arguments/port.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"github.com/arduino/arduino-cli/arduino"
-	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/commands/board"
+	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/sirupsen/logrus"
@@ -89,7 +89,7 @@ func (p *Port) GetPort(instance *rpc.Instance, defaultAddress, defaultProtocol s
 	logrus.WithField("port", address).Tracef("Upload port")
 
 	// FIXME: We must not access PackageManager directly here but use one of the commands.* functions
-	pme, release := commands.GetPackageManagerExplorer(instance)
+	pme, release := instances.GetPackageManagerExplorer(instance)
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/internal/cli/arguments/port.go
+++ b/internal/cli/arguments/port.go
@@ -89,7 +89,7 @@ func (p *Port) GetPort(instance *rpc.Instance, defaultAddress, defaultProtocol s
 	logrus.WithField("port", address).Tracef("Upload port")
 
 	// FIXME: We must not access PackageManager directly here but use one of the commands.* functions
-	pme, release := commands.GetPackageManagerExplorer(&rpc.BoardListAllRequest{Instance: instance})
+	pme, release := commands.GetPackageManagerExplorer(instance)
 	if pme == nil {
 		return nil, &arduino.InvalidInstanceError{}
 	}

--- a/internal/cli/arguments/port.go
+++ b/internal/cli/arguments/port.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/commands/board"
-	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/sirupsen/logrus"
@@ -87,13 +86,6 @@ func (p *Port) GetPort(instance *rpc.Instance, defaultAddress, defaultProtocol s
 		}, nil
 	}
 	logrus.WithField("port", address).Tracef("Upload port")
-
-	// FIXME: We must not access PackageManager directly here but use one of the commands.* functions
-	pme, release := instances.GetPackageManagerExplorer(instance)
-	if pme == nil {
-		return nil, &arduino.InvalidInstanceError{}
-	}
-	defer release()
 
 	dm := pme.DiscoveryManager()
 	watcher, err := dm.Watch()

--- a/internal/cli/arguments/port.go
+++ b/internal/cli/arguments/port.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/arduino/arduino-cli/arduino"
 	"github.com/arduino/arduino-cli/commands/board"
+	f "github.com/arduino/arduino-cli/internal/algorithms"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/sirupsen/logrus"
@@ -41,11 +42,11 @@ type Port struct {
 func (p *Port) AddToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&p.address, "port", "p", "", tr("Upload port address, e.g.: COM3 or /dev/ttyACM2"))
 	cmd.RegisterFlagCompletionFunc("port", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return GetConnectedBoards(), cobra.ShellCompDirectiveDefault
+		return f.Map(GetAvailablePorts(), (*rpc.Port).GetAddress), cobra.ShellCompDirectiveDefault
 	})
 	cmd.Flags().StringVarP(&p.protocol, "protocol", "l", "", tr("Upload port protocol, e.g: serial"))
 	cmd.RegisterFlagCompletionFunc("protocol", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return GetInstalledProtocols(), cobra.ShellCompDirectiveDefault
+		return f.Map(GetAvailablePorts(), (*rpc.Port).GetProtocol), cobra.ShellCompDirectiveDefault
 	})
 	p.timeout.AddToCommand(cmd)
 }

--- a/internal/integrationtest/completion/completion_test.go
+++ b/internal/integrationtest/completion/completion_test.go
@@ -216,16 +216,10 @@ func TestCoreCompletion(t *testing.T) {
 	require.Contains(t, string(stdout), "arduino:avr:uno")
 	stdout, _, _ = cli.Run("__complete", "monitor", "-b", "")
 	require.Contains(t, string(stdout), "arduino:avr:uno")
-	stdout, _, _ = cli.Run("__complete", "burn-bootloader", "-l", "")
-	require.Contains(t, string(stdout), "network")
-	stdout, _, _ = cli.Run("__complete", "compile", "-l", "")
-	require.Contains(t, string(stdout), "network")
-	stdout, _, _ = cli.Run("__complete", "debug", "-l", "")
-	require.Contains(t, string(stdout), "network")
-	stdout, _, _ = cli.Run("__complete", "upload", "-l", "")
-	require.Contains(t, string(stdout), "network")
-	stdout, _, _ = cli.Run("__complete", "monitor", "-l", "")
-	require.Contains(t, string(stdout), "network")
+
+	// -l/--protocol and -p/--port cannot be tested because there are
+	// no board connected.
+
 	stdout, _, _ = cli.Run("__complete", "burn-bootloader", "-P", "")
 	require.Contains(t, string(stdout), "atmel_ice")
 	stdout, _, _ = cli.Run("__complete", "compile", "-P", "")

--- a/rpc/cc/arduino/cli/commands/v1/common.go
+++ b/rpc/cc/arduino/cli/commands/v1/common.go
@@ -56,9 +56,3 @@ func (d DownloadProgressCB) End(success bool, message string) {
 
 // TaskProgressCB is a callback to receive progress messages
 type TaskProgressCB func(msg *TaskProgress)
-
-// InstanceCommand is an interface that represents a gRPC command with
-// a gRPC Instance.
-type InstanceCommand interface {
-	GetInstance() *Instance
-}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This refactoring aims to make the following functions of the `commands` package private:
```
commands.GetPackageManagerExplorer(...)
commands.GetPackageManager(...)
commands.GetLibrariesManager(...)
```

This change should clarify that the `arduino` package must not be used from the `cli` package (to avoid bypassing the gRPC API).
It also highlights where incorrect access to the `arduino` package is made, because those places are now reported as compile-time errors:
```
package github.com/arduino/arduino-cli
	imports github.com/arduino/arduino-cli/internal/cli
	imports github.com/arduino/arduino-cli/internal/cli/board
	imports github.com/arduino/arduino-cli/internal/cli/arguments
	internal/cli/arguments/completion.go:23:2: use of internal package github.com/arduino/arduino-cli/commands/internal/instances not allowed
package github.com/arduino/arduino-cli
	imports github.com/arduino/arduino-cli/internal/cli
	imports github.com/arduino/arduino-cli/internal/cli/board
	imports github.com/arduino/arduino-cli/internal/cli/arguments
	internal/cli/arguments/port.go:24:2: use of internal package github.com/arduino/arduino-cli/commands/internal/instances not allowed
```

The first one tries to list the available upload protocols. The second one performs a board watch to get available ports.

Both have been updated to use only the public gRPC API.

## What is the current behavior?

No changes.

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Once, completed this PR should fix https://github.com/arduino/arduino-cli/issues/1948