### PR TITLE
Added `--timestamp` option to monitor command.

### DIFF
--- a/internal/cli/monitor/monitor.go
+++ b/internal/cli/monitor/monitor.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"sort"
 	"strings"
-        "time"
+	"time"
 
 	"github.com/arduino/arduino-cli/commands/monitor"
 	"github.com/arduino/arduino-cli/configuration"
@@ -250,13 +250,13 @@ func contains(s []string, searchterm string) bool {
 }
 
 type timeStampWriter struct {
-	writer io.Writer
+	writer            io.Writer
 	sendTimeStampNext bool
 }
 
 func newTimeStampWriter(writer io.Writer) *timeStampWriter {
 	return &timeStampWriter{
-		writer: writer,
+		writer:            writer,
 		sendTimeStampNext: true,
 	}
 }
@@ -264,19 +264,19 @@ func newTimeStampWriter(writer io.Writer) *timeStampWriter {
 func (t *timeStampWriter) Write(p []byte) (int, error) {
 	written := 0
 	for _, b := range p {
-		if (t.sendTimeStampNext) {
+		if t.sendTimeStampNext {
 			_, err := t.writer.Write([]byte(time.Now().Format("[2006-01-02 15:04:05] ")))
 			if err != nil {
 				return written, err
 			}
-			t.sendTimeStampNext = false;
+			t.sendTimeStampNext = false
 		}
 		n, err := t.writer.Write([]byte{b})
 		written += n
 		if err != nil {
 			return written, err
 		}
-		t.sendTimeStampNext = b == '\n';
+		t.sendTimeStampNext = b == '\n'
 	}
 	return written, nil
 }

--- a/internal/cli/monitor/monitor.go
+++ b/internal/cli/monitor/monitor.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+        "time"
 
 	"github.com/arduino/arduino-cli/commands/monitor"
 	"github.com/arduino/arduino-cli/configuration"
@@ -44,12 +45,13 @@ var tr = i18n.Tr
 // NewCommand created a new `monitor` command
 func NewCommand() *cobra.Command {
 	var (
-		raw      bool
-		portArgs arguments.Port
-		describe bool
-		configs  []string
-		quiet    bool
-		fqbn     arguments.Fqbn
+		raw       bool
+		portArgs  arguments.Port
+		describe  bool
+		configs   []string
+		quiet     bool
+		timestamp bool
+		fqbn      arguments.Fqbn
 	)
 	monitorCommand := &cobra.Command{
 		Use:   "monitor",
@@ -59,7 +61,7 @@ func NewCommand() *cobra.Command {
 			"  " + os.Args[0] + " monitor -p /dev/ttyACM0\n" +
 			"  " + os.Args[0] + " monitor -p /dev/ttyACM0 --describe",
 		Run: func(cmd *cobra.Command, args []string) {
-			runMonitorCmd(&portArgs, &fqbn, configs, describe, quiet, raw)
+			runMonitorCmd(&portArgs, &fqbn, configs, describe, timestamp, quiet, raw)
 		},
 	}
 	portArgs.AddToCommand(monitorCommand)
@@ -67,12 +69,13 @@ func NewCommand() *cobra.Command {
 	monitorCommand.Flags().BoolVar(&describe, "describe", false, tr("Show all the settings of the communication port."))
 	monitorCommand.Flags().StringSliceVarP(&configs, "config", "c", []string{}, tr("Configure communication port settings. The format is <ID>=<value>[,<ID>=<value>]..."))
 	monitorCommand.Flags().BoolVarP(&quiet, "quiet", "q", false, tr("Run in silent mode, show only monitor input and output."))
+	monitorCommand.Flags().BoolVar(&timestamp, "timestamp", false, tr("Timestamp each incoming line."))
 	fqbn.AddToCommand(monitorCommand)
 	monitorCommand.MarkFlagRequired("port")
 	return monitorCommand
 }
 
-func runMonitorCmd(portArgs *arguments.Port, fqbn *arguments.Fqbn, configs []string, describe, quiet, raw bool) {
+func runMonitorCmd(portArgs *arguments.Port, fqbn *arguments.Fqbn, configs []string, describe, timestamp, quiet, raw bool) {
 	instance := instance.CreateAndInit()
 	logrus.Info("Executing `arduino-cli monitor`")
 
@@ -160,6 +163,10 @@ func runMonitorCmd(portArgs *arguments.Port, fqbn *arguments.Fqbn, configs []str
 		feedback.FatalError(err, feedback.ErrGeneric)
 	}
 
+	if timestamp {
+		ttyOut = newTimeStampWriter(ttyOut)
+	}
+
 	ctx, cancel := cleanup.InterruptableContext(context.Background())
 	if raw {
 		feedback.SetRawModeStdin()
@@ -240,4 +247,36 @@ func contains(s []string, searchterm string) bool {
 		}
 	}
 	return false
+}
+
+type timeStampWriter struct {
+	writer io.Writer
+	sendTimeStampNext bool
+}
+
+func newTimeStampWriter(writer io.Writer) *timeStampWriter {
+	return &timeStampWriter{
+		writer: writer,
+		sendTimeStampNext: true,
+	}
+}
+
+func (t *timeStampWriter) Write(p []byte) (int, error) {
+	written := 0
+	for _, b := range p {
+		if (t.sendTimeStampNext) {
+			_, err := t.writer.Write([]byte(time.Now().Format("[2006-01-02 15:04:05] ")))
+			if err != nil {
+				return written, err
+			}
+			t.sendTimeStampNext = false;
+		}
+		n, err := t.writer.Write([]byte{b})
+		written += n
+		if err != nil {
+			return written, err
+		}
+		t.sendTimeStampNext = b == '\n';
+	}
+	return written, nil
 }

--- a/internal/cli/monitor/monitor_test.go
+++ b/internal/cli/monitor/monitor_test.go
@@ -1,0 +1,37 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2023 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package monitor
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeStampWriter(t *testing.T) {
+	buf := &bytes.Buffer{}
+	writer := newTimeStampWriter(buf)
+
+	writer.Write([]byte("foo"))
+	// The first received bytes get a timestamp prepended
+	require.Regexp(t, `^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] foo$`, buf)
+
+	buf.Reset()
+	writer.Write([]byte("\nbar\n"))
+	// A timestamp should be inserted before the first char of the next line
+	require.Regexp(t, "^\n"+`\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] bar` + "\n$", buf)
+}

--- a/internal/cli/monitor/monitor_test.go
+++ b/internal/cli/monitor/monitor_test.go
@@ -33,5 +33,5 @@ func TestTimeStampWriter(t *testing.T) {
 	buf.Reset()
 	writer.Write([]byte("\nbar\n"))
 	// A timestamp should be inserted before the first char of the next line
-	require.Regexp(t, "^\n"+`\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] bar` + "\n$", buf)
+	require.Regexp(t, "^\n"+`\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] bar`+"\n$", buf)
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?

New feature in the monitor that can add a timestamp to the beginning of each received line.

## What is the current behavior?

No such option.

## What is the new behavior?

When `--timestamp` is provided, the monitor wraps the output tty with a timestamping Writer. The format of the timestamps is `YYYY-mm-dd HH:MM:SS`.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

Negative.

## Other information

This is my first time writing Go (except for the sample program I used to work out the approach), so please review carefully.

There don't appear to be any docs specifically about the monitor command, nor tests of the CLI entry point.

The change was tested by hand using this sketch:
```
void setup()
{
    Serial.begin(115200);
}

static const uint32_t period = 100; // millis

void loop()
{
    static uint32_t last_print_tm = 0;
    static uint8_t next_ch = 0;
    static const char* message = "tick\n";
    if (millis() - last_print_tm > period) {
        Serial.print(message[next_ch++]);
        if (message[next_ch] == '\0')
            next_ch = 0;
        last_print_tm += period;
    }
    delay(10);
}
```

Testing confirmed that individual non-newline characters received are still output immediately, and only newline characters cause the timestamp output:
```
Zacharys-iMac:arduino-cli zvonler$ ./arduino-cli -b adafruit:avr:metro monitor -p /dev/cu.usbserial-015F62D6 -c baudrate=115200 --quiet
tick
tick
tick
tick
ti^C
Zacharys-iMac:arduino-cli zvonler$ ./arduino-cli -b adafruit:avr:metro monitor -p /dev/cu.usbserial-015F62D6 -c baudrate=115200 --quiet --timestamp
[2023-09-22 12:12:18] tick
[2023-09-22 12:12:19] tick
[2023-09-22 12:12:19] tick
[2023-09-22 12:12:20] tick
[2023-09-22 12:12:20] tic^C
Zacharys-iMac:arduino-cli zvonler$ 
```