### PR TITLE
legacy: Fixed regression on `compile --preprocess` output

### DIFF
--- a/arduino/builder/builder.go
+++ b/arduino/builder/builder.go
@@ -243,10 +243,17 @@ func (b *Builder) ImportedLibraries() libraries.List {
 }
 
 // Preprocess fixdoc
-func (b *Builder) Preprocess() error {
+func (b *Builder) Preprocess() ([]byte, error) {
 	b.Progress.AddSubSteps(6)
 	defer b.Progress.RemoveSubSteps()
-	return b.preprocess()
+
+	if err := b.preprocess(); err != nil {
+		return nil, err
+	}
+
+	// Return arduino-preprocessed source
+	preprocessedSketch, err := b.sketchBuildPath.Join(b.sketch.MainFile.Base() + ".cpp").ReadFile()
+	return preprocessedSketch, err
 }
 
 func (b *Builder) preprocess() error {
@@ -302,13 +309,6 @@ func (b *Builder) preprocess() error {
 	}
 	b.Progress.CompleteStep()
 	b.Progress.PushProgress()
-
-	// Output arduino-preprocessed source
-	preprocessedSketch, err := b.sketchBuildPath.Join(b.sketch.MainFile.Base() + ".cpp").ReadFile()
-	if err != nil {
-		return err
-	}
-	b.logger.WriteStdout(preprocessedSketch)
 
 	return nil
 }

--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -240,11 +240,13 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 
 	if req.GetPreprocess() {
 		// Just output preprocessed source code and exit
-		compileErr := sketchBuilder.Preprocess()
-		if compileErr != nil {
-			compileErr = &arduino.CompileFailedError{Message: compileErr.Error()}
+		preprocessedSketch, err := sketchBuilder.Preprocess()
+		if err != nil {
+			err = &arduino.CompileFailedError{Message: err.Error()}
+			return r, err
 		}
-		return r, compileErr
+		_, err = outStream.Write(preprocessedSketch)
+		return r, err
 	}
 
 	defer func() {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fixed a regression after legacy builder refactoring.

## What is the current behavior?

Preprocessor output is always displayed.

## What is the new behavior?

The preprocessor output is displayed only with `--preprocess` flag.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
