### PR TITLE
bugfix: excessive CPU/Disk usage when multiple build-paths points in the sketch directory

### DIFF
--- a/arduino/globals/globals.go
+++ b/arduino/globals/globals.go
@@ -16,33 +16,31 @@
 package globals
 
 var (
-	empty struct{}
-
 	// MainFileValidExtension is the extension that must be used for files in new sketches
 	MainFileValidExtension string = ".ino"
 
 	// MainFileValidExtensions lists valid extensions for a sketch file
-	MainFileValidExtensions = map[string]struct{}{
-		MainFileValidExtension: empty,
+	MainFileValidExtensions = map[string]bool{
+		MainFileValidExtension: true,
 		// .pde extension is deprecated and must not be used for new sketches
-		".pde": empty,
+		".pde": true,
 	}
 
 	// AdditionalFileValidExtensions lists any file extension the builder considers as valid
-	AdditionalFileValidExtensions = map[string]struct{}{
-		".h":    empty,
-		".c":    empty,
-		".hpp":  empty,
-		".hh":   empty,
-		".cpp":  empty,
-		".cxx":  empty,
-		".cc":   empty,
-		".S":    empty,
-		".adoc": empty,
-		".md":   empty,
-		".json": empty,
-		".tpp":  empty,
-		".ipp":  empty,
+	AdditionalFileValidExtensions = map[string]bool{
+		".h":    true,
+		".c":    true,
+		".hpp":  true,
+		".hh":   true,
+		".cpp":  true,
+		".cxx":  true,
+		".cc":   true,
+		".S":    true,
+		".adoc": true,
+		".md":   true,
+		".json": true,
+		".tpp":  true,
+		".ipp":  true,
 	}
 
 	// SourceFilesValidExtensions lists valid extensions for source files (no headers).
@@ -57,10 +55,10 @@ var (
 	}
 
 	// HeaderFilesValidExtensions lists valid extensions for header files
-	HeaderFilesValidExtensions = map[string]struct{}{
-		".h":   empty,
-		".hpp": empty,
-		".hh":  empty,
+	HeaderFilesValidExtensions = map[string]bool{
+		".h":   true,
+		".hpp": true,
+		".hh":  true,
 	}
 
 	// DefaultIndexURL is the default index url

--- a/arduino/sketch/sketch.go
+++ b/arduino/sketch/sketch.go
@@ -166,8 +166,12 @@ func (s *Sketch) supportedFiles() (*paths.PathList, error) {
 		validExtensions = append(validExtensions, ext)
 	}
 
+	filterOutBuildPaths := func(p *paths.Path) bool {
+		return !p.Join("build.options.json").Exist()
+	}
+
 	files, err := s.FullPath.ReadDirRecursiveFiltered(
-		nil,
+		filterOutBuildPaths,
 		paths.AndFilter(
 			paths.FilterOutPrefixes("."),
 			paths.FilterSuffixes(validExtensions...),

--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -752,7 +752,7 @@ func detectSketchNameFromBuildPath(buildPath *paths.Path) (string, error) {
 
 		// Sometimes we may have particular files like:
 		// Blink.ino.with_bootloader.bin
-		if _, ok := globals.MainFileValidExtensions[filepath.Ext(name)]; !ok {
+		if !globals.MainFileValidExtensions[filepath.Ext(name)] {
 			// just ignore those files
 			continue
 		}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Reduce CPU and disk consumption if multiple build paths are created in the sketch directory.

## What is the current behavior?

See #2266 for details, for example running a build using the build-path to multiple subdirs of the sketch:
```
arduino-cli compile -b arduino:mbed_nano:nano33ble --build-cache-path build-nano33ble --build-path build-nano33ble
arduino-cli compile -b arduino:mbed_nano:nano33ble --build-cache-path build-nano33blesense2 --build-path build-nano33blesense2 --build-property 'compiler.cpp.extra_flags=-DSENSE_REV2'
```
results in:
* a full sketch rebuild when the target directory is changed (unneeded CPU consumption)
* a multiple recursive copy of the not-used build paths (unneeded disk space consumption)

## What is the new behavior?

The sketch is compiled as expected:
* without a full rebuild when the sketch is unchanged
* without unneeded copying of the build folders

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

It's worth noting that the compiled sketch is not broken, it just takes more resources/time to compile.

Fix #2266 
