### PR TITLE
legacy: build options refinements

### DIFF
--- a/arduino/builder/build_options_manager.go
+++ b/arduino/builder/build_options_manager.go
@@ -17,6 +17,7 @@ package builder
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/arduino/arduino-cli/arduino/sketch"
 	"github.com/arduino/go-paths-helper"
 	properties "github.com/arduino/go-properties-orderedmap"
-	"github.com/pkg/errors"
 )
 
 // buildOptions fixdoc
@@ -100,7 +100,7 @@ func newBuildOptions(
 func (b *Builder) createBuildOptionsJSON() error {
 	buildOptionsJSON, err := json.MarshalIndent(b.buildOptions.currentOptions, "", "  ")
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	return b.buildOptions.buildPath.Join("build.options.json").WriteFile(buildOptionsJSON)
 }
@@ -110,10 +110,10 @@ func (b *Builder) wipeBuildPath() error {
 	// control when this should be printed.
 	// logger.Println(constants.LOG_LEVEL_INFO, constants.MSG_BUILD_OPTIONS_CHANGED + constants.MSG_REBUILD_ALL)
 	if err := b.buildOptions.buildPath.RemoveAll(); err != nil {
-		return errors.WithMessage(err, tr("cleaning build path"))
+		return fmt.Errorf("%s: %w", tr("cleaning build path"), err)
 	}
 	if err := b.buildOptions.buildPath.MkdirAll(); err != nil {
-		return errors.WithMessage(err, tr("cleaning build path"))
+		return fmt.Errorf("%s: %w", tr("cleaning build path"), err)
 	}
 	return nil
 }
@@ -125,11 +125,11 @@ func (b *Builder) wipeBuildPathIfBuildOptionsChanged() error {
 
 	// Load previous build options map
 	var buildOptionsJSONPrevious []byte
-	var _err error
 	if buildOptionsFile := b.buildOptions.buildPath.Join("build.options.json"); buildOptionsFile.Exist() {
-		buildOptionsJSONPrevious, _err = buildOptionsFile.ReadFile()
-		if _err != nil {
-			return errors.WithStack(_err)
+		var err error
+		buildOptionsJSONPrevious, err = buildOptionsFile.ReadFile()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/arduino/builder/builder.go
+++ b/arduino/builder/builder.go
@@ -210,7 +210,7 @@ func NewBuilder(
 		),
 		buildOptions: newBuildOptions(
 			hardwareDirs, builtInToolsDirs, otherLibrariesDirs,
-			builtInLibrariesDirs, buildPath,
+			builtInLibrariesDirs,
 			sk,
 			customBuildPropertiesArgs,
 			fqbn,


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Slight simplification of the builder's `BuildOptions` struct.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
