### PR TITLE
fix wrong IndexFile truncate

### DIFF
--- a/arduino/resources/index.go
+++ b/arduino/resources/index.go
@@ -42,11 +42,16 @@ type IndexResource struct {
 // IndexFileName returns the index file name as it is saved in data dir (package_xxx_index.json).
 func (res *IndexResource) IndexFileName() (string, error) {
 	filename := path.Base(res.URL.Path) // == package_index.json[.gz] || packacge_index.tar.bz2
-	if filename == "." || filename == "" {
+	if filename == "." || filename == "" || filename == "/" {
 		return "", &arduino.InvalidURLError{}
 	}
-	if i := strings.Index(filename, "."); i != -1 {
-		filename = filename[:i]
+	switch {
+	case strings.HasSuffix(filename, ".json"):
+		return filename, nil
+	case strings.HasSuffix(filename, ".gz"):
+		return strings.TrimSuffix(filename, ".gz"), nil
+	case strings.HasSuffix(filename, ".tar.bz2"):
+		return strings.TrimSuffix(filename, ".tar.bz2") + ".json", nil
 	}
 	return filename + ".json", nil
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fixes a regression that truncates every `.` in the filename.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
