### PR TITLE
Added `{sketch_path}` to build properties

### DIFF
--- a/arduino/builder/builder.go
+++ b/arduino/builder/builder.go
@@ -131,7 +131,9 @@ func NewBuilder(
 	if boardBuildProperties != nil {
 		buildProperties.Merge(boardBuildProperties)
 	}
-
+	if sk != nil {
+		buildProperties.SetPath("sketch_path", sk.FullPath)
+	}
 	if buildPath != nil {
 		buildProperties.SetPath("build.path", buildPath)
 	}

--- a/internal/integrationtest/compile_3/compile_show_properties_test.go
+++ b/internal/integrationtest/compile_3/compile_show_properties_test.go
@@ -48,6 +48,7 @@ func TestCompileShowProperties(t *testing.T) {
 	require.NoError(t, err, "Output must be a clean property list")
 	require.Empty(t, stderr)
 	require.True(t, props.ContainsKey("archive_file_path"))
+	require.True(t, props.ContainsKey("sketch_path"))
 	require.NotContains(t, props.Get("archive_file_path"), "{build.path}")
 
 	// Test --show-properties --format JSON output is clean


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Adds the missing `sketch_path` variable to the build properties.

## What is the current behavior?

`{sketch_path}` is missing from the build properties:
```
$ arduino-cli compile -b arduino:avr:uno --show-properties | grep sketch_path
$
```

## What is the new behavior?

`{sketch_path}` is present in the build properties:
```
$ arduino-cli compile -b arduino:avr:uno --show-properties | grep sketch_path
sketch_path=/home/cmaglie/Arduino/Blink
$
```
## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2340