### PR TITLE
Introduce new "v" version format

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -13,7 +13,7 @@ env:
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   create-release-artifacts:
@@ -45,7 +45,7 @@ jobs:
         if: matrix.os == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
-          tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
+          tag-regex: '^v[0-9]+\.[0-9]+\.[0-9]+.*$'
           filter-regex: '^\[(skip|changelog)[ ,-](skip|changelog)\].*'
           case-insensitive-regex: true
           changelog-file-path: "${{ env.DIST_DIR }}/CHANGELOG.md"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -363,7 +363,7 @@ vars:
   TIMESTAMP_SHORT:
     sh: echo "{{now | date "20060102"}}"
   TAG:
-    sh: echo "$(git tag --points-at=HEAD 2> /dev/null | head -n1)"
+    sh: echo "$(git tag --points-at=HEAD 2> /dev/null | head -n1 | sed 's/^v//')"
   VERSION: "{{if .NIGHTLY}}nightly-{{.TIMESTAMP_SHORT}}{{else if .TAG}}{{.TAG}}{{else}}{{.PACKAGE_NAME_PREFIX}}git-snapshot{{end}}"
   CONFIGURATION_PACKAGE: "github.com/arduino/arduino-cli/version"
   LDFLAGS: >-

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -2,7 +2,7 @@
 
 Here you can find a list of migration guides to handle breaking changes between releases of the CLI.
 
-## 0.35.0
+## v0.35.0
 
 ### CLI `debug --info` changed JSON output.
 

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ initDownloadTool() {
 checkLatestVersion() {
   # Use the GitHub releases webpage to find the latest version for this project
   # so we don't get rate-limited.
-  CHECKLATESTVERSION_REGEX="[0-9][A-Za-z0-9\.-]*"
+  CHECKLATESTVERSION_REGEX="v?[0-9][A-Za-z0-9\.-]*"
   CHECKLATESTVERSION_LATEST_URL="https://github.com/${PROJECT_OWNER}/${PROJECT_NAME}/releases/latest"
   if [ "$DOWNLOAD_TOOL" = "curl" ]; then
     CHECKLATESTVERSION_TAG=$(curl -SsL $CHECKLATESTVERSION_LATEST_URL | grep -o "<title>Release $CHECKLATESTVERSION_REGEX · ${PROJECT_OWNER}/${PROJECT_NAME}" | grep -o "$CHECKLATESTVERSION_REGEX")


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->
Infrastructure change
## What is the current behavior?
<!-- You can also link to an open issue here -->
Fix #2341 
## What is the new behavior?
We release Arduino CLI with "v" version format
We still use `0.35.x` format for the doc branch and internally in the CLI the format is semver-compliant.
Test run after pushing `0.35.x` branch: https://github.com/umbynos/arduino-cli/actions?query=branch%3A0.35.x
Test run of `release-go-task` after pushing `v.0.35.0` tag https://github.com/umbynos/arduino-cli/actions/runs/6576137988
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
Technically no
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
