### PR TITLE
Fix "Failed to install arduino-cli" when invoked by install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,6 @@ initDownloadTool() {
 checkLatestVersion() {
   # Use the GitHub releases webpage to find the latest version for this project
   # so we don't get rate-limited.
-  #CHECKLATESTVERSION_REGEX="v?[0-9][A-Za-z0-9\.-]*"
   CHECKLATESTVERSION_REGEX="v\?[0-9][A-Za-z0-9\.-]*"
   CHECKLATESTVERSION_LATEST_URL="https://github.com/${PROJECT_OWNER}/${PROJECT_NAME}/releases/latest"
   if [ "$DOWNLOAD_TOOL" = "curl" ]; then

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,8 @@ initDownloadTool() {
 checkLatestVersion() {
   # Use the GitHub releases webpage to find the latest version for this project
   # so we don't get rate-limited.
-  CHECKLATESTVERSION_REGEX="v?[0-9][A-Za-z0-9\.-]*"
+  #CHECKLATESTVERSION_REGEX="v?[0-9][A-Za-z0-9\.-]*"
+  CHECKLATESTVERSION_REGEX="v\?[0-9][A-Za-z0-9\.-]*"
   CHECKLATESTVERSION_LATEST_URL="https://github.com/${PROJECT_OWNER}/${PROJECT_NAME}/releases/latest"
   if [ "$DOWNLOAD_TOOL" = "curl" ]; then
     CHECKLATESTVERSION_TAG=$(curl -SsL $CHECKLATESTVERSION_LATEST_URL | grep -o "<title>Release $CHECKLATESTVERSION_REGEX · ${PROJECT_OWNER}/${PROJECT_NAME}" | grep -o "$CHECKLATESTVERSION_REGEX")


### PR DESCRIPTION
Due to PR https://github.com/arduino/arduino-cli/pull/2374, `install.sh` fails to run on the latest release tag:

```
curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
Installing in [dir]
ARCH=64bit
OS=macOS
Using curl as download tool
Failed to install arduino-cli
```

In turn, this causes repositories that have automated tooling and rely upon `install.sh` (such as adafruit/ci-arduino) to fail.

This pull request implements a fix suggested by @tobozo in https://github.com/arduino/arduino-cli/issues/2370 because the `v?` prefix requires escaping to be passed to `grep`.

cc @cmaglie @per1234 