### PR TITLE
test: Fixed runners not running 'board' integration test

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -70,8 +70,9 @@ jobs:
 
       - name: Collect tests
         id: collection
+        # jq flags must be "-cRn" see: https://stackoverflow.com/a/68859958/1655275
         run: |
-          echo "tests-data=$(go list ./internal/integrationtest/... | grep integrationtest/ | tr "/" " " | cut -d " " -f 6 | jq -cR '[inputs]')" >> $GITHUB_OUTPUT
+          echo "tests-data=$(go list ./internal/integrationtest/... | grep integrationtest/ | tr "/" " " | cut -d " " -f 6 | jq -cRn '[inputs]')" >> $GITHUB_OUTPUT
 
   test-integration:
     needs: tests-collector

--- a/internal/integrationtest/board/board_test.go
+++ b/internal/integrationtest/board/board_test.go
@@ -630,6 +630,7 @@ func TestCLIStartupWithCorruptedInventory(t *testing.T) {
 	require.NoError(t, err)
 	_, err = f.WriteString(`data: '[{"name":"WCH;32?'","fqbn":"esp32:esp32:esp32s3camlcd"}]'`)
 	require.NoError(t, err)
+	require.NoError(t, f.Close())
 
 	// the CLI should not be able to load inventory and report it to the logs
 	_, stderr, err := cli.Run("core", "update-index", "-v")

--- a/internal/integrationtest/board/hardware_loading_test.go
+++ b/internal/integrationtest/board/hardware_loading_test.go
@@ -154,12 +154,7 @@ func TestHardwareLoading(t *testing.T) {
 			out, _, err := cli.Run("core", "list", "--format", "json")
 			require.NoError(t, err)
 			jsonOut := requirejson.Parse(t, out)
-			if runtime.GOOS == "windows" {
-				// a package is a symlink, and windows does not support them
-				jsonOut.LengthMustEqualTo(2)
-			} else {
-				jsonOut.LengthMustEqualTo(3)
-			}
+			jsonOut.LengthMustEqualTo(3)
 			jsonOut.MustContain(`[
 				{
 					"id": "arduino:avr",


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

The `board` integration test package was skipped during integration tests. This was due to a strange behavior of `jq`, which was cutting the first package in the list unless the `-n` flag was passed.

The documentation of jq reports:

```
○   --null-input/-n:
           Don't  read any input at all! Instead, the filter is run once using null as the input. This is useful when using jq as
           a simple calculator or to construct JSON data from scratch.
```
¯\\\_(ツ)\_/¯


## What is the current behavior?

## What is the new behavior?

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

## Other information

See https://stackoverflow.com/a/68859958/1655275