### PR TITLE
Use feedback/result structs in cli commands instead of rpc ones

### DIFF
--- a/internal/cli/board/details.go
+++ b/internal/cli/board/details.go
@@ -23,6 +23,7 @@ import (
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/internal/cli/arguments"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
+	fResult "github.com/arduino/arduino-cli/internal/cli/feedback/result"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/arduino-cli/table"
@@ -74,7 +75,7 @@ func runDetailsCommand(fqbn string, showFullDetails, listProgrammers bool, showP
 	}
 
 	feedback.PrintResult(detailsResult{
-		details:         res,
+		details:         fResult.NewBoardDetailsResponse(res),
 		listProgrammers: listProgrammers,
 		showFullDetails: showFullDetails,
 		showProperties:  showPropertiesMode != arguments.ShowPropertiesDisabled,
@@ -84,7 +85,7 @@ func runDetailsCommand(fqbn string, showFullDetails, listProgrammers bool, showP
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type detailsResult struct {
-	details         *rpc.BoardDetailsResponse
+	details         *fResult.BoardDetailsResponse
 	listProgrammers bool
 	showFullDetails bool
 	showProperties  bool
@@ -99,7 +100,7 @@ func (dr detailsResult) String() string {
 
 	if dr.showProperties {
 		res := ""
-		for _, prop := range details.GetBuildProperties() {
+		for _, prop := range details.BuildProperties {
 			res += fmt.Sprintln(prop)
 		}
 		return res
@@ -109,7 +110,10 @@ func (dr detailsResult) String() string {
 		t := table.New()
 		t.AddRow(tr("Id"), tr("Programmer name"))
 		for _, programmer := range details.Programmers {
-			t.AddRow(programmer.GetId(), programmer.GetName())
+			if programmer == nil {
+				continue
+			}
+			t.AddRow(programmer.Id, programmer.Name)
 		}
 		return t.Render()
 	}
@@ -138,7 +142,7 @@ func (dr detailsResult) String() string {
 	t.AddRow(tr("Board name:"), details.Name)
 	t.AddRow(tr("FQBN:"), details.Fqbn)
 	addIfNotEmpty(tr("Board version:"), details.Version)
-	if details.GetDebuggingSupported() {
+	if details.DebuggingSupported {
 		t.AddRow(tr("Debugging supported:"), table.NewCell("✔", color.New(color.FgGreen)))
 	}
 
@@ -148,11 +152,15 @@ func (dr detailsResult) String() string {
 			table.NewCell("✔", color.New(color.FgGreen)))
 	}
 
-	for _, idp := range details.GetIdentificationProperties() {
+	for _, idp := range details.IdentificationProperties {
+		if idp == nil || idp.Properties == nil {
+			continue
+		}
 		t.AddRow() // get some space from above
 		header := tr("Identification properties:")
-		for k, v := range idp.GetProperties() {
-			t.AddRow(header, k+"="+v)
+		keys := idp.Properties.Keys()
+		for _, k := range keys {
+			t.AddRow(header, k+"="+idp.Properties.Get(k))
 			header = ""
 		}
 	}
@@ -213,7 +221,10 @@ func (dr detailsResult) String() string {
 
 	tab.AddRow(tr("Programmers:"), tr("ID"), tr("Name"))
 	for _, programmer := range details.Programmers {
-		tab.AddRow("", programmer.GetId(), programmer.GetName())
+		if programmer == nil {
+			continue
+		}
+		tab.AddRow("", programmer.Id, programmer.Name)
 	}
 
 	return t.Render() + tab.Render()

--- a/internal/cli/board/details.go
+++ b/internal/cli/board/details.go
@@ -23,7 +23,7 @@ import (
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/internal/cli/arguments"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
-	fResult "github.com/arduino/arduino-cli/internal/cli/feedback/result"
+	"github.com/arduino/arduino-cli/internal/cli/feedback/result"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/arduino-cli/table"
@@ -75,7 +75,7 @@ func runDetailsCommand(fqbn string, showFullDetails, listProgrammers bool, showP
 	}
 
 	feedback.PrintResult(detailsResult{
-		details:         fResult.NewBoardDetailsResponse(res),
+		details:         result.NewBoardDetailsResponse(res),
 		listProgrammers: listProgrammers,
 		showFullDetails: showFullDetails,
 		showProperties:  showPropertiesMode != arguments.ShowPropertiesDisabled,
@@ -85,7 +85,7 @@ func runDetailsCommand(fqbn string, showFullDetails, listProgrammers bool, showP
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type detailsResult struct {
-	details         *fResult.BoardDetailsResponse
+	details         *result.BoardDetailsResponse
 	listProgrammers bool
 	showFullDetails bool
 	showProperties  bool

--- a/internal/cli/board/details.go
+++ b/internal/cli/board/details.go
@@ -110,9 +110,6 @@ func (dr detailsResult) String() string {
 		t := table.New()
 		t.AddRow(tr("Id"), tr("Programmer name"))
 		for _, programmer := range details.Programmers {
-			if programmer == nil {
-				continue
-			}
 			t.AddRow(programmer.Id, programmer.Name)
 		}
 		return t.Render()
@@ -153,7 +150,7 @@ func (dr detailsResult) String() string {
 	}
 
 	for _, idp := range details.IdentificationProperties {
-		if idp == nil || idp.Properties == nil {
+		if idp.Properties == nil {
 			continue
 		}
 		t.AddRow() // get some space from above
@@ -221,9 +218,6 @@ func (dr detailsResult) String() string {
 
 	tab.AddRow(tr("Programmers:"), tr("ID"), tr("Name"))
 	for _, programmer := range details.Programmers {
-		if programmer == nil {
-			continue
-		}
 		tab.AddRow("", programmer.Id, programmer.Name)
 	}
 

--- a/internal/cli/board/list.go
+++ b/internal/cli/board/list.go
@@ -100,12 +100,14 @@ func watchList(inst *rpc.Instance) {
 	}
 
 	for event := range eventsChan {
-		feedback.PrintResult(watchEventResult{
-			Type:   event.EventType,
-			Boards: result.NewBoardListItems(event.Port.MatchingBoards),
-			Port:   result.NewPort(event.Port.Port),
-			Error:  event.Error,
-		})
+		if res := result.NewBoardListWatchResponse(event); res != nil {
+			feedback.PrintResult(watchEventResult{
+				Type:   res.EventType,
+				Boards: res.Port.MatchingBoards,
+				Port:   res.Port.Port,
+				Error:  res.Error,
+			})
+		}
 	}
 }
 

--- a/internal/cli/board/list.go
+++ b/internal/cli/board/list.go
@@ -133,9 +133,6 @@ func (dr listResult) String() string {
 	t := table.New()
 	t.SetHeader(tr("Port"), tr("Protocol"), tr("Type"), tr("Board Name"), tr("FQBN"), tr("Core"))
 	for _, detectedPort := range dr.ports {
-		if detectedPort == nil {
-			continue
-		}
 		port := detectedPort.Port
 		protocol := port.Protocol
 		address := port.Address

--- a/internal/cli/board/listall.go
+++ b/internal/cli/board/listall.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
+	fResult "github.com/arduino/arduino-cli/internal/cli/feedback/result"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/arduino-cli/table"
@@ -63,13 +64,13 @@ func runListAllCommand(cmd *cobra.Command, args []string) {
 		feedback.Fatal(tr("Error listing boards: %v", err), feedback.ErrGeneric)
 	}
 
-	feedback.PrintResult(resultAll{list})
+	feedback.PrintResult(resultAll{fResult.NewBoardListAllResponse(list)})
 }
 
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type resultAll struct {
-	list *rpc.BoardListAllResponse
+	list *fResult.BoardListAllResponse
 }
 
 func (dr resultAll) Data() interface{} {
@@ -77,18 +78,26 @@ func (dr resultAll) Data() interface{} {
 }
 
 func (dr resultAll) String() string {
-	sort.Slice(dr.list.Boards, func(i, j int) bool {
-		return dr.list.Boards[i].GetName() < dr.list.Boards[j].GetName()
-	})
-
 	t := table.New()
 	t.SetHeader(tr("Board Name"), tr("FQBN"), "")
-	for _, item := range dr.list.GetBoards() {
+
+	if dr.list == nil || len(dr.list.Boards) == 0 {
+		return t.Render()
+	}
+
+	sort.Slice(dr.list.Boards, func(i, j int) bool {
+		return dr.list.Boards[i].Name < dr.list.Boards[j].Name
+	})
+
+	for _, item := range dr.list.Boards {
+		if item == nil {
+			continue
+		}
 		hidden := ""
 		if item.IsHidden {
 			hidden = tr("(hidden)")
 		}
-		t.AddRow(item.GetName(), item.GetFqbn(), hidden)
+		t.AddRow(item.Name, item.Fqbn, hidden)
 	}
 	return t.Render()
 }

--- a/internal/cli/board/listall.go
+++ b/internal/cli/board/listall.go
@@ -90,9 +90,6 @@ func (dr resultAll) String() string {
 	})
 
 	for _, item := range dr.list.Boards {
-		if item == nil {
-			continue
-		}
 		hidden := ""
 		if item.IsHidden {
 			hidden = tr("(hidden)")

--- a/internal/cli/board/search.go
+++ b/internal/cli/board/search.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
+	fResult "github.com/arduino/arduino-cli/internal/cli/feedback/result"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/arduino-cli/table"
@@ -60,13 +61,13 @@ func runSearchCommand(cmd *cobra.Command, args []string) {
 		feedback.Fatal(tr("Error searching boards: %v", err), feedback.ErrGeneric)
 	}
 
-	feedback.PrintResult(searchResults{res.Boards})
+	feedback.PrintResult(searchResults{fResult.NewBoardListItems(res.Boards)})
 }
 
 // output from this command requires special formatting so we create a dedicated
 // feedback.Result implementation
 type searchResults struct {
-	boards []*rpc.BoardListItem
+	boards []*fResult.BoardListItem
 }
 
 func (r searchResults) Data() interface{} {
@@ -74,18 +75,26 @@ func (r searchResults) Data() interface{} {
 }
 
 func (r searchResults) String() string {
-	sort.Slice(r.boards, func(i, j int) bool {
-		return r.boards[i].GetName() < r.boards[j].GetName()
-	})
-
 	t := table.New()
 	t.SetHeader(tr("Board Name"), tr("FQBN"), tr("Platform ID"), "")
+
+	if len(r.boards) == 0 {
+		return t.Render()
+	}
+
+	sort.Slice(r.boards, func(i, j int) bool {
+		return r.boards[i].Name < r.boards[j].Name
+	})
+
 	for _, item := range r.boards {
+		if item == nil {
+			continue
+		}
 		hidden := ""
 		if item.IsHidden {
 			hidden = tr("(hidden)")
 		}
-		t.AddRow(item.GetName(), item.GetFqbn(), item.Platform.Metadata.Id, hidden)
+		t.AddRow(item.Name, item.Fqbn, item.Platform.Metadata.Id, hidden)
 	}
 	return t.Render()
 }

--- a/internal/cli/board/search.go
+++ b/internal/cli/board/search.go
@@ -75,12 +75,12 @@ func (r searchResults) Data() interface{} {
 }
 
 func (r searchResults) String() string {
+	if len(r.boards) == 0 {
+		return ""
+	}
+
 	t := table.New()
 	t.SetHeader(tr("Board Name"), tr("FQBN"), tr("Platform ID"), "")
-
-	if len(r.boards) == 0 {
-		return t.Render()
-	}
 
 	sort.Slice(r.boards, func(i, j int) bool {
 		return r.boards[i].Name < r.boards[j].Name

--- a/internal/cli/board/search.go
+++ b/internal/cli/board/search.go
@@ -87,9 +87,6 @@ func (r searchResults) String() string {
 	})
 
 	for _, item := range r.boards {
-		if item == nil {
-			continue
-		}
 		hidden := ""
 		if item.IsHidden {
 			hidden = tr("(hidden)")

--- a/internal/cli/compile/compile.go
+++ b/internal/cli/compile/compile.go
@@ -344,9 +344,7 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 		CompilerOut:   stdIO.Stdout,
 		CompilerErr:   stdIO.Stderr,
 		BuilderResult: result.NewCompileResponse(compileRes),
-		UploadResult: struct {
-			UpdatedUploadPort *result.Port `json:"updated_upload_port,omitempty"`
-		}{
+		UploadResult: updatedUploadPortResult{
 			UpdatedUploadPort: result.NewPort(uploadRes.GetUpdatedUploadPort()),
 		},
 		ProfileOut:         profileOut,
@@ -389,16 +387,18 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 	feedback.PrintResult(res)
 }
 
+type updatedUploadPortResult struct {
+	UpdatedUploadPort *result.Port `json:"updated_upload_port,omitempty"`
+}
+
 type compileResult struct {
 	CompilerOut   string                  `json:"compiler_out"`
 	CompilerErr   string                  `json:"compiler_err"`
 	BuilderResult *result.CompileResponse `json:"builder_result"`
-	UploadResult  struct {
-		UpdatedUploadPort *result.Port `json:"updated_upload_port,omitempty"`
-	} `json:"upload_result"`
-	Success    bool   `json:"success"`
-	ProfileOut string `json:"profile_out,omitempty"`
-	Error      string `json:"error,omitempty"`
+	UploadResult  updatedUploadPortResult `json:"upload_result"`
+	Success       bool                    `json:"success"`
+	ProfileOut    string                  `json:"profile_out,omitempty"`
+	Error         string                  `json:"error,omitempty"`
 
 	showPropertiesMode arguments.ShowPropertiesMode
 	hideStats          bool

--- a/internal/cli/compile/compile.go
+++ b/internal/cli/compile/compile.go
@@ -433,9 +433,6 @@ func (r *compileResult) String() string {
 			table.NewCell(tr("Version"), titleColor),
 			table.NewCell(tr("Path"), pathColor))
 		for _, l := range build.UsedLibraries {
-			if l == nil {
-				continue
-			}
 			libraries.AddRow(
 				table.NewCell(l.Name, nameColor),
 				l.Version,

--- a/internal/cli/core/list.go
+++ b/internal/cli/core/list.go
@@ -91,13 +91,13 @@ func GetList(inst *rpc.Instance, all bool, updatableOnly bool) []*rpc.PlatformSu
 func newCoreListResult(in []*rpc.PlatformSummary) *coreListResult {
 	res := &coreListResult{}
 	for _, platformSummary := range in {
-		res.platforms = append(res.platforms, result.NewPlatformResult(platformSummary))
+		res.platforms = append(res.platforms, result.NewPlatformSummary(platformSummary))
 	}
 	return res
 }
 
 type coreListResult struct {
-	platforms []*result.Platform
+	platforms []*result.PlatformSummary
 }
 
 // Data implements Result interface

--- a/internal/cli/core/search.go
+++ b/internal/cli/core/search.go
@@ -88,13 +88,13 @@ func runSearchCommand(cmd *cobra.Command, args []string) {
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type searchResults struct {
-	platforms []*result.Platform
+	platforms []*result.PlatformSummary
 }
 
 func newSearchResult(in []*rpc.PlatformSummary) *searchResults {
 	res := &searchResults{}
 	for _, platformSummary := range in {
-		res.platforms = append(res.platforms, result.NewPlatformResult(platformSummary))
+		res.platforms = append(res.platforms, result.NewPlatformSummary(platformSummary))
 	}
 	return res
 }

--- a/internal/cli/feedback/result/rpc.go
+++ b/internal/cli/feedback/result/rpc.go
@@ -136,7 +136,46 @@ type InstalledLibrary struct {
 
 type LibraryLocation string
 
+const (
+	LibraryLocationUser                      LibraryLocation = "user"
+	LibraryLocationIDEBuiltin                LibraryLocation = "ide"
+	LibraryLocationPlatformBuiltin           LibraryLocation = "platform"
+	LibraryLocationReferencedPlatformBuiltin LibraryLocation = "ref-platform"
+	LibraryLocationUnmanged                  LibraryLocation = "unmanaged"
+)
+
+func NewLibraryLocation(r rpc.LibraryLocation) LibraryLocation {
+	switch r {
+	case rpc.LibraryLocation_LIBRARY_LOCATION_BUILTIN:
+		return LibraryLocationIDEBuiltin
+	case rpc.LibraryLocation_LIBRARY_LOCATION_PLATFORM_BUILTIN:
+		return LibraryLocationPlatformBuiltin
+	case rpc.LibraryLocation_LIBRARY_LOCATION_REFERENCED_PLATFORM_BUILTIN:
+		return LibraryLocationReferencedPlatformBuiltin
+	case rpc.LibraryLocation_LIBRARY_LOCATION_USER:
+		return LibraryLocationUser
+	case rpc.LibraryLocation_LIBRARY_LOCATION_UNMANAGED:
+		return LibraryLocationUnmanged
+	}
+	return LibraryLocationIDEBuiltin
+}
+
 type LibraryLayout string
+
+const (
+	LibraryLayoutFlat      LibraryLayout = "flat"
+	LibraryLayoutRecursive LibraryLayout = "recursive"
+)
+
+func NewLibraryLayout(r rpc.LibraryLayout) LibraryLayout {
+	switch r {
+	case rpc.LibraryLayout_LIBRARY_LAYOUT_FLAT:
+		return LibraryLayoutFlat
+	case rpc.LibraryLayout_LIBRARY_LAYOUT_RECURSIVE:
+		return LibraryLayoutRecursive
+	}
+	return LibraryLayoutFlat
+}
 
 type Library struct {
 	Name              string                         `json:"name,omitempty"`
@@ -204,8 +243,8 @@ func NewLibrary(l *rpc.Library) *Library {
 		Version:           l.GetVersion(),
 		License:           l.GetLicense(),
 		Properties:        libraryPropsMap,
-		Location:          LibraryLocation(l.GetLocation().String()),
-		Layout:            LibraryLayout(l.GetLayout().String()),
+		Location:          NewLibraryLocation(l.GetLocation()),
+		Layout:            NewLibraryLayout(l.GetLayout()),
 		Examples:          l.GetExamples(),
 		ProvidesIncludes:  l.GetProvidesIncludes(),
 		CompatibleWith:    libraryCompatibleWithMap,
@@ -751,6 +790,21 @@ func NewLibraryDependencyStatus(l *rpc.LibraryDependencyStatus) *LibraryDependen
 
 type LibrarySearchStatus string
 
+const (
+	LibrarySearchStatusFailed  LibrarySearchStatus = "failed"
+	LibrarySearchStatusSuccess LibrarySearchStatus = "success"
+)
+
+func NewLibrarySearchStatus(r rpc.LibrarySearchStatus) LibrarySearchStatus {
+	switch r {
+	case rpc.LibrarySearchStatus_LIBRARY_SEARCH_STATUS_FAILED:
+		return LibrarySearchStatusFailed
+	case rpc.LibrarySearchStatus_LIBRARY_SEARCH_STATUS_SUCCESS:
+		return LibrarySearchStatusSuccess
+	}
+	return LibrarySearchStatusFailed
+}
+
 type LibrarySearchResponse struct {
 	Libraries []*SearchedLibrary  `json:"libraries,omitempty"`
 	Status    LibrarySearchStatus `json:"status,omitempty"`
@@ -768,7 +822,7 @@ func NewLibrarySearchResponse(l *rpc.LibrarySearchResponse) *LibrarySearchRespon
 
 	return &LibrarySearchResponse{
 		Libraries: searchedLibraries,
-		Status:    LibrarySearchStatus(l.GetStatus().Enum().String()),
+		Status:    NewLibrarySearchStatus(l.GetStatus()),
 	}
 }
 

--- a/internal/cli/feedback/result/rpc.go
+++ b/internal/cli/feedback/result/rpc.go
@@ -888,3 +888,20 @@ func NewInstalledPlatformReference(r *rpc.InstalledPlatformReference) *Installed
 		PackageUrl: r.GetPackageUrl(),
 	}
 }
+
+type BoardListWatchResponse struct {
+	EventType string        `json:"event_type,omitempty"`
+	Port      *DetectedPort `json:"port,omitempty"`
+	Error     string        `json:"error,omitempty"`
+}
+
+func NewBoardListWatchResponse(r *rpc.BoardListWatchResponse) *BoardListWatchResponse {
+	if r == nil {
+		return nil
+	}
+	return &BoardListWatchResponse{
+		EventType: r.EventType,
+		Port:      NewDetectedPort(r.Port),
+		Error:     r.Error,
+	}
+}

--- a/internal/cli/feedback/result/rpc.go
+++ b/internal/cli/feedback/result/rpc.go
@@ -25,23 +25,27 @@ import (
 
 // NewPlatformSummary creates a new result.Platform from rpc.PlatformSummary
 func NewPlatformSummary(in *rpc.PlatformSummary) *PlatformSummary {
+	if in == nil {
+		return nil
+	}
+
 	releases := orderedmap.NewWithConversionFunc[*semver.Version, *PlatformRelease, string]((*semver.Version).String)
-	for k, v := range in.Releases {
+	for k, v := range in.GetReleases() {
 		releases.Set(semver.MustParse(k), NewPlatformRelease(v))
 	}
 	releases.SortKeys((*semver.Version).CompareTo)
 
 	return &PlatformSummary{
-		Id:                in.Metadata.Id,
-		Maintainer:        in.Metadata.Maintainer,
-		Website:           in.Metadata.Website,
-		Email:             in.Metadata.Email,
-		ManuallyInstalled: in.Metadata.ManuallyInstalled,
-		Deprecated:        in.Metadata.Deprecated,
-		Indexed:           in.Metadata.Indexed,
+		Id:                in.GetMetadata().GetId(),
+		Maintainer:        in.GetMetadata().GetMaintainer(),
+		Website:           in.GetMetadata().GetWebsite(),
+		Email:             in.GetMetadata().GetEmail(),
+		ManuallyInstalled: in.GetMetadata().GetManuallyInstalled(),
+		Deprecated:        in.GetMetadata().GetDeprecated(),
+		Indexed:           in.GetMetadata().GetIndexed(),
 		Releases:          releases,
-		InstalledVersion:  semver.MustParse(in.InstalledVersion),
-		LatestVersion:     semver.MustParse(in.LatestVersion),
+		InstalledVersion:  semver.MustParse(in.GetInstalledVersion()),
+		LatestVersion:     semver.MustParse(in.GetLatestVersion()),
 	}
 }
 
@@ -73,6 +77,9 @@ func (p *PlatformSummary) GetInstalledRelease() *PlatformRelease {
 
 // NewPlatformRelease creates a new result.PlatformRelease from rpc.PlatformRelease
 func NewPlatformRelease(in *rpc.PlatformRelease) *PlatformRelease {
+	if in == nil {
+		return nil
+	}
 	var boards []*Board
 	for _, board := range in.Boards {
 		boards = append(boards, &Board{

--- a/internal/cli/feedback/result/rpc.go
+++ b/internal/cli/feedback/result/rpc.go
@@ -23,15 +23,15 @@ import (
 	semver "go.bug.st/relaxed-semver"
 )
 
-// NewPlatformResult creates a new result.Platform from rpc.PlatformSummary
-func NewPlatformResult(in *rpc.PlatformSummary) *Platform {
+// NewPlatformSummary creates a new result.Platform from rpc.PlatformSummary
+func NewPlatformSummary(in *rpc.PlatformSummary) *PlatformSummary {
 	releases := orderedmap.NewWithConversionFunc[*semver.Version, *PlatformRelease, string]((*semver.Version).String)
 	for k, v := range in.Releases {
 		releases.Set(semver.MustParse(k), NewPlatformReleaseResult(v))
 	}
 	releases.SortKeys((*semver.Version).CompareTo)
 
-	return &Platform{
+	return &PlatformSummary{
 		Id:                in.Metadata.Id,
 		Maintainer:        in.Metadata.Maintainer,
 		Website:           in.Metadata.Website,
@@ -45,8 +45,8 @@ func NewPlatformResult(in *rpc.PlatformSummary) *Platform {
 	}
 }
 
-// Platform maps a rpc.Platform
-type Platform struct {
+// PlatformSummary maps a rpc.PlatformSummary
+type PlatformSummary struct {
 	Id                string `json:"id,omitempty"`
 	Maintainer        string `json:"maintainer,omitempty"`
 	Website           string `json:"website,omitempty"`
@@ -62,12 +62,12 @@ type Platform struct {
 }
 
 // GetLatestRelease returns the latest relase of this platform or nil if none available.
-func (p *Platform) GetLatestRelease() *PlatformRelease {
+func (p *PlatformSummary) GetLatestRelease() *PlatformRelease {
 	return p.Releases.Get(p.LatestVersion)
 }
 
 // GetInstalledRelease returns the installed relase of this platform or nil if none available.
-func (p *Platform) GetInstalledRelease() *PlatformRelease {
+func (p *PlatformSummary) GetInstalledRelease() *PlatformRelease {
 	return p.Releases.Get(p.InstalledVersion)
 }
 

--- a/internal/cli/feedback/result/rpc.go
+++ b/internal/cli/feedback/result/rpc.go
@@ -16,6 +16,8 @@
 package result
 
 import (
+	"cmp"
+
 	"github.com/arduino/arduino-cli/internal/orderedmap"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	semver "go.bug.st/relaxed-semver"
@@ -118,4 +120,467 @@ type Board struct {
 // HelpResource maps a rpc.HelpResource
 type HelpResource struct {
 	Online string `json:"online,omitempty"`
+}
+
+type InstalledLibrary struct {
+	Library *Library        `json:"library,omitempty"`
+	Release *LibraryRelease `json:"release,omitempty"`
+}
+
+type LibraryLocation string
+
+type LibraryLayout string
+
+type Library struct {
+	Name              string                         `json:"name,omitempty"`
+	Author            string                         `json:"author,omitempty"`
+	Maintainer        string                         `json:"maintainer,omitempty"`
+	Sentence          string                         `json:"sentence,omitempty"`
+	Paragraph         string                         `json:"paragraph,omitempty"`
+	Website           string                         `json:"website,omitempty"`
+	Category          string                         `json:"category,omitempty"`
+	Architectures     []string                       `json:"architectures,omitempty"`
+	Types             []string                       `json:"types,omitempty"`
+	InstallDir        string                         `json:"install_dir,omitempty"`
+	SourceDir         string                         `json:"source_dir,omitempty"`
+	UtilityDir        string                         `json:"utility_dir,omitempty"`
+	ContainerPlatform string                         `json:"container_platform,omitempty"`
+	DotALinkage       bool                           `json:"dot_a_linkage,omitempty"`
+	Precompiled       bool                           `json:"precompiled,omitempty"`
+	LdFlags           string                         `json:"ld_flags,omitempty"`
+	IsLegacy          bool                           `json:"is_legacy,omitempty"`
+	Version           string                         `json:"version,omitempty"`
+	License           string                         `json:"license,omitempty"`
+	Properties        orderedmap.Map[string, string] `json:"properties,omitempty"`
+	Location          LibraryLocation                `json:"location,omitempty"`
+	Layout            LibraryLayout                  `json:"layout,omitempty"`
+	Examples          []string                       `json:"examples,omitempty"`
+	ProvidesIncludes  []string                       `json:"provides_includes,omitempty"`
+	CompatibleWith    orderedmap.Map[string, bool]   `json:"compatible_with,omitempty"`
+	InDevelopment     bool                           `json:"in_development,omitempty"`
+}
+
+type LibraryRelease struct {
+	Author           string               `json:"author,omitempty"`
+	Version          string               `json:"version,omitempty"`
+	Maintainer       string               `json:"maintainer,omitempty"`
+	Sentence         string               `json:"sentence,omitempty"`
+	Paragraph        string               `json:"paragraph,omitempty"`
+	Website          string               `json:"website,omitempty"`
+	Category         string               `json:"category,omitempty"`
+	Architectures    []string             `json:"architectures,omitempty"`
+	Types            []string             `json:"types,omitempty"`
+	Resources        *DownloadResource    `json:"resources,omitempty"`
+	License          string               `json:"license,omitempty"`
+	ProvidesIncludes []string             `json:"provides_includes,omitempty"`
+	Dependencies     []*LibraryDependency `json:"dependencies,omitempty"`
+}
+
+type DownloadResource struct {
+	Url             string `json:"url,omitempty"`
+	ArchiveFilename string `json:"archive_filename,omitempty"`
+	Checksum        string `json:"checksum,omitempty"`
+	Size            int64  `json:"size,omitempty"`
+	CachePath       string `json:"cache_path,omitempty"`
+}
+
+type LibraryDependency struct {
+	Name              string `json:"name,omitempty"`
+	VersionConstraint string `json:"version_constraint,omitempty"`
+}
+
+func NewInstalledLibraryResult(l *rpc.InstalledLibrary) *InstalledLibrary {
+	libraryPropsMap := orderedmap.New[string, string]()
+	for k, v := range l.GetLibrary().GetProperties() {
+		libraryPropsMap.Set(k, v)
+	}
+	libraryPropsMap.SortStableKeys(cmp.Compare)
+
+	libraryCompatibleWithMap := orderedmap.New[string, bool]()
+	for k, v := range l.GetLibrary().GetCompatibleWith() {
+		libraryCompatibleWithMap.Set(k, v)
+	}
+	libraryCompatibleWithMap.SortStableKeys(cmp.Compare)
+
+	return &InstalledLibrary{
+		Library: &Library{
+			Name:              l.GetLibrary().GetName(),
+			Author:            l.GetLibrary().GetAuthor(),
+			Maintainer:        l.GetLibrary().GetMaintainer(),
+			Sentence:          l.GetLibrary().GetSentence(),
+			Paragraph:         l.GetLibrary().GetParagraph(),
+			Website:           l.GetLibrary().GetWebsite(),
+			Category:          l.GetLibrary().GetCategory(),
+			Architectures:     l.GetLibrary().GetArchitectures(),
+			Types:             l.GetLibrary().GetTypes(),
+			InstallDir:        l.GetLibrary().GetInstallDir(),
+			SourceDir:         l.GetLibrary().GetSourceDir(),
+			UtilityDir:        l.GetLibrary().GetUtilityDir(),
+			ContainerPlatform: l.GetLibrary().GetContainerPlatform(),
+			DotALinkage:       l.GetLibrary().GetDotALinkage(),
+			Precompiled:       l.GetLibrary().GetPrecompiled(),
+			LdFlags:           l.GetLibrary().GetLdFlags(),
+			IsLegacy:          l.GetLibrary().GetIsLegacy(),
+			Version:           l.GetLibrary().GetVersion(),
+			License:           l.GetLibrary().GetLicense(),
+			Properties:        libraryPropsMap,
+			Location:          LibraryLocation(l.GetLibrary().GetLocation().String()),
+			Layout:            LibraryLayout(l.GetLibrary().GetLayout().String()),
+			Examples:          l.GetLibrary().GetExamples(),
+			ProvidesIncludes:  l.GetLibrary().GetProvidesIncludes(),
+			CompatibleWith:    libraryCompatibleWithMap,
+			InDevelopment:     l.GetLibrary().GetInDevelopment(),
+		},
+		Release: &LibraryRelease{
+			Author:           l.GetRelease().GetAuthor(),
+			Version:          l.GetRelease().GetVersion(),
+			Maintainer:       l.GetRelease().GetMaintainer(),
+			Sentence:         l.GetRelease().GetSentence(),
+			Paragraph:        l.GetRelease().GetParagraph(),
+			Website:          l.GetRelease().GetWebsite(),
+			Category:         l.GetRelease().GetCategory(),
+			Architectures:    l.GetRelease().GetArchitectures(),
+			Types:            l.GetRelease().GetTypes(),
+			Resources:        NewDownloadResource(l.GetRelease().GetResources()),
+			License:          l.GetRelease().GetLicense(),
+			ProvidesIncludes: l.GetRelease().GetProvidesIncludes(),
+			Dependencies:     NewLibraryDependencies(l.GetRelease().GetDependencies()),
+		},
+	}
+}
+
+func NewDownloadResource(r *rpc.DownloadResource) *DownloadResource {
+	if r == nil {
+		return nil
+	}
+	return &DownloadResource{
+		Url:             r.GetUrl(),
+		ArchiveFilename: r.GetArchiveFilename(),
+		Checksum:        r.GetChecksum(),
+		Size:            r.GetSize(),
+		CachePath:       r.GetCachePath(),
+	}
+}
+
+func NewLibraryDependencies(d []*rpc.LibraryDependency) []*LibraryDependency {
+	if d == nil {
+		return nil
+	}
+	result := make([]*LibraryDependency, len(d))
+	for i, v := range d {
+		result[i] = NewLibraryDependency(v)
+	}
+	return result
+}
+
+func NewLibraryDependency(d *rpc.LibraryDependency) *LibraryDependency {
+	if d == nil {
+		return nil
+	}
+	return &LibraryDependency{
+		Name:              d.GetName(),
+		VersionConstraint: d.GetVersionConstraint(),
+	}
+}
+
+type Port struct {
+	Address       string                         `json:"address,omitempty"`
+	Label         string                         `json:"label,omitempty"`
+	Protocol      string                         `json:"protocol,omitempty"`
+	ProtocolLabel string                         `json:"protocol_label,omitempty"`
+	Properties    orderedmap.Map[string, string] `json:"properties,omitempty"`
+	HardwareId    string                         `json:"hardware_id,omitempty"`
+}
+
+func NewPort(p *rpc.Port) *Port {
+	propertiesMap := orderedmap.New[string, string]()
+	for k, v := range p.GetProperties() {
+		propertiesMap.Set(k, v)
+	}
+	propertiesMap.SortStableKeys(cmp.Compare)
+	if p == nil {
+		return nil
+	}
+	return &Port{
+		Address:       p.GetAddress(),
+		Label:         p.GetLabel(),
+		Protocol:      p.GetProtocol(),
+		ProtocolLabel: p.GetProtocolLabel(),
+		Properties:    propertiesMap,
+		HardwareId:    p.GetHardwareId(),
+	}
+}
+
+type BoardDetailsResponse struct {
+	Fqbn                     string                           `json:"fqbn,omitempty"`
+	Name                     string                           `json:"name,omitempty"`
+	Version                  string                           `json:"version,omitempty"`
+	PropertiesId             string                           `json:"properties_id,omitempty"`
+	Alias                    string                           `json:"alias,omitempty"`
+	Official                 bool                             `json:"official,omitempty"`
+	Pinout                   string                           `json:"pinout,omitempty"`
+	Package                  *Package                         `json:"package,omitempty"`
+	Platform                 *BoardPlatform                   `json:"platform,omitempty"`
+	ToolsDependencies        []*ToolsDependency               `json:"tools_dependencies,omitempty"`
+	ConfigOptions            []*ConfigOption                  `json:"config_options,omitempty"`
+	Programmers              []*Programmer                    `json:"programmers,omitempty"`
+	DebuggingSupported       bool                             `json:"debugging_supported,omitempty"`
+	IdentificationProperties []*BoardIdentificationProperties `json:"identification_properties,omitempty"`
+	BuildProperties          []string                         `json:"build_properties,omitempty"`
+}
+
+func NewBoardDetailsResponse(b *rpc.BoardDetailsResponse) *BoardDetailsResponse {
+	if b == nil {
+		return nil
+	}
+	return &BoardDetailsResponse{
+		Fqbn:                     b.GetFqbn(),
+		Name:                     b.GetName(),
+		Version:                  b.GetVersion(),
+		PropertiesId:             b.GetPropertiesId(),
+		Alias:                    b.GetAlias(),
+		Official:                 b.GetOfficial(),
+		Pinout:                   b.GetPinout(),
+		Package:                  NewPackage(b.GetPackage()),
+		Platform:                 NewBoardPlatform(b.GetPlatform()),
+		ToolsDependencies:        NewToolsDependencies(b.GetToolsDependencies()),
+		ConfigOptions:            NewConfigOptions(b.GetConfigOptions()),
+		Programmers:              NewProgrammers(b.GetProgrammers()),
+		DebuggingSupported:       b.GetDebuggingSupported(),
+		IdentificationProperties: NewBoardIdentificationProperties(b.GetIdentificationProperties()),
+		BuildProperties:          b.GetBuildProperties(),
+	}
+}
+
+type Package struct {
+	Maintainer string `json:"maintainer,omitempty"`
+	Url        string `json:"url,omitempty"`
+	WebsiteUrl string `json:"website_url,omitempty"`
+	Email      string `json:"email,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Help       *Help  `json:"help,omitempty"`
+}
+
+func NewPackage(p *rpc.Package) *Package {
+	if p == nil {
+		return nil
+	}
+	return &Package{
+		Maintainer: p.GetMaintainer(),
+		Url:        p.GetUrl(),
+		WebsiteUrl: p.GetWebsiteUrl(),
+		Email:      p.GetEmail(),
+		Name:       p.GetName(),
+		Help:       NewHelp(p.GetHelp()),
+	}
+}
+
+type Help struct {
+	Online string `json:"online,omitempty"`
+}
+
+func NewHelp(h *rpc.Help) *Help {
+	if h == nil {
+		return nil
+	}
+	return &Help{Online: h.GetOnline()}
+}
+
+type BoardPlatform struct {
+	Architecture    string `json:"architecture,omitempty"`
+	Category        string `json:"category,omitempty"`
+	Url             string `json:"url,omitempty"`
+	ArchiveFilename string `json:"archive_filename,omitempty"`
+	Checksum        string `json:"checksum,omitempty"`
+	Size            int64  `json:"size,omitempty"`
+	Name            string `json:"name,omitempty"`
+}
+
+func NewBoardPlatform(p *rpc.BoardPlatform) *BoardPlatform {
+	if p == nil {
+		return nil
+	}
+	return &BoardPlatform{
+		Architecture:    p.GetArchitecture(),
+		Category:        p.GetCategory(),
+		Url:             p.GetUrl(),
+		ArchiveFilename: p.GetArchiveFilename(),
+		Checksum:        p.GetChecksum(),
+		Size:            p.GetSize(),
+		Name:            p.GetName(),
+	}
+}
+
+type ToolsDependency struct {
+	Packager string    `json:"packager,omitempty"`
+	Name     string    `json:"name,omitempty"`
+	Version  string    `json:"version,omitempty"`
+	Systems  []*System `json:"systems,omitempty"`
+}
+
+func NewToolsDependencies(p []*rpc.ToolsDependencies) []*ToolsDependency {
+	if p == nil {
+		return nil
+	}
+	res := make([]*ToolsDependency, len(p))
+	for i, v := range p {
+		res[i] = NewToolsDependency(v)
+	}
+	return res
+}
+
+func NewToolsDependency(p *rpc.ToolsDependencies) *ToolsDependency {
+	if p == nil {
+		return nil
+	}
+	return &ToolsDependency{
+		Packager: p.GetPackager(),
+		Name:     p.GetName(),
+		Version:  p.GetVersion(),
+		Systems:  NewSystems(p.GetSystems()),
+	}
+}
+
+type System struct {
+	Checksum        string `json:"checksum,omitempty"`
+	Host            string `json:"host,omitempty"`
+	ArchiveFilename string `json:"archive_filename,omitempty"`
+	Url             string `json:"url,omitempty"`
+	Size            int64  `json:"size,omitempty"`
+}
+
+func NewSystems(p []*rpc.Systems) []*System {
+	if p == nil {
+		return nil
+	}
+	res := make([]*System, len(p))
+	for i, v := range p {
+		res[i] = NewSystem(v)
+	}
+	return res
+}
+
+func NewSystem(s *rpc.Systems) *System {
+	if s == nil {
+		return nil
+	}
+	return &System{
+		Checksum:        s.GetChecksum(),
+		Host:            s.GetHost(),
+		ArchiveFilename: s.GetArchiveFilename(),
+		Url:             s.GetUrl(),
+		Size:            s.GetSize(),
+	}
+}
+
+type ConfigOption struct {
+	Option      string         `json:"option,omitempty"`
+	OptionLabel string         `json:"option_label,omitempty"`
+	Values      []*ConfigValue `json:"values,omitempty"`
+}
+
+func NewConfigOptions(c []*rpc.ConfigOption) []*ConfigOption {
+	if c == nil {
+		return nil
+	}
+	res := make([]*ConfigOption, len(c))
+	for i, v := range c {
+		res[i] = NewConfigOption(v)
+	}
+	return res
+}
+
+func NewConfigOption(o *rpc.ConfigOption) *ConfigOption {
+	if o == nil {
+		return nil
+	}
+	return &ConfigOption{
+		Option:      o.GetOption(),
+		OptionLabel: o.GetOptionLabel(),
+		Values:      NewConfigValues(o.GetValues()),
+	}
+}
+
+type ConfigValue struct {
+	Value      string `json:"value,omitempty"`
+	ValueLabel string `json:"value_label,omitempty"`
+	Selected   bool   `json:"selected,omitempty"`
+}
+
+func NewConfigValues(c []*rpc.ConfigValue) []*ConfigValue {
+	if c == nil {
+		return nil
+	}
+	res := make([]*ConfigValue, len(c))
+	for i, v := range c {
+		res[i] = NewConfigValue(v)
+	}
+	return res
+}
+
+func NewConfigValue(c *rpc.ConfigValue) *ConfigValue {
+	if c == nil {
+		return nil
+	}
+	return &ConfigValue{
+		Value:      c.GetValue(),
+		ValueLabel: c.GetValueLabel(),
+		Selected:   c.GetSelected(),
+	}
+}
+
+type Programmer struct {
+	Platform string `json:"platform,omitempty"`
+	Id       string `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+}
+
+func NewProgrammers(c []*rpc.Programmer) []*Programmer {
+	if c == nil {
+		return nil
+	}
+	res := make([]*Programmer, len(c))
+	for i, v := range c {
+		res[i] = NewProgrammer(v)
+	}
+	return res
+}
+
+func NewProgrammer(c *rpc.Programmer) *Programmer {
+	if c == nil {
+		return nil
+	}
+	return &Programmer{
+		Platform: c.GetPlatform(),
+		Id:       c.GetId(),
+		Name:     c.GetName(),
+	}
+}
+
+type BoardIdentificationProperties struct {
+	Properties orderedmap.Map[string, string] `json:"properties,omitempty"`
+}
+
+func NewBoardIdentificationProperties(p []*rpc.BoardIdentificationProperties) []*BoardIdentificationProperties {
+	if p == nil {
+		return nil
+	}
+	res := make([]*BoardIdentificationProperties, len(p))
+	for i, v := range p {
+		res[i] = NewBoardIndentificationProperty(v)
+	}
+	return res
+}
+
+func NewBoardIndentificationProperty(p *rpc.BoardIdentificationProperties) *BoardIdentificationProperties {
+	if p == nil {
+		return nil
+	}
+	propertiesMap := orderedmap.New[string, string]()
+	for k, v := range p.GetProperties() {
+		propertiesMap.Set(k, v)
+	}
+	propertiesMap.SortStableKeys(cmp.Compare)
+
+	return &BoardIdentificationProperties{Properties: propertiesMap}
 }

--- a/internal/cli/feedback/result/rpc.go
+++ b/internal/cli/feedback/result/rpc.go
@@ -621,6 +621,17 @@ type BoardListItem struct {
 	Platform *Platform `json:"platform,omitempty"`
 }
 
+func NewBoardListItems(b []*rpc.BoardListItem) []*BoardListItem {
+	if b == nil {
+		return nil
+	}
+	res := make([]*BoardListItem, len(b))
+	for i, v := range b {
+		res[i] = NewBoardListItem(v)
+	}
+	return res
+}
+
 func NewBoardListItem(b *rpc.BoardListItem) *BoardListItem {
 	if b == nil {
 		return nil

--- a/internal/cli/feedback/result/rpc.go
+++ b/internal/cli/feedback/result/rpc.go
@@ -23,7 +23,7 @@ import (
 	semver "go.bug.st/relaxed-semver"
 )
 
-// NewPlatformSummary creates a new result.Platform from rpc.PlatformSummary
+// NewPlatformSummary creates a new result.PlatformSummary from rpc.PlatformSummary
 func NewPlatformSummary(in *rpc.PlatformSummary) *PlatformSummary {
 	if in == nil {
 		return nil

--- a/internal/cli/feedback/result/rpc.go
+++ b/internal/cli/feedback/result/rpc.go
@@ -840,8 +840,8 @@ func NewCompileResponse(c *rpc.CompileResponse) *CompileResponse {
 		BuildPath:              c.GetBuildPath(),
 		UsedLibraries:          usedLibs,
 		ExecutableSectionsSize: executableSectionsSizes,
-		BoardPlatform:          &InstalledPlatformReference{},
-		BuildPlatform:          &InstalledPlatformReference{},
+		BoardPlatform:          NewInstalledPlatformReference(c.GetBoardPlatform()),
+		BuildPlatform:          NewInstalledPlatformReference(c.GetBuildPlatform()),
 		BuildProperties:        c.GetBuildProperties(),
 	}
 }

--- a/internal/cli/feedback/result/rpc_test.go
+++ b/internal/cli/feedback/result/rpc_test.go
@@ -206,3 +206,44 @@ func TestAllFieldAreMapped(t *testing.T) {
 	boardListWatchResponseResult := result.NewBoardListWatchResponse(boardListWatchResponseRpc)
 	mustContainsAllPropertyOfRpcStruct(t, boardListWatchResponseRpc, boardListWatchResponseResult)
 }
+
+func TestEnumsMapsEveryRpcCounterpart(t *testing.T) {
+	t.Run("LibraryLocation enums maps every element", func(t *testing.T) {
+		results := make([]result.LibraryLocation, 0, len(rpc.LibraryLocation_name))
+		for key := range rpc.LibraryLocation_name {
+			results = append(results, result.NewLibraryLocation(rpc.LibraryLocation(key)))
+		}
+		require.NotEmpty(t, results)
+		require.Len(t, results, len(rpc.LibraryLocation_name))
+		require.True(t, isUnique(results))
+	})
+	t.Run("LibraryLayout enums maps every element", func(t *testing.T) {
+		results := make([]result.LibraryLayout, 0, len(rpc.LibraryLayout_name))
+		for key := range rpc.LibraryLayout_name {
+			results = append(results, result.NewLibraryLayout(rpc.LibraryLayout(key)))
+		}
+		require.NotEmpty(t, results)
+		require.Len(t, results, len(rpc.LibraryLayout_name))
+		require.True(t, isUnique(results))
+	})
+	t.Run("LibrarySearchStatus enums maps every element", func(t *testing.T) {
+		results := make([]result.LibrarySearchStatus, 0, len(rpc.LibrarySearchStatus_name))
+		for key := range rpc.LibrarySearchStatus_name {
+			results = append(results, result.NewLibrarySearchStatus(rpc.LibrarySearchStatus(key)))
+		}
+		require.NotEmpty(t, results)
+		require.Len(t, results, len(rpc.LibrarySearchStatus_name))
+		require.True(t, isUnique(results))
+	})
+}
+
+func isUnique[T comparable](s []T) bool {
+	seen := map[T]bool{}
+	for _, v := range s {
+		if _, ok := seen[v]; ok {
+			return false
+		}
+		seen[v] = true
+	}
+	return true
+}

--- a/internal/cli/feedback/result/rpc_test.go
+++ b/internal/cli/feedback/result/rpc_test.go
@@ -45,7 +45,7 @@ func getStructJsonTags(t *testing.T, a any) []string {
 }
 
 func mustContainsAllPropertyOfRpcStruct(t *testing.T, a, b any, excludeFields ...string) {
-	// must not be the same pointer, a and b struct must be of differnt type
+	// must not be the same pointer, a and b struct must be of different type
 	require.NotSame(t, a, b)
 	rta, rtb := reflect.TypeOf(a), reflect.TypeOf(b)
 	if rta.Kind() != reflect.Struct {
@@ -201,4 +201,8 @@ func TestAllFieldAreMapped(t *testing.T) {
 	installedPlatformReferenceRpc := &rpc.InstalledPlatformReference{}
 	installedPlatformReferenceResult := result.NewInstalledPlatformReference(installedPlatformReferenceRpc)
 	mustContainsAllPropertyOfRpcStruct(t, installedPlatformReferenceRpc, installedPlatformReferenceResult)
+
+	boardListWatchResponseRpc := &rpc.BoardListWatchResponse{}
+	boardListWatchResponseResult := result.NewBoardListWatchResponse(boardListWatchResponseRpc)
+	mustContainsAllPropertyOfRpcStruct(t, boardListWatchResponseRpc, boardListWatchResponseResult)
 }

--- a/internal/cli/feedback/result/rpc_test.go
+++ b/internal/cli/feedback/result/rpc_test.go
@@ -1,0 +1,204 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2023 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package result_test
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/arduino/arduino-cli/internal/cli/feedback/result"
+	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func getStructJsonTags(t *testing.T, a any) []string {
+	tags := []string{}
+	rt := reflect.TypeOf(a)
+	if rt.Kind() != reflect.Struct {
+		rt = rt.Elem()
+		require.Equal(t, reflect.Struct, rt.Kind())
+	}
+	for i := 0; i < rt.NumField(); i++ {
+		tag := rt.Field(i).Tag.Get("json")
+		if tag == "" {
+			continue
+		}
+		key, _, _ := strings.Cut(tag, ",")
+		tags = append(tags, key)
+	}
+	return tags
+}
+
+func mustContainsAllPropertyOfRpcStruct(t *testing.T, a, b any, excludeFields ...string) {
+	// must not be the same pointer, a and b struct must be of differnt type
+	require.NotSame(t, a, b)
+	rta, rtb := reflect.TypeOf(a), reflect.TypeOf(b)
+	if rta.Kind() != reflect.Struct {
+		rta = rta.Elem()
+		require.Equal(t, reflect.Struct, rta.Kind())
+	}
+	if rtb.Kind() != reflect.Struct {
+		rtb = rtb.Elem()
+		require.Equal(t, reflect.Struct, rtb.Kind())
+	}
+	require.NotEqual(t, rta.String(), rtb.String())
+
+	aTags := getStructJsonTags(t, a)
+	bTags := getStructJsonTags(t, b)
+	if len(excludeFields) > 0 {
+		aTags = slices.DeleteFunc(aTags, func(s string) bool { return slices.Contains(excludeFields, s) })
+		bTags = slices.DeleteFunc(bTags, func(s string) bool { return slices.Contains(excludeFields, s) })
+	}
+	require.ElementsMatch(t, aTags, bTags)
+}
+
+func TestAllFieldAreMapped(t *testing.T) {
+	// Our PlatformSummary expands the PlatformMetadata without the need to nest it as the rpc does.
+	platformSummaryRpc := &rpc.PlatformSummary{
+		InstalledVersion: "1.0.0",
+		LatestVersion:    "1.0.0",
+	}
+	platformSummaryRpcTags := getStructJsonTags(t, platformSummaryRpc)
+	platformSummaryRpcTags = append(platformSummaryRpcTags, getStructJsonTags(t, platformSummaryRpc.GetMetadata())...)
+	platformSummaryRpcTags = slices.DeleteFunc(platformSummaryRpcTags, func(s string) bool { return s == "metadata" })
+
+	platformSummaryResult := result.NewPlatformSummary(platformSummaryRpc)
+	platformSummaryResultTags := getStructJsonTags(t, platformSummaryResult)
+
+	require.ElementsMatch(t, platformSummaryRpcTags, platformSummaryResultTags)
+
+	platformRelease := &rpc.PlatformRelease{}
+	platformReleaseResult := result.NewPlatformRelease(platformRelease)
+	mustContainsAllPropertyOfRpcStruct(t, platformRelease, platformReleaseResult)
+
+	libraryRpc := &rpc.Library{}
+	libraryResult := result.NewLibrary(libraryRpc)
+	mustContainsAllPropertyOfRpcStruct(t, libraryRpc, libraryResult)
+
+	libraryReleaseRpc := &rpc.LibraryRelease{}
+	libraryReleaseResult := result.NewLibraryRelease(libraryReleaseRpc)
+	mustContainsAllPropertyOfRpcStruct(t, libraryReleaseRpc, libraryReleaseResult)
+
+	installedLibrary := &rpc.InstalledLibrary{}
+	installedLibraryResult := result.NewInstalledLibrary(installedLibrary)
+	mustContainsAllPropertyOfRpcStruct(t, installedLibrary, installedLibraryResult)
+
+	downloadResource := &rpc.DownloadResource{}
+	downloadResourceResult := result.NewDownloadResource(downloadResource)
+	mustContainsAllPropertyOfRpcStruct(t, downloadResource, downloadResourceResult)
+
+	libraryDependencyRpc := &rpc.LibraryDependency{}
+	libraryDependencyResult := result.NewLibraryDependency(libraryDependencyRpc)
+	mustContainsAllPropertyOfRpcStruct(t, libraryDependencyRpc, libraryDependencyResult)
+
+	portRpc := &rpc.Port{}
+	portResult := result.NewPort(portRpc)
+	mustContainsAllPropertyOfRpcStruct(t, portRpc, portResult)
+
+	boardDetailsResponseRpc := &rpc.BoardDetailsResponse{}
+	boardDetailsResponseResult := result.NewBoardDetailsResponse(boardDetailsResponseRpc)
+	mustContainsAllPropertyOfRpcStruct(t, boardDetailsResponseRpc, boardDetailsResponseResult)
+
+	packageRpc := &rpc.Package{}
+	packageResult := result.NewPackage(packageRpc)
+	mustContainsAllPropertyOfRpcStruct(t, packageRpc, packageResult)
+
+	helpRpc := &rpc.Help{}
+	helpResult := result.NewHelp(helpRpc)
+	mustContainsAllPropertyOfRpcStruct(t, helpRpc, helpResult)
+
+	boardPlatformRpc := &rpc.BoardPlatform{}
+	boardPlatformResult := result.NewBoardPlatform(boardPlatformRpc)
+	mustContainsAllPropertyOfRpcStruct(t, boardPlatformRpc, boardPlatformResult)
+
+	toolsDependencyRpc := &rpc.ToolsDependencies{}
+	toolsDependencyResult := result.NewToolsDependency(toolsDependencyRpc)
+	mustContainsAllPropertyOfRpcStruct(t, toolsDependencyRpc, toolsDependencyResult)
+
+	systemRpc := &rpc.Systems{}
+	systemResult := result.NewSystem(systemRpc)
+	mustContainsAllPropertyOfRpcStruct(t, systemRpc, systemResult)
+
+	configOptionRpc := &rpc.ConfigOption{}
+	configOptionResult := result.NewConfigOption(configOptionRpc)
+	mustContainsAllPropertyOfRpcStruct(t, configOptionRpc, configOptionResult)
+
+	configValueRpc := &rpc.ConfigValue{}
+	configValueResult := result.NewConfigValue(configValueRpc)
+	mustContainsAllPropertyOfRpcStruct(t, configValueRpc, configValueResult)
+
+	programmerRpc := &rpc.Programmer{}
+	programmerResult := result.NewProgrammer(programmerRpc)
+	mustContainsAllPropertyOfRpcStruct(t, programmerRpc, programmerResult)
+
+	boardIdentificationPropertiesRpc := &rpc.BoardIdentificationProperties{}
+	boardIdentificationPropertiesResult := result.NewBoardIndentificationProperty(boardIdentificationPropertiesRpc)
+	mustContainsAllPropertyOfRpcStruct(t, boardIdentificationPropertiesRpc, boardIdentificationPropertiesResult)
+
+	boardListAllResponseRpc := &rpc.BoardListAllResponse{}
+	boardListAllResponseResult := result.NewBoardListAllResponse(boardListAllResponseRpc)
+	mustContainsAllPropertyOfRpcStruct(t, boardListAllResponseRpc, boardListAllResponseResult)
+
+	boardListItemRpc := &rpc.BoardListItem{}
+	boardListItemResult := result.NewBoardListItem(boardListItemRpc)
+	mustContainsAllPropertyOfRpcStruct(t, boardListItemRpc, boardListItemResult)
+
+	platformRpc := &rpc.Platform{}
+	platformResult := result.NewPlatform(platformRpc)
+	mustContainsAllPropertyOfRpcStruct(t, platformRpc, platformResult)
+
+	platformMetadataRpc := &rpc.PlatformMetadata{}
+	platformMetadataResult := result.NewPlatformMetadata(platformMetadataRpc)
+	mustContainsAllPropertyOfRpcStruct(t, platformMetadataRpc, platformMetadataResult)
+
+	detectedPortRpc := &rpc.DetectedPort{}
+	detectedPortResult := result.NewDetectedPort(detectedPortRpc)
+	mustContainsAllPropertyOfRpcStruct(t, detectedPortRpc, detectedPortResult)
+
+	libraryResolveDependenciesResponseRpc := &rpc.LibraryResolveDependenciesResponse{}
+	libraryResolveDependenciesResponseResult := result.NewLibraryResolveDependenciesResponse(libraryResolveDependenciesResponseRpc)
+	mustContainsAllPropertyOfRpcStruct(t, libraryResolveDependenciesResponseRpc, libraryResolveDependenciesResponseResult)
+
+	libraryDependencyStatusRpc := &rpc.LibraryDependencyStatus{}
+	libraryDependencyStatusResult := result.NewLibraryDependencyStatus(libraryDependencyStatusRpc)
+	mustContainsAllPropertyOfRpcStruct(t, libraryDependencyStatusRpc, libraryDependencyStatusResult)
+
+	librarySearchResponseRpc := &rpc.LibrarySearchResponse{}
+	librarySearchResponseResult := result.NewLibrarySearchResponse(librarySearchResponseRpc)
+	mustContainsAllPropertyOfRpcStruct(t, librarySearchResponseRpc, librarySearchResponseResult)
+
+	searchedLibraryRpc := &rpc.SearchedLibrary{}
+	searchedLibraryResult := result.NewSearchedLibrary(searchedLibraryRpc)
+	mustContainsAllPropertyOfRpcStruct(t, searchedLibraryRpc, searchedLibraryResult)
+
+	monitorPortSettingDescriptorRpc := &rpc.MonitorPortSettingDescriptor{}
+	monitorPortSettingDescriptorResult := result.NewMonitorPortSettingDescriptor(monitorPortSettingDescriptorRpc)
+	mustContainsAllPropertyOfRpcStruct(t, monitorPortSettingDescriptorRpc, monitorPortSettingDescriptorResult)
+
+	compileResponseRpc := &rpc.CompileResponse{}
+	compileResponseResult := result.NewCompileResponse(compileResponseRpc)
+	mustContainsAllPropertyOfRpcStruct(t, compileResponseRpc, compileResponseResult, "progress")
+
+	executableSectionSizeRpc := &rpc.ExecutableSectionSize{}
+	executableSectionSizeResult := result.NewExecutableSectionSize(executableSectionSizeRpc)
+	mustContainsAllPropertyOfRpcStruct(t, executableSectionSizeRpc, executableSectionSizeResult)
+
+	installedPlatformReferenceRpc := &rpc.InstalledPlatformReference{}
+	installedPlatformReferenceResult := result.NewInstalledPlatformReference(installedPlatformReferenceRpc)
+	mustContainsAllPropertyOfRpcStruct(t, installedPlatformReferenceRpc, installedPlatformReferenceResult)
+}

--- a/internal/cli/lib/examples.go
+++ b/internal/cli/lib/examples.go
@@ -115,7 +115,7 @@ func (ir libraryExamplesResult) String() string {
 		name := lib.Library.Name
 		if lib.Library.ContainerPlatform != "" {
 			name += " (" + lib.Library.ContainerPlatform + ")"
-		} else if string(lib.Library.Location) != rpc.LibraryLocation_LIBRARY_LOCATION_USER.String() {
+		} else if lib.Library.Location != result.LibraryLocationUser {
 			name += " (" + string(lib.Library.Location) + ")"
 		}
 		r := tr("Examples for library %s", color.GreenString("%s", name)) + "\n"

--- a/internal/cli/lib/examples.go
+++ b/internal/cli/lib/examples.go
@@ -25,6 +25,7 @@ import (
 	"github.com/arduino/arduino-cli/commands/lib"
 	"github.com/arduino/arduino-cli/internal/cli/arguments"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
+	"github.com/arduino/arduino-cli/internal/cli/feedback/result"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-paths-helper"
@@ -75,7 +76,7 @@ func runExamplesCommand(cmd *cobra.Command, args []string) {
 	found := []*libraryExamples{}
 	for _, lib := range res.GetInstalledLibraries() {
 		found = append(found, &libraryExamples{
-			Library:  lib.Library,
+			Library:  result.NewLibrary(lib.Library),
 			Examples: lib.Library.Examples,
 		})
 	}
@@ -88,8 +89,8 @@ func runExamplesCommand(cmd *cobra.Command, args []string) {
 // feedback.Result implementation
 
 type libraryExamples struct {
-	Library  *rpc.Library `json:"library"`
-	Examples []string     `json:"examples"`
+	Library  *result.Library `json:"library"`
+	Examples []string        `json:"examples"`
 }
 
 type libraryExamplesResult struct {
@@ -113,9 +114,9 @@ func (ir libraryExamplesResult) String() string {
 	for _, lib := range ir.Examples {
 		name := lib.Library.Name
 		if lib.Library.ContainerPlatform != "" {
-			name += " (" + lib.Library.GetContainerPlatform() + ")"
-		} else if lib.Library.Location != rpc.LibraryLocation_LIBRARY_LOCATION_USER {
-			name += " (" + lib.Library.GetLocation().String() + ")"
+			name += " (" + lib.Library.ContainerPlatform + ")"
+		} else if string(lib.Library.Location) != rpc.LibraryLocation_name[int32(rpc.LibraryLocation_LIBRARY_LOCATION_USER)] {
+			name += " (" + string(lib.Library.Location) + ")"
 		}
 		r := tr("Examples for library %s", color.GreenString("%s", name)) + "\n"
 		sort.Slice(lib.Examples, func(i, j int) bool {

--- a/internal/cli/lib/examples.go
+++ b/internal/cli/lib/examples.go
@@ -115,7 +115,7 @@ func (ir libraryExamplesResult) String() string {
 		name := lib.Library.Name
 		if lib.Library.ContainerPlatform != "" {
 			name += " (" + lib.Library.ContainerPlatform + ")"
-		} else if string(lib.Library.Location) != rpc.LibraryLocation_name[int32(rpc.LibraryLocation_LIBRARY_LOCATION_USER)] {
+		} else if string(lib.Library.Location) != rpc.LibraryLocation_LIBRARY_LOCATION_USER.String() {
 			name += " (" + string(lib.Library.Location) + ")"
 		}
 		r := tr("Examples for library %s", color.GreenString("%s", name)) + "\n"

--- a/internal/cli/lib/list.go
+++ b/internal/cli/lib/list.go
@@ -146,9 +146,6 @@ func (ir installedResult) String() string {
 
 	lastName := ""
 	for _, libMeta := range ir.installedLibs {
-		if libMeta == nil {
-			continue
-		}
 		lib := libMeta.Library
 		name := lib.Name
 		if name == lastName {

--- a/internal/cli/lib/search.go
+++ b/internal/cli/lib/search.go
@@ -173,12 +173,12 @@ func (res librarySearchResult) String() string {
 
 	var out strings.Builder
 
-	if string(res.results.Status) == rpc.LibrarySearchStatus_name[int32(rpc.LibrarySearchStatus_LIBRARY_SEARCH_STATUS_FAILED)] {
+	if string(res.results.Status) == rpc.LibrarySearchStatus_LIBRARY_SEARCH_STATUS_FAILED.String() {
 		out.WriteString(tr("No libraries matching your search.\nDid you mean...\n"))
 	}
 
 	for _, lib := range results {
-		if string(res.results.Status) == rpc.LibrarySearchStatus_name[int32(rpc.LibrarySearchStatus_LIBRARY_SEARCH_STATUS_SUCCESS)] {
+		if string(res.results.Status) == rpc.LibrarySearchStatus_LIBRARY_SEARCH_STATUS_SUCCESS.String() {
 			out.WriteString(tr(`Name: "%s"`, lib.Name) + "\n")
 			if res.namesOnly {
 				continue

--- a/internal/cli/lib/search.go
+++ b/internal/cli/lib/search.go
@@ -173,12 +173,12 @@ func (res librarySearchResult) String() string {
 
 	var out strings.Builder
 
-	if string(res.results.Status) == rpc.LibrarySearchStatus_LIBRARY_SEARCH_STATUS_FAILED.String() {
+	if res.results.Status == result.LibrarySearchStatusFailed {
 		out.WriteString(tr("No libraries matching your search.\nDid you mean...\n"))
 	}
 
 	for _, lib := range results {
-		if string(res.results.Status) == rpc.LibrarySearchStatus_LIBRARY_SEARCH_STATUS_SUCCESS.String() {
+		if res.results.Status == result.LibrarySearchStatusSuccess {
 			out.WriteString(tr(`Name: "%s"`, lib.Name) + "\n")
 			if res.namesOnly {
 				continue

--- a/internal/cli/lib/search.go
+++ b/internal/cli/lib/search.go
@@ -156,9 +156,6 @@ func (res librarySearchResult) Data() interface{} {
 
 		names := []LibName{}
 		for _, lib := range res.results.Libraries {
-			if lib == nil {
-				continue
-			}
 			names = append(names, LibName{lib.Name})
 		}
 
@@ -181,9 +178,6 @@ func (res librarySearchResult) String() string {
 	}
 
 	for _, lib := range results {
-		if lib == nil {
-			continue
-		}
 		if string(res.results.Status) == rpc.LibrarySearchStatus_name[int32(rpc.LibrarySearchStatus_LIBRARY_SEARCH_STATUS_SUCCESS)] {
 			out.WriteString(tr(`Name: "%s"`, lib.Name) + "\n")
 			if res.namesOnly {
@@ -198,9 +192,6 @@ func (res librarySearchResult) String() string {
 
 		deps := []string{}
 		for _, dep := range latest.Dependencies {
-			if dep == nil {
-				continue
-			}
 			if dep.VersionConstraint == "" {
 				deps = append(deps, dep.Name)
 			} else {

--- a/internal/cli/monitor/monitor.go
+++ b/internal/cli/monitor/monitor.go
@@ -290,12 +290,11 @@ func (r *detailsResult) Data() interface{} {
 }
 
 func (r *detailsResult) String() string {
+	if len(r.Settings) == 0 {
+		return ""
+	}
 	t := table.New()
 	t.SetHeader(tr("ID"), tr("Setting"), tr("Default"), tr("Values"))
-
-	if len(r.Settings) == 0 {
-		return t.Render()
-	}
 
 	green := color.New(color.FgGreen)
 	sort.Slice(r.Settings, func(i, j int) bool {

--- a/internal/cli/outdated/outdated.go
+++ b/internal/cli/outdated/outdated.go
@@ -65,17 +65,17 @@ func Outdated(inst *rpc.Instance) {
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type outdatedResult struct {
-	Platforms     []*result.Platform         `json:"platforms,omitempty"`
+	Platforms     []*result.PlatformSummary  `json:"platforms,omitempty"`
 	InstalledLibs []*result.InstalledLibrary `json:"libraries,omitempty"`
 }
 
 func newOutdatedResult(inPlatforms []*rpc.PlatformSummary, inLibraries []*rpc.InstalledLibrary) *outdatedResult {
 	res := &outdatedResult{
-		Platforms:     make([]*result.Platform, len(inPlatforms)),
+		Platforms:     make([]*result.PlatformSummary, len(inPlatforms)),
 		InstalledLibs: make([]*result.InstalledLibrary, len(inLibraries)),
 	}
 	for i, v := range inPlatforms {
-		res.Platforms[i] = result.NewPlatformResult(v)
+		res.Platforms[i] = result.NewPlatformSummary(v)
 	}
 	for i, v := range inLibraries {
 		res.InstalledLibs[i] = result.NewInstalledLibraryResult(v)

--- a/internal/cli/outdated/outdated.go
+++ b/internal/cli/outdated/outdated.go
@@ -78,7 +78,7 @@ func newOutdatedResult(inPlatforms []*rpc.PlatformSummary, inLibraries []*rpc.In
 		res.Platforms[i] = result.NewPlatformSummary(v)
 	}
 	for i, v := range inLibraries {
-		res.InstalledLibs[i] = result.NewInstalledLibraryResult(v)
+		res.InstalledLibs[i] = result.NewInstalledLibrary(v)
 	}
 	return res
 }

--- a/internal/cli/sketch/new.go
+++ b/internal/cli/sketch/new.go
@@ -81,5 +81,17 @@ func runNewCommand(args []string, overwrite bool) {
 		feedback.Fatal(tr("Error creating sketch: %v", err), feedback.ErrGeneric)
 	}
 
-	feedback.Print(tr("Sketch created in: %s", sketchDirPath))
+	feedback.PrintResult(sketchResult{SketchDirPath: sketchDirPath})
+}
+
+type sketchResult struct {
+	SketchDirPath *paths.Path `json:"sketch_path"`
+}
+
+func (ir sketchResult) Data() interface{} {
+	return ir
+}
+
+func (ir sketchResult) String() string {
+	return tr("Sketch created in: %s", ir.SketchDirPath)
 }

--- a/internal/cli/upload/upload.go
+++ b/internal/cli/upload/upload.go
@@ -29,6 +29,7 @@ import (
 	"github.com/arduino/arduino-cli/i18n"
 	"github.com/arduino/arduino-cli/internal/cli/arguments"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
+	"github.com/arduino/arduino-cli/internal/cli/feedback/result"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/arduino-cli/version"
@@ -199,15 +200,15 @@ func runUploadCommand(args []string, uploadFieldsArgs map[string]string) {
 		feedback.PrintResult(&uploadResult{
 			Stdout:            io.Stdout,
 			Stderr:            io.Stderr,
-			UpdatedUploadPort: res.UpdatedUploadPort,
+			UpdatedUploadPort: result.NewPort(res.GetUpdatedUploadPort()),
 		})
 	}
 }
 
 type uploadResult struct {
-	Stdout            string    `json:"stdout"`
-	Stderr            string    `json:"stderr"`
-	UpdatedUploadPort *rpc.Port `json:"updated_upload_port,omitempty"`
+	Stdout            string       `json:"stdout"`
+	Stderr            string       `json:"stderr"`
+	UpdatedUploadPort *result.Port `json:"updated_upload_port,omitempty"`
 }
 
 func (r *uploadResult) Data() interface{} {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

IT add a layer of mappers used only in the cli output of ours command and subcommand

## What is the current behavior?

We are currently returning/using the rpc structs which isn't ideal for 2 reasons:
- Maps can be serialized randomly
- Enums are serialized as a number instead of their string representation. 

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
