### PR TITLE
debug: Enforce programmer selection

### DIFF
--- a/commands/debug/debug_info.go
+++ b/commands/debug/debug_info.go
@@ -108,14 +108,15 @@ func getDebugProperties(req *rpc.GetDebugConfigRequest, pme *packagemanager.Expl
 		}
 	}
 
-	if req.GetProgrammer() != "" {
-		if p, ok := platformRelease.Programmers[req.GetProgrammer()]; ok {
-			toolProperties.Merge(p.Properties)
-		} else if refP, ok := referencedPlatformRelease.Programmers[req.GetProgrammer()]; ok {
-			toolProperties.Merge(refP.Properties)
-		} else {
-			return nil, &arduino.ProgrammerNotFoundError{Programmer: req.GetProgrammer()}
-		}
+	if req.GetProgrammer() == "" {
+		return nil, &arduino.MissingProgrammerError{}
+	}
+	if p, ok := platformRelease.Programmers[req.GetProgrammer()]; ok {
+		toolProperties.Merge(p.Properties)
+	} else if refP, ok := referencedPlatformRelease.Programmers[req.GetProgrammer()]; ok {
+		toolProperties.Merge(refP.Properties)
+	} else {
+		return nil, &arduino.ProgrammerNotFoundError{Programmer: req.GetProgrammer()}
 	}
 
 	var importPath *paths.Path

--- a/commands/debug/debug_test.go
+++ b/commands/debug/debug_test.go
@@ -70,6 +70,13 @@ func TestGetCommandLine(t *testing.T) {
 		require.Error(t, err)
 	}
 
+	{
+		// Check programmer not found
+		req.Programmer = "not-existent"
+		_, err := getCommandLine(req, pme)
+		require.Error(t, err)
+	}
+
 	req.Programmer = "edbg"
 	command, err := getCommandLine(req, pme)
 	require.Nil(t, err)

--- a/commands/debug/debug_test.go
+++ b/commands/debug/debug_test.go
@@ -63,6 +63,14 @@ func TestGetCommandLine(t *testing.T) {
 	pm := pmb.Build()
 	pme, release := pm.NewExplorer()
 	defer release()
+
+	{
+		// Check programmer required
+		_, err := getCommandLine(req, pme)
+		require.Error(t, err)
+	}
+
+	req.Programmer = "edbg"
 	command, err := getCommandLine(req, pme)
 	require.Nil(t, err)
 	commandToTest := strings.Join(command, " ")
@@ -76,6 +84,7 @@ func TestGetCommandLine(t *testing.T) {
 		SketchPath:  sketchPath.String(),
 		Interpreter: "mi1",
 		ImportDir:   sketchPath.Join("build", "arduino-test.samd.mkr1000").String(),
+		Programmer:  "edbg",
 	}
 
 	goldCommand2 := fmt.Sprintf("%s/arduino-test/tools/arm-none-eabi-gcc/7-2017q4/bin/arm-none-eabi-gdb%s", dataDir, toolExtension) +

--- a/commands/debug/testdata/custom_hardware/arduino-test/samd/programmers.txt
+++ b/commands/debug/testdata/custom_hardware/arduino-test/samd/programmers.txt
@@ -1,0 +1,1 @@
+edbg.name=edbg


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Enforce programmer selection to `debug`.

## What is the current behavior?

The `debug` command allows running without specifying the `-P` flag.

## What is the new behavior?

```
$ arduino-cli debug -b arduino:samd:mkr1000 
Error during Debug: Missing programmer
$ arduino-cli debug -b arduino:samd:mkr1000 --info
Error getting Debug info: Missing programmer
$ arduino-cli debug -b arduino:samd:mkr1000 --info --format json
{
  "error": "Error getting Debug info: Missing programmer"
}
$ 
```
## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
