### PR TITLE
feat: added exit codes for CLI `daemon` command errors

### DIFF
--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -136,18 +136,18 @@ func runDaemonCommand(cmd *cobra.Command, args []string) {
 		feedback.Fatal(tr("Failed to listen on TCP port: %[1]s. Unexpected error: %[2]v", port, err), feedback.ErrFailedToListenToTCPPort)
 	}
 
-	// We need to parse the port used only if the user let
-	// us choose it randomly, in all other cases we already
-	// know which is used.
+	// We need to retrieve the port used only if the user did not specify it
+	// and let the OS choose it randomly, in all other cases we already know
+	// which port is used.
 	if port == "0" {
 		address := lis.Addr()
 		split := strings.Split(address.String(), ":")
 
-		if len(split) == 0 {
+		if len(split) <= 1 {
 			feedback.Fatal(tr("Invalid TCP address: port is missing"), feedback.ErrBadTCPPortArgument)
 		}
 
-		port = split[len(split)-1]
+		port = split[1]
 	}
 
 	feedback.PrintResult(daemonResult{

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -121,19 +121,19 @@ func runDaemonCommand(cmd *cobra.Command, args []string) {
 		// Invalid port, such as "Foo"
 		var dnsError *net.DNSError
 		if errors.As(err, &dnsError) {
-			feedback.Fatal(tr("Failed to listen on TCP port: %[1]s. %[2]s is unknown name.", port, dnsError.Name), feedback.ErrCoreConfig)
+			feedback.Fatal(tr("Failed to listen on TCP port: %[1]s. %[2]s is unknown name.", port, dnsError.Name), feedback.ErrBadTCPPortArgument)
 		}
 		// Invalid port number, such as -1
 		var addrError *net.AddrError
 		if errors.As(err, &addrError) {
-			feedback.Fatal(tr("Failed to listen on TCP port: %[1]s. %[2]s is an invalid port.", port, addrError.Addr), feedback.ErrCoreConfig)
+			feedback.Fatal(tr("Failed to listen on TCP port: %[1]s. %[2]s is an invalid port.", port, addrError.Addr), feedback.ErrBadTCPPortArgument)
 		}
 		// Port is already in use
 		var syscallErr *os.SyscallError
 		if errors.As(err, &syscallErr) && errors.Is(syscallErr.Err, syscall.EADDRINUSE) {
-			feedback.Fatal(tr("Failed to listen on TCP port: %s. Address already in use.", port), feedback.ErrNetwork)
+			feedback.Fatal(tr("Failed to listen on TCP port: %s. Address already in use.", port), feedback.ErrFailedToListenToTCPPort)
 		}
-		feedback.Fatal(tr("Failed to listen on TCP port: %[1]s. Unexpected error: %[2]v", port, err), feedback.ErrGeneric)
+		feedback.Fatal(tr("Failed to listen on TCP port: %[1]s. Unexpected error: %[2]v", port, err), feedback.ErrFailedToListenToTCPPort)
 	}
 
 	// We need to parse the port used only if the user let
@@ -144,7 +144,7 @@ func runDaemonCommand(cmd *cobra.Command, args []string) {
 		split := strings.Split(address.String(), ":")
 
 		if len(split) == 0 {
-			feedback.Fatal(tr("Invalid TCP address: port is missing"), feedback.ErrBadArgument)
+			feedback.Fatal(tr("Invalid TCP address: port is missing"), feedback.ErrBadTCPPortArgument)
 		}
 
 		port = split[len(split)-1]
@@ -156,7 +156,7 @@ func runDaemonCommand(cmd *cobra.Command, args []string) {
 	})
 
 	if err := s.Serve(lis); err != nil {
-		logrus.Fatalf("Failed to serve: %v", err)
+		feedback.Fatal(fmt.Sprintf("Failed to serve: %v", err), feedback.ErrFailedToListenToTCPPort)
 	}
 }
 

--- a/internal/cli/feedback/errorcodes.go
+++ b/internal/cli/feedback/errorcodes.go
@@ -42,4 +42,11 @@ const (
 
 	// ErrBadArgument is returned when the arguments are not valid (7)
 	ErrBadArgument
+
+	// ErrFailedToListenToTCPPort is returned if the CLI failed to open a TCP port
+	// to listen for incoming connections (8)
+	ErrFailedToListenToTCPPort
+
+	// ErrBadTCPPortArgument is returned if the TCP port argument is not valid (9)
+	ErrBadTCPPortArgument
 )


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Makes the `daemon` command return a consistent exit code for specific errors.

## What is the current behavior?

The exit code was a bit random:
* If "CLI failed to open a TCP port to listen for incoming connections" the exit code could be 1 (Generic error), 5 (Network error), or 0 (Success!)
* If "TCP port argument is not valid" the exit code could be 6 (Core config error) or 7 (Bad Argument error).

## What is the new behavior?

The following error codes have been added:
* code `8`: CLI failed to open a TCP port to listen for incoming connections
* code `9`: TCP port argument is not valid

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Related to #2352 