### PR TITLE
Added specific CLI return error-code if inventory can not be created

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -150,7 +150,7 @@ func preRun(cmd *cobra.Command, args []string) {
 	// initialize inventory
 	err := inventory.Init(configuration.DataDir(configuration.Settings).String())
 	if err != nil {
-		feedback.Fatal(fmt.Sprintf("Error: %v", err), feedback.ErrBadArgument)
+		feedback.Fatal(fmt.Sprintf("Error: %v", err), feedback.ErrInitializingInventory)
 	}
 
 	// https://no-color.org/

--- a/internal/cli/feedback/errorcodes.go
+++ b/internal/cli/feedback/errorcodes.go
@@ -49,4 +49,8 @@ const (
 
 	// ErrBadTCPPortArgument is returned if the TCP port argument is not valid (9)
 	ErrBadTCPPortArgument
+
+	// ErrInitializingInventory is returned when the inventory cannot be initialized,
+	// usually depends on a wrong configuration of the data dir (10)
+	ErrInitializingInventory
 )


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Add a specific exit code for the CLI to signal failure on initializing the "inventory" storage.

## What is the current behavior?

In case of failure to initialize inventory, the CLI returned a generic error code `7`, i.e. `ErrBadArgument`.

## What is the new behavior?

In case of failure to initialize inventory, the CLI return an error code `10`, i.e. `ErrInitializingInventory`.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Fix #2352