### PR TITLE
[breaking] cli: format json always start with a json object

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -6,49 +6,50 @@ Here you can find a list of migration guides to handle breaking changes between 
 
 ### CLI changed JSON output for some `lib`, `core`, `config`, `board`, and `sketch` commands.
 
-- `arduino-cli lib list` results are wrapped under `installed_libraries` key
+- `arduino-cli lib list --format json` results are now wrapped under `installed_libraries` key
 
   ```
   { "installed_libraries": [ {...}, {...} ] }
   ```
 
-- `arduino-cli lib list` results are wrapped under `examples` key
+- `arduino-cli lib examples --format json` results are now wrapped under `examples` key
 
   ```
   { "examples": [ {...}, {...} ] }
   ```
 
-- `arduino-cli core search` and `arduino-cli core list` results are wrapped under `platforms` key
+- `arduino-cli core search --format json` and `arduino-cli core list --format json` results are now wrapped under
+  `platforms` key
 
   ```
   { "platforms": [ {...}, {...} ] }
   ```
 
-- `arduino-cli config init` now correctly returns a json containg the config path
+- `arduino-cli config init --format json` now correctly returns a json object containg the config path
 
   ```
   { "config_path": "/home/user/.arduino15/arduino-cli.yaml" }
   ```
 
-- `arduino-cli core dump` results are wrapped under `config` key
+- `arduino-cli config dump --format json` results are now wrapped under `config` key
 
   ```
   { "config": { ... } }
   ```
 
-- `arduino-cli board search` results are wrapped under `boards` key
+- `arduino-cli board search --format json` results are now wrapped under `boards` key
 
   ```
   { "boards": [ {...}, {...} ] }
   ```
 
-- `arduino-cli board list` results are wrapped under `detected_ports` key
+- `arduino-cli board list --format json` results are now wrapped under `detected_ports` key
 
   ```
   { "detected_ports": [ {...}, {...} ] }
   ```
 
-- `arduino-cli sketch new` now correctly returns a json containing the sketch path
+- `arduino-cli sketch new` now correctly returns a json object containing the sketch path
 
   ```
   { "sketch_path": "/tmp/my_sketch" }

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -4,6 +4,56 @@ Here you can find a list of migration guides to handle breaking changes between 
 
 ## 0.36.0
 
+### CLI changed JSON output for some `lib`, `core`, `config`, `board`, and `sketch` commands.
+
+- `arduino-cli lib list` results are wrapped under `installed_libraries` key
+
+  ```
+  { "installed_libraries": [ {...}, {...} ] }
+  ```
+
+- `arduino-cli lib list` results are wrapped under `examples` key
+
+  ```
+  { "examples": [ {...}, {...} ] }
+  ```
+
+- `arduino-cli core search` and `arduino-cli core list` results are wrapped under `platforms` key
+
+  ```
+  { "platforms": [ {...}, {...} ] }
+  ```
+
+- `arduino-cli config init` now correctly returns a json containg the config path
+
+  ```
+  { "config_path": "/home/user/.arduino15/arduino-cli.yaml" }
+  ```
+
+- `arduino-cli core dump` results are wrapped under `config` key
+
+  ```
+  { "config": { ... } }
+  ```
+
+- `arduino-cli board search` results are wrapped under `boards` key
+
+  ```
+  { "boards": [ {...}, {...} ] }
+  ```
+
+- `arduino-cli board list` results are wrapped under `detected_ports` key
+
+  ```
+  { "detected_ports": [ {...}, {...} ] }
+  ```
+
+- `arduino-cli sketch new` now correctly returns a json containing the sketch path
+
+  ```
+  { "sketch_path": "/tmp/my_sketch" }
+  ```
+
 ### The gRPC `cc.arduino.cli.commands.v1.PlatformRelease` has been changed.
 
 We've added a new field called `compatible`. This field indicates if the current platform release is installable or not.

--- a/internal/cli/board/list.go
+++ b/internal/cli/board/list.go
@@ -114,27 +114,27 @@ func watchList(inst *rpc.Instance) {
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type listResult struct {
-	ports []*result.DetectedPort
+	Ports []*result.DetectedPort `json:"detected_ports"`
 }
 
 func (dr listResult) Data() interface{} {
-	return dr.ports
+	return dr
 }
 
 func (dr listResult) String() string {
-	if len(dr.ports) == 0 {
+	if len(dr.Ports) == 0 {
 		return tr("No boards found.")
 	}
 
-	sort.Slice(dr.ports, func(i, j int) bool {
-		x, y := dr.ports[i].Port, dr.ports[j].Port
+	sort.Slice(dr.Ports, func(i, j int) bool {
+		x, y := dr.Ports[i].Port, dr.Ports[j].Port
 		return x.Protocol < y.Protocol ||
 			(x.Protocol == y.Protocol && x.Address < y.Address)
 	})
 
 	t := table.New()
 	t.SetHeader(tr("Port"), tr("Protocol"), tr("Type"), tr("Board Name"), tr("FQBN"), tr("Core"))
-	for _, detectedPort := range dr.ports {
+	for _, detectedPort := range dr.Ports {
 		port := detectedPort.Port
 		protocol := port.Protocol
 		address := port.Address

--- a/internal/cli/board/listall.go
+++ b/internal/cli/board/listall.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
-	fResult "github.com/arduino/arduino-cli/internal/cli/feedback/result"
+	"github.com/arduino/arduino-cli/internal/cli/feedback/result"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/arduino-cli/table"
@@ -64,13 +64,13 @@ func runListAllCommand(cmd *cobra.Command, args []string) {
 		feedback.Fatal(tr("Error listing boards: %v", err), feedback.ErrGeneric)
 	}
 
-	feedback.PrintResult(resultAll{fResult.NewBoardListAllResponse(list)})
+	feedback.PrintResult(resultAll{result.NewBoardListAllResponse(list)})
 }
 
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type resultAll struct {
-	list *fResult.BoardListAllResponse
+	list *result.BoardListAllResponse
 }
 
 func (dr resultAll) Data() interface{} {

--- a/internal/cli/board/search.go
+++ b/internal/cli/board/search.go
@@ -67,26 +67,26 @@ func runSearchCommand(cmd *cobra.Command, args []string) {
 // output from this command requires special formatting so we create a dedicated
 // feedback.Result implementation
 type searchResults struct {
-	boards []*fResult.BoardListItem
+	Boards []*fResult.BoardListItem `json:"boards"`
 }
 
 func (r searchResults) Data() interface{} {
-	return r.boards
+	return r
 }
 
 func (r searchResults) String() string {
-	if len(r.boards) == 0 {
+	if len(r.Boards) == 0 {
 		return ""
 	}
 
 	t := table.New()
 	t.SetHeader(tr("Board Name"), tr("FQBN"), tr("Platform ID"), "")
 
-	sort.Slice(r.boards, func(i, j int) bool {
-		return r.boards[i].Name < r.boards[j].Name
+	sort.Slice(r.Boards, func(i, j int) bool {
+		return r.Boards[i].Name < r.Boards[j].Name
 	})
 
-	for _, item := range r.boards {
+	for _, item := range r.Boards {
 		hidden := ""
 		if item.IsHidden {
 			hidden = tr("(hidden)")

--- a/internal/cli/board/search.go
+++ b/internal/cli/board/search.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/arduino/arduino-cli/commands/board"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
-	fResult "github.com/arduino/arduino-cli/internal/cli/feedback/result"
+	"github.com/arduino/arduino-cli/internal/cli/feedback/result"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/arduino-cli/table"
@@ -61,13 +61,13 @@ func runSearchCommand(cmd *cobra.Command, args []string) {
 		feedback.Fatal(tr("Error searching boards: %v", err), feedback.ErrGeneric)
 	}
 
-	feedback.PrintResult(searchResults{fResult.NewBoardListItems(res.Boards)})
+	feedback.PrintResult(searchResults{result.NewBoardListItems(res.Boards)})
 }
 
 // output from this command requires special formatting so we create a dedicated
 // feedback.Result implementation
 type searchResults struct {
-	Boards []*fResult.BoardListItem `json:"boards"`
+	Boards []*result.BoardListItem `json:"boards"`
 }
 
 func (r searchResults) Data() interface{} {

--- a/internal/cli/config/add.go
+++ b/internal/cli/config/add.go
@@ -25,33 +25,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// // TODO: When update to go 1.18 or later, convert to generic
-// //       to allow uniquify() on any slice that supports
-// //       `comparable`
-// //       See https://gosamples.dev/generics-remove-duplicates-slice/
-// func uniquify[T comparable](s []T) []T {
-// 	// use a map, which enforces unique keys
-// 	inResult := make(map[T]bool)
-// 	var result []T
-// 	// loop through input slice **in order**,
-// 	// to ensure output retains that order
-// 	// (except that it removes duplicates)
-// 	for i := 0; i < len(s); i++ {
-// 		// attempt to use the element as a key
-// 		if _, ok := inResult[s[i]]; !ok {
-// 			// if key didn't exist in map,
-// 			// add to map and append to result
-// 			inResult[s[i]] = true
-// 			result = append(result, s[i])
-// 		}
-// 	}
-// 	return result
-// }
-
-func uniquifyStringSlice(s []string) []string {
+func uniquify[T comparable](s []T) []T {
 	// use a map, which enforces unique keys
-	inResult := make(map[string]bool)
-	var result []string
+	inResult := make(map[T]bool)
+	var result []T
 	// loop through input slice **in order**,
 	// to ensure output retains that order
 	// (except that it removes duplicates)
@@ -96,7 +73,7 @@ func runAddCommand(cmd *cobra.Command, args []string) {
 
 	v := configuration.Settings.GetStringSlice(key)
 	v = append(v, args[1:]...)
-	v = uniquifyStringSlice(v)
+	v = uniquify(v)
 	configuration.Settings.Set(key, v)
 
 	if err := configuration.Settings.WriteConfig(); err != nil {

--- a/internal/cli/config/dump.go
+++ b/internal/cli/config/dump.go
@@ -45,15 +45,15 @@ func runDumpCommand(cmd *cobra.Command, args []string) {
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type dumpResult struct {
-	data map[string]interface{}
+	Config map[string]interface{} `json:"config"`
 }
 
 func (dr dumpResult) Data() interface{} {
-	return dr.data
+	return dr
 }
 
 func (dr dumpResult) String() string {
-	bs, err := yaml.Marshal(dr.data)
+	bs, err := yaml.Marshal(dr.Config)
 	if err != nil {
 		// Should never happen
 		panic(tr("unable to marshal config to YAML: %v", err))

--- a/internal/cli/config/init.go
+++ b/internal/cli/config/init.go
@@ -108,8 +108,21 @@ func runInitCommand(cmd *cobra.Command, args []string) {
 	if err := newSettings.WriteConfigAs(configFileAbsPath.String()); err != nil {
 		feedback.Fatal(tr("Cannot create config file: %v", err), feedback.ErrGeneric)
 	}
+	feedback.PrintResult(initResult{ConfigFileAbsPath: configFileAbsPath})
+}
 
-	msg := tr("Config file written to: %s", configFileAbsPath.String())
+// output from this command requires special formatting, let's create a dedicated
+// feedback.Result implementation
+type initResult struct {
+	ConfigFileAbsPath *paths.Path `json:"config_path"`
+}
+
+func (dr initResult) Data() interface{} {
+	return dr
+}
+
+func (dr initResult) String() string {
+	msg := tr("Config file written to: %s", dr.ConfigFileAbsPath.String())
 	logrus.Info(msg)
-	feedback.Print(msg)
+	return msg
 }

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -57,7 +57,7 @@ func runSetCommand(cmd *cobra.Command, args []string) {
 	var value interface{}
 	switch kind {
 	case reflect.Slice:
-		value = uniquifyStringSlice(args[1:])
+		value = uniquify(args[1:])
 	case reflect.String:
 		value = args[1]
 	case reflect.Bool:

--- a/internal/cli/core/list.go
+++ b/internal/cli/core/list.go
@@ -89,24 +89,24 @@ func GetList(inst *rpc.Instance, all bool, updatableOnly bool) []*rpc.PlatformSu
 func newCoreListResult(in []*rpc.PlatformSummary, updatableOnly bool) *coreListResult {
 	res := &coreListResult{updatableOnly: updatableOnly}
 	for _, platformSummary := range in {
-		res.platforms = append(res.platforms, result.NewPlatformSummary(platformSummary))
+		res.Platforms = append(res.Platforms, result.NewPlatformSummary(platformSummary))
 	}
 	return res
 }
 
 type coreListResult struct {
-	platforms     []*result.PlatformSummary
+	Platforms     []*result.PlatformSummary `json:"platforms"`
 	updatableOnly bool
 }
 
 // Data implements Result interface
 func (ir coreListResult) Data() interface{} {
-	return ir.platforms
+	return ir
 }
 
 // String implements Result interface
 func (ir coreListResult) String() string {
-	if len(ir.platforms) == 0 {
+	if len(ir.Platforms) == 0 {
 		if ir.updatableOnly {
 			return tr("All platforms are up to date.")
 		}
@@ -114,7 +114,7 @@ func (ir coreListResult) String() string {
 	}
 	t := table.New()
 	t.SetHeader(tr("ID"), tr("Installed"), tr("Latest"), tr("Name"))
-	for _, platform := range ir.platforms {
+	for _, platform := range ir.Platforms {
 		latestVersion := platform.LatestVersion.String()
 		if latestVersion == "" {
 			latestVersion = "n/a"

--- a/internal/cli/core/search.go
+++ b/internal/cli/core/search.go
@@ -86,27 +86,27 @@ func runSearchCommand(cmd *cobra.Command, args []string, allVersions bool) {
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type searchResults struct {
-	platforms   []*result.PlatformSummary
+	Platforms   []*result.PlatformSummary `json:"platforms"`
 	allVersions bool
 }
 
 func newSearchResult(in []*rpc.PlatformSummary, allVersions bool) *searchResults {
 	res := &searchResults{
-		platforms:   make([]*result.PlatformSummary, len(in)),
+		Platforms:   make([]*result.PlatformSummary, len(in)),
 		allVersions: allVersions,
 	}
 	for i, platformSummary := range in {
-		res.platforms[i] = result.NewPlatformSummary(platformSummary)
+		res.Platforms[i] = result.NewPlatformSummary(platformSummary)
 	}
 	return res
 }
 
 func (sr searchResults) Data() interface{} {
-	return sr.platforms
+	return sr
 }
 
 func (sr searchResults) String() string {
-	if len(sr.platforms) == 0 {
+	if len(sr.Platforms) == 0 {
 		return tr("No platforms matching your search.")
 	}
 
@@ -121,7 +121,7 @@ func (sr searchResults) String() string {
 		t.AddRow(platform.Id, release.Version, release.FormatName())
 	}
 
-	for _, platform := range sr.platforms {
+	for _, platform := range sr.Platforms {
 		// When allVersions is not requested we only show the latest compatible version
 		if !sr.allVersions {
 			addRow(platform, platform.GetLatestRelease())

--- a/internal/cli/lib/check_deps.go
+++ b/internal/cli/lib/check_deps.go
@@ -24,7 +24,7 @@ import (
 	"github.com/arduino/arduino-cli/commands/lib"
 	"github.com/arduino/arduino-cli/internal/cli/arguments"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
-	fResult "github.com/arduino/arduino-cli/internal/cli/feedback/result"
+	"github.com/arduino/arduino-cli/internal/cli/feedback/result"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/fatih/color"
@@ -66,13 +66,13 @@ func runDepsCommand(cmd *cobra.Command, args []string) {
 		feedback.Fatal(tr("Error resolving dependencies for %[1]s: %[2]s", libRef, err), feedback.ErrGeneric)
 	}
 
-	feedback.PrintResult(&checkDepResult{deps: fResult.NewLibraryResolveDependenciesResponse(deps)})
+	feedback.PrintResult(&checkDepResult{deps: result.NewLibraryResolveDependenciesResponse(deps)})
 }
 
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type checkDepResult struct {
-	deps *fResult.LibraryResolveDependenciesResponse
+	deps *result.LibraryResolveDependenciesResponse
 }
 
 func (dr checkDepResult) Data() interface{} {
@@ -103,7 +103,7 @@ func (dr checkDepResult) String() string {
 	return res
 }
 
-func outputDep(dep *fResult.LibraryDependencyStatus) string {
+func outputDep(dep *result.LibraryDependencyStatus) string {
 	res := ""
 	green := color.New(color.FgGreen)
 	red := color.New(color.FgRed)

--- a/internal/cli/lib/examples.go
+++ b/internal/cli/lib/examples.go
@@ -94,11 +94,11 @@ type libraryExamples struct {
 }
 
 type libraryExamplesResult struct {
-	Examples []*libraryExamples
+	Examples []*libraryExamples `json:"examples"`
 }
 
 func (ir libraryExamplesResult) Data() interface{} {
-	return ir.Examples
+	return ir
 }
 
 func (ir libraryExamplesResult) String() string {

--- a/internal/cli/lib/list.go
+++ b/internal/cli/lib/list.go
@@ -67,7 +67,7 @@ func List(instance *rpc.Instance, args []string, all bool, updatable bool) {
 	}
 	feedback.PrintResult(installedResult{
 		onlyUpdates:   updatable,
-		installedLibs: installedLibsResult,
+		InstalledLibs: installedLibsResult,
 	})
 	logrus.Info("Done")
 }
@@ -118,24 +118,24 @@ func GetList(
 // output from this command requires special formatting, let's create a dedicated
 // feedback.Result implementation
 type installedResult struct {
+	InstalledLibs []*result.InstalledLibrary `json:"installed_libraries"`
 	onlyUpdates   bool
-	installedLibs []*result.InstalledLibrary
 }
 
 func (ir installedResult) Data() interface{} {
-	return ir.installedLibs
+	return ir
 }
 
 func (ir installedResult) String() string {
-	if len(ir.installedLibs) == 0 {
+	if len(ir.InstalledLibs) == 0 {
 		if ir.onlyUpdates {
 			return tr("No libraries update is available.")
 		}
 		return tr("No libraries installed.")
 	}
-	sort.Slice(ir.installedLibs, func(i, j int) bool {
-		return strings.ToLower(ir.installedLibs[i].Library.Name) < strings.ToLower(ir.installedLibs[j].Library.Name) ||
-			strings.ToLower(ir.installedLibs[i].Library.ContainerPlatform) < strings.ToLower(ir.installedLibs[j].Library.ContainerPlatform)
+	sort.Slice(ir.InstalledLibs, func(i, j int) bool {
+		return strings.ToLower(ir.InstalledLibs[i].Library.Name) < strings.ToLower(ir.InstalledLibs[j].Library.Name) ||
+			strings.ToLower(ir.InstalledLibs[i].Library.ContainerPlatform) < strings.ToLower(ir.InstalledLibs[j].Library.ContainerPlatform)
 	})
 
 	t := table.New()
@@ -145,7 +145,7 @@ func (ir installedResult) String() string {
 	t.SetColumnWidthMode(4, table.Average)
 
 	lastName := ""
-	for _, libMeta := range ir.installedLibs {
+	for _, libMeta := range ir.InstalledLibs {
 		lib := libMeta.Library
 		name := lib.Name
 		if name == lastName {

--- a/internal/integrationtest/board/hardware_loading_test.go
+++ b/internal/integrationtest/board/hardware_loading_test.go
@@ -47,27 +47,28 @@ func TestHardwareLoading(t *testing.T) {
 			require.NoError(t, err)
 			jsonOut := requirejson.Parse(t, out)
 			jsonOut.LengthMustEqualTo(1)
-			jsonOut.MustContain(`[
-				{
-					"id": "arduino:avr",
-					"installed_version": "1.8.6",
-					"releases": {
-						"1.8.6": {
-							"name": "Arduino AVR Boards",
-							"boards": [
-								{
-									"name": "Arduino Uno",
-									"fqbn": "arduino:avr:uno"
-								},
-								{
-									"name": "Arduino Yún",
-									"fqbn": "arduino:avr:yun"
-								}
-							]
+			jsonOut.MustContain(`{
+				"platforms": [
+					{
+						"id": "arduino:avr",
+						"installed_version": "1.8.6",
+						"releases": {
+							"1.8.6": {
+								"name": "Arduino AVR Boards",
+								"boards": [
+									{
+										"name": "Arduino Uno",
+										"fqbn": "arduino:avr:uno"
+									},
+									{
+										"name": "Arduino Yún",
+										"fqbn": "arduino:avr:yun"
+									}
+								]
+							}
 						}
 					}
-				}
-			]`)
+				]}`)
 		}
 
 		{
@@ -154,60 +155,63 @@ func TestHardwareLoading(t *testing.T) {
 			out, _, err := cli.Run("core", "list", "--format", "json")
 			require.NoError(t, err)
 			jsonOut := requirejson.Parse(t, out)
-			jsonOut.LengthMustEqualTo(3)
-			jsonOut.MustContain(`[
-				{
-					"id": "arduino:avr",
-					"installed_version": "1.8.6",
-					"releases": {
-						"1.8.6": {
-							"name": "Arduino AVR Boards",
-							"boards": [
-								{
-									"name": "Arduino Uno",
-									"fqbn": "arduino:avr:uno"
-								},
-								{
-									"name": "Arduino Yún",
-									"fqbn": "arduino:avr:yun"
-								}
-							]
+			jsonOut.Query(`.platforms | length`).LengthMustEqualTo(3)
+			jsonOut.MustContain(`{
+				"platforms": [
+					{
+						"id": "arduino:avr",
+						"installed_version": "1.8.6",
+						"releases": {
+							"1.8.6": {
+								"name": "Arduino AVR Boards",
+								"boards": [
+									{
+										"name": "Arduino Uno",
+										"fqbn": "arduino:avr:uno"
+									},
+									{
+										"name": "Arduino Yún",
+										"fqbn": "arduino:avr:yun"
+									}
+								]
+							}
 						}
 					}
-				}
-			]`)
-			jsonOut.MustContain(`[
-				{
-					"id": "my_avr_platform:avr",
-					"installed_version": "9.9.9",
-					"releases": {
-						"9.9.9": {
-							"name": "My AVR Boards",
-							"boards": [
-								{
-									"name": "Arduino Yún",
-									"fqbn": "my_avr_platform:avr:custom_yun"
-								}
-							]
-						}
-					},
-					"manually_installed": true
-				}
-			]`)
+				]}`)
+			jsonOut.MustContain(`{
+				"platforms": [
+					{
+						"id": "my_avr_platform:avr",
+						"installed_version": "9.9.9",
+						"releases": {
+							"9.9.9": {
+								"name": "My AVR Boards",
+								"boards": [
+									{
+										"name": "Arduino Yún",
+										"fqbn": "my_avr_platform:avr:custom_yun"
+									}
+								]
+							}
+						},
+						"manually_installed": true
+					}
+				]}`)
 
 			//		require.False(t, myAVRPlatformAvrArch.Properties.ContainsKey("preproc.includes.flags"))
 
 			if runtime.GOOS != "windows" {
-				jsonOut.MustContain(`[
-					{
-						"id": "my_symlinked_avr_platform:avr",
-						"manually_installed": true,
-						"releases": {
-							"9.9.9": {
+				jsonOut.MustContain(`{
+					"platforms": [
+						{
+							"id": "my_symlinked_avr_platform:avr",
+							"manually_installed": true,
+							"releases": {
+								"9.9.9": {
+								}
 							}
 						}
-					}
-				]`)
+					]}`)
 			}
 		}
 

--- a/internal/integrationtest/compile_1/compile_test.go
+++ b/internal/integrationtest/compile_1/compile_test.go
@@ -499,9 +499,11 @@ func compileWithExportBinariesConfig(t *testing.T, env *integrationtest.Environm
 	require.NoError(t, err)
 	requirejson.Contains(t, stdout, `
 		{
-			"sketch": {
-			"always_export_binaries": "true"
-	  		}
+			"config": {
+				"sketch": {
+					"always_export_binaries": "true"
+				}
+			}
 		}`)
 
 	// Test compilation with export binaries env var set
@@ -824,10 +826,8 @@ func TestCompileWithArchivesAndLongPaths(t *testing.T) {
 
 	stdout, _, err := cli.Run("lib", "examples", "ArduinoIoTCloud", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	var libOutput []map[string]interface{}
-	err = json.Unmarshal(stdout, &libOutput)
-	require.NoError(t, err)
-	sketchPath := paths.New(libOutput[0]["library"].(map[string]interface{})["install_dir"].(string))
+	libOutput := strings.Trim(requirejson.Parse(t, stdout).Query(`.examples.[0].library.install_dir`).String(), `"`)
+	sketchPath := paths.New(libOutput)
 	sketchPath = sketchPath.Join("examples", "ArduinoIoTCloud-Advanced")
 
 	_, _, err = cli.Run("compile", "-b", "esp8266:esp8266:huzzah", sketchPath.String(), "--config-file", "arduino-cli.yaml")

--- a/internal/integrationtest/config/config_test.go
+++ b/internal/integrationtest/config/config_test.go
@@ -239,7 +239,7 @@ func TestDump(t *testing.T) {
 
 	stdout, _, err := cli.Run("config", "dump", "--config-file", configFile.String(), "--format", "json")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[]")
 
 	stdout, _, err = cli.Run("config", "init", "--additional-urls", "https://example.com")
 	require.NoError(t, err)
@@ -249,7 +249,7 @@ func TestDump(t *testing.T) {
 
 	stdout, _, err = cli.Run("config", "dump", "--format", "json")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[\"https://example.com\"]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[\"https://example.com\"]")
 }
 
 func TestDumpWithConfigFileFlag(t *testing.T) {
@@ -265,7 +265,7 @@ func TestDumpWithConfigFileFlag(t *testing.T) {
 
 	stdout, _, err := cli.Run("config", "dump", "--config-file", configFile.String(), "--format", "json")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[\"https://example.com\"]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[\"https://example.com\"]")
 
 	stdout, _, err = cli.Run(
 		"config",
@@ -277,7 +277,7 @@ func TestDumpWithConfigFileFlag(t *testing.T) {
 		"json",
 	)
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[\"https://another-url.com\"]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[\"https://another-url.com\"]")
 }
 
 func TestAddRemoveSetDeleteOnUnexistingKey(t *testing.T) {
@@ -316,7 +316,7 @@ func TestAddSingleArgument(t *testing.T) {
 	// Verifies no additional urls are present
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[]")
 
 	// Adds one URL
 	url := "https://example.com"
@@ -326,7 +326,7 @@ func TestAddSingleArgument(t *testing.T) {
 	// Verifies URL has been saved
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[\"https://example.com\"]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[\"https://example.com\"]")
 
 	// Adds the same URL (should not error)
 	_, _, err = cli.Run("config", "add",
@@ -337,7 +337,7 @@ func TestAddSingleArgument(t *testing.T) {
 	// Verifies a second copy has NOT been added
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[\"https://example.com\"]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[\"https://example.com\"]")
 }
 
 func TestAddMultipleArguments(t *testing.T) {
@@ -351,7 +351,7 @@ func TestAddMultipleArguments(t *testing.T) {
 	// Verifies no additional urls are present
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[]")
 
 	// Adds multiple URLs at the same time
 	urls := [3]string{
@@ -366,14 +366,16 @@ func TestAddMultipleArguments(t *testing.T) {
 	// Verifies URL has been saved
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls | length", "2")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls | length", "2")
 	requirejson.Contains(t, stdout, `
 	{
-		"board_manager": {
-			"additional_urls": [
-				"https://example.com/package_example_index.json",
-				"https://example.com/yet_another_package_example_index.json"
-			]
+		"config": {
+			"board_manager": {
+				"additional_urls": [
+					"https://example.com/package_example_index.json",
+					"https://example.com/yet_another_package_example_index.json"
+				]
+			}
 		}
 	}`)
 
@@ -384,14 +386,16 @@ func TestAddMultipleArguments(t *testing.T) {
 	// Verifies no change in result array
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls | length", "2")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls | length", "2")
 	requirejson.Contains(t, stdout, `
 	{
-		"board_manager": {
-			"additional_urls": [
-				"https://example.com/package_example_index.json",
-				"https://example.com/yet_another_package_example_index.json"
-			]
+		"config": {
+			"board_manager": {
+				"additional_urls": [
+					"https://example.com/package_example_index.json",
+					"https://example.com/yet_another_package_example_index.json"
+				]
+			}
 		}
 	}`)
 
@@ -407,15 +411,17 @@ func TestAddMultipleArguments(t *testing.T) {
 	// Verifies URL has been saved
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls | length", "3")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls | length", "3")
 	requirejson.Contains(t, stdout, `
 	{
-		"board_manager": {
-			"additional_urls": [
-				"https://example.com/package_example_index.json",
-				"https://example.com/a_third_package_example_index.json",
-				"https://example.com/yet_another_package_example_index.json"
-			]
+		"config": {
+			"board_manager": {
+				"additional_urls": [
+					"https://example.com/package_example_index.json",
+					"https://example.com/a_third_package_example_index.json",
+					"https://example.com/yet_another_package_example_index.json"
+				]
+			}
 		}
 	}`)
 }
@@ -431,7 +437,7 @@ func TestAddOnUnsupportedKey(t *testing.T) {
 	// Verifies default value
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".daemon | .port", "\"50051\"")
+	requirejson.Query(t, stdout, ".config | .daemon | .port", "\"50051\"")
 
 	// Tries and fails to add a new item
 	_, stderr, err := cli.Run("config", "add", "daemon.port", "50000", "--config-file", "arduino-cli.yaml")
@@ -441,7 +447,7 @@ func TestAddOnUnsupportedKey(t *testing.T) {
 	// Verifies value is not changed
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".daemon | .port", "\"50051\"")
+	requirejson.Query(t, stdout, ".config | .daemon | .port", "\"50051\"")
 }
 
 func TestRemoveSingleArgument(t *testing.T) {
@@ -463,14 +469,16 @@ func TestRemoveSingleArgument(t *testing.T) {
 	// Verifies default state
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls | length", "2")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls | length", "2")
 	requirejson.Contains(t, stdout, `
 	{
-		"board_manager": {
-			"additional_urls": [
-				"https://example.com/package_example_index.json",
-				"https://example.com/yet_another_package_example_index.json"
-			]
+		"config": {
+			"board_manager": {
+				"additional_urls": [
+					"https://example.com/package_example_index.json",
+					"https://example.com/yet_another_package_example_index.json"
+				]
+			}
 		}
 	}`)
 
@@ -481,7 +489,7 @@ func TestRemoveSingleArgument(t *testing.T) {
 	// Verifies URLs has been removed
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[\"https://example.com/yet_another_package_example_index.json\"]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[\"https://example.com/yet_another_package_example_index.json\"]")
 }
 
 func TestRemoveMultipleArguments(t *testing.T) {
@@ -503,14 +511,16 @@ func TestRemoveMultipleArguments(t *testing.T) {
 	// Verifies default state
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls | length", "2")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls | length", "2")
 	requirejson.Contains(t, stdout, `
 	{
-		"board_manager": {
-			"additional_urls": [
-				"https://example.com/package_example_index.json",
-				"https://example.com/yet_another_package_example_index.json"
-			]
+		"config": {
+			"board_manager": {
+				"additional_urls": [
+					"https://example.com/package_example_index.json",
+					"https://example.com/yet_another_package_example_index.json"
+				]
+			}
 		}
 	}`)
 
@@ -521,7 +531,7 @@ func TestRemoveMultipleArguments(t *testing.T) {
 	// Verifies all URLs have been removed
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[]")
 }
 
 func TestRemoveOnUnsupportedKey(t *testing.T) {
@@ -535,7 +545,7 @@ func TestRemoveOnUnsupportedKey(t *testing.T) {
 	// Verifies default value
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".daemon | .port", "\"50051\"")
+	requirejson.Query(t, stdout, ".config | .daemon | .port", "\"50051\"")
 
 	// Tries and fails to remove an item
 	_, stderr, err := cli.Run("config", "remove", "daemon.port", "50051", "--config-file", "arduino-cli.yaml")
@@ -545,7 +555,7 @@ func TestRemoveOnUnsupportedKey(t *testing.T) {
 	// Verifies value is not changed
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".daemon | .port", "\"50051\"")
+	requirejson.Query(t, stdout, ".config | .daemon | .port", "\"50051\"")
 }
 
 func TestSetSliceWithSingleArgument(t *testing.T) {
@@ -559,7 +569,7 @@ func TestSetSliceWithSingleArgument(t *testing.T) {
 	// Verifies default state
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[]")
 
 	// Set an URL in the list
 	url := "https://example.com/package_example_index.json"
@@ -569,7 +579,7 @@ func TestSetSliceWithSingleArgument(t *testing.T) {
 	// Verifies value is changed
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[\"https://example.com/package_example_index.json\"]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[\"https://example.com/package_example_index.json\"]")
 
 	// Set an URL in the list
 	url = "https://example.com/yet_another_package_example_index.json"
@@ -579,7 +589,7 @@ func TestSetSliceWithSingleArgument(t *testing.T) {
 	// Verifies value is changed
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[\"https://example.com/yet_another_package_example_index.json\"]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[\"https://example.com/yet_another_package_example_index.json\"]")
 }
 
 func TestSetSliceWithMultipleArguments(t *testing.T) {
@@ -593,7 +603,7 @@ func TestSetSliceWithMultipleArguments(t *testing.T) {
 	// Verifies default state
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[]")
 
 	// Set some URLs in the list
 	urls := [7]string{
@@ -606,14 +616,16 @@ func TestSetSliceWithMultipleArguments(t *testing.T) {
 	// Verifies value is changed
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls | length", "2")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls | length", "2")
 	requirejson.Contains(t, stdout, `
 	{
-		"board_manager": {
-			"additional_urls": [
-				"https://example.com/first_package_index.json",
-        		"https://example.com/second_package_index.json"
-			]
+		"config": {
+			"board_manager": {
+				"additional_urls": [
+					"https://example.com/first_package_index.json",
+					"https://example.com/second_package_index.json"
+				]
+			}
 		}
 	}`)
 
@@ -628,14 +640,16 @@ func TestSetSliceWithMultipleArguments(t *testing.T) {
 	// Verifies previous value is overwritten
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls | length", "2")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls | length", "2")
 	requirejson.Contains(t, stdout, `
 	{
-		"board_manager": {
-			"additional_urls": [
-				"https://example.com/third_package_index.json",
-				"https://example.com/fourth_package_index.json"
-			]
+		"config": {
+			"board_manager": {
+				"additional_urls": [
+					"https://example.com/third_package_index.json",
+					"https://example.com/fourth_package_index.json"
+				]
+			}
 		}
 	}`)
 
@@ -658,16 +672,18 @@ func TestSetSliceWithMultipleArguments(t *testing.T) {
 	// Verifies all unique values exist in config
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls | length", "4")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls | length", "4")
 	requirejson.Contains(t, stdout, `
 	{
-		"board_manager": {
-			"additional_urls": [
-				"https://example.com/first_package_index.json",
-				"https://example.com/second_package_index.json",
-				"https://example.com/fifth_package_index.json",
-				"https://example.com/sixth_package_index.json"
-			]
+		"config": {
+			"board_manager": {
+				"additional_urls": [
+					"https://example.com/first_package_index.json",
+					"https://example.com/second_package_index.json",
+					"https://example.com/fifth_package_index.json",
+					"https://example.com/sixth_package_index.json"
+				]
+			}
 		}
 	}`)
 }
@@ -683,7 +699,7 @@ func TestSetStringWithSingleArgument(t *testing.T) {
 	// Verifies default state
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".logging | .level", "\"info\"")
+	requirejson.Query(t, stdout, ".config | .logging | .level", "\"info\"")
 
 	// Changes value
 	_, _, err = cli.Run("config", "set", "logging.level", "trace", "--config-file", "arduino-cli.yaml")
@@ -692,7 +708,7 @@ func TestSetStringWithSingleArgument(t *testing.T) {
 	// Verifies value is changed
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".logging | .level", "\"trace\"")
+	requirejson.Query(t, stdout, ".config | .logging | .level", "\"trace\"")
 }
 
 func TestSetStringWithMultipleArguments(t *testing.T) {
@@ -706,7 +722,7 @@ func TestSetStringWithMultipleArguments(t *testing.T) {
 	// Verifies default state
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".logging | .level", "\"info\"")
+	requirejson.Query(t, stdout, ".config | .logging | .level", "\"info\"")
 
 	// Tries to change value
 	_, stderr, err := cli.Run("config", "set", "logging.level", "trace", "debug")
@@ -725,7 +741,7 @@ func TestSetBoolWithSingleArgument(t *testing.T) {
 	// Verifies default state
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".library | .enable_unsafe_install", "false")
+	requirejson.Query(t, stdout, ".config | .library | .enable_unsafe_install", "false")
 
 	// Changes value
 	_, _, err = cli.Run("config", "set", "library.enable_unsafe_install", "true", "--config-file", "arduino-cli.yaml")
@@ -734,7 +750,7 @@ func TestSetBoolWithSingleArgument(t *testing.T) {
 	// Verifies value is changed
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".library | .enable_unsafe_install", "true")
+	requirejson.Query(t, stdout, ".config | .library | .enable_unsafe_install", "true")
 }
 
 func TestSetBoolWithMultipleArguments(t *testing.T) {
@@ -748,7 +764,7 @@ func TestSetBoolWithMultipleArguments(t *testing.T) {
 	// Verifies default state
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".library | .enable_unsafe_install", "false")
+	requirejson.Query(t, stdout, ".config | .library | .enable_unsafe_install", "false")
 
 	// Changes value
 	_, stderr, err := cli.Run("config", "set", "library.enable_unsafe_install", "true", "foo", "--config-file", "arduino-cli.yaml")
@@ -767,7 +783,7 @@ func TestDelete(t *testing.T) {
 	// Verifies default state
 	stdout, _, err := cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".library | .enable_unsafe_install", "false")
+	requirejson.Query(t, stdout, ".config | .library | .enable_unsafe_install", "false")
 
 	// Delete config key
 	_, _, err = cli.Run("config", "delete", "library.enable_unsafe_install", "--config-file", "arduino-cli.yaml")
@@ -784,7 +800,7 @@ func TestDelete(t *testing.T) {
 	// Verifies default state
 	stdout, _, err = cli.Run("config", "dump", "--format", "json", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
-	requirejson.Query(t, stdout, ".board_manager | .additional_urls", "[]")
+	requirejson.Query(t, stdout, ".config | .board_manager | .additional_urls", "[]")
 
 	// Delete config key and sub keys
 	_, _, err = cli.Run("config", "delete", "board_manager", "--config-file", "arduino-cli.yaml")


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

We're wrapping in json object all the results that previously were emitting directly an array

## What is the current behavior?

Currently, some commands when printing with json, are starting with an array instead of an object

## What is the new behavior?

We uniformed every command to always output a json Object.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
