### PR TITLE
Improved logging on GitHub Actions runners (using log folding commands)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,7 +48,7 @@ tasks:
     desc: Build the Go code
     dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
-      - go build -v {{default "" .EXTRA_FLAGS}} {{.LDFLAGS}}
+      - go build {{default "" .EXTRA_FLAGS}} {{.LDFLAGS}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/deploy-cobra-mkdocs-versioned-poetry/Taskfile.yml
   go:cli-docs:

--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -298,6 +298,13 @@ func (cli *ArduinoCLI) run(stdoutBuff, stderrBuff io.Writer, stdinBuff io.Reader
 	if cli.cliConfigPath != nil {
 		args = append([]string{"--config-file", cli.cliConfigPath.String()}, args...)
 	}
+
+	// Github-actions workflow tags to fold log lines
+	if os.Getenv("GITHUB_ACTIONS") != "" {
+		fmt.Printf("::group::Running %s\n", strings.Join(args, " "))
+		defer fmt.Println("::endgroup::")
+	}
+
 	fmt.Println(color.HiBlackString(">>> Running: ") + color.HiYellowString("%s %s", cli.path, strings.Join(args, " ")))
 	cliProc, err := executils.NewProcessFromPath(cli.convertEnvForExecutils(env), cli.path, args...)
 	cli.t.NoError(err)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

* Adds logs folding in GH-actions runners, to improve the readability of logs.
* Remove the `-v` flags from `go build` command to avoid printing hundreds of package name being build, clogging up the log with useless information.

## What is the current behavior?

## What is the new behavior?

![image](https://github.com/arduino/arduino-cli/assets/423515/0d90adfe-8fec-4542-bc43-c105d609e763)

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

## Other information

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines