### PR TITLE
Removed useless file-readable check while enumerating source code files

### DIFF
--- a/arduino/builder/internal/utils/utils.go
+++ b/arduino/builder/internal/utils/utils.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/arduino/arduino-cli/i18n"
 	f "github.com/arduino/arduino-cli/internal/algorithms"
 	"github.com/arduino/go-paths-helper"
 	"github.com/pkg/errors"
@@ -29,8 +28,6 @@ import (
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
 )
-
-var tr = i18n.Tr
 
 // ObjFileIsUpToDate fixdoc
 func ObjFileIsUpToDate(sourceFile, objectFile, dependencyFile *paths.Path) (bool, error) {

--- a/arduino/builder/internal/utils/utils.go
+++ b/arduino/builder/internal/utils/utils.go
@@ -160,17 +160,6 @@ func filterOutSCCS(file *paths.Path) bool {
 	return !sourceControlFolders[file.Base()]
 }
 
-// filterReadableFiles is a ReadDirFilter that accepts only readable files
-func filterReadableFiles(file *paths.Path) bool {
-	// See if the file is readable by opening it
-	f, err := file.Open()
-	if err != nil {
-		return false
-	}
-	f.Close()
-	return true
-}
-
 // filterOutHiddenFiles is a ReadDirFilter that exclude files with a "." prefix in their name
 var filterOutHiddenFiles = paths.FilterOutPrefixes(".")
 
@@ -180,7 +169,6 @@ func FindFilesInFolder(dir *paths.Path, recurse bool, extensions ...string) (pat
 		filterOutHiddenFiles,
 		filterOutSCCS,
 		paths.FilterOutDirectories(),
-		filterReadableFiles,
 	)
 	if len(extensions) > 0 {
 		fileFilter = paths.AndFilter(


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Removes the following file filter:

```go
// filterReadableFiles is a ReadDirFilter that accepts only readable files
func filterReadableFiles(file *paths.Path) bool {
```

from the `FindFilesInFolder` function. The filter has been inherited from the legacy builder, but the reason for it is unclear. On the other hand, it triggers the ESET antivirus software, slowing down the compile.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?


## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
