### PR TITLE
make boards details JSON output deterministic

### DIFF
--- a/internal/cli/feedback/result/rpc.go
+++ b/internal/cli/feedback/result/rpc.go
@@ -18,6 +18,7 @@ package result
 import (
 	"cmp"
 	"fmt"
+	"slices"
 
 	"github.com/arduino/arduino-cli/i18n"
 	f "github.com/arduino/arduino-cli/internal/algorithms"
@@ -425,6 +426,8 @@ func NewBoardDetailsResponse(b *rpc.BoardDetailsResponse) *BoardDetailsResponse 
 	if b == nil {
 		return nil
 	}
+	buildProperties := b.GetBuildProperties()
+	slices.Sort(buildProperties)
 	return &BoardDetailsResponse{
 		Fqbn:                     b.GetFqbn(),
 		Name:                     b.GetName(),
@@ -440,7 +443,7 @@ func NewBoardDetailsResponse(b *rpc.BoardDetailsResponse) *BoardDetailsResponse 
 		Programmers:              NewProgrammers(b.GetProgrammers()),
 		DebuggingSupported:       b.GetDebuggingSupported(),
 		IdentificationProperties: NewBoardIdentificationProperties(b.GetIdentificationProperties()),
-		BuildProperties:          b.GetBuildProperties(),
+		BuildProperties:          buildProperties,
 		DefaultProgrammerID:      b.GetDefaultProgrammerId(),
 	}
 }
@@ -636,6 +639,10 @@ func NewProgrammers(c []*rpc.Programmer) []*Programmer {
 	for i, v := range c {
 		res[i] = NewProgrammer(v)
 	}
+
+	slices.SortFunc(res, func(a, b *Programmer) int {
+		return cmp.Compare(a.Id, b.Id)
+	})
 	return res
 }
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Make `programmers` and `build_properties` deterministic in JSON output.

## What is the current behavior?

Now when performing `arduino-cli boards details ...` it produces a JSON that has some fields that contain values that are always randomly sorted.

## What is the new behavior?

Now the `arduino-cli boards details ...` output produces a JSON that is always deterministic. No more randomly sorted values in arrays 🤘

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
