### PR TITLE
Drop support of package_bundled_index.json and builtin_tools_versions.txt

### DIFF
--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -187,7 +187,6 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 		int(req.GetJobs()),
 		req.GetBuildProperties(),
 		configuration.HardwareDirectories(configuration.Settings),
-		configuration.BuiltinToolsDirectories(configuration.Settings),
 		otherLibrariesDirs,
 		configuration.IDEBuiltinLibrariesDir(configuration.Settings),
 		fqbn,

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -4,6 +4,10 @@ Here you can find a list of migration guides to handle breaking changes between 
 
 ## 0.36.0
 
+### Drop support for `builtin.tools`
+
+We're dropping the `builtin.tools` support. It was the equivalent of Arduino IDE 1.x bundled tools directory.
+
 ### Some golang modules from `github.com/arduino/arduino-cli/*` have been made private.
 
 The following golang modules are no longer available as public API:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,8 +12,6 @@
   - `builtin.libraries` - the libraries in this directory will be available to all platforms without the need for the
     user to install them, but with the lowest priority over other installed libraries with the same name, it's the
     equivalent of the Arduino IDE's bundled libraries directory.
-  - `builtin.tools` - it's a list of directories of tools that will be available to all platforms without the need for
-    the user to install them, it's the equivalent of the Arduino IDE 1.x bundled tools directory.
 - `library` - configuration options relating to Arduino libraries.
   - `enable_unsafe_install` - set to `true` to enable the use of the `--git-url` and `--zip-file` flags with
     [`arduino-cli lib install`][arduino cli lib install]. These are considered "unsafe" installation methods because

--- a/internal/arduino/builder/build_options_manager.go
+++ b/internal/arduino/builder/build_options_manager.go
@@ -33,7 +33,6 @@ type buildOptions struct {
 	currentOptions *properties.Map
 
 	hardwareDirs              paths.PathList
-	builtInToolsDirs          paths.PathList
 	otherLibrariesDirs        paths.PathList
 	builtInLibrariesDirs      *paths.Path
 	buildPath                 *paths.Path
@@ -47,7 +46,7 @@ type buildOptions struct {
 
 // newBuildOptions fixdoc
 func newBuildOptions(
-	hardwareDirs, builtInToolsDirs, otherLibrariesDirs paths.PathList,
+	hardwareDirs, otherLibrariesDirs paths.PathList,
 	builtInLibrariesDirs, buildPath *paths.Path,
 	sketch *sketch.Sketch,
 	customBuildProperties []string,
@@ -59,7 +58,6 @@ func newBuildOptions(
 	opts := properties.NewMap()
 
 	opts.Set("hardwareFolders", strings.Join(hardwareDirs.AsStrings(), ","))
-	opts.Set("builtInToolsFolders", strings.Join(builtInToolsDirs.AsStrings(), ","))
 	opts.Set("otherLibrariesFolders", strings.Join(otherLibrariesDirs.AsStrings(), ","))
 	opts.SetPath("sketchLocation", sketch.FullPath)
 	opts.Set("fqbn", fqbn.String())
@@ -84,7 +82,6 @@ func newBuildOptions(
 	return &buildOptions{
 		currentOptions:            opts,
 		hardwareDirs:              hardwareDirs,
-		builtInToolsDirs:          builtInToolsDirs,
 		otherLibrariesDirs:        otherLibrariesDirs,
 		builtInLibrariesDirs:      builtInLibrariesDirs,
 		buildPath:                 buildPath,

--- a/internal/arduino/builder/builder.go
+++ b/internal/arduino/builder/builder.go
@@ -121,7 +121,7 @@ func NewBuilder(
 	coreBuildCachePath *paths.Path,
 	jobs int,
 	requestBuildProperties []string,
-	hardwareDirs, builtInToolsDirs, otherLibrariesDirs paths.PathList,
+	hardwareDirs, otherLibrariesDirs paths.PathList,
 	builtInLibrariesDirs *paths.Path,
 	fqbn *cores.FQBN,
 	clean bool,
@@ -223,7 +223,7 @@ func NewBuilder(
 			logger,
 		),
 		buildOptions: newBuildOptions(
-			hardwareDirs, builtInToolsDirs, otherLibrariesDirs,
+			hardwareDirs, otherLibrariesDirs,
 			builtInLibrariesDirs, buildPath,
 			sk,
 			customBuildPropertiesArgs,

--- a/internal/arduino/cores/cores.go
+++ b/internal/arduino/cores/cores.go
@@ -70,7 +70,6 @@ type PlatformRelease struct {
 	Programmers             map[string]*Programmer        `json:"-"`
 	Menus                   *properties.Map               `json:"-"`
 	InstallDir              *paths.Path                   `json:"-"`
-	IsIDEBundled            bool                          `json:"-"`
 	IsTrusted               bool                          `json:"-"`
 	PluggableDiscoveryAware bool                          `json:"-"` // true if the Platform supports pluggable discovery (no compatibility layer required)
 	Monitors                map[string]*MonitorDependency `json:"-"`

--- a/internal/arduino/cores/packagemanager/package_manager.go
+++ b/internal/arduino/cores/packagemanager/package_manager.go
@@ -621,8 +621,7 @@ func (pme *Explorer) GetInstalledPlatformRelease(platform *cores.Platform) *core
 	}
 
 	debug := func(msg string, pl *cores.PlatformRelease) {
-		pme.log.WithField("bundle", pl.IsIDEBundled).
-			WithField("version", pl.Version).
+		pme.log.WithField("version", pl.Version).
 			WithField("managed", pme.IsManagedPlatformRelease(pl)).
 			Debugf("%s: %s", msg, pl)
 	}
@@ -634,20 +633,14 @@ func (pme *Explorer) GetInstalledPlatformRelease(platform *cores.Platform) *core
 	for _, candidate := range releases[1:] {
 		candidateIsManaged := pme.IsManagedPlatformRelease(candidate)
 		debug("candidate", candidate)
-		// TODO: Disentangle this algorithm and make it more straightforward
-		if bestIsManaged == candidateIsManaged {
-			if best.IsIDEBundled == candidate.IsIDEBundled {
-				if candidate.Version.GreaterThan(best.Version) {
-					best = candidate
-				}
-			}
-			if best.IsIDEBundled && !candidate.IsIDEBundled {
-				best = candidate
-			}
+		if !candidateIsManaged {
+			continue
 		}
-		if !bestIsManaged && candidateIsManaged {
+		if !bestIsManaged {
 			best = candidate
 			bestIsManaged = true
+		} else if candidate.Version.GreaterThan(best.Version) {
+			best = candidate
 		}
 		debug("current best", best)
 	}

--- a/internal/arduino/cores/packagemanager/package_manager.go
+++ b/internal/arduino/cores/packagemanager/package_manager.go
@@ -633,6 +633,12 @@ func (pme *Explorer) GetInstalledPlatformRelease(platform *cores.Platform) *core
 	for _, candidate := range releases[1:] {
 		candidateIsManaged := pme.IsManagedPlatformRelease(candidate)
 		debug("candidate", candidate)
+		if !candidateIsManaged && !bestIsManaged {
+			if candidate.Version.GreaterThan(best.Version) {
+				best = candidate
+			}
+			continue
+		}
 		if !candidateIsManaged {
 			continue
 		}

--- a/internal/cli/configuration/directories.go
+++ b/internal/cli/configuration/directories.go
@@ -42,11 +42,6 @@ func HardwareDirectories(settings *viper.Viper) paths.PathList {
 	return res
 }
 
-// BuiltinToolsDirectories returns all paths that may contains bundled-tools.
-func BuiltinToolsDirectories(settings *viper.Viper) paths.PathList {
-	return paths.NewPathList(settings.GetStringSlice("directories.builtin.Tools")...)
-}
-
 // IDEBuiltinLibrariesDir returns the IDE-bundled libraries path. Usually
 // this directory is present in the Arduino IDE.
 func IDEBuiltinLibrariesDir(settings *viper.Viper) *paths.Path {

--- a/internal/integrationtest/compile_4/compile_test.go
+++ b/internal/integrationtest/compile_4/compile_test.go
@@ -1030,7 +1030,6 @@ func TestBuildOptionsFile(t *testing.T) {
 
 	requirejson.Query(t, buildOptionsBytes, "keys", `[
 		"additionalFiles",
-		"builtInToolsFolders",
 		"compiler.optimization_flags",
 		"customBuildProperties",
 		"fqbn",


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

After an internal discussion, we have decided that after the refactoring of the legacy builder, is impossible to maintain the old arduino-builder used by the Java IDE.
In the spirit of the upcoming v1.0.0 we're dropping the support of: package_bundled_index.json and builtin_tools_versions.txt for good as the Java IDE is deprecated trying to maintain this legacy part doesn't bring any relevant value.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
