### PR TITLE
Use mocked serial discovery in board integration tests that weren't running in CI

### DIFF
--- a/internal/integrationtest/board/board_test.go
+++ b/internal/integrationtest/board/board_test.go
@@ -16,7 +16,6 @@
 package board_test
 
 import (
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -73,15 +72,14 @@ func TestCorrectBoardListOrdering(t *testing.T) {
 }
 
 func TestBoardList(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skip("VMs have no serial ports")
-	}
-
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
 	_, _, err := cli.Run("core", "update-index")
 	require.NoError(t, err)
+
+	cli.InstallMockedSerialDiscovery(t)
+
 	stdout, _, err := cli.Run("board", "list", "--format", "json")
 	require.NoError(t, err)
 	// check is a valid json and contains a list of ports
@@ -130,31 +128,27 @@ func TestBoardListMock(t *testing.T) {
 }
 
 func TestBoardListWithFqbnFilter(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skip("VMs have no serial ports")
-	}
-
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
 	_, _, err := cli.Run("core", "update-index")
 	require.NoError(t, err)
+
+	cli.InstallMockedSerialDiscovery(t)
+
 	stdout, _, err := cli.Run("board", "list", "-b", "foo:bar:baz", "--format", "json")
 	require.NoError(t, err)
-	// this is a bit of a passpartout test, it actually filters the "bluetooth boards" locally
-	// but it would succeed even if the filtering wasn't working properly
-	// TODO: find a way to simulate connected boards or create a unit test which
-	// mocks or initializes multiple components
-	requirejson.Query(t, stdout, `.boards | length`, `0`)
+	requirejson.Query(t, stdout, `.detected_ports | length`, `0`)
 }
 
 func TestBoardListWithFqbnFilterInvalid(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skip("VMs have no serial ports")
-	}
-
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
+
+	_, _, err := cli.Run("core", "update-index")
+	require.NoError(t, err)
+
+	cli.InstallMockedSerialDiscovery(t)
 
 	_, stderr, err := cli.Run("board", "list", "-b", "yadayada", "--format", "json")
 	require.Error(t, err)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Improve the `TestBoardListWithFqbnFilter`, `TestBoardList` , and `TestBoardListWithFqbnFilterInvalid` tests by using the mocked serial discovery

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
