### PR TITLE
fix: Fixed regression in `compile_commands.json` generation

### DIFF
--- a/arduino/builder/internal/detector/detector.go
+++ b/arduino/builder/internal/detector/detector.go
@@ -231,8 +231,7 @@ func (l *SketchLibrariesDetector) findIncludes(
 		if err != nil {
 			return err
 		}
-		includeFolders := l.includeFolders
-		if err := json.Unmarshal(d, &includeFolders); err != nil {
+		if err := json.Unmarshal(d, &l.includeFolders); err != nil {
 			return err
 		}
 		if l.logger.Verbose() {

--- a/internal/integrationtest/compile_3/compile_commands_test.go
+++ b/internal/integrationtest/compile_3/compile_commands_test.go
@@ -1,0 +1,89 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2022 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package compile_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/arduino/arduino-cli/internal/integrationtest"
+	"github.com/arduino/go-paths-helper"
+	"github.com/stretchr/testify/require"
+	"go.bug.st/testifyjson/requirejson"
+)
+
+func TestCompileCommandsJSONGeneration(t *testing.T) {
+	// See: https://github.com/arduino/arduino-cli/issues/2401
+
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	// Run update-index with our test index
+	_, _, err := cli.Run("core", "install", "arduino:avr@1.8.5")
+	require.NoError(t, err)
+
+	// Create a test sketch
+	out, _, err := cli.Run("sketch", "new", "Test", "--format", "json")
+	require.NoError(t, err)
+	var s struct {
+		Path string `json:"sketch_path"`
+	}
+	require.NoError(t, json.Unmarshal(out, &s))
+	sketchPath := paths.New(s.Path)
+	buildPath := sketchPath.Join("build")
+
+	{
+		// Normal build
+		_, _, err = cli.Run(
+			"compile",
+			"-b", "arduino:avr:uno",
+			"--build-path", buildPath.String(),
+			sketchPath.String())
+		require.NoError(t, err)
+
+		compileCommandsPath := buildPath.Join("compile_commands.json")
+		require.True(t, compileCommandsPath.Exist())
+		compileCommandJson, err := compileCommandsPath.ReadFile()
+		require.NoError(t, err)
+		compileCommands := requirejson.Parse(t, compileCommandJson)
+		// Check that the variant include path is present, one of the arguments must be
+		// something like:
+		// "-I/home/user/.arduino15/packages/arduino/hardware/avr/1.8.6/variants/standard"
+		compileCommands.Query(`[ .[0].arguments[] | contains("standard") ] | any`).MustEqual(`true`)
+	}
+
+	{
+		// Build with skip-library-check
+		_, _, err = cli.Run(
+			"compile",
+			"-b", "arduino:avr:uno",
+			"--only-compilation-database",
+			"--skip-libraries-discovery",
+			"--build-path", buildPath.String(),
+			sketchPath.String())
+		require.NoError(t, err)
+
+		compileCommandsPath := buildPath.Join("compile_commands.json")
+		require.True(t, compileCommandsPath.Exist())
+		compileCommandJson, err := compileCommandsPath.ReadFile()
+		require.NoError(t, err)
+		compileCommands := requirejson.Parse(t, compileCommandJson)
+		// Check that the variant include path is present, one of the arguments must be
+		// something like:
+		// "-I/home/user/.arduino15/packages/arduino/hardware/avr/1.8.6/variants/standard"
+		compileCommands.Query(`[ .[0].arguments[] | contains("standard") ] | any`).MustEqual(`true`)
+	}
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fixed a regression in `compile_commands.json` generation.
This feature is mainly used in arduino-language-server.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Fix #2401
