### PR TITLE
Added a compatibility trick in `debug -I` for `toolchain.prefix` key

### DIFF
--- a/commands/debug/debug.go
+++ b/commands/debug/debug.go
@@ -130,7 +130,7 @@ func getCommandLine(req *rpc.GetDebugConfigRequest, pme *packagemanager.Explorer
 	var gdbPath *paths.Path
 	switch debugInfo.GetToolchain() {
 	case "gcc":
-		gdbexecutable := debugInfo.GetToolchainPrefix() + "gdb"
+		gdbexecutable := debugInfo.GetToolchainPrefix() + "-gdb"
 		if runtime.GOOS == "windows" {
 			gdbexecutable += ".exe"
 		}

--- a/commands/debug/debug_info.go
+++ b/commands/debug/debug_info.go
@@ -169,6 +169,13 @@ func getDebugProperties(req *rpc.GetDebugConfigRequest, pme *packagemanager.Expl
 		}
 	}
 
+	// HOTFIX: for samd (and maybe some other platforms). We should keep this for a reasonable
+	// amount of time to allow seamless platforms update.
+	toolchainPrefix := debugProperties.Get("toolchain.prefix")
+	if toolchainPrefix == "arm-none-eabi-" {
+		toolchainPrefix = "arm-none-eabi"
+	}
+
 	customConfigs := map[string]string{}
 	if cortexDebugProps := debugProperties.SubTree("cortex-debug.custom"); cortexDebugProps.Size() > 0 {
 		customConfigs["cortex-debug"] = convertToJsonMap(cortexDebugProps)
@@ -181,7 +188,7 @@ func getDebugProperties(req *rpc.GetDebugConfigRequest, pme *packagemanager.Expl
 		SvdFile:                debugProperties.Get("svd_file"),
 		Toolchain:              toolchain,
 		ToolchainPath:          debugProperties.Get("toolchain.path"),
-		ToolchainPrefix:        debugProperties.Get("toolchain.prefix"),
+		ToolchainPrefix:        toolchainPrefix,
 		ToolchainConfiguration: &toolchainConfiguration,
 		CustomConfigs:          customConfigs,
 		Programmer:             req.GetProgrammer(),

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -282,7 +282,7 @@ The string field `server_configuration.script` is now an array and has been rena
   "executable": "/tmp/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/Blink.ino.elf",
   "toolchain": "gcc",
   "toolchain_path": "/home/user/.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin/",
-  "toolchain_prefix": "arm-none-eabi-",
+  "toolchain_prefix": "arm-none-eabi",
   "server": "openocd",
   "server_path": "/home/user/.arduino15/packages/arduino/tools/openocd/0.10.0-arduino7/bin/openocd",
   "server_configuration": {
@@ -2514,7 +2514,7 @@ Now:
 debug.executable={build.path}/{build.project_name}.elf
 debug.toolchain=gcc
 debug.toolchain.path={runtime.tools.arm-none-eabi-gcc-7-2017q4.path}/bin/
-debug.toolchain.prefix=arm-none-eabi-
+debug.toolchain.prefix=arm-none-eabi
 debug.server=openocd
 debug.server.openocd.path={runtime.tools.openocd-0.10.0-arduino7.path}/bin/
 debug.server.openocd.scripts_dir={runtime.tools.openocd-0.10.0-arduino7.path}/share/openocd/scripts/

--- a/rpc/cc/arduino/cli/commands/v1/debug.pb.go
+++ b/rpc/cc/arduino/cli/commands/v1/debug.pb.go
@@ -284,7 +284,7 @@ type GetDebugConfigResponse struct {
 	Toolchain string `protobuf:"bytes,2,opt,name=toolchain,proto3" json:"toolchain,omitempty"`
 	// The toolchain directory
 	ToolchainPath string `protobuf:"bytes,3,opt,name=toolchain_path,json=toolchainPath,proto3" json:"toolchain_path,omitempty"`
-	// The toolchain architecture prefix (for example "arm-none-eabi-")
+	// The toolchain architecture prefix (for example "arm-none-eabi")
 	ToolchainPrefix string `protobuf:"bytes,4,opt,name=toolchain_prefix,json=toolchainPrefix,proto3" json:"toolchain_prefix,omitempty"`
 	// The GDB server type used to connect to the programmer/board (for example
 	// "openocd")

--- a/rpc/cc/arduino/cli/commands/v1/debug.proto
+++ b/rpc/cc/arduino/cli/commands/v1/debug.proto
@@ -80,7 +80,7 @@ message GetDebugConfigResponse {
   string toolchain = 2;
   // The toolchain directory
   string toolchain_path = 3;
-  // The toolchain architecture prefix (for example "arm-none-eabi-")
+  // The toolchain architecture prefix (for example "arm-none-eabi")
   string toolchain_prefix = 4;
   // The GDB server type used to connect to the programmer/board (for example
   // "openocd")


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

The `debug.toolchain.prefix` key was ignored in older versions of the Arduino IDE.

In the upcoming release (Arduino IDE 2.2.2) instead the key is used, but in the older releases of the platforms it was wrongly set to `"arm-none-eabi-"` when we actually want `"arm-none-eabi"`.

This patch ensures backward and forward compatibility.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
