### PR TITLE
Allow empty configuration merging

### DIFF
--- a/commands/daemon/settings.go
+++ b/commands/daemon/settings.go
@@ -79,9 +79,13 @@ func (s *ArduinoCoreServerImpl) SettingsMerge(ctx context.Context, req *rpc.Sett
 	// Set each value individually.
 	// This is done because Viper ignores empty strings or maps when
 	// using the MergeConfigMap function.
+	updatedSettings := configuration.Init("")
 	for k, v := range mapped {
-		configuration.Settings.Set(k, v)
+		updatedSettings.Set(k, v)
 	}
+	configPath := configuration.Settings.ConfigFileUsed()
+	updatedSettings.SetConfigFile(configPath)
+	configuration.Settings = updatedSettings
 
 	return &rpc.SettingsMergeResponse{}, nil
 }

--- a/commands/daemon/settings_test.go
+++ b/commands/daemon/settings_test.go
@@ -81,6 +81,13 @@ func TestMerge(t *testing.T) {
 	require.Equal(t, "", configuration.Settings.GetString("foo"))
 	require.Equal(t, false, configuration.Settings.GetBool("sketch.always_export_binaries"))
 
+	bulkSettings = `{"network": {}}`
+	res, err = svc.SettingsMerge(context.Background(), &rpc.SettingsMergeRequest{JsonData: bulkSettings})
+	require.NotNil(t, res)
+	require.NoError(t, err)
+
+	require.Equal(t, "", configuration.Settings.GetString("proxy"))
+
 	reset()
 }
 

--- a/commands/daemon/settings_test.go
+++ b/commands/daemon/settings_test.go
@@ -120,6 +120,8 @@ func TestGetMergedValue(t *testing.T) {
 	res, err = svc.SettingsGetValue(context.Background(), key)
 	require.NoError(t, err)
 	require.Equal(t, `"bar"`, res.GetJsonData())
+
+	reset()
 }
 
 func TestGetValueNotFound(t *testing.T) {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Code enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
It is not possible to merge empty values to delete elements inside the configuration.
<!-- You can also link to an open issue here -->

## What is the new behavior?
It is possible to delete non-defaults elements inside the configuration using an empty value. A full json configuration must be passed to the merge command.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
