### PR TITLE
feat: allow boards to change debug support via FQBN options

### DIFF
--- a/commands/debug/debug_info.go
+++ b/commands/debug/debug_info.go
@@ -134,7 +134,7 @@ func getDebugProperties(req *rpc.GetDebugConfigRequest, pme *packagemanager.Expl
 		debugProperties.Set(k, toolProperties.ExpandPropsInString(v))
 	}
 
-	if !debugProperties.ContainsKey("executable") {
+	if !debugProperties.ContainsKey("executable") || debugProperties.Get("executable") == "" {
 		return nil, &arduino.FailedDebugError{Message: tr("Debugging not supported for board %s", req.GetFqbn())}
 	}
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -2521,6 +2521,8 @@ debug.server.openocd.scripts_dir={runtime.tools.openocd-0.10.0-arduino7.path}/sh
 debug.server.openocd.script={runtime.platform.path}/variants/{build.variant}/{build.openocdscript}
 ```
 
+The `debug.executable` key must be present and non-empty for debugging to be supported.
+
 The `debug.server.XXXX` subkeys are optional and also "free text", this means that the configuration may be extended as
 needed by the specific server. For now only `openocd` is supported. Anyway, if this change works, any other kind of
 server may be fairly easily added.


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

"debug.executable" must be present AND non-empty for debugging to be supported, allowing board overrides. Also, use the same logic in the details view and in the actual debug command implementation.

## What is the current behavior?

Debug support is enabled if any of the `txt` files define a key named `debug.executable`, regardless of its contents, preventing overrides by board and/or menu options

## What is the new behavior?

"debug.executable" must be present AND non-empty for debugging to be supported, allowing board overrides. Also, use the same logic in the details view and in the actual debug command implementation.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No, it is backwards compatible (all cores using debug define the key to a valid string, cores without debug never define the key).

## Other information

Tested with Arduino Nano ESP32 package.
Original `platform.txt` already contains:
```
debug.executable={build.path}/{build.project_name}.elf 
```

Lines added to `boards.txt`:
```
nano_nora.debug.executable=   
nano_nora.menu.USBMode.hwcdc.debug.executable={build.path}/{build.project_name}.elf   
```

* Output from `arduino-cli board details -b arduino-git:esp32:nano_nora --format json` does not include `debugging_supported` key.
* Output from `arduino-cli board details -b arduino-git:esp32:nano_nora:USBMode=hwcdc --format json` includes `"debugging_supported": true`.


