### PR TITLE
fix: debugging requires a non empty debug.executable

### DIFF
--- a/commands/debug/debug_info.go
+++ b/commands/debug/debug_info.go
@@ -140,7 +140,7 @@ func getDebugProperties(req *rpc.GetDebugConfigRequest, pme *packagemanager.Expl
 		}
 	}
 
-	if !debugProperties.ContainsKey("executable") {
+	if !debugProperties.ContainsKey("executable") || debugProperties.Get("executable") == "" {
 		return nil, &arduino.FailedDebugError{Message: tr("Debugging not supported for board %s", req.GetFqbn())}
 	}
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -2533,6 +2533,8 @@ debug.server.openocd.scripts_dir={runtime.tools.openocd-0.10.0-arduino7.path}/sh
 debug.server.openocd.script={runtime.platform.path}/variants/{build.variant}/{build.openocdscript}
 ```
 
+The `debug.executable` key must be present and non-empty for debugging to be supported.
+
 The `debug.server.XXXX` subkeys are optional and also "free text", this means that the configuration may be extended as
 needed by the specific server. For now only `openocd` is supported. Anyway, if this change works, any other kind of
 server may be fairly easily added.

--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -1369,11 +1369,14 @@ to provide some debug configuration directives.
 All the debug directives are grouped under the `debug.*` directives. Here is the complete list of the supported
 directives:
 
+- `debug.executable`: is the absolute path to the compiled binary of the sketch
 - `debug.toolchain`: is a unique identifier of the required toolchain, currently we support `gcc` (and compatible) only
 - `debug.toolchain.path`: is the absolute path to the toolchain directory
 - `debug.toolchain.prefix`: is the prefix of the toolchain (for example `arm-none-eabi-`)
 - `debug.server`: is a unique identifier of the required debug server, currently we support only `openocd`
 - `debug.svd_file`: is the absolute path to the SVD descriptor.
+
+If the `debug.executable` property is not present or is empty debugging will not be allowed.
 
 OpenOCD server specific configurations:
 


### PR DESCRIPTION
Allow debugger to be disabled in case `debug.executable` property is undefined OR defined as the empty string.
Previously the debugger was disabled only if undefined.