### PR TITLE
Parallelize `upload_mock` integration tests

### DIFF
--- a/internal/integrationtest/upload_mock/upload_mock_test.go
+++ b/internal/integrationtest/upload_mock/upload_mock_test.go
@@ -44,7 +44,7 @@ type parametersMap struct {
 
 func TestUploadSketch(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
-	defer env.CleanUp()
+	t.Cleanup(env.CleanUp)
 
 	indexes := []string{
 		"https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json",
@@ -655,13 +655,14 @@ func TestUploadSketch(t *testing.T) {
 	sketchPath := cli.SketchbookDir().Join(sketchName)
 	_, _, err := cli.Run("sketch", "new", sketchPath.String())
 	require.NoError(t, err)
+	buildDir := generateBuildDir(sketchPath, t)
+	t.Cleanup(func() { buildDir.RemoveAll() })
 
-	var stdout []byte
-
-	for i, test := range testParameters {
+	for i, _test := range testParameters {
+		test := _test
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			buildDir := generateBuildDir(sketchPath, t)
-			defer buildDir.RemoveAll()
+			t.Parallel()
+			var stdout []byte
 			if test.Programmer != "" {
 				if test.UploadPort != "" {
 					stdout, _, err = cli.Run("upload", "-p", test.UploadPort, "-P", test.Programmer, "-b", test.Fqbn, sketchPath.String(), "--dry-run", "-v")
@@ -686,10 +687,11 @@ func TestUploadSketch(t *testing.T) {
 		})
 	}
 
-	for i, test := range testParametersMap {
+	for i, _test := range testParametersMap {
+		test := _test
 		t.Run(fmt.Sprintf("WithMap%d", i), func(t *testing.T) {
-			buildDir := generateBuildDir(sketchPath, t)
-			defer buildDir.RemoveAll()
+			t.Parallel()
+			var stdout []byte
 			if test.Programmer != "" {
 				if test.UploadPort != "" {
 					stdout, _, err = cli.Run("upload", "-p", test.UploadPort, "-P", test.Programmer, "-b", test.Fqbn, sketchPath.String(), "--dry-run", "-v")


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Parallelize `upload_mock` integration test.
Since the `upload_mock` tests are the longest, this change should reduce the overall execution time, I didn't check accurately, but I'm pretty sure we are gaining at least a couple of minutes over the full CI process.

## What is the current behavior?

`test-integration (windows-latest, upload_modk)` completes in roughly ~12 minutes.

## What is the new behavior?

`test-integration (windows-latest, upload_modk)` completes in roughly ~8 minutes.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
