### PR TITLE
Fix caching for libraries when installation folder differents from Name

### DIFF
--- a/arduino/builder/libraries.go
+++ b/arduino/builder/libraries.go
@@ -245,7 +245,7 @@ func (b *Builder) removeUnusedCompiledLibraries(importedLibraries libraries.List
 	toLibraryNames := func(libraries []*libraries.Library) []string {
 		libraryNames := []string{}
 		for _, library := range libraries {
-			libraryNames = append(libraryNames, library.Name)
+			libraryNames = append(libraryNames, library.DirName)
 		}
 		return libraryNames
 	}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

The PR fixes a bug when a library was wrongly purged as "unused" during compilation since its containing folder differed from its Name filed in `library.properties`
 
## What is the current behavior?

When compiling for `mbed_giga` core any sketch including `RPC.h`, library `openamp_arduino` will be recompiled every time. The library name is `openamp` (without `_arduino`).

## What is the new behavior?

The library gets properly cached and recompilation is avoided on the next turn.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

## Other information

<!-- Any additional information that could help the review process -->
