### PR TITLE
Update Taskfile.yml

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -341,7 +341,7 @@ tasks:
   general:get-version:
     desc: Returns the version used in the project
     cmds:
-      - echo {{.VERSION}}
+      - echo v{{.VERSION}}
 
 vars:
   PROJECT_NAME: "arduino-cli"


### PR DESCRIPTION
Address https://github.com/arduino/arduino-cli/issues/2483 in single place

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [x] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Fix for CI

## What is the current behavior?

Releases are created with incorrect name according to new release tags using v prefix for version number

## What is the new behavior?

v is prefixed to the version returned by Go, used later in other CI steps.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
No
## Other information

<!-- Any additional information that could help the review process -->
