### PR TITLE
Fix install.sh for versions targs with `v` prefixed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,7 +117,7 @@ downloadFile() {
     TAG=$1
   fi
   #  arduino-lint_0.4.0-rc1_Linux_64bit.[tar.gz, zip]
-  APPLICATION_DIST_PREFIX="${PROJECT_NAME}_${TAG}_"
+  APPLICATION_DIST_PREFIX="${PROJECT_NAME}_${TAG#"v"}_"
   if [ "$OS" = "Windows" ]; then
     APPLICATION_DIST_EXTENSION=".zip"
   else


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fix the `install.sh` script that broke: https://github.com/arduino/arduino-cli/issues/2483
Since we are going to prefix a `v` in the version tag to follow golang standards about publishing modules versions, the `v` should be removed from the download link.

## What is the current behavior?

```
$ curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
Installing in /home/megabug/bin
ARCH=64bit
OS=Linux
Using curl as download tool
Downloading https://downloads.arduino.cc/arduino-cli/arduino-cli_v0.35.0_Linux_64bit.tar.gz
Did not find a release for your system: Linux 64bit
Trying to find a release using the GitHub API.
Downloading https://github.com/arduino/arduino-cli/releases/download/v0.35.0/0.35.0-checksums.txt
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_configuration.schema.json
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_Linux_32bit.tar.gz
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_Linux_64bit.tar.gz
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_Linux_ARM64.tar.gz
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_Linux_ARMv6.tar.gz
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_Linux_ARMv7.tar.gz
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_macOS_64bit.tar.gz
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_macOS_ARM64.tar.gz
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_proto.zip
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_Windows_32bit.zip
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_Windows_64bit.msi
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/arduino-cli_0.35.0_Windows_64bit.zip
https://github.com/arduino/arduino-cli/releases/download/v0.35.0/CHANGELOG.md
Failed to install arduino-cli
```

## What is the new behavior?

```
$ sh install.sh 
Installing in /home/megabug/Workspace/arduino-cli/bin
ARCH=64bit
OS=Linux
Using curl as download tool
Downloading https://downloads.arduino.cc/arduino-cli/arduino-cli_0.35.0_Linux_64bit.tar.gz
An existing arduino-cli was found at /usr/bin/arduino-cli. Please prepend "/home/megabug/Workspace/arduino-cli/bin" to your $PATH or remove the existing one.
arduino-cli  Versione: 0.35.0 Commit: ebab482d Data: 2024-01-02T14:16:15Z installed successfully in /home/cmaglie/Workspace/arduino-cli/bin
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Fix #2483