### PR TITLE
Allow to specify the config file through `ARDUINO_CONFIG_FILE` env

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,6 +127,7 @@ The configuration file must be named `arduino-cli`, with the appropriate file ex
 Configuration files in the following locations are recognized by Arduino CLI:
 
 1. Location specified by the [`--config-file`][arduino cli command reference] command line flag
+1. Location specified by the `ARDUINO_CONFIG_FILE` environment variable
 1. Arduino CLI data directory (as configured by `directories.data`)
 
 If multiple configuration files are present, the one highest on the above list is used. Configuration files are not

--- a/internal/cli/configuration/configuration.go
+++ b/internal/cli/configuration/configuration.go
@@ -133,9 +133,10 @@ func GetDefaultBuiltinLibrariesDir() string {
 	return filepath.Join(getDefaultArduinoDataDir(), "libraries")
 }
 
-// FindConfigFileInArgs returns the config file path using the
-// argument '--config-file' (if specified) or looking in the current working dir
-func FindConfigFileInArgs(args []string) string {
+// FindConfigFileInArgsFallbackOnEnv returns the config file path using the
+// argument '--config-file' (if specified), if empty looks for the ARDUINO_CONFIG_FILE env,
+// or looking in the current working dir
+func FindConfigFileInArgsFallbackOnEnv(args []string) string {
 	// Look for '--config-file' argument
 	for i, arg := range args {
 		if arg == "--config-file" {
@@ -144,5 +145,5 @@ func FindConfigFileInArgs(args []string) string {
 			}
 		}
 	}
-	return ""
+	return os.Getenv("ARDUINO_CONFIG_FILE")
 }

--- a/internal/cli/configuration/configuration_test.go
+++ b/internal/cli/configuration/configuration_test.go
@@ -60,15 +60,23 @@ func TestInit(t *testing.T) {
 }
 
 func TestFindConfigFile(t *testing.T) {
-	configFile := FindConfigFileInArgs([]string{"--config-file"})
+	configFile := FindConfigFileInArgsFallbackOnEnv([]string{"--config-file"})
 	require.Equal(t, "", configFile)
 
-	configFile = FindConfigFileInArgs([]string{"--config-file", "some/path/to/config"})
+	configFile = FindConfigFileInArgsFallbackOnEnv([]string{"--config-file", "some/path/to/config"})
 	require.Equal(t, "some/path/to/config", configFile)
 
-	configFile = FindConfigFileInArgs([]string{"--config-file", "some/path/to/config/arduino-cli.yaml"})
+	configFile = FindConfigFileInArgsFallbackOnEnv([]string{"--config-file", "some/path/to/config/arduino-cli.yaml"})
 	require.Equal(t, "some/path/to/config/arduino-cli.yaml", configFile)
 
-	configFile = FindConfigFileInArgs([]string{})
+	configFile = FindConfigFileInArgsFallbackOnEnv([]string{})
 	require.Equal(t, "", configFile)
+
+	t.Setenv("ARDUINO_CONFIG_FILE", "some/path/to/config")
+	configFile = FindConfigFileInArgsFallbackOnEnv([]string{})
+	require.Equal(t, "some/path/to/config", configFile)
+
+	// when both env and flag are specified flag takes precedence
+	configFile = FindConfigFileInArgsFallbackOnEnv([]string{"--config-file", "flag/path"})
+	require.Equal(t, "flag/path", configFile)
 }

--- a/internal/docsgen/main.go
+++ b/internal/docsgen/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	os.MkdirAll(os.Args[1], 0755) // Create the output folder if it doesn't already exist
 
-	configuration.Settings = configuration.Init(configuration.FindConfigFileInArgs(os.Args))
+	configuration.Settings = configuration.Init(configuration.FindConfigFileInArgsFallbackOnEnv(os.Args))
 	cli := cli.NewCommand()
 	cli.DisableAutoGenTag = true // Disable addition of auto-generated date stamp
 	err := doc.GenMarkdownTree(cli, os.Args[1])

--- a/internal/integrationtest/monitor/monitor_grpc_test.go
+++ b/internal/integrationtest/monitor/monitor_grpc_test.go
@@ -58,7 +58,7 @@ func TestMonitorGRPCClose(t *testing.T) {
 	tmpFileMatcher := regexp.MustCompile("Tmpfile: (.*)\n")
 	{
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
-		mon, err := grpcInst.Monitor(ctx, ports[0].Port)
+		mon, err := grpcInst.Monitor(ctx, ports[0].GetPort())
 		var tmpFile *paths.Path
 		for {
 			monResp, err := mon.Recv()
@@ -85,7 +85,7 @@ func TestMonitorGRPCClose(t *testing.T) {
 	{
 		// Keep a timeout to allow the test to exit in any case
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		mon, err := grpcInst.Monitor(ctx, ports[0].Port)
+		mon, err := grpcInst.Monitor(ctx, ports[0].GetPort())
 		var tmpFile *paths.Path
 		for {
 			monResp, err := mon.Recv()

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	configuration.Settings = configuration.Init(configuration.FindConfigFileInArgs(os.Args))
+	configuration.Settings = configuration.Init(configuration.FindConfigFileInArgsFallbackOnEnv(os.Args))
 	i18n.Init(configuration.Settings.GetString("locale"))
 	arduinoCmd := cli.NewCommand()
 	if err := arduinoCmd.Execute(); err != nil {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Add `ARDUINO_CONFIG_FILE` env var, which as the same behaviour of the `--config-file` flag.

## What is the current behavior?

Currently an user can only specify a specifc config file through the usage of `--config-file` flag.
It's not possible to specify the config file thorugh an env var.

## What is the new behavior?

Adding the `ARDUINO_CONFIG_FILE` is now possible to specify either a specifc config file or a directory
containing the default configuration file.
If the cli is provied with both `--config-file` and the new env the flag takes precedence.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

no

## Other information

