### PR TITLE
refactoring: Added `LibrariesManager.Clone()` / Auto-scan libs on `LibrariesManager.Build()`

### DIFF
--- a/commands/instances.go
+++ b/commands/instances.go
@@ -389,16 +389,11 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 		}
 	}
 
-	lm := lmb.Build()
+	lm, libsLoadingWarnings := lmb.Build()
 	_ = instances.SetLibraryManager(instance, lm) // should never fail
-
-	{
-		lmi, release := lm.NewInstaller()
-		for _, status := range lmi.RescanLibraries() {
-			logrus.WithError(status.Err()).Warnf("Error loading library")
-			// TODO: report as warning: responseError(err)
-		}
-		release()
+	for _, status := range libsLoadingWarnings {
+		logrus.WithError(status.Err()).Warnf("Error loading library")
+		// TODO: report as warning: responseError(err)
 	}
 
 	// Refreshes the locale used, this will change the

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -307,7 +307,7 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 	for _, pack := range pme.GetPackages() {
 		for _, platform := range pack.Platforms {
 			if platformRelease := pme.GetInstalledPlatformRelease(platform); platformRelease != nil {
-				lmb.AddLibrariesDir(&librariesmanager.LibrariesDir{
+				lmb.AddLibrariesDir(librariesmanager.LibrariesDir{
 					PlatformRelease: platformRelease,
 					Path:            platformRelease.GetLibrariesDir(),
 					Location:        libraries.PlatformBuiltIn,
@@ -335,14 +335,14 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 	if profile == nil {
 		// Add directories of libraries bundled with IDE
 		if bundledLibsDir := configuration.IDEBuiltinLibrariesDir(configuration.Settings); bundledLibsDir != nil {
-			lmb.AddLibrariesDir(&librariesmanager.LibrariesDir{
+			lmb.AddLibrariesDir(librariesmanager.LibrariesDir{
 				Path:     bundledLibsDir,
 				Location: libraries.IDEBuiltIn,
 			})
 		}
 
 		// Add libraries directory from config file
-		lmb.AddLibrariesDir(&librariesmanager.LibrariesDir{
+		lmb.AddLibrariesDir(librariesmanager.LibrariesDir{
 			Path:     configuration.LibrariesDir(configuration.Settings),
 			Location: libraries.User,
 		})
@@ -382,7 +382,7 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 				taskCallback(&rpc.TaskProgress{Completed: true})
 			}
 
-			lmb.AddLibrariesDir(&librariesmanager.LibrariesDir{
+			lmb.AddLibrariesDir(librariesmanager.LibrariesDir{
 				Path:     libRoot,
 				Location: libraries.User,
 			})

--- a/commands/internal/instances/instances.go
+++ b/commands/internal/instances/instances.go
@@ -126,9 +126,12 @@ func Create(dataDir, packagesDir, downloadsDir *paths.Path, extraUserAgent ...st
 	}
 	tempDir := dataDir.Join("tmp")
 
+	pm := packagemanager.NewBuilder(dataDir, packagesDir, downloadsDir, tempDir, userAgent).Build()
+	lm, _ := librariesmanager.NewBuilder().Build()
+
 	instance := &coreInstance{
-		pm: packagemanager.NewBuilder(dataDir, packagesDir, downloadsDir, tempDir, userAgent).Build(),
-		lm: librariesmanager.NewBuilder().Build(),
+		pm: pm,
+		lm: lm,
 		li: librariesindex.EmptyIndex,
 	}
 

--- a/internal/arduino/builder/internal/detector/detector.go
+++ b/internal/arduino/builder/internal/detector/detector.go
@@ -598,7 +598,7 @@ func LibrariesLoader(
 	if useCachedLibrariesResolution {
 		// Since we are using the cached libraries resolution
 		// the library manager is not needed.
-		lm = librariesmanager.NewBuilder().Build()
+		lm, _ = librariesmanager.NewBuilder().Build()
 	}
 	if librariesManager == nil {
 		lmb := librariesmanager.NewBuilder()
@@ -646,21 +646,17 @@ func LibrariesLoader(
 			})
 		}
 
-		lm = lmb.Build()
-
-		{
-			lmi, release := lm.NewInstaller()
-			for _, status := range lmi.RescanLibraries() {
-				// With the refactoring of the initialization step of the CLI we changed how
-				// errors are returned when loading platforms and libraries, that meant returning a list of
-				// errors instead of a single one to enhance the experience for the user.
-				// I have no intention right now to start a refactoring of the legacy package too, so
-				// here's this shitty solution for now.
-				// When we're gonna refactor the legacy package this will be gone.
-				verboseOut.Write([]byte(status.Message()))
-			}
-			release()
+		newLm, libsLoadingWarnings := lmb.Build()
+		for _, status := range libsLoadingWarnings {
+			// With the refactoring of the initialization step of the CLI we changed how
+			// errors are returned when loading platforms and libraries, that meant returning a list of
+			// errors instead of a single one to enhance the experience for the user.
+			// I have no intention right now to start a refactoring of the legacy package too, so
+			// here's this shitty solution for now.
+			// When we're gonna refactor the legacy package this will be gone.
+			verboseOut.Write([]byte(status.Message()))
 		}
+		lm = newLm
 	}
 
 	allLibs := lm.FindAllInstalled()

--- a/internal/arduino/builder/internal/detector/detector.go
+++ b/internal/arduino/builder/internal/detector/detector.go
@@ -608,20 +608,20 @@ func LibrariesLoader(
 			if err := builtInLibrariesFolders.ToAbs(); err != nil {
 				return nil, nil, nil, err
 			}
-			lmb.AddLibrariesDir(&librariesmanager.LibrariesDir{
+			lmb.AddLibrariesDir(librariesmanager.LibrariesDir{
 				Path:     builtInLibrariesFolders,
 				Location: libraries.IDEBuiltIn,
 			})
 		}
 
 		if actualPlatform != targetPlatform {
-			lmb.AddLibrariesDir(&librariesmanager.LibrariesDir{
+			lmb.AddLibrariesDir(librariesmanager.LibrariesDir{
 				PlatformRelease: actualPlatform,
 				Path:            actualPlatform.GetLibrariesDir(),
 				Location:        libraries.ReferencedPlatformBuiltIn,
 			})
 		}
-		lmb.AddLibrariesDir(&librariesmanager.LibrariesDir{
+		lmb.AddLibrariesDir(librariesmanager.LibrariesDir{
 			PlatformRelease: targetPlatform,
 			Path:            targetPlatform.GetLibrariesDir(),
 			Location:        libraries.PlatformBuiltIn,
@@ -632,14 +632,14 @@ func LibrariesLoader(
 			return nil, nil, nil, err
 		}
 		for _, folder := range librariesFolders {
-			lmb.AddLibrariesDir(&librariesmanager.LibrariesDir{
+			lmb.AddLibrariesDir(librariesmanager.LibrariesDir{
 				Path:     folder,
 				Location: libraries.User, // XXX: Should be libraries.Unmanaged?
 			})
 		}
 
 		for _, dir := range libraryDirs {
-			lmb.AddLibrariesDir(&librariesmanager.LibrariesDir{
+			lmb.AddLibrariesDir(librariesmanager.LibrariesDir{
 				Path:            dir,
 				Location:        libraries.Unmanaged,
 				IsSingleLibrary: true,

--- a/internal/arduino/libraries/librariesmanager/librariesmanager.go
+++ b/internal/arduino/libraries/librariesmanager/librariesmanager.go
@@ -129,7 +129,7 @@ func (lm *LibrariesManager) NewInstaller() (*Installer, func()) {
 func (lmb *Builder) Build() (*LibrariesManager, []*status.Status) {
 	var statuses []*status.Status
 	res := &LibrariesManager{}
-	for _, dir := range res.librariesDir {
+	for _, dir := range lmb.librariesDir {
 		if !dir.scanned {
 			if errs := lmb.loadLibrariesFromDir(dir); len(errs) > 0 {
 				statuses = append(statuses, errs...)

--- a/internal/arduino/libraries/librariesmanager/librariesmanager.go
+++ b/internal/arduino/libraries/librariesmanager/librariesmanager.go
@@ -98,7 +98,7 @@ func NewBuilder() *Builder {
 
 // Clone creates a Builder starting with a copy of the same configuration
 // of this LibrariesManager. At the moment of the Build() only the added
-// libraries directories will be scanned, keeping the exising directories
+// libraries directories will be scanned, keeping the existing directories
 // "cached" to optimize scan. If you need to do a full rescan you must use
 // the RescanLibraries method of the Installer.
 func (lm *LibrariesManager) Clone() *Builder {
@@ -152,7 +152,7 @@ func (lmb *Builder) BuildIntoExistingLibrariesManager(old *LibrariesManager) {
 // AddLibrariesDir adds path to the list of directories
 // to scan when searching for libraries. If a path is already
 // in the list it is ignored.
-func (lmb *Builder) AddLibrariesDir(libDir *LibrariesDir) {
+func (lmb *Builder) AddLibrariesDir(libDir LibrariesDir) {
 	if libDir.Path == nil {
 		return
 	}
@@ -165,7 +165,7 @@ func (lmb *Builder) AddLibrariesDir(libDir *LibrariesDir) {
 		WithField("location", libDir.Location.String()).
 		WithField("isSingleLibrary", libDir.IsSingleLibrary).
 		Info("Adding libraries dir")
-	lmb.librariesDir = append(lmb.librariesDir, libDir)
+	lmb.librariesDir = append(lmb.librariesDir, &libDir)
 }
 
 // RescanLibraries reload all installed libraries in the system.

--- a/internal/arduino/libraries/librariesmanager/librariesmanager_test.go
+++ b/internal/arduino/libraries/librariesmanager/librariesmanager_test.go
@@ -21,17 +21,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_RescanLibrariesCallClear(t *testing.T) {
+func TestLibrariesBuilderScanCloneRescan(t *testing.T) {
 	lmb := NewBuilder()
 	lmb.libraries["testLibA"] = libraries.List{}
 	lmb.libraries["testLibB"] = libraries.List{}
-	lm := lmb.Build()
+	lm, warns := lmb.Build()
+	require.Empty(t, warns)
+	require.Len(t, lm.libraries, 2)
 
+	// Cloning should keep existing libraries
+	lm2, warns2 := lm.Clone().Build()
+	require.Empty(t, warns2)
+	require.Len(t, lm2.libraries, 2)
+
+	// Full rescan should update libs
 	{
-		lmi, release := lm.NewInstaller()
-		lmi.RescanLibraries()
+		lmi2, release := lm2.NewInstaller()
+		lmi2.RescanLibraries()
 		release()
 	}
-
-	require.Len(t, lm.libraries, 0)
+	require.Len(t, lm.libraries, 2) // Ensure deep-coping worked as expected...
+	require.Len(t, lm2.libraries, 0)
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This is a code refactoring to improve `librariesmanager` package.

## What is the current behavior?

No user-visible changes

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No user-facing API change

## Other information

<!-- Any additional information that could help the review process -->
