### PR TITLE
Fixed missing `ARDUINO_USER_AGENT` env var setting.

### DIFF
--- a/commands/compile/compile.go
+++ b/commands/compile/compile.go
@@ -199,6 +199,7 @@ func Compile(ctx context.Context, req *rpc.CompileRequest, outStream, errStream 
 		paths.NewPathList(req.GetLibrary()...),
 		outStream, errStream, req.GetVerbose(), req.GetWarnings(),
 		progressCB,
+		pme.GetEnvVarsForSpawnedProcess(),
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "invalid build properties") {

--- a/internal/arduino/builder/builder.go
+++ b/internal/arduino/builder/builder.go
@@ -92,6 +92,8 @@ type Builder struct {
 
 	libsDetector *detector.SketchLibrariesDetector
 
+	toolEnv []string
+
 	// This is a function used to parse the output of the compiler
 	// It is used to extract errors and warnings
 	compilerOutputParser diagnostics.CompilerOutputParserCB
@@ -133,6 +135,7 @@ func NewBuilder(
 	libraryDirs paths.PathList,
 	stdout, stderr io.Writer, verbose bool, warningsLevel string,
 	progresCB rpc.TaskProgressCB,
+	toolEnv []string,
 ) (*Builder, error) {
 	buildProperties := properties.NewMap()
 	if boardBuildProperties != nil {
@@ -216,6 +219,7 @@ func NewBuilder(
 		buildArtifacts:                &buildArtifacts{},
 		targetPlatform:                targetPlatform,
 		actualPlatform:                actualPlatform,
+		toolEnv:                       toolEnv,
 		libsDetector: detector.NewSketchLibrariesDetector(
 			libsManager, libsResolver,
 			useCachedLibrariesResolution,
@@ -521,7 +525,7 @@ func (b *Builder) prepareCommandForRecipe(buildProperties *properties.Map, recip
 		}
 	}
 
-	command, err := paths.NewProcess(nil, parts...)
+	command, err := paths.NewProcess(b.toolEnv, parts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/integrationtest/compile_3/compile_env_var_test.go
+++ b/internal/integrationtest/compile_3/compile_env_var_test.go
@@ -1,0 +1,60 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2024 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package compile_test
+
+import (
+	"testing"
+
+	"github.com/arduino/arduino-cli/internal/integrationtest"
+	"github.com/arduino/go-paths-helper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileEnvVarOnNewProcess(t *testing.T) {
+	// See: https://github.com/arduino/arduino-cli/issues/2499
+
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	// Run update-index with our test index
+	_, _, err := cli.Run("core", "install", "arduino:avr@1.8.6")
+	require.NoError(t, err)
+
+	// Prepare sketchbook and sketch
+	sketch, err := paths.New("testdata", "bare_minimum").Abs()
+	require.NoError(t, err)
+
+	// Build "printenv" helper insider testdata/printenv
+	printenvDir, err := paths.New("testdata", "printenv").Abs()
+	require.NoError(t, err)
+	builder, err := paths.NewProcess(nil, "go", "build")
+	require.NoError(t, err)
+	builder.SetDir(printenvDir.String())
+	require.NoError(t, builder.Run())
+	printenv := printenvDir.Join("printenv")
+
+	// Patch avr core to run printenv instead of size
+	plTxt, err := cli.DataDir().Join("packages", "arduino", "hardware", "avr", "1.8.6", "platform.txt").Append()
+	require.NoError(t, err)
+	_, err = plTxt.WriteString("recipe.size.pattern=" + printenv.String() + "\n")
+	require.NoError(t, err)
+	require.NoError(t, plTxt.Close())
+
+	// Run compile and get ENV
+	_, stderr, err := cli.Run("compile", "-v", "-b", "arduino:avr:uno", sketch.String())
+	require.NoError(t, err)
+	require.Contains(t, string(stderr), "ENV> ARDUINO_USER_AGENT=")
+}

--- a/internal/integrationtest/compile_3/testdata/printenv/.gitignore
+++ b/internal/integrationtest/compile_3/testdata/printenv/.gitignore
@@ -1,0 +1,1 @@
+printenv

--- a/internal/integrationtest/compile_3/testdata/printenv/main.go
+++ b/internal/integrationtest/compile_3/testdata/printenv/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	for _, env := range os.Environ() {
+		fmt.Fprintln(os.Stderr, "ENV>", env)
+	}
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fix `ARDUINO_USER_AGENT` env var.

## What is the current behavior?

The `ARDUINO_USER_AGENT` is not set during the build.

## What is the new behavior?

The `ARDUINO_USER_AGENT` is set during the build.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Should fix #2499 
