### PR TITLE
bugfix: do not panic if a sketch profile has a syntax error

### DIFF
--- a/commands/instances.go
+++ b/commands/instances.go
@@ -96,10 +96,6 @@ func Init(req *rpc.InitRequest, responseCallback func(r *rpc.InitResponse)) erro
 	if responseCallback == nil {
 		responseCallback = func(r *rpc.InitResponse) {}
 	}
-	reqInst := req.GetInstance()
-	if reqInst == nil {
-		return &cmderrors.InvalidInstanceError{}
-	}
 	instance := req.GetInstance()
 	if !instances.IsValid(instance) {
 		return &cmderrors.InvalidInstanceError{}

--- a/internal/arduino/sketch/profiles.go
+++ b/internal/arduino/sketch/profiles.go
@@ -72,7 +72,7 @@ func (p *Project) AsYaml() string {
 	return res
 }
 
-func (p *projectRaw) getProfiles() []*Profile {
+func (p *projectRaw) getProfiles() ([]*Profile, error) {
 	profiles := []*Profile{}
 	for i, node := range p.ProfilesRaw.Content {
 		if node.Tag != "!!str" {
@@ -82,11 +82,11 @@ func (p *projectRaw) getProfiles() []*Profile {
 		var profile Profile
 		profile.Name = node.Value
 		if err := p.ProfilesRaw.Content[i+1].Decode(&profile); err != nil {
-			panic(fmt.Sprintf("profiles parsing err: %v", err.Error()))
+			return nil, err
 		}
 		profiles = append(profiles, &profile)
 	}
-	return profiles
+	return profiles, nil
 }
 
 // UnmarshalYAML decodes a Profiles section from YAML source.
@@ -270,8 +270,12 @@ func LoadProjectFile(file *paths.Path) (*Project, error) {
 		return nil, err
 	}
 
+	profiles, err := raw.getProfiles()
+	if err != nil {
+		return nil, err
+	}
 	return &Project{
-		Profiles:        raw.getProfiles(),
+		Profiles:        profiles,
 		DefaultProfile:  raw.DefaultProfile,
 		DefaultFqbn:     raw.DefaultFqbn,
 		DefaultPort:     raw.DefaultPort,


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Do not panic if a sketch profile has a syntax error.

## What is the current behavior?

```
~/Arduino/Blink$ cat sketch.yaml 
profiles:
  uno:
    fqbn: arduino:avr:uno
    platforms:
      - platform: arduino:avr (aaaa1.8.6)

~/Arduino/Blink$ arduino-cli compile --profile uno 
panic: profiles parsing err: si è verificato un errore durante il parsing dei vincoli di versione: no major version found

goroutine 1 [running]:
github.com/arduino/arduino-cli/internal/arduino/sketch.(*projectRaw).getProfiles(0xc000500000)
	/home/megabug/Workspace/arduino-cli/internal/arduino/sketch/profiles.go:85 +0x1fe
github.com/arduino/arduino-cli/internal/arduino/sketch.LoadProjectFile(0xc00034a620?)
	/home/megabug/Workspace/arduino-cli/internal/arduino/sketch/profiles.go:274 +0xb6
github.com/arduino/arduino-cli/internal/arduino/sketch.New(0xc000275608?)
	/home/megabug/Workspace/arduino-cli/internal/arduino/sketch/sketch.go:93 +0x5de
github.com/arduino/arduino-cli/commands/sketch.LoadSketch({0x0?, 0x4?}, 0xc000275930?)
	/home/megabug/Workspace/arduino-cli/commands/sketch/load.go:29 +0x4d
github.com/arduino/arduino-cli/internal/cli/compile.runCompileCommand(0xc000445800?, {0xc0004425a0, 0x0, 0xf1664a?})
	/home/megabug/Workspace/arduino-cli/internal/cli/compile/compile.go:162 +0x1dc
github.com/spf13/cobra.(*Command).execute(0xc000445800, {0xc000442580, 0x2, 0x2})
	/home/megabug/Software/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xaa3
github.com/spf13/cobra.(*Command).ExecuteC(0xc000137b00)
	/home/megabug/Software/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0x0?)
	/home/megabug/Software/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x13
main.main()
	/home/megabug/Workspace/arduino-cli/main.go:31 +0x74
```

## What is the new behavior?

```
:~/Arduino/Blink$ arduino-cli compile --profile uno 
Can't open sketch: error loading sketch project file: error parsing version constraints: no major version found
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

<!-- Any additional information that could help the review process -->
