### PR TITLE
[skip-changelog] Improve the definition of FQBN and explicitly state which characters are allowed

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -9,7 +9,11 @@ When you run [`arduino-cli board list`][arduino cli board list], your board does
 
 ## What's the FQBN string?
 
-For a deeper understanding of how FQBN works, you should understand the [Arduino platform specification][0].
+FQBN stands for Fully Qualified Board Name. It has the following format:
+`VENDOR:ARCHITECTURE:BOARD_ID[:MENU_ID=OPTION_ID[,MENU2_ID=OPTION_ID ...]]`, with each `MENU_ID=OPTION_ID` being an
+optional key-value pair configuration. Each field accepts letters (`A-Z` or `a-z`), numbers (`0-9`), underscores (`_`),
+dashes(`-`) and dots(`.`). The special character `=` is accepted in the configuration value. For a deeper understanding
+of how FQBN works, you should understand the [Arduino platform specification][0].
 
 ## How to set multiple board options?
 

--- a/internal/arduino/cores/fqbn_test.go
+++ b/internal/arduino/cores/fqbn_test.go
@@ -155,3 +155,18 @@ func TestMatch(t *testing.T) {
 		require.False(t, b.Match(a))
 	}
 }
+
+func TestValidCharacters(t *testing.T) {
+	// These FQBNs contain valid characters
+	validFqbns := []string{"ardui_no:av_r:un_o", "arduin.o:av.r:un.o", "arduin-o:av-r:un-o", "arduin-o:av-r:un-o:a=b=c=d"}
+	for _, fqbn := range validFqbns {
+		_, err := ParseFQBN(fqbn)
+		require.NoError(t, err)
+	}
+	// These FQBNs contain invalid characters
+	invalidFqbns := []string{"arduin-o:av-r:un=o", "arduin?o:av-r:uno", "arduino:av*r:uno"}
+	for _, fqbn := range invalidFqbns {
+		_, err := ParseFQBN(fqbn)
+		require.Error(t, err)
+	}
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Documentation enhancement
<!-- Bug fix, feature, docs update, ... -->

## What is the new behavior?
Each field of the `fqbn` is checked to verify if it contains invalid characters.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
No
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
