### PR TITLE
Added `--jobs/-j` flag to `compile` command

### DIFF
--- a/internal/cli/compile/compile.go
+++ b/internal/cli/compile/compile.go
@@ -68,6 +68,7 @@ var (
 	compilationDatabaseOnly bool                     // Only create compilation database without actually compiling
 	sourceOverrides         string                   // Path to a .json file that contains a set of replacements of the sketch source code.
 	dumpProfile             bool                     // Create and print a profile configuration from the build
+	jobs                    int32                    // Max number of parallel jobs
 	// library and libraries sound similar but they're actually different.
 	// library expects a path to the root folder of one single library.
 	// libraries expects a path to a directory containing multiple libraries, similarly to the <directories.user>/libraries path.
@@ -134,6 +135,7 @@ func NewCommand() *cobra.Command {
 	compileCommand.Flag("source-override").Hidden = true
 	compileCommand.Flags().BoolVar(&skipLibrariesDiscovery, "skip-libraries-discovery", false, "Skip libraries discovery. This flag is provided only for use in language server and other, very specific, use cases. Do not use for normal compiles")
 	compileCommand.Flag("skip-libraries-discovery").Hidden = true
+	compileCommand.Flags().Int32VarP(&jobs, "jobs", "j", 0, tr("Max number of parallel compiles. If set to 0 the number of available CPUs cores will be used."))
 	configuration.Settings.BindPFlag("sketch.always_export_binaries", compileCommand.Flags().Lookup("export-binaries"))
 
 	compileCommand.Flags().MarkDeprecated("build-properties", tr("please use --build-property instead."))
@@ -244,6 +246,7 @@ func runCompileCommand(cmd *cobra.Command, args []string) {
 		EncryptKey:                    encryptKey,
 		SkipLibrariesDiscovery:        skipLibrariesDiscovery,
 		DoNotExpandBuildProperties:    showProperties == arguments.ShowPropertiesUnexpanded,
+		Jobs:                          jobs,
 	}
 	builderRes, compileError := compile.Compile(context.Background(), compileRequest, stdOut, stdErr, nil)
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Adds the `--jobs/-j` to the command line interface to allow fine-tuning the number of parallel threads used during compilation.
The gRPC API is unchanged because it already had this parameter available.

## What is the current behavior?

Using Arduino CLI as a command line app, the number of parallel jobs was fixed to the number of available CPU cores in the system.

## What is the new behavior?

The maximum number of cores can be tuned with `--jobs/-j` flag.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

<!-- Any additional information that could help the review process -->
