### PR TITLE
Allow empty programmer in `debug` command

### DIFF
--- a/commands/debug/debug_info.go
+++ b/commands/debug/debug_info.go
@@ -169,15 +169,14 @@ func getDebugProperties(req *rpc.GetDebugConfigRequest, pme *packagemanager.Expl
 		}
 	}
 
-	if req.GetProgrammer() == "" {
-		return nil, &arduino.MissingProgrammerError{}
-	}
-	if p, ok := platformRelease.Programmers[req.GetProgrammer()]; ok {
-		toolProperties.Merge(p.Properties)
-	} else if refP, ok := referencedPlatformRelease.Programmers[req.GetProgrammer()]; ok {
-		toolProperties.Merge(refP.Properties)
-	} else {
-		return nil, &arduino.ProgrammerNotFoundError{Programmer: req.GetProgrammer()}
+	if req.GetProgrammer() != "" {
+		if p, ok := platformRelease.Programmers[req.GetProgrammer()]; ok {
+			toolProperties.Merge(p.Properties)
+		} else if refP, ok := referencedPlatformRelease.Programmers[req.GetProgrammer()]; ok {
+			toolProperties.Merge(refP.Properties)
+		} else {
+			return nil, &arduino.ProgrammerNotFoundError{Programmer: req.GetProgrammer()}
+		}
 	}
 
 	var importPath *paths.Path

--- a/commands/debug/debug_test.go
+++ b/commands/debug/debug_test.go
@@ -66,12 +66,6 @@ func TestGetCommandLine(t *testing.T) {
 	defer release()
 
 	{
-		// Check programmer required
-		_, err := getCommandLine(req, pme)
-		require.Error(t, err)
-	}
-
-	{
 		// Check programmer not found
 		req.Programmer = "not-existent"
 		_, err := getCommandLine(req, pme)

--- a/internal/integrationtest/debug/debug_test.go
+++ b/internal/integrationtest/debug/debug_test.go
@@ -336,9 +336,6 @@ func testAllDebugInformation(t *testing.T, env *integrationtest.Environment, cli
 }
 
 func testDebugCheck(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
-	_, _, err := cli.Run("debug", "check", "-b", "arduino:samd:mkr1000")
-	require.Error(t, err)
-
 	out, _, err := cli.Run("debug", "check", "-b", "arduino:samd:mkr1000", "-P", "atmel_ice")
 	require.NoError(t, err)
 	require.Contains(t, string(out), "The given board/programmer configuration supports debugging.")


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Allow optional `programmer` in debugging.

Normally configurations for debugging are layered one over the other in the following order:
* `platforms.txt`
* `boards.txt` (the part relative to the board selected)
* `boards.txt` (the parts relative to the board options selected)
* `programmers.txt` (the part relative to the programmer selected)

BTW some platforms seem to have managed to go without the `programmers.txt` facility. This is a tentative fix to support them.

## What is the current behavior?

The CLI will fail to debug with the `missing programmer` error.

## What is the new behavior?

The CLI will try to proceed with the debugging anyway.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

This PR builds upon Arduino CLI 0.35.2.
@ubidefeo @kittaakos @per1234 
