### PR TITLE
[skip-changelog] use OIDC to retrieve the credentials

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -8,6 +8,7 @@ env:
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /arduino-cli/
+  AWS_REGION: "us-east-1"
   ARTIFACT_NAME: dist
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
@@ -17,6 +18,10 @@ on:
     - cron: "0 1 * * *"
   workflow_dispatch:
   repository_dispatch:
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
 
 jobs:
   create-nightly-artifacts:
@@ -258,6 +263,13 @@ jobs:
           VERSION=${{ needs.create-nightly-artifacts.outputs.version }}
           sha256sum ${{ env.PROJECT_NAME }}_${VERSION}* > ${VERSION}-checksums.txt
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: "github_${{ env.PROJECT_NAME }}"
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Upload release files on Arduino downloads servers
         uses: docker://plugins/s3
         env:
@@ -265,8 +277,6 @@ jobs:
           PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
           PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -8,12 +8,17 @@ env:
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /arduino-cli/
+  AWS_REGION: "us-east-1"
   ARTIFACT_NAME: dist
 
 on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
 
 jobs:
   create-release-artifacts:
@@ -283,6 +288,13 @@ jobs:
           # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: "github_${{ env.PROJECT_NAME }}"
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Upload release files on Arduino downloads servers
         uses: docker://plugins/s3
         env:
@@ -290,8 +302,6 @@ jobs:
           PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
           PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Update Homebrew formula
         if: steps.prerelease.outputs.IS_PRE != 'true'


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
~~- [ ] Tests for the changes have been added (for bug fixes / features)~~
~~- [ ] Docs have been added / updated (for bug fixes / features)~~
~~- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)~~
~~- [ ] `configuration.schema.json` updated if new parameters are added.~~

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->

infra change
## What is the current behavior?

<!-- You can also link to an open issue here -->
We currently use statically generated credentials to access to s3 buckets.
## What is the new behavior?

<!-- if this is a feature change -->
OpenID Connect allows workflows to exchange short-lived tokens directly from your cloud provider (see [here](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect))
## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
 
<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
no
## Other information
- [x] TODO remove `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from secrets
- [x] TODO add `AWS_ROLE_TO_ASSUME` to secrets

<!-- Any additional information that could help the review process -->
