### PR TITLE
Allow optional programmer in `debug` command

### DIFF
--- a/commands/debug/debug_info.go
+++ b/commands/debug/debug_info.go
@@ -154,15 +154,14 @@ func getDebugProperties(req *rpc.GetDebugConfigRequest, pme *packagemanager.Expl
 		}
 	}
 
-	if req.GetProgrammer() == "" {
-		return nil, &cmderrors.MissingProgrammerError{}
-	}
-	if p, ok := platformRelease.Programmers[req.GetProgrammer()]; ok {
-		toolProperties.Merge(p.Properties)
-	} else if refP, ok := referencedPlatformRelease.Programmers[req.GetProgrammer()]; ok {
-		toolProperties.Merge(refP.Properties)
-	} else {
-		return nil, &cmderrors.ProgrammerNotFoundError{Programmer: req.GetProgrammer()}
+	if req.GetProgrammer() != "" {
+		if p, ok := platformRelease.Programmers[req.GetProgrammer()]; ok {
+			toolProperties.Merge(p.Properties)
+		} else if refP, ok := referencedPlatformRelease.Programmers[req.GetProgrammer()]; ok {
+			toolProperties.Merge(refP.Properties)
+		} else {
+			return nil, &cmderrors.ProgrammerNotFoundError{Programmer: req.GetProgrammer()}
+		}
 	}
 
 	var importPath *paths.Path

--- a/commands/debug/debug_test.go
+++ b/commands/debug/debug_test.go
@@ -66,12 +66,6 @@ func TestGetCommandLine(t *testing.T) {
 	defer release()
 
 	{
-		// Check programmer required
-		_, err := getCommandLine(req, pme)
-		require.Error(t, err)
-	}
-
-	{
 		// Check programmer not found
 		req.Programmer = "not-existent"
 		_, err := getCommandLine(req, pme)

--- a/internal/integrationtest/debug/debug_test.go
+++ b/internal/integrationtest/debug/debug_test.go
@@ -336,9 +336,6 @@ func testAllDebugInformation(t *testing.T, env *integrationtest.Environment, cli
 }
 
 func testDebugCheck(t *testing.T, env *integrationtest.Environment, cli *integrationtest.ArduinoCLI) {
-	_, _, err := cli.Run("debug", "check", "-b", "arduino:samd:mkr1000")
-	require.Error(t, err)
-
 	out, _, err := cli.Run("debug", "check", "-b", "arduino:samd:mkr1000", "-P", "atmel_ice")
 	require.NoError(t, err)
 	require.Contains(t, string(out), "The given board/programmer configuration supports debugging.")


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This is a cherry-pick of https://github.com/arduino/arduino-cli/pull/2540 from the 0.35.x branch

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
