### PR TITLE
fix ncipollo/release-action not being able to write

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -240,6 +240,8 @@ jobs:
       - create-release-artifacts
       - notarize-macos
       - create-windows-installer
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
https://github.com/ncipollo/release-action/issues/208#issuecomment-1398625039

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
~~- [ ] Tests for the changes have been added (for bug fixes / features)~~
~~- [ ] Docs have been added / updated (for bug fixes / features)~~
~~- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)~~
~~- [ ] `configuration.schema.json` updated if new parameters are added.~~

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->
Bug fix
## What is the current behavior?
After #2541 the release CI is not working anymore: 
```
Run ncipollo/release-action@v1
Error: Error 403: Resource not accessible by integration
```
<!-- You can also link to an open issue here -->

## What is the new behavior?
The release pipeline should be able to push again the artifacts on the github releases
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->
no
## Other information

<!-- Any additional information that could help the review process -->
