### PR TITLE
Fixed nil pointer exception in `upload` (regression)

### DIFF
--- a/commands/upload/upload.go
+++ b/commands/upload/upload.go
@@ -150,7 +150,7 @@ func Upload(ctx context.Context, req *rpc.UploadRequest, outStream io.Writer, er
 	if programmer == "" && pme.GetProfile() != nil {
 		programmer = pme.GetProfile().Programmer
 	}
-	if programmer == "" {
+	if programmer == "" && sk != nil {
 		programmer = sk.GetDefaultProgrammer()
 	}
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Running an upload _outside_ of a sketch with the `--input-dir` flag will result in a nil pointer exception.
This PR fixed it.

## What is the current behavior?

```
~/Arduino/Blink$ arduino-cli upload -b arduino:mbed_opta:opta -i build/Blink.ino.bin -t -p /dev/cu.usbmodem11301 --dry-run -v
Esecuzione di un touch reset a 1200-bps sulla porta seriale /dev/cu.usbmodem11301
In attesa della porta di caricamento...
Non è stata trovata alcuna porta di upload, come alternativa verrà utilizzata /dev/cu.usbmodem11301
"/home/cmaglie/.arduino15/packages/arduino/tools/dfu-util/0.10.0-arduino1/dfu-util" --device 0x2341:0x0364 -D "build/Blink.ino.bin" -a0 --dfuse-address=0x08040000:leave
Nuova porta di caricamento: /dev/cu.usbmodem11301 (serial)
~/Arduino/Blink$ cd ..
~/Arduino$ arduino-cli upload -b arduino:mbed_opta:opta -i Blink/build/Blink.ino.bin -t -p /dev/cu.usbmodem11301 --dry-run -v
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0xc56765]

goroutine 1 [running]:
github.com/arduino/arduino-cli/internal/arduino/sketch.(*Sketch).GetDefaultProgrammer(...)
	/home/cmaglie/Workspace/arduino-cli/internal/arduino/sketch/sketch.go:252
github.com/arduino/arduino-cli/commands/upload.Upload({0x19a5be0?, 0x0?}, 0xc000531ba8, {0x127afc0, 0xc000013728}, {0x127afc0, 0xc000013740})
	/home/cmaglie/Workspace/arduino-cli/commands/upload/upload.go:154 +0x345
github.com/arduino/arduino-cli/internal/cli/upload.runUploadCommand({0xc0003ba120, 0x0, 0x0?}, 0xc000398750)
	/home/cmaglie/Workspace/arduino-cli/internal/cli/upload/upload.go:201 +0xc1f
github.com/arduino/arduino-cli/internal/cli/upload.NewCommand.func2(0xc0003a3b00?, {0xc0003ba120?, 0x4?, 0xf22d11?})
	/home/cmaglie/Workspace/arduino-cli/internal/cli/upload/upload.go:68 +0x2b
github.com/spf13/cobra.(*Command).execute(0xc0003a3b00, {0xc0003ba090, 0x9, 0x9})
	/home/cmaglie/Software/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xaa3
github.com/spf13/cobra.(*Command).ExecuteC(0xc000188300)
	/home/cmaglie/Software/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0x0?)
	/home/cmaglie/Software/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x13
main.main()
	/home/cmaglie/Workspace/arduino-cli/main.go:31 +0x74
```
## What is the new behavior?

```
~/Arduino/Blink$ arduino-cli upload -b arduino:mbed_opta:opta -i build/Blink.ino.bin -t -p /dev/cu.usbmodem11301 --dry-run -v
Esecuzione di un touch reset a 1200-bps sulla porta seriale /dev/cu.usbmodem11301
In attesa della porta di caricamento...
Non è stata trovata alcuna porta di upload, come alternativa verrà utilizzata /dev/cu.usbmodem11301
"/home/cmaglie/.arduino15/packages/arduino/tools/dfu-util/0.10.0-arduino1/dfu-util" --device 0x2341:0x0364 -D "build/Blink.ino.bin" -a0 --dfuse-address=0x08040000:leave
Nuova porta di caricamento: /dev/cu.usbmodem11301 (serial)
~/Arduino/Blink$ cd ..
~/Arduino$ arduino-cli upload -b arduino:mbed_opta:opta -i Blink/build/Blink.ino.bin -t -p /dev/cu.usbmodem11301 --dry-run -v
Esecuzione di un touch reset a 1200-bps sulla porta seriale /dev/cu.usbmodem11301
In attesa della porta di caricamento...
Non è stata trovata alcuna porta di upload, come alternativa verrà utilizzata /dev/cu.usbmodem11301
"/home/cmaglie/.arduino15/packages/arduino/tools/dfu-util/0.10.0-arduino1/dfu-util" --device 0x2341:0x0364 -D "Blink/build/Blink.ino.bin" -a0 --dfuse-address=0x08040000:leave
Nuova porta di caricamento: /dev/cu.usbmodem11301 (serial)
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
