### PR TITLE
feat(doc): document empty vendor and arch in FQBN

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -12,8 +12,9 @@ When you run [`arduino-cli board list`][arduino cli board list], your board does
 FQBN stands for Fully Qualified Board Name. It has the following format:
 `VENDOR:ARCHITECTURE:BOARD_ID[:MENU_ID=OPTION_ID[,MENU2_ID=OPTION_ID ...]]`, with each `MENU_ID=OPTION_ID` being an
 optional key-value pair configuration. Each field accepts letters (`A-Z` or `a-z`), numbers (`0-9`), underscores (`_`),
-dashes(`-`) and dots(`.`). The special character `=` is accepted in the configuration value. For a deeper understanding
-of how FQBN works, you should understand the [Arduino platform specification][0].
+dashes(`-`) and dots(`.`). The special character `=` is accepted in the configuration value. The `VENDOR` and
+`ARCHITECTURE` parts can be empty. For a deeper understanding of how FQBN works, you should understand the [Arduino
+platform specification][0].
 
 ## How to set multiple board options?
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->

The spec should be aligned with the implementation; empty `vendor` and `architecture` parts are allowed in the FQBN.

This PR updates the documentation to mention the empty `vendor` and `architecture` parts in the FQBN.

## What is the current behavior?

<!-- You can also link to an open issue here -->

The [docs](https://arduino.github.io/arduino-cli/dev/FAQ/#whats-the-fqbn-string) do not mention the empty `vendor`/`architecture` cases but the CLI supports them:

https://github.com/arduino/arduino-cli/blob/870a48fce24256aa81f4b609a61f48b8d412ad41/internal/arduino/cores/fqbn_test.go#L33-L56

## What is the new behavior?

<!-- if this is a feature change -->

The new doc includes the special empty parts case: https://github.com/dankeboy36/arduino-cli/blob/feat-doc-fqbn/docs/FAQ.md#whats-the-fqbn-string

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No.

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
