### PR TITLE
Add [skip-changelog] prefix to dependabot commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+    commit-message:
+      prefix: "[skip-changelog] "
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -18,3 +20,5 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "topic: infrastructure"
+    commit-message:
+      prefix: "[skip-changelog] "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     labels:
       - "topic: infrastructure"
     commit-message:
-      prefix: "[skip-changelog] "
+      prefix: "[skip changelog] "
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -21,4 +21,4 @@ updates:
     labels:
       - "topic: infrastructure"
     commit-message:
-      prefix: "[skip-changelog] "
+      prefix: "[skip changelog] "


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

We use the `[skip-changelog]` prefix to avoid having such commits in our
changelog history.
When merging dependabot PRs we always manually add the prefix, but it's
common to forget about it at the cost of manually removing that entry in
the changelog when publishing a new release.

With this PR dependabot will add that prefix in every commit, the GH PR
will be open with the same commit name, and when pressing the `merge squash`
we won't need to add the prefix manually.
## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
