### PR TITLE
[skip-changelog] Correct profile dependency version constraint format in demo sketch project file

### DIFF
--- a/docs/sketch-project-file.md
+++ b/docs/sketch-project-file.md
@@ -81,9 +81,9 @@ profiles:
     notes: testing the very limit of the AVR platform, it will be very unstable
     fqbn: attiny:avr:ATtinyX5:cpu=attiny85,clock=internal16
     platforms:
-      - platform: attiny:avr@1.0.2
+      - platform: attiny:avr (1.0.2)
         platform_index_url: https://raw.githubusercontent.com/damellis/attiny/ide-1.6.x-boards-manager/package_damellis_attiny_index.json
-      - platform: arduino:avr@1.8.3
+      - platform: arduino:avr (1.8.3)
     libraries:
       - ArduinoIoTCloud (1.0.2)
       - Arduino_ConnectionHandler (0.6.4)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Docs fix

## What is the current behavior?

The [sketch project file documentation](https://arduino.github.io/arduino-cli/0.35/sketch-project-file/) includes [a demonstration of a complete project file](https://arduino.github.io/arduino-cli/dev/sketch-project-file/#build-profiles:~:text=field%20is%20optional.-,A%20complete%20example,-of%20a%20sketch).

Sketch project files use Arduino CLI's `<dependency ID> (<constraint>)` version constraint format but previously an unsupported `<dependency ID>@<version>` format was used in some of the dependencies specified in the demonstration project file. This causes a panic if used in a project file:

```text
panic: profiles parsing err: invalid 'platform' directive

goroutine 1 [running]:
github.com/arduino/arduino-cli/arduino/sketch.(*projectRaw).getProfiles(0xc0003f2000)
        E:/git/arduino/arduino-cli/arduino/sketch/profiles.go:84 +0x1fe
github.com/arduino/arduino-cli/arduino/sketch.LoadProjectFile(0xc0002fac40?)
        E:/git/arduino/arduino-cli/arduino/sketch/profiles.go:265 +0xb6
github.com/arduino/arduino-cli/arduino/sketch.New(0xc00022d6c0?)
        E:/git/arduino/arduino-cli/arduino/sketch/sketch.go:90 +0x587
github.com/arduino/arduino-cli/commands/sketch.LoadSketch({0xc000150060?, 0xc000000004?}, 0xc00022d9b8?)
        E:/git/arduino/arduino-cli/commands/sketch/load.go:30 +0x58
github.com/arduino/arduino-cli/internal/cli/compile.runCompileCommand(0xc0003aa000?, {0xc0003029c0, 0x1, 0x15c1559?})
        E:/git/arduino/arduino-cli/internal/cli/compile/compile.go:162 +0x1dc
github.com/spf13/cobra.(*Command).execute(0xc0003aa000, {0xc000302990, 0x1, 0x1})
        C:/Users/per/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x863
github.com/spf13/cobra.(*Command).ExecuteC(0xc00019e300)
        C:/Users/per/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
github.com/spf13/cobra.(*Command).Execute(0x0?)
        C:/Users/per/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992 +0x13
main.main()
        E:/git/arduino/arduino-cli/main.go:31 +0xda
```


## What is the new behavior?

Use valid version constraint format in demonstration sketch project file.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.
