### PR TITLE
Fixed broken link (failing `check-links` test)

### DIFF
--- a/docs/sketch-build-process.md
+++ b/docs/sketch-build-process.md
@@ -137,8 +137,8 @@ The "location priority" is determined as follows (in order of highest to lowest 
 
 #### Location priorities in Arduino Web Editor
 
-The location priorities system works in the same manner in [Arduino Web Editor](https://create.arduino.cc/editor), but
-its cloud-based nature may make the locations of libraries less obvious.
+The location priorities system works in the same manner in [Arduino Web Editor](https://create.arduino.cc/), but its
+cloud-based nature may make the locations of libraries less obvious.
 
 1. **Custom**: the imported libraries, shown under the **Libraries > Custom** tab.
    - These libraries are under `/tmp/\<some number>/custom`


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fix a link that reports 404 in the documentation.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
