### PR TITLE
use eToken for signing

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -90,7 +90,7 @@ jobs:
             EXPIRATION_DATE="$(
                 (
                 openssl pkcs12 \
-                    -in "${{ env.CERTIFICATE_PATH }}" \
+                    -in ${{ env.CERTIFICATE_PATH }} \
                     -clcerts \
                     -legacy \
                     -nodes \
@@ -111,7 +111,7 @@ jobs:
             EXPIRATION_DATE="$(
                 (
                 openssl x509 \
-                    -in "${{ env.CERTIFICATE_PATH }}" \
+                    -in ${{ env.CERTIFICATE_PATH }} \
                     -noout \
                     -enddate
                 ) | (

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -36,9 +36,11 @@ jobs:
           - identifier: macOS signing certificate # Text used to identify certificate in notifications.
             certificate-secret: INSTALLER_CERT_MAC_P12 # Name of the secret that contains the certificate.
             password-secret: INSTALLER_CERT_MAC_PASSWORD # Name of the secret that contains the certificate password.
+            type: pkcs12
           - identifier: Windows signing certificate
-            certificate-secret: INSTALLER_CERT_WINDOWS_PFX
-            password-secret: INSTALLER_CERT_WINDOWS_PASSWORD
+            certificate-secret: INSTALLER_CERT_WINDOWS_CER
+            # The password for the Windows certificate is not needed, because its not a container, but a single certificate.
+            type: x509
 
     steps:
       - name: Set certificate path environment variable
@@ -57,7 +59,7 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets[matrix.certificate.password-secret] }}
         run: |
           (
-            openssl pkcs12 \
+            openssl ${{ matrix.certificate.type }} \
               -in "${{ env.CERTIFICATE_PATH }}" \
               -legacy \
               -noout \
@@ -84,26 +86,43 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets[matrix.certificate.password-secret] }}
         id: get-days-before-expiration
         run: |
-          EXPIRATION_DATE="$(
-            (
-              openssl pkcs12 \
-                -in "${{ env.CERTIFICATE_PATH }}" \
-                -clcerts \
-                -legacy \
-                -nodes \
-                -passin env:CERTIFICATE_PASSWORD
-            ) | (
-              openssl x509 \
-                -noout \
-                -enddate
-            ) | (
-              grep \
-                --max-count=1 \
-                --only-matching \
-                --perl-regexp \
-                'notAfter=(\K.*)'
-            )
-          )"
+          if [[ ${{ matrix.certificate.type }} == "pkcs12" ]]; then
+            EXPIRATION_DATE="$(
+                (
+                openssl pkcs12 \
+                    -in "${{ env.CERTIFICATE_PATH }}" \
+                    -clcerts \
+                    -legacy \
+                    -nodes \
+                    -passin env:CERTIFICATE_PASSWORD
+                ) | (
+                openssl x509 \
+                    -noout \
+                    -enddate
+                ) | (
+                grep \
+                    --max-count=1 \
+                    --only-matching \
+                    --perl-regexp \
+                    'notAfter=(\K.*)'
+                )
+            )"
+          elif [[ ${{ matrix.certificate.type }} == "x509" ]]; then
+            EXPIRATION_DATE="$(
+                (
+                openssl x509 \
+                    -in "${{ env.CERTIFICATE_PATH }}" \
+                    -noout \
+                    -enddate
+                ) | (
+                grep \
+                    --max-count=1 \
+                    --only-matching \
+                    --perl-regexp \
+                    'notAfter=(\K.*)'
+                )
+            )"
+          fi
 
           DAYS_BEFORE_EXPIRATION="$((($(date --utc --date="$EXPIRATION_DATE" +%s) - $(date --utc +%s)) / 60 / 60 / 24))"
 

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -174,7 +174,7 @@ jobs:
           path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
   create-windows-installer:
-    runs-on: windows-latest
+    runs-on: windows-sign-pc
     needs: create-nightly-artifacts
 
     defaults:
@@ -182,11 +182,10 @@ jobs:
         shell: bash
 
     env:
-      INSTALLER_CERT_WINDOWS_PFX: "/tmp/cert.pfx"
+      INSTALLER_CERT_WINDOWS_CER: "/tmp/cert.cer"
       # We are hardcoding the path for signtool because is not present on the windows PATH env var by default.
       # Keep in mind that this path could change when upgrading to a new runner version
-      # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#installed-windows-sdks
-      SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe"
+      SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.19041.0/x86/signtool.exe"
 
     steps:
       - name: Checkout repository
@@ -211,14 +210,16 @@ jobs:
           MSBuild.exe ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_VERSION"
 
       - name: Save Win signing certificate to file
-        run: echo "${{ secrets.INSTALLER_CERT_WINDOWS_PFX }}" | base64 --decode > ${{ env.INSTALLER_CERT_WINDOWS_PFX}}
+        run: echo "${{ secrets.INSTALLER_CERT_WINDOWS_CER }}" | base64 --decode > ${{ env.INSTALLER_CERT_WINDOWS_CER}}
 
       - name: Sign MSI
         env:
           MSI_FILE: ${{ steps.buildmsi.outputs.msi }} # this comes from .installer/cli.wixproj
           CERT_PASSWORD: ${{ secrets.INSTALLER_CERT_WINDOWS_PASSWORD }}
+          CONTAINER_NAME: ${{ secrets.INSTALLER_CERT_WINDOWS_CONTAINER }}
+          # https://stackoverflow.com/questions/17927895/automate-extended-validation-ev-code-signing-with-safenet-etoken
         run: |
-          "${{ env.SIGNTOOL_PATH }}" sign -d "Arduino CLI" -f ${{ env.INSTALLER_CERT_WINDOWS_PFX}} -p ${{ env.CERT_PASSWORD }} -fd sha256 -tr http://timestamp.digicert.com -td SHA256 -v "${{ env.MSI_FILE }}"
+          "${{ env.SIGNTOOL_PATH }}" sign -d "Arduino CLI" -f ${{ env.INSTALLER_CERT_WINDOWS_CER}} -csp "eToken Base Cryptographic Provider" -k "[{{${{ env.CERT_PASSWORD }}}}]=${{ env.CONTAINER_NAME }}" -fd sha256 -tr http://timestamp.digicert.com -td SHA256 -v "${{ env.MSI_FILE }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -174,7 +174,7 @@ jobs:
           path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
   create-windows-installer:
-    runs-on: windows-latest
+    runs-on: windows-sign-pc
     needs: create-release-artifacts
 
     defaults:
@@ -182,11 +182,10 @@ jobs:
         shell: bash
 
     env:
-      INSTALLER_CERT_WINDOWS_PFX: "/tmp/cert.pfx"
+      INSTALLER_CERT_WINDOWS_CER: "/tmp/cert.cer"
       # We are hardcoding the path for signtool because is not present on the windows PATH env var by default.
       # Keep in mind that this path could change when upgrading to a new runner version
-      # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#installed-windows-sdks
-      SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe"
+      SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.19041.0/x86/signtool.exe"
 
     steps:
       - name: Checkout repository
@@ -211,14 +210,16 @@ jobs:
           MSBuild.exe ./installer/cli.wixproj -p:SourceDir="$SOURCE_DIR" -p:OutputPath="${GITHUB_WORKSPACE}/${{ env.DIST_DIR }}" -p:OutputName="$PACKAGE_FILENAME" -p:ProductVersion="$WIX_TAG"
 
       - name: Save Win signing certificate to file
-        run: echo "${{ secrets.INSTALLER_CERT_WINDOWS_PFX }}" | base64 --decode > ${{ env.INSTALLER_CERT_WINDOWS_PFX}}
+        run: echo "${{ secrets.INSTALLER_CERT_WINDOWS_CER }}" | base64 --decode > ${{ env.INSTALLER_CERT_WINDOWS_CER}}
 
       - name: Sign MSI
         env:
           MSI_FILE: ${{ steps.buildmsi.outputs.msi }} # this comes from .installer/cli.wixproj
           CERT_PASSWORD: ${{ secrets.INSTALLER_CERT_WINDOWS_PASSWORD }}
+          CONTAINER_NAME: ${{ secrets.INSTALLER_CERT_WINDOWS_CONTAINER }}
+          # https://stackoverflow.com/questions/17927895/automate-extended-validation-ev-code-signing-with-safenet-etoken
         run: |
-          "${{ env.SIGNTOOL_PATH }}" sign -d "Arduino CLI" -f ${{ env.INSTALLER_CERT_WINDOWS_PFX}} -p ${{ env.CERT_PASSWORD }} -fd sha256 -tr http://timestamp.digicert.com -td SHA256 -v "${{ env.MSI_FILE }}"
+          "${{ env.SIGNTOOL_PATH }}" sign -d "Arduino CLI" -f ${{ env.INSTALLER_CERT_WINDOWS_CER}} -csp "eToken Base Cryptographic Provider" -k "[{{${{ env.CERT_PASSWORD }}}}]=${{ env.CONTAINER_NAME }}" -fd sha256 -tr http://timestamp.digicert.com -td SHA256 -v "${{ env.MSI_FILE }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->
Infra change

## What is the current behavior?
The certificate used to sign windows binaries is expiring, and the provider no longer ships a digital one.
<!-- You can also link to an open issue here -->

## What is the new behavior?
We have setup a local runner used to sign.

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?
no

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->

TODO:
- [x] Remove `INSTALLER_CERT_WINDOWS_PFX` and use `INSTALLER_CERT_WINDOWS_CER`
- [x] Replace `INSTALLER_CERT_WINDOWS_PASSWORD`
- [x] Add `INSTALLER_CERT_WINDOWS_CONTAINER`