### PR TITLE
Run integration tests on Linux as latest

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -80,9 +80,9 @@ jobs:
       fail-fast: false
       matrix:
         operating-system:
-          - ubuntu-latest
           - windows-latest
           - macos-latest
+          - ubuntu-latest
         tests: ${{ fromJSON(needs.tests-collector.outputs.tests-data) }}
 
     runs-on: ${{ matrix.operating-system }}
@@ -127,9 +127,9 @@ jobs:
       fail-fast: false
       matrix:
         operating-system:
-          - ubuntu-latest
           - windows-latest
           - macos-latest
+          - ubuntu-latest
 
     runs-on: ${{ matrix.operating-system }}
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Since Windows and MacOSX are the slowest to complete this reordering allows us to start the long-running tests early and reduce the overall completion time.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
