### PR TITLE
gRPC: Added progress callback in CompileServerToStreams adapter

### DIFF
--- a/internal/cli/compile/compile.go
+++ b/internal/cli/compile/compile.go
@@ -245,7 +245,7 @@ func runCompileCommand(cmd *cobra.Command, args []string, srv rpc.ArduinoCoreSer
 		DoNotExpandBuildProperties:    showProperties == arguments.ShowPropertiesUnexpanded,
 		Jobs:                          jobs,
 	}
-	server, builderResCB := commands.CompilerServerToStreams(ctx, stdOut, stdErr)
+	server, builderResCB := commands.CompilerServerToStreams(ctx, stdOut, stdErr, nil)
 	compileError := srv.Compile(compileRequest, server)
 	builderRes := builderResCB()
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

I forget to report progress in the gRPC API adapter.

## What is the current behavior?

No changes, just an API improvement

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No, because it's already part of a breaking change that has not been released yet.

## Other information

<!-- Any additional information that could help the review process -->
