### PR TITLE
Force the use of the latest prettier in `general:format-prettier` task

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -327,8 +327,8 @@ changes in the generated code.
 ### Additional settings
 
 If you need to push a commit that's only shipping documentation changes or example files, thus a complete no-op for the
-test suite, please start the commit message with the string **[skip ci]** to skip the build and give that slot to
-someone else who does need it.
+test suite, please start the commit message with the string **[skip ci]** to skip the build and give that slot to someone
+else who does need it.
 
 If your PR doesn't need to be included in the changelog, please start the commit message and PR title with the string
 **[skip changelog]**

--- a/docs/integration-options.md
+++ b/docs/integration-options.md
@@ -4,8 +4,8 @@ The Arduino CLI is an open source Command Line Application written in [Golang] t
 compile, verify and upload sketches to Arduino boards and that’s capable of managing all the software and tools needed
 in the process. But don’t get fooled by its name: Arduino CLI can do much more than the average console application, as
 shown by [Arduino IDE 2.x][arduino ide 2.x] and [Arduino Cloud], which rely on it for similar purposes but each one in a
-completely different way from the other. In this article we introduce the three pillars of the Arduino CLI, explaining
-how we designed the software so that it can be effectively leveraged under different scenarios.
+completely different way from the other. In this article we introduce the three pillars of the Arduino CLI, explaining how
+we designed the software so that it can be effectively leveraged under different scenarios.
 
 ## The first pillar: command line interface
 
@@ -132,18 +132,17 @@ $ arduino-cli lib search FlashStorage --format json | jq .libraries[0].latest
 ```
 
 Even if not related to software design, one last feature that’s worth mentioning is the availability of a one-line
-[installation script] that can be used to make the latest version of the Arduino CLI available on most systems with an
-HTTP client like curl or wget and a shell like bash.
+[installation script] that can be used to make the latest version of the Arduino CLI available on most systems with an HTTP
+client like curl or wget and a shell like bash.
 
 For more information on Arduino CLI's command line interface, see the [command reference].
 
 ## The second pillar: gRPC interface
 
 [gRPC] is a high performance [RPC] framework that can efficiently connect client and server applications. The Arduino
-CLI can act as a gRPC server (we call it [daemon mode]), exposing a set of procedures that implement the very same set
-of features of the command line interface and waiting for clients to connect and use them. To give an idea, the
-following is some [Golang] code capable of retrieving the version number of a remote running Arduino CLI server
-instance:
+CLI can act as a gRPC server (we call it [daemon mode]), exposing a set of procedures that implement the very same set of
+features of the command line interface and waiting for clients to connect and use them. To give an idea, the following is
+some [Golang] code capable of retrieving the version number of a remote running Arduino CLI server instance:
 
 ```go
 // This file is part of arduino-cli.
@@ -211,8 +210,8 @@ a common Golang API, based on the gRPC protobuf definitions: a set of functions 
 offered by the Arduino CLI, so that when we provide a fix or a new feature, they are automatically available to both the
 command line and gRPC interfaces. The source modules implementing this API are implemented through the `commands`
 package, and it can be imported in other Golang programs to embed a full-fledged Arduino CLI. For example, this is how
-some backend services powering [Arduino Cloud] can compile sketches and manage libraries. Just to give you a taste of
-what it means to embed the Arduino CLI, here is how to search for a core using the API:
+some backend services powering [Arduino Cloud] can compile sketches and manage libraries. Just to give you a taste of what
+it means to embed the Arduino CLI, here is how to search for a core using the API:
 
 ```go
 // This file is part of arduino-cli.
@@ -297,7 +296,8 @@ use and provide support for.
 You can start playing with the Arduino CLI right away. The code is open source and [the repo][arduino cli repository]
 contains [example code showing how to implement a gRPC client][grpc client example]. If you’re curious about how we
 designed the low level API, have a look at the [commands package] and don’t hesitate to leave feedback on the [issue
-tracker] if you’ve got a use case that doesn’t fit one of the three pillars.
+tracker]
+if you’ve got a use case that doesn’t fit one of the three pillars.
 
 [golang]: https://go.dev/
 [arduino ide 2.x]: https://github.com/arduino/arduino-ide

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "devDependencies": {
         "markdown-link-check": "3.10.3",
-        "markdownlint-cli": "^0.33.0"
+        "markdownlint-cli": "^0.33.0",
+        "prettier": "^3.3.1"
       }
     },
     "node_modules/ansi-styles": {
@@ -664,6 +665,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.1.tgz",
+      "integrity": "sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -1242,6 +1258,12 @@
         "domhandler": "^5.0.2",
         "parse5": "^7.0.0"
       }
+    },
+    "prettier": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.1.tgz",
+      "integrity": "sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "markdown-link-check": "3.10.3",
-    "markdownlint-cli": "^0.33.0"
+    "markdownlint-cli": "^0.33.0",
+    "prettier": "^3.3.1"
   }
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Force the use of the same prettier version as in the CI.

## What is the current behavior?

The CI may use a more recent version of the `prettier` tool since it's installed fresh at each run.

## What is the new behavior?

The local task now forces the update of the `prettier` tool if available.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
