### PR TITLE
Silence "config warnings" in text mode, except for `config ...` commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,8 +76,14 @@ func main() {
 		if parentPreRun != nil {
 			parentPreRun(cmd, args)
 		}
-		for _, warning := range configFileLoadingWarnings {
-			feedback.Warning(warning)
+
+		// In Text mode print the warnings about the configuration file
+		// only if we are inside the "config ..." command. In JSON mode always
+		// output the warning.
+		if feedback.GetFormat() != feedback.Text || (cmd.HasParent() && cmd.Parent().Name() == "config") {
+			for _, warning := range configFileLoadingWarnings {
+				feedback.Warning(fmt.Sprintf("%s: %s", i18n.Tr("Invalid value in configuration"), warning))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Prints configuration warnings in text mode only if running one of the `config ...` commands.
Previously if there was an error in the configuration file, the warning was printed on all commands run from the cli.
In JSON mode the warning is always returned.

Also improve the error message from:
```
schema not defined for key 'asdasd'
```
to
```
Invalid value in configuration: schema not defined for key 'asdasd'
```

## What is the current behavior?

```
$ arduino-cli version 
schema not defined for key 'asdasd'
arduino-cli  Version: 0.0.0-git Commit:  Date: 
$ arduino-cli version --json
{
  "Application": "arduino-cli",
  "Commit": "",
  "Date": "",
  "Status": "",
  "VersionString": "0.0.0-git",
  "warnings": [
    "schema not defined for key 'asdasd'"
  ]
}
$ arduino-cli config get directories.data
schema not defined for key 'asdasd'
/home/cmaglie/.arduino15
```

## What is the new behavior?

```
$ arduino-cli version
arduino-cli  Version: 0.0.0-git Commit:  Date: 
$ arduino-cli version --json
{
  "Application": "arduino-cli",
  "Commit": "",
  "Date": "",
  "Status": "",
  "VersionString": "0.0.0-git",
  "warnings": [
    "Invalid value in configuration: schema not defined for key 'asdasd'"
  ]
}
$ arduino-cli config get directories.data
Invalid value in configuration: schema not defined for key 'asdasd'
/home/cmaglie/.arduino15

```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Partially fix #2638 