### PR TITLE
configuration: env vars with array values rendered as a single string

### DIFF
--- a/internal/go-configmap/cli.go
+++ b/internal/go-configmap/cli.go
@@ -27,6 +27,17 @@ func (c *Map) SetFromCLIArgs(key string, args ...string) error {
 		return nil
 	}
 
+	// Some args might be coming from env vars that are specifying multiple values
+	// in a single string. We expand those cases by splitting every args with whitespace
+	// Example: args=["e1 e2", "e3"] -> args=["e1","e2","e3"]
+	argsExpantion := func(values []string) []string {
+		result := []string{}
+		for _, v := range values {
+			result = append(result, strings.Split(v, " ")...)
+		}
+		return result
+	}
+	args = argsExpantion(args)
 	// in case of schemaless configuration, we don't know the type of the setting
 	// we will save it as a string or array of strings
 	if len(c.schema) == 0 {

--- a/internal/go-configmap/configuration_test.go
+++ b/internal/go-configmap/configuration_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/arduino/arduino-cli/internal/go-configmap"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -79,10 +80,22 @@ func TestApplyEnvVars(t *testing.T) {
 	c.Set("foo", "bar")
 	c.Set("fooz.bar", "baz")
 	c.Set("answer", 42)
+	c.Set("array", []string{})
 	c.InjectEnvVars([]string{"APP_FOO=app-bar", "APP_FOOZ_BAR=app-baz"}, "APP")
-	require.Equal(t, "app-bar", c.Get("foo"))
-	require.Equal(t, "app-baz", c.Get("fooz.bar"))
-	require.Equal(t, 42, c.Get("answer"))
+	assert.Equal(t, "app-bar", c.Get("foo"))
+	assert.Equal(t, "app-baz", c.Get("fooz.bar"))
+	assert.Equal(t, 42, c.Get("answer"))
+
+	c.InjectEnvVars([]string{"APP_ARRAY=element1 element2 element3"}, "APP")
+	require.Equal(t, []string{"element1", "element2", "element3"}, c.GetStringSlice("array"))
+
+	// Test env containing array values with typed schema
+	{
+		m := configmap.New()
+		m.SetKeyTypeSchema("array", []string{})
+		m.InjectEnvVars([]string{"APP_ARRAY=e1 e2 e3"}, "APP")
+		require.Equal(t, []string{"e1", "e2", "e3"}, m.GetStringSlice("array"))
+	}
 }
 
 func TestMerge(t *testing.T) {

--- a/internal/go-configmap/configuration_test.go
+++ b/internal/go-configmap/configuration_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/arduino/arduino-cli/internal/go-configmap"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -82,12 +81,12 @@ func TestApplyEnvVars(t *testing.T) {
 	c.Set("answer", 42)
 	c.Set("array", []string{})
 	c.InjectEnvVars([]string{"APP_FOO=app-bar", "APP_FOOZ_BAR=app-baz"}, "APP")
-	assert.Equal(t, "app-bar", c.Get("foo"))
-	assert.Equal(t, "app-baz", c.Get("fooz.bar"))
-	assert.Equal(t, 42, c.Get("answer"))
+	require.Equal(t, "app-bar", c.Get("foo"))
+	require.Equal(t, "app-baz", c.Get("fooz.bar"))
+	require.Equal(t, 42, c.Get("answer"))
 
-	c.InjectEnvVars([]string{"APP_ARRAY=element1 element2 element3"}, "APP")
-	require.Equal(t, []string{"element1", "element2", "element3"}, c.GetStringSlice("array"))
+	c.InjectEnvVars([]string{"APP_ARRAY=e1 e2 e3"}, "APP")
+	require.Equal(t, []string{"e1", "e2", "e3"}, c.GetStringSlice("array"))
 
 	// Test env containing array values with typed schema
 	{


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fix a regression in passing multiple values to a single env var that wasn't correctly expanded.

## What is the current behavior?

When passing multiple values in a single env var, they are rendered a single string, causing unexpected behaviors. 

## What is the new behavior?

Now we treat such values as multiple values and not as a single string. We split them by whitespace.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
