### PR TITLE
fix regression: setting 3rd party URL via `ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS` env var

### DIFF
--- a/internal/cli/configuration/defaults.go
+++ b/internal/cli/configuration/defaults.go
@@ -84,7 +84,7 @@ func InjectEnvVars(settings *Settings) {
 	// Bind env aliases to keep backward compatibility
 	setIfEnvExists := func(key, env string) {
 		if v, ok := os.LookupEnv(env); ok {
-			settings.SetFromCLIArgs(key, v)
+			settings.SetFromENV(key, v)
 		}
 	}
 	setIfEnvExists("library.enable_unsafe_install", "ARDUINO_ENABLE_UNSAFE_LIBRARY_INSTALL")

--- a/internal/integrationtest/config/config_test.go
+++ b/internal/integrationtest/config/config_test.go
@@ -902,3 +902,32 @@ build.unk: 123
 	require.NoError(t, err)
 	require.Equal(t, "en", strings.TrimSpace(string(out)))
 }
+
+func TestConfigViaEnvVars(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	// array of strings
+	out, _, err := cli.RunWithCustomEnv(
+		map[string]string{"ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS": "https://espressif.github.io/arduino-esp32/package_esp32_index.json https://arduino.esp8266.com/stable/package_esp8266com_index.json"},
+		"config", "get", "board_manager.additional_urls",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "- https://espressif.github.io/arduino-esp32/package_esp32_index.json\n- https://arduino.esp8266.com/stable/package_esp8266com_index.json\n\n", string(out))
+
+	// boolean
+	out, _, err = cli.RunWithCustomEnv(
+		map[string]string{"ARDUINO_LIBRARY_ENABLE_UNSAFE_INSTALL": "True"},
+		"config", "get", "library.enable_unsafe_install",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "true\n\n", string(out))
+
+	// integer
+	out, _, err = cli.RunWithCustomEnv(
+		map[string]string{"ARDUINO_BUILD_CACHE_COMPILATIONS_BEFORE_PURGE": "20"},
+		"config", "get", "build_cache.compilations_before_purge",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "20\n\n", string(out))
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fixes a regression of release 1.0.0: setting more than one URL via `ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS` was impossible.

## What is the current behavior?

```
$ export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS="https://espressif.github.io/arduino-esp32/package_esp32_index.json https://arduino.esp8266.com/stable/package_esp8266com_index.json"
$ arduino-cli config get board_manager.additional_urls
- https://espressif.github.io/arduino-esp32/package_esp32_index.json https://arduino.esp8266.com/stable/package_esp8266com_index.json

```
The configuration is incorrect because the two URLs are concatenated in a single string.

## What is the new behavior?

```
$ export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS="https://espressif.github.io/arduino-esp32/package_esp32_index.json https://arduino.esp8266.com/stable/package_esp8266com_index.json"
$ arduino-cli config get board_manager.additional_urls
- https://espressif.github.io/arduino-esp32/package_esp32_index.json
- https://arduino.esp8266.com/stable/package_esp8266com_index.json

```
## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Fix #2643 