### PR TITLE
regression: allow `monitor` to not require to specify the board if the port cannot be identified.

### DIFF
--- a/internal/cli/arguments/fqbn.go
+++ b/internal/cli/arguments/fqbn.go
@@ -80,8 +80,8 @@ func CalculateFQBNAndPort(ctx context.Context, portArgs *Port, fqbnArg *Fqbn, in
 		if portArgs == nil || portArgs.address == "" {
 			feedback.FatalError(&cmderrors.MissingFQBNError{}, feedback.ErrGeneric)
 		}
-		fqbn, port := portArgs.DetectFQBN(ctx, instance, srv)
-		if fqbn == "" {
+		fqbn, port, err := portArgs.DetectFQBN(ctx, instance, srv)
+		if err != nil {
 			feedback.FatalError(&cmderrors.MissingFQBNError{}, feedback.ErrGeneric)
 		}
 		return fqbn, port

--- a/internal/cli/monitor/monitor.go
+++ b/internal/cli/monitor/monitor.go
@@ -59,6 +59,8 @@ func NewCommand(srv rpc.ArduinoCoreServiceServer) *cobra.Command {
 		Long:  i18n.Tr("Open a communication port with a board."),
 		Example: "" +
 			"  " + os.Args[0] + " monitor -p /dev/ttyACM0\n" +
+			"  " + os.Args[0] + " monitor -p /dev/ttyACM0 -b arduino:avr:uno\n" +
+			"  " + os.Args[0] + " monitor -p /dev/ttyACM0 --config 115200\n" +
 			"  " + os.Args[0] + " monitor -p /dev/ttyACM0 --describe",
 		Run: func(cmd *cobra.Command, args []string) {
 			sketchPath := ""

--- a/internal/cli/monitor/monitor.go
+++ b/internal/cli/monitor/monitor.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -136,7 +135,7 @@ func runMonitorCmd(
 	case sketch.GetDefaultFqbn() != "":
 		fqbn = sketch.GetDefaultFqbn()
 	default:
-		fqbn, _ = portArgs.DetectFQBN(ctx, inst, srv)
+		fqbn, _, _ = portArgs.DetectFQBN(ctx, inst, srv)
 	}
 
 	portAddress, portProtocol, err := portArgs.GetPortAddressAndProtocol(ctx, inst, srv, defaultPort, defaultProtocol)

--- a/internal/cli/monitor/monitor.go
+++ b/internal/cli/monitor/monitor.go
@@ -239,10 +239,12 @@ func runMonitorCmd(
 	})
 	go func() {
 		if !quiet {
-			if fqbn != "" {
-				feedback.Print(i18n.Tr("Using default monitor configuration for board: %s", fqbn))
-			} else if portProtocol == "serial" {
-				feedback.Print(i18n.Tr("Using generic monitor configuration.\nWARNING: Your board may require different settings to work!\n"))
+			if len(configs) == 0 {
+				if fqbn != "" {
+					feedback.Print(i18n.Tr("Using default monitor configuration for board: %s", fqbn))
+				} else if portProtocol == "serial" {
+					feedback.Print(i18n.Tr("Using generic monitor configuration.\nWARNING: Your board may require different settings to work!\n"))
+				}
 			}
 			feedback.Print(i18n.Tr("Monitor port settings:"))
 			keys := actualConfigurationLabels.Keys()


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

If a port cannot be identified (i.e. can not be associated with a board) the current version of the CLI requires to specify a board with the `-b` flag. Previously this wasn't necessary and the monitor would sometimes fail to work because it may require special `dtr` / `rts` settings.

This PR now reverts the old behavior that is more convenient but also adds a warning to the user when the board can not be identified and the default settings may not work as expected.

## What is the current behavior?

```
$ arduino-cli board list
Port       Protocol Type        Board Name FQBN Core
/dev/ttyS4 serial   Serial Port Unknown

$ arduino-cli monitor -p /dev/ttyS4
Please specify an FQBN. The board on port /dev/ttyS4 with protocol serial can't be identified
$ arduino-cli monitor -p /dev/ttyS4 -b esp32:esp32:esp32
Connecting to /dev/ttyS4. Press CTRL-C to exit.
^C
```

## What is the new behavior?

```
$ arduino-cli board list
Port       Protocol Type        Board Name FQBN Core
/dev/ttyS4 serial   Serial Port Unknown

$ arduino-cli monitor -p /dev/ttyS4
Using generic monitor configuration.
WARNING: Your board may require different settings to work!

Monitor port settings:
  baudrate=9600
  bits=8
  dtr=on
  parity=none
  rts=on
  stop_bits=1

Connecting to /dev/ttyS4. Press CTRL-C to exit.
^C
$ arduino-cli monitor -p /dev/ttyS4 -b esp32:esp32:esp32
Using default monitor configuration for board: esp32:esp32:esp32
Monitor port settings:
  baudrate=9600
  bits=8
  dtr=off            <-- notice the esp32 requires DTR=off
  parity=none
  rts=off            <-- and also RTS=off
  stop_bits=1

Connecting to /dev/ttyS4. Press CTRL-C to exit.
^C
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2638