### PR TITLE
[skip changelog] Correct format of `upload_port` identification properties in snippet

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -547,14 +547,14 @@ will be used to identify a board by the discovery process when plugged in.
 For example we could declare a series of `upload_port.vid` and `upload_port.pid` properties for the Uno like so:
 
 ```
-uno.upload_port.vid.0=0x2341
-uno.upload_port.pid.0=0x0043
-uno.upload_port.vid.1=0x2341
-uno.upload_port.pid.1=0x0001
-uno.upload_port.vid.2=0x2A03
-uno.upload_port.pid.2=0x0043
-uno.upload_port.vid.3=0x2341
-uno.upload_port.pid.3=0x0243
+uno.upload_port.0.vid=0x2341
+uno.upload_port.0.pid=0x0043
+uno.upload_port.1.vid=0x2341
+uno.upload_port.1.pid=0x0001
+uno.upload_port.2.vid=0x2A03
+uno.upload_port.2.pid=0x0043
+uno.upload_port.3.vid=0x2341
+uno.upload_port.3.pid=0x0243
 ```
 
 In this case we're using the board's USB VID/PID pair to identify it but `upload_port.*` properties can be anything that


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [NA] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [NA] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [NA] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Docs fix

## What is the current behavior?

The platform developer can [associate port properties with a board definition](https://arduino.github.io/arduino-cli/dev/pluggable-discovery-specification/#board-identification) in order to cause Arduino CLI to identify ports having those properties as that board.

The [list format](https://pkg.go.dev/github.com/arduino/go-properties-orderedmap#Map.ExtractSubIndexLists) is supported for these platform properties in order to allow multiple alternative sets of port properties to be associated with a board definition. The platform property must have the format `upload_port.n.<property ID>` (where `n` is the array index of the port properties set).

Although the platform property format is correctly documented in the Arduino Platform Specification, an incorrect format `upload_port.<property ID>.n` was previously used in the `boards.txt` snippet illustrating the use of the platform properties.

## What is the new behavior?

The snippet uses the correct property format.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.
