### PR TITLE
grpc: fixed BoardListWatch streaming call

### DIFF
--- a/commands/service_board_list.go
+++ b/commands/service_board_list.go
@@ -318,5 +318,6 @@ func (s *arduinoCoreServerImpl) BoardListWatch(req *rpc.BoardListWatchRequest, s
 		}
 	}()
 
+	<-stream.Context().Done()
 	return nil
 }

--- a/internal/cli/board/list.go
+++ b/internal/cli/board/list.go
@@ -91,10 +91,12 @@ func runListCommand(ctx context.Context, srv rpc.ArduinoCoreServiceServer, watch
 
 func watchList(ctx context.Context, inst *rpc.Instance, srv rpc.ArduinoCoreServiceServer) {
 	stream, eventsChan := commands.BoardListWatchProxyToChan(ctx)
-	err := srv.BoardListWatch(&rpc.BoardListWatchRequest{Instance: inst}, stream)
-	if err != nil {
-		feedback.Fatal(i18n.Tr("Error detecting boards: %v", err), feedback.ErrNetwork)
-	}
+	go func() {
+		err := srv.BoardListWatch(&rpc.BoardListWatchRequest{Instance: inst}, stream)
+		if err != nil {
+			feedback.Fatal(i18n.Tr("Error detecting boards: %v", err), feedback.ErrNetwork)
+		}
+	}()
 
 	// This is done to avoid printing the header each time a new event is received
 	if feedback.GetFormat() == feedback.Text {

--- a/internal/integrationtest/daemon/daemon_test.go
+++ b/internal/integrationtest/daemon/daemon_test.go
@@ -91,6 +91,24 @@ func TestArduinoCliDaemon(t *testing.T) {
 
 	testWatcher()
 	testWatcher()
+
+	{
+		// Test that the watcher stays open until the grpc call is canceled
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+		defer cancel()
+
+		start := time.Now()
+		watcher, err := grpcInst.BoardListWatch(ctx)
+		require.NoError(t, err)
+		for {
+			_, err := watcher.Recv()
+			if err != nil {
+				break
+			}
+		}
+		require.Greater(t, time.Since(start), 2*time.Second)
+	}
 }
 
 func TestDaemonAutoUpdateIndexOnFirstInit(t *testing.T) {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

The gRPC streaming call `BoardListWatch` does not persist until the client cancels the gRPC call. Instead the call is immediately canceled server side. This is a regression introduced in CLI 1.0.0. 

## What is the current behavior?

The gRPC call `BoardListWatch` is canceled server-side almost immediately.

## What is the new behavior?

The gRPC call `BoardListWatch` runs until it is canceled client-side.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

<!-- Any additional information that could help the review process -->
