### PR TITLE
 Document breaking change to `config get` command output

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -535,7 +535,7 @@ breaking changes as needed.
 The `CompilerResponse` message has been refactored to made explicit which fields are intended for streaming the build
 process and which fields are part of the build result.
 
-The old `CompilerResposne`:
+The old `CompilerResponse`:
 
 ```protoc
 message CompileResponse {

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -530,6 +530,15 @@ breaking changes as needed.
   { "sketch_path": "/tmp/my_sketch" }
   ```
 
+### `config dump` no longer returns default configuration values
+
+Previously, the `config dump` CLI command returned the effective configuration, including both the values explicitly set
+via the configuration file and environment variables as well as the values provided by defaults.
+
+It now only returns the explicitly set configuration data.
+
+Use `config get <configuration key>` to get the effective value of the configuration
+
 ### The gRPC response `cc.arduino.cli.commands.v1.CompileResponse` has been changed.
 
 The `CompilerResponse` message has been refactored to made explicit which fields are intended for streaming the build


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

Previously, the `config dump` CLI command returned the effective configuration, including both the values explicitly set via the [configuration file](https://arduino.github.io/arduino-cli/1.0/configuration/#configuration-file) and [environment variables](https://arduino.github.io/arduino-cli/dev/configuration/#environment-variables) as well as the values provided by defaults.

It was changed to only return the explicitly set configuration data (https://github.com/arduino/arduino-cli/commit/1fddba76a15360b083f457c1028065f764747b10). The breaking change was not documented at that time.

## What is the new behavior?

The breaking change is documented in the "Upgrading" document in compliance with the project's development policies.

The new approach for getting the effective configuration values is also documented there.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change

## Other information

Related:

- https://github.com/arduino/arduino-cli/issues/2637
- https://forum.arduino.cc/t/arduino-cli-config-dump-with-default-values/1286105
