### PR TITLE
Added `--config-dir` flag

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -181,9 +181,12 @@ func NewCommand(srv rpc.ArduinoCoreServiceServer) *cobra.Command {
 	cmd.PersistentFlags().StringSliceVar(&additionalUrls, "additional-urls", defaultAdditionalURLs, i18n.Tr("Comma-separated list of additional URLs for the Boards Manager."))
 	cmd.PersistentFlags().BoolVar(&noColor, "no-color", defaultOutputNoColor, "Disable colored output.")
 
-	// We are not using cobra to parse this flag, because we manually parse it in main.go.
-	// Just leaving it here so cobra will not complain about it.
-	cmd.PersistentFlags().String("config-file", "", i18n.Tr("The custom config file (if not specified the default will be used)."))
+	// We are not using cobra to parse the following flags, because we manually parse them in main.go.
+	// Just leaving it here so cobra will output help usage and not complain about them.
+	cmd.PersistentFlags().String("config-file", "",
+		i18n.Tr("The custom config file (if not specified the default will be used)."))
+	cmd.PersistentFlags().String("config-dir", "",
+		i18n.Tr("Sets the default data directory (Arduino CLI will look for configuration file in this directory)."))
 	return cmd
 }
 

--- a/internal/cli/configuration/configuration.go
+++ b/internal/cli/configuration/configuration.go
@@ -101,10 +101,10 @@ func getDefaultUserDir() string {
 	}
 }
 
-// FindConfigFileInArgsFallbackOnEnv returns the config file path using the
+// FindConfigFlagsInArgsOrFallbackOnEnv returns the config file path using the
 // argument '--config-file' (if specified), if empty looks for the ARDUINO_CONFIG_FILE env,
 // or looking in the current working dir
-func FindConfigFileInArgsFallbackOnEnv(args []string) string {
+func FindConfigFlagsInArgsOrFallbackOnEnv(args []string) string {
 	// Look for '--config-dir' argument
 	for i, arg := range args {
 		if arg == "--config-dir" {

--- a/internal/cli/configuration/configuration_test.go
+++ b/internal/cli/configuration/configuration_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,4 +63,12 @@ func TestFindConfigFile(t *testing.T) {
 	// when both env and flag are specified flag takes precedence
 	configFile = FindConfigFlagsInArgsOrFallbackOnEnv([]string{"--config-file", "flag/path"})
 	require.Equal(t, "flag/path", configFile)
+}
+
+func TestFindConfigDir(t *testing.T) {
+	// Check behaviour with --config-dir
+	expected, err := paths.New("anotherpath", "arduino-cli.yaml").Abs()
+	require.NoError(t, err)
+	configFile := FindConfigFlagsInArgsOrFallbackOnEnv([]string{"--config-dir", "anotherpath"})
+	require.Equal(t, expected.String(), configFile)
 }

--- a/internal/cli/configuration/configuration_test.go
+++ b/internal/cli/configuration/configuration_test.go
@@ -43,23 +43,23 @@ func TestInit(t *testing.T) {
 
 func TestFindConfigFile(t *testing.T) {
 	defaultConfigFile := filepath.Join(getDefaultArduinoDataDir(), "arduino-cli.yaml")
-	configFile := FindConfigFileInArgsFallbackOnEnv([]string{"--config-file"})
+	configFile := FindConfigFlagsInArgsOrFallbackOnEnv([]string{"--config-file"})
 	require.Equal(t, defaultConfigFile, configFile)
 
-	configFile = FindConfigFileInArgsFallbackOnEnv([]string{"--config-file", "some/path/to/config"})
+	configFile = FindConfigFlagsInArgsOrFallbackOnEnv([]string{"--config-file", "some/path/to/config"})
 	require.Equal(t, "some/path/to/config", configFile)
 
-	configFile = FindConfigFileInArgsFallbackOnEnv([]string{"--config-file", "some/path/to/config/arduino-cli.yaml"})
+	configFile = FindConfigFlagsInArgsOrFallbackOnEnv([]string{"--config-file", "some/path/to/config/arduino-cli.yaml"})
 	require.Equal(t, "some/path/to/config/arduino-cli.yaml", configFile)
 
-	configFile = FindConfigFileInArgsFallbackOnEnv([]string{})
+	configFile = FindConfigFlagsInArgsOrFallbackOnEnv([]string{})
 	require.Equal(t, defaultConfigFile, configFile)
 
 	t.Setenv("ARDUINO_CONFIG_FILE", "some/path/to/config")
-	configFile = FindConfigFileInArgsFallbackOnEnv([]string{})
+	configFile = FindConfigFlagsInArgsOrFallbackOnEnv([]string{})
 	require.Equal(t, "some/path/to/config", configFile)
 
 	// when both env and flag are specified flag takes precedence
-	configFile = FindConfigFileInArgsFallbackOnEnv([]string{"--config-file", "flag/path"})
+	configFile = FindConfigFlagsInArgsOrFallbackOnEnv([]string{"--config-file", "flag/path"})
 	require.Equal(t, "flag/path", configFile)
 }

--- a/main.go
+++ b/main.go
@@ -37,12 +37,12 @@ func main() {
 	// Disable logging until it is setup in the arduino-cli pre-run
 	logrus.SetOutput(io.Discard)
 
-	// Create a new ArduinoCoreServer
-	srv := commands.NewArduinoCoreServer()
-
 	// Search for the configuration file in the command line arguments and in the environment
 	configFile := configuration.FindConfigFileInArgsFallbackOnEnv(os.Args)
 	ctx := config.SetConfigFile(context.Background(), configFile)
+
+	// Create a new ArduinoCoreServer
+	srv := commands.NewArduinoCoreServer()
 
 	// Read the settings from the configuration file
 	openReq := &rpc.ConfigurationOpenRequest{SettingsFormat: "yaml"}

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 	logrus.SetOutput(io.Discard)
 
 	// Search for the configuration file in the command line arguments and in the environment
-	configFile := configuration.FindConfigFileInArgsFallbackOnEnv(os.Args)
+	configFile := configuration.FindConfigFlagsInArgsOrFallbackOnEnv(os.Args)
 	ctx := config.SetConfigFile(context.Background(), configFile)
 
 	// Create a new ArduinoCoreServer


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Adds the `--config-dir` global flag that overrides the default data directory. This command can be used with `config init --dest-dir` to work in an "isolated" environment.

## What is the current behavior?

## What is the new behavior?

```
$ arduino-cli config init --dest-dir test --additional-urls https://arduino.esp8266.com/stable/package_esp8266com_index.json
Config file written to: /home/cmaglie/test/arduino-cli.yaml
$ cat test/arduino-cli.yaml 
board_manager:
    additional_urls:
        - https://arduino.esp8266.com/stable/package_esp8266com_index.json
$ arduino-cli core update-index --config-dir test/
Downloading index: library_index.tar.bz2 downloaded                                                                                                                                    
Downloading index: package_index.tar.bz2 downloaded                                                                                                                                    
Downloading index: package_esp8266com_index.json downloaded                                                                                                                            
Downloading missing tool builtin:serial-discovery@1.4.1...
builtin:serial-discovery@1.4.1 downloaded                                                                                                                                              
Installing builtin:serial-discovery@1.4.1...
Skipping tool configuration....
builtin:serial-discovery@1.4.1 installed
Downloading missing tool builtin:serial-monitor@0.14.1...
builtin:serial-monitor@0.14.1 downloaded                                                                                                                                               
Installing builtin:serial-monitor@0.14.1...
Skipping tool configuration....
builtin:serial-monitor@0.14.1 installed
Downloading missing tool builtin:ctags@5.8-arduino11...
builtin:ctags@5.8-arduino11 downloaded                                                                                                                                                 
Installing builtin:ctags@5.8-arduino11...
Skipping tool configuration....
builtin:ctags@5.8-arduino11 installed
Downloading missing tool builtin:dfu-discovery@0.1.2...
builtin:dfu-discovery@0.1.2 downloaded                                                                                                                                                 
Installing builtin:dfu-discovery@0.1.2...
Skipping tool configuration....
builtin:dfu-discovery@0.1.2 installed
Downloading missing tool builtin:mdns-discovery@1.0.9...
builtin:mdns-discovery@1.0.9 downloaded                                                                                                                                                
Installing builtin:mdns-discovery@1.0.9...
Skipping tool configuration....
builtin:mdns-discovery@1.0.9 installed
Sto scaricando l'indice: package_index.tar.bz2 scaricato                                                                                                                               
Sto scaricando l'indice: package_esp8266com_index.json scaricato                                                                                                                       
$ ls -l test/
totale 40320
-rw-r--r-- 1 cmaglie cmaglie      111 lug 30 20:43 arduino-cli.yaml
-rw-r--r-- 1 cmaglie cmaglie      108 lug 30 20:43 inventory.yaml
-rw-r--r-- 1 cmaglie cmaglie 40052066 lug 30 20:43 library_index.json
-rw-r--r-- 1 cmaglie cmaglie      566 lug 30 20:43 library_index.json.sig
-rw-r--r-- 1 cmaglie cmaglie   181534 lug 30 20:43 package_esp8266com_index.json
-rw-r--r-- 1 cmaglie cmaglie  1012551 lug 30 20:43 package_index.json
-rw-r--r-- 1 cmaglie cmaglie      566 lug 30 20:43 package_index.json.sig
drwxr-xr-x 3 cmaglie cmaglie     4096 lug 30 20:43 packages
drwxr-xr-x 3 cmaglie cmaglie     4096 lug 30 20:43 staging
drwxr-xr-x 2 cmaglie cmaglie     4096 lug 30 20:43 tmp
$ 
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Fix #2533
cc @pillo79 