### PR TITLE
regression: Ensure BoardListWatch gRPC call correctly release resources

### DIFF
--- a/commands/service_board_list.go
+++ b/commands/service_board_list.go
@@ -282,19 +282,13 @@ func (s *arduinoCoreServerImpl) BoardListWatch(req *rpc.BoardListWatchRequest, s
 	if err != nil {
 		return err
 	}
-	defer release()
 	dm := pme.DiscoveryManager()
 
 	watcher, err := dm.Watch()
+	release()
 	if err != nil {
 		return err
 	}
-
-	go func() {
-		<-stream.Context().Done()
-		logrus.Trace("closed watch")
-		watcher.Close()
-	}()
 
 	go func() {
 		for event := range watcher.Feed() {
@@ -319,5 +313,7 @@ func (s *arduinoCoreServerImpl) BoardListWatch(req *rpc.BoardListWatchRequest, s
 	}()
 
 	<-stream.Context().Done()
+	logrus.Trace("closed watch")
+	watcher.Close()
 	return nil
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

It's a bugfix to a regression: the gRPC API call `BoardListWatch` kept the `packagemanager` locked until the watcher was closed.

## What is the current behavior?

## What is the new behavior?

The `packagemanager` is released right after the board watcher feed is obtained.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
