### PR TITLE
Another small gh-action workflow fix.

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Remove unneeded artifact
         uses: geekyeggo/delete-artifact@v5
         with:
-          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}-*
 
       - name: Merge label configuration files
         run: |


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

A small change in the sync-label workflow: the 'name' value `${{ env.CONFIGURATIONS_ARTIFACT }}` would not match the name of the produced intermediate artifacts. The correct pattern is `${{ env.CONFIGURATIONS_ARTIFACT }}-*`.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
