### PR TITLE
Updated pluggable-discovery-protocol-handler library

### DIFF
--- a/.licenses/go/github.com/arduino/pluggable-discovery-protocol-handler/v2.dep.yml
+++ b/.licenses/go/github.com/arduino/pluggable-discovery-protocol-handler/v2.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: github.com/arduino/pluggable-discovery-protocol-handler/v2
-version: v2.2.0
+version: v2.2.1
 type: go
 summary: Package discovery is a library for handling the Arduino Pluggable-Discovery
   protocol (https://github.com/arduino/tooling-rfcs/blob/main/RFCs/0002-pluggable-discovery.md#pluggable-discovery-api-via-stdinstdout)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/arduino/go-serial-utils v0.1.2
 	github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b
 	github.com/arduino/go-win32-utils v1.0.0
-	github.com/arduino/pluggable-discovery-protocol-handler/v2 v2.2.0
+	github.com/arduino/pluggable-discovery-protocol-handler/v2 v2.2.1
 	github.com/arduino/pluggable-monitor-protocol-handler v0.9.2
 	github.com/cmaglie/pb v1.0.27
 	github.com/codeclysm/extract/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b h1:9hDi4F2st6
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b/go.mod h1:uwGy5PpN4lqW97FiLnbcx+xx8jly5YuPMJWfVwwjJiQ=
 github.com/arduino/go-win32-utils v1.0.0 h1:/cXB86sOJxOsCHP7sQmXGLkdValwJt56mIwOHYxgQjQ=
 github.com/arduino/go-win32-utils v1.0.0/go.mod h1:0jqM7doGEAs6DaJCxxhLBUDS5OawrqF48HqXkcEie/Q=
-github.com/arduino/pluggable-discovery-protocol-handler/v2 v2.2.0 h1:v7og6LpskewFabmaShKVzWXl5MXbmsxaRP3yo4dJta8=
-github.com/arduino/pluggable-discovery-protocol-handler/v2 v2.2.0/go.mod h1:1dgblsmK2iBx3L5iNTyRIokeaxbTLUrYiUbHBK6yC3Y=
+github.com/arduino/pluggable-discovery-protocol-handler/v2 v2.2.1 h1:Fw8zKj1b/FkcQrWgN7aBw3ubSxpKIUtdANLXvd1Qdzw=
+github.com/arduino/pluggable-discovery-protocol-handler/v2 v2.2.1/go.mod h1:1dgblsmK2iBx3L5iNTyRIokeaxbTLUrYiUbHBK6yC3Y=
 github.com/arduino/pluggable-monitor-protocol-handler v0.9.2 h1:vb5AmE3bT9we5Ej4AdBxcC9dJLXasRimVqaComf9L3M=
 github.com/arduino/pluggable-monitor-protocol-handler v0.9.2/go.mod h1:vMG8tgHyE+hli26oT0JB/M7NxUMzzWoU5wd6cgJQRK4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Updates the pluggable-discovery client library.

## What is the current behavior?

In some circumstances the pluggable-discovery client panics (in particular if the discovery crashes on startup).

## What is the new behavior?

The crashing discovery is handled gracefully.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Upstream fix https://github.com/arduino/pluggable-discovery-protocol-handler/pull/50
Fix #2665
