### PR TITLE
Improved package index merging logic

### DIFF
--- a/internal/arduino/cores/packagemanager/testdata/data_dir_1/package_with_empty_dfu_util_index.json
+++ b/internal/arduino/cores/packagemanager/testdata/data_dir_1/package_with_empty_dfu_util_index.json
@@ -1,0 +1,41 @@
+{
+    "packages": [
+        {
+            "name": "arduino",
+            "maintainer": "Arduino",
+            "websiteURL": "http://www.arduino.cc/",
+            "email": "packages@arduino.cc",
+            "help": {
+                "online": "http://www.arduino.cc/en/Reference/HomePage"
+            },
+            "platforms": [],
+            "tools": [
+                {
+                    "name": "test-tool",
+                    "version": "1.0.0",
+                    "systems": [
+                        {
+                            "host": "i386-apple-darwin11",
+                            "url": "INVALID",
+                            "archiveFileName": "INVALID",
+                            "size": "100",
+                            "checksum": "SHA-256:9e576c6e44f54b1e921a43ea77bcc08ec99e0e4e0905f4b9acf9ab2c979f0a22"
+                        },
+                        {
+                            "host": "arm-linux-gnueabihf",
+                            "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-linux_arm.tar.gz",
+                            "archiveFileName": "dfu-util-0.11-arduino5-linux_arm.tar.gz",
+                            "size": "2512819",
+                            "checksum": "SHA-256:acd4bd283fd408515279a44dd830499ad37b0767e8f2fde5c27e878ded909dc3"
+                        }
+                    ]
+                },
+                {
+                    "name": "dfu-util",
+                    "version": "0.11.0-arduino5",
+                    "systems": []
+                }
+            ]
+        }
+    ]
+}

--- a/internal/arduino/cores/packagemanager/testdata/data_dir_1/package_with_regular_dfu_util_index.json
+++ b/internal/arduino/cores/packagemanager/testdata/data_dir_1/package_with_regular_dfu_util_index.json
@@ -1,0 +1,77 @@
+{
+    "packages": [
+        {
+            "name": "arduino",
+            "maintainer": "Arduino",
+            "websiteURL": "http://www.arduino.cc/",
+            "email": "packages@arduino.cc",
+            "help": {
+                "online": "http://www.arduino.cc/en/Reference/HomePage"
+            },
+            "platforms": [],
+            "tools": [
+                {
+                    "name": "test-tool",
+                    "version": "1.0.0",
+                    "systems": [
+                        {
+                            "host": "i386-apple-darwin11",
+                            "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-darwin_amd64.tar.gz",
+                            "archiveFileName": "dfu-util-0.11-arduino5-darwin_amd64.tar.gz",
+                            "size": "72429",
+                            "checksum": "SHA-256:9e576c6e44f54b1e921a43ea77bcc08ec99e0e4e0905f4b9acf9ab2c979f0a22"
+                        }
+                    ]
+                },
+                {
+                    "name": "dfu-util",
+                    "version": "0.11.0-arduino5",
+                    "systems": [
+                        {
+                            "host": "i386-apple-darwin11",
+                            "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-darwin_amd64.tar.gz",
+                            "archiveFileName": "dfu-util-0.11-arduino5-darwin_amd64.tar.gz",
+                            "size": "72429",
+                            "checksum": "SHA-256:9e576c6e44f54b1e921a43ea77bcc08ec99e0e4e0905f4b9acf9ab2c979f0a22"
+                        },
+                        {
+                            "host": "arm-linux-gnueabihf",
+                            "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-linux_arm.tar.gz",
+                            "archiveFileName": "dfu-util-0.11-arduino5-linux_arm.tar.gz",
+                            "size": "2512819",
+                            "checksum": "SHA-256:acd4bd283fd408515279a44dd830499ad37b0767e8f2fde5c27e878ded909dc3"
+                        },
+                        {
+                            "host": "aarch64-linux-gnu",
+                            "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-linux_arm64.tar.gz",
+                            "archiveFileName": "dfu-util-0.11-arduino5-linux_arm64.tar.gz",
+                            "size": "2607592",
+                            "checksum": "SHA-256:b3f46a65da0c2fed2449dc5a3351c3c74953a868aa7f8d99ba2bb8c418344fe9"
+                        },
+                        {
+                            "host": "x86_64-linux-gnu",
+                            "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-linux_amd64.tar.gz",
+                            "archiveFileName": "dfu-util-0.11-arduino5-linux_amd64.tar.gz",
+                            "size": "2283425",
+                            "checksum": "SHA-256:96c64c278561af806b585c123c85748926ad02b1aedc07e5578ca9bee2be0d2a"
+                        },
+                        {
+                            "host": "i686-linux-gnu",
+                            "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-linux_386.tar.gz",
+                            "archiveFileName": "dfu-util-0.11-arduino5-linux_386.tar.gz",
+                            "size": "2524406",
+                            "checksum": "SHA-256:9a707692261e5710ed79a6d8a4031ffd0bfe1e585216569934346e9b2d68d0c2"
+                        },
+                        {
+                            "host": "i686-mingw32",
+                            "url": "http://downloads.arduino.cc/tools/dfu-util-0.11-arduino5-windows_386.tar.gz",
+                            "archiveFileName": "dfu-util-0.11-arduino5-windows_386.tar.gz",
+                            "size": "571340",
+                            "checksum": "SHA-256:6451e16bf77600fe2436c8708ab4b75077c49997cf8bedf03221d9d6726bb641"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

In some sporadic cases, there may exist some stale `package_*_index.json` files with an invalid or empty entry in the tools section. In particular, due to the way the package indexes are loaded, the tool resource metadata may be overwritten or deleted by an invalid index. This change should improve the resilience of the Arduino CLI in most of these cases.

## What is the current behavior?

## What is the new behavior?

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

## Other information
