### PR TITLE
Disable auto-rebase on dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       - "topic: infrastructure"
     commit-message:
       prefix: "[skip changelog] "
+    rebase-strategy: disabled
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -22,3 +23,4 @@ updates:
       - "topic: infrastructure"
     commit-message:
       prefix: "[skip changelog] "
+    rebase-strategy: disabled


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Disable the auto-rebase feature on pull requests opened by dependabot.
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#rebase-strategy

## What is the current behavior?

Any change made on `master` will trigger a rebase on all PR opened by dependabot. If a bunch of pending PR is opened, this will trigger a storm of integration tests that will keep the available runners busy for a long time.

## What is the new behavior?

Dependabot should not auto-rebase on `master`.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
