### PR TITLE
Fixed locales (translations) not being detected with default config

### DIFF
--- a/commands/instances.go
+++ b/commands/instances.go
@@ -419,7 +419,9 @@ func (s *arduinoCoreServerImpl) Init(req *rpc.InitRequest, stream rpc.ArduinoCor
 	// Refreshes the locale used, this will change the
 	// language of the CLI if the locale is different
 	// after started.
-	i18n.Init(s.settings.GetString("locale"))
+	if locale, ok, _ := s.settings.GetStringOk("locale"); ok {
+		i18n.Init(locale)
+	}
 
 	return nil
 }

--- a/commands/service.go
+++ b/commands/service.go
@@ -19,7 +19,6 @@ import (
 	"context"
 
 	"github.com/arduino/arduino-cli/internal/cli/configuration"
-	"github.com/arduino/arduino-cli/internal/i18n"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/arduino-cli/version"
 )
@@ -27,12 +26,7 @@ import (
 // NewArduinoCoreServer returns an implementation of the ArduinoCoreService gRPC service
 // that uses the provided version string.
 func NewArduinoCoreServer() rpc.ArduinoCoreServiceServer {
-	settings := configuration.NewSettings()
-
-	// Setup i18n
-	i18n.Init(settings.Locale())
-
-	return &arduinoCoreServerImpl{settings: settings}
+	return &arduinoCoreServerImpl{settings: configuration.NewSettings()}
 }
 
 type arduinoCoreServerImpl struct {

--- a/commands/service_settings_test.go
+++ b/commands/service_settings_test.go
@@ -62,7 +62,6 @@ func TestGetAll(t *testing.T) {
 			"user": `+defaultUserDir.GetEncodedValue()+`
 		},
 		"library": {},
-		"locale": "en",
 		"logging": {
 			"format": "text",
 			"level": "info"

--- a/internal/cli/configuration/defaults.go
+++ b/internal/cli/configuration/defaults.go
@@ -73,7 +73,7 @@ func SetDefaults(settings *Settings) {
 	setKeyTypeSchema("network.user_agent_ext", "")
 
 	// locale
-	setDefaultValueAndKeyTypeSchema("locale", "en")
+	setKeyTypeSchema("locale", "")
 }
 
 // InjectEnvVars change settings based on the environment variables values

--- a/internal/cli/configuration/locale.go
+++ b/internal/cli/configuration/locale.go
@@ -16,5 +16,8 @@
 package configuration
 
 func (s *Settings) Locale() string {
+	if locale, ok, err := s.GetStringOk("locale"); ok && err == nil {
+		return locale
+	}
 	return s.Defaults.GetString("locale")
 }

--- a/internal/i18n/detect_windows.go
+++ b/internal/i18n/detect_windows.go
@@ -30,6 +30,10 @@ func getLocaleIdentifier() string {
 		}
 	}()
 
+	if loc := getLocaleIdentifierFromEnv(); loc != "" {
+		return loc
+	}
+
 	dll := syscall.MustLoadDLL("kernel32")
 	defer dll.Release()
 	proc := dll.MustFindProc("GetUserDefaultLocaleName")

--- a/internal/i18n/detect_windows.go
+++ b/internal/i18n/detect_windows.go
@@ -16,16 +16,17 @@
 package i18n
 
 import (
-	"fmt"
 	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/sirupsen/logrus"
 )
 
 func getLocaleIdentifier() string {
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Println("failed to get windows user locale", r)
+			logrus.WithField("error", r).Errorf("Failed to get windows user locale")
 		}
 	}()
 

--- a/internal/integrationtest/config/config_test.go
+++ b/internal/integrationtest/config/config_test.go
@@ -931,3 +931,16 @@ func TestConfigViaEnvVars(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "20\n\n", string(out))
 }
+
+func TestI18N(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	out, _, err := cli.RunWithCustomEnv(map[string]string{"LC_ALL": "it"})
+	require.NoError(t, err)
+	require.Contains(t, string(out), "Comandi disponibili")
+
+	out, _, err = cli.RunWithCustomEnv(map[string]string{"LC_ALL": "en"})
+	require.NoError(t, err)
+	require.Contains(t, string(out), "Available Commands")
+}

--- a/internal/integrationtest/config/config_test.go
+++ b/internal/integrationtest/config/config_test.go
@@ -882,25 +882,25 @@ build.unk: 123
 	t.Cleanup(func() { unkwnownConfig.Remove() })
 
 	// Run "config get" with a configuration containing an unknown key
-	out, _, err := cli.Run("config", "get", "locale", "--config-file", unkwnownConfig.String())
+	out, _, err := cli.Run("config", "get", "daemon.port", "--config-file", unkwnownConfig.String())
 	require.NoError(t, err)
-	require.Equal(t, "en", strings.TrimSpace(string(out)))
+	require.Equal(t, `"50051"`, strings.TrimSpace(string(out)))
 
-	// Run "config get" with a configuration containing an invalid key
+	// Run "config get" with a configuration containing an invalid value
 	invalidConfig := paths.New(filepath.Join(tmp, "invalid.yaml"))
-	invalidConfig.WriteFile([]byte(`locale: 123`))
+	invalidConfig.WriteFile([]byte(`daemon.port: 123`))
 	t.Cleanup(func() { invalidConfig.Remove() })
-	out, _, err = cli.Run("config", "get", "locale", "--config-file", invalidConfig.String())
+	out, _, err = cli.Run("config", "get", "daemon.port", "--config-file", invalidConfig.String())
 	require.NoError(t, err)
-	require.Equal(t, "en", strings.TrimSpace(string(out)))
+	require.Equal(t, `"50051"`, strings.TrimSpace(string(out)))
 
 	// Run "config get" with a configuration containing a null array
 	nullArrayConfig := paths.New(filepath.Join(tmp, "null_array.yaml"))
 	nullArrayConfig.WriteFile([]byte(`board_manager.additional_urls:`))
 	t.Cleanup(func() { nullArrayConfig.Remove() })
-	out, _, err = cli.Run("config", "get", "locale", "--config-file", invalidConfig.String())
+	out, _, err = cli.Run("config", "get", "daemon.port", "--config-file", nullArrayConfig.String())
 	require.NoError(t, err)
-	require.Equal(t, "en", strings.TrimSpace(string(out)))
+	require.Equal(t, `"50051"`, strings.TrimSpace(string(out)))
 }
 
 func TestConfigViaEnvVars(t *testing.T) {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fixed incorrect locales detection.

## What is the current behavior?

```
$ LANG=it arduino-cli
Arduino Command Line Interface (arduino-cli).

Usage:
  arduino-cli [command]

Examples:
  arduino-cli <command> [flags...]

Available Commands:
  board           Arduino board commands.
  burn-bootloader Upload the bootloader.
  cache           Arduino cache commands.
  compile         Compiles Arduino sketches.
  completion      Generates completion scripts
  config          Arduino configuration commands.
  core            Arduino core operations.
  daemon          Run the Arduino CLI as a gRPC daemon.
  debug           Debug Arduino sketches.
  help            Help about any command
  lib             Arduino commands about libraries.
  monitor         Open a communication port with a board.
  outdated        Lists cores and libraries that can be upgraded
  sketch          Arduino CLI sketch commands.
  update          Updates the index of cores and libraries
  upgrade         Upgrades installed cores and libraries.
  upload          Upload Arduino sketches.
  version         Shows version number of Arduino CLI.

Flags:
      --additional-urls strings   Comma-separated list of additional URLs for the Boards Manager.
      --config-dir string         Sets the default data directory (Arduino CLI will look for configuration file in this directory).
      --config-file string        The custom config file (if not specified the default will be used).
  -h, --help                      help for arduino-cli
      --json                      Print the output in JSON format.
      --log                       Print the logs on the standard output.
      --log-file string           Path to the file where logs will be written.
      --log-format string         The output format for the logs, can be: text, json (default "text")
      --log-level string          Messages with this level and above will be logged. Valid levels are: trace, debug, info, warn, error, fatal, panic (default "info")
      --no-color                  Disable colored output.

Use "arduino-cli [command] --help" for more information about a command.
```

The `en` version is displayed instead of `it`

## What is the new behavior?

```
$ LANG=it arduino-cli 
Interfaccia a linea di comando di Arduino (arduino-cli).

Uso: 
  arduino-cli [command]

Esempi:
  arduino-cli <comando> [flag...]

Comandi disponibili:
  board           Comandi delle schede Arduino.
  burn-bootloader Carica il bootloader.
  cache           Comandi della cache Arduino.
  compile         Compila gli sketch di Arduino.
  completion      Genera gli script di completamento
  config          Comandi di configurazione Arduino.
  core            Operazioni core Arduino
  daemon          Avvia la CLI di Arduino come demone gRPC.
  debug           Eseguire il debug degli sketch di Arduino
  help            Help about any command
  lib             Comandi Arduino riguardo le librerie.
  monitor         Apre una porta di comunicazione con una scheda.
  outdated        Elenca i core e le librerie che possono essere aggiornati
  sketch          Comandi degli sketch di Arduino CLI.
  update          Aggiorna l'indice dei core e delle librerie
  upgrade         Aggiorna i core e le librerie installate.
  upload          Carica gli sketch di Arduino.
  version         Mostra il numero di versione di Arduino CLI.

Flag:
      --additional-urls strings   Elenco separato da virgole degli URL aggiuntivi per il Boards Manager.
      --config-dir string         Imposta la directory predefinita dei dati (Arduino CLI cercherà il file di configurazione in questa directory).
      --config-file string        Il file di configurazione personalizzato (se non specificato, verrà utilizzato quello predefinito).
  -h, --help                      help for arduino-cli
      --json                      Stampa l'output in formato JSON.
      --log                       Stampa i log sull'output standard.
      --log-file string           Percorso del file in cui verranno scritti i log.
      --log-format string         Il formato di output dei log può essere: text, json (default "text")
      --log-level string          I messaggi con questo livello o superiore saranno registrati. I livelli validi sono: trace, debug, info, warn, error, fatal, panic (default "info")
      --no-color                  Disable colored output.

Usa "arduino-cli [command] --help"  per ulteriori informazioni su un comando.
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
