### PR TITLE
Fix monitor init handling

### DIFF
--- a/commands/service_monitor.go
+++ b/commands/service_monitor.go
@@ -125,8 +125,8 @@ func (s *arduinoCoreServerImpl) Monitor(stream rpc.ArduinoCoreService_MonitorSer
 	if err != nil {
 		return err
 	}
-	defer release()
 	monitor, boardSettings, err := findMonitorAndSettingsForProtocolAndBoard(pme, openReq.GetPort().GetProtocol(), openReq.GetFqbn())
+	release()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -35,7 +35,6 @@ import (
 )
 
 var (
-	tr           = i18n.Tr
 	daemonize    bool
 	debug        bool
 	debugFile    string

--- a/internal/integrationtest/daemon/daemon_concurrency_test.go
+++ b/internal/integrationtest/daemon/daemon_concurrency_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -75,4 +76,52 @@ func TestArduinoCliDaemonCompileWithLotOfOutput(t *testing.T) {
 	testCompile()
 	testCompile()
 	testCompile()
+}
+
+func TestInitAndMonitorConcurrency(t *testing.T) {
+	// See: https://github.com/arduino/arduino-cli/issues/2719
+
+	env, cli := integrationtest.CreateEnvForDaemon(t)
+	defer env.CleanUp()
+
+	_, _, err := cli.Run("core", "install", "arduino:avr")
+	require.NoError(t, err)
+
+	grpcInst := cli.Create()
+	require.NoError(t, grpcInst.Init("", "", func(ir *commands.InitResponse) {
+		fmt.Printf("INIT> %v\n", ir.GetMessage())
+	}))
+
+	cli.InstallMockedSerialMonitor(t)
+
+	// Open the serial monitor for 5 seconds
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	mon, err := grpcInst.Monitor(ctx, &commands.Port{
+		Address:  "/dev/test",
+		Protocol: "serial",
+	})
+	require.NoError(t, err)
+	var monitorCompleted sync.WaitGroup
+	monitorCompleted.Add(1)
+	go func() {
+		for {
+			msg, err := mon.Recv()
+			if err != nil {
+				break
+			}
+			fmt.Println("MON> ", msg)
+		}
+		fmt.Println("MON CLOSED")
+		monitorCompleted.Done()
+	}()
+
+	// Check that Init completes without blocking when the monitor is open
+	start := time.Now()
+	require.NoError(t, grpcInst.Init("", "", func(ir *commands.InitResponse) {
+		fmt.Printf("INIT> %v\n", ir.GetMessage())
+	}))
+	require.LessOrEqual(t, time.Since(start), 4*time.Second)
+	cancel()
+	monitorCompleted.Wait()
 }

--- a/internal/integrationtest/daemon/daemon_concurrency_test.go
+++ b/internal/integrationtest/daemon/daemon_concurrency_test.go
@@ -124,4 +124,9 @@ func TestInitAndMonitorConcurrency(t *testing.T) {
 	require.LessOrEqual(t, time.Since(start), 4*time.Second)
 	cancel()
 	monitorCompleted.Wait()
+
+	// Allow some time for the mocked-monitor process to terminate (otherwise the
+	// test will fail on Windows when the cleanup function tries to remove the
+	// executable).
+	time.Sleep(2 * time.Second)
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fix a deadlock in the gRPC `Monitor` command that keeps the package manager busy for no reason.

## What is the current behavior?

While a call to gRPC `Monitor` command is running, other calls may be blocked, in particular the `Init` call. This lead to the Arduino IDE bug described in #2719 

## What is the new behavior?

The `Monitor` command doesn't lock the package manager anymore.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2719 
