### PR TITLE
Increased gRPC message size limit to 16MB / added CLI flag to set the value

### DIFF
--- a/internal/cli/daemon/interceptors.go
+++ b/internal/cli/daemon/interceptors.go
@@ -28,6 +28,7 @@ import (
 
 var debugStdOut io.Writer
 var debugSeq uint32
+var debugFilters []string
 
 func log(isRequest bool, seq uint32, msg interface{}) {
 	prefix := fmt.Sprint(seq, " |  ")


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

* Increase gRPC message size limit from 4MB to 16MB
* Added `--max-grpc-recv-message-size <SIZE>` flag to `daemon` command

## What is the current behavior?

gRPC message size limit is 4MB

## What is the new behavior?

gRPC message size limit is 16MB

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2718 
