### PR TITLE
Set installer tmp path to env var

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ PROJECT_NAME="arduino-cli"
 # BINDIR represents the local bin location, defaults to ./bin.
 EFFECTIVE_BINDIR=""
 DEFAULT_BINDIR="$PWD/bin"
+TEMPDIR="${TMPDIR:-${TEMP:-${TMP:-/tmp}}}"
 
 fail() {
   echo "$1"
@@ -137,7 +138,7 @@ downloadFile() {
   esac
   DOWNLOAD_URL="${DOWNLOAD_URL_PREFIX}${APPLICATION_DIST}"
 
-  INSTALLATION_TMP_FILE="/tmp/$APPLICATION_DIST"
+  INSTALLATION_TMP_FILE="${TEMPDIR}/$APPLICATION_DIST"
   echo "Downloading $DOWNLOAD_URL"
   httpStatusCode=$(getFile "$DOWNLOAD_URL" "$INSTALLATION_TMP_FILE")
   if [ "$httpStatusCode" -ne 200 ]; then
@@ -186,7 +187,7 @@ downloadFile() {
 }
 
 installFile() {
-  INSTALLATION_TMP_DIR="/tmp/$PROJECT_NAME"
+  INSTALLATION_TMP_DIR="${TEMPDIR}/$PROJECT_NAME"
   mkdir -p "$INSTALLATION_TMP_DIR"
   if [ "$OS" = "Windows" ]; then
     unzip -d "$INSTALLATION_TMP_DIR" "$INSTALLATION_TMP_FILE"


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This is an improvement in the `install.sh` script to support more platforms. For example, Termux is an Android terminal emulator which doesn't follow conventional UNIX file system, which means `/tmp` folder does not exist. Although, `$TMPDIR` is a variable that can be used to reference the `/tmp` equivalent in Termux.

## What is the current behavior?

The current behavior of the `install.sh` script is that it crashes when running from Termux, as the installer tries to write the installation files in a folder that doesn't exist (`/tmp`).

## What is the new behavior?

A new variable `$TEMPDIR` is defined based on some default variables that holds those paths, and if none of those are found, it defaults to previous `/tmp`.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Android environments have the potential to be a development environment, so it would be nice that tools like arduino-cli could support it.
