### PR TITLE
Do not fail if downloaded file has good checksum but incorrect size.

### DIFF
--- a/internal/arduino/resources/resources_test.go
+++ b/internal/arduino/resources/resources_test.go
@@ -82,6 +82,10 @@ func TestDownloadAndChecksums(t *testing.T) {
 	require.NoError(t, err)
 	downloadAndTestChecksum()
 
+	require.NoError(t, r.TestLocalArchiveSize(tmp))
+	r.Size = 500
+	require.NoError(t, r.TestLocalArchiveSize(tmp))
+
 	r.Checksum = ""
 	_, err = r.TestLocalArchiveChecksum(tmp)
 	require.Error(t, err)

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -1354,3 +1354,15 @@ func TestReferencedCoreBuildAndRuntimeProperties(t *testing.T) {
 		out.ArrayMustContain(jsonEncode("runtime.platform.path=" + corePlatformPath))
 	}
 }
+
+func TestCoreInstallWithWrongArchiveSize(t *testing.T) {
+	// See: https://github.com/arduino/arduino-cli/issues/2332
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	_, _, err := cli.Run("--additional-urls", "https://raw.githubusercontent.com/geolink/opentracker-arduino-board/bf6158ebab0402db217bfb02ea61461ddc6f2940/package_opentracker_index.json", "core", "update-index")
+	require.NoError(t, err)
+
+	_, _, err = cli.Run("--additional-urls", "https://raw.githubusercontent.com/geolink/opentracker-arduino-board/bf6158ebab0402db217bfb02ea61461ddc6f2940/package_opentracker_index.json", "core", "install", "opentracker:sam@1.0.5")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

As requested in #2332 

> Do not error if the downloaded file size doesn't match the size value in the index.
> 🙂 Users will no longer suffer when package developers fail to correctly set a size value.

## What is the current behavior?

If a downloaded file has an incorrect size written in the index (but a correct checksum), it will fail to download.

## What is the new behavior?

If a downloaded file has an incorrect size written in the index (but a correct checksum), it will download successfully.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2332 
