### PR TITLE
Added option to disable integrity checks in `core install` (for development purposes)

### DIFF
--- a/commands/service_platform_install.go
+++ b/commands/service_platform_install.go
@@ -22,6 +22,7 @@ import (
 	"github.com/arduino/arduino-cli/commands/cmderrors"
 	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/internal/arduino/cores/packagemanager"
+	"github.com/arduino/arduino-cli/internal/arduino/resources"
 	"github.com/arduino/arduino-cli/internal/i18n"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
@@ -95,7 +96,11 @@ func (s *arduinoCoreServerImpl) PlatformInstall(req *rpc.PlatformInstallRequest,
 			}
 		}
 
-		if err := pme.DownloadAndInstallPlatformAndTools(ctx, platformRelease, tools, downloadCB, taskCB, req.GetSkipPostInstall(), req.GetSkipPreUninstall()); err != nil {
+		checks := resources.IntegrityCheckFull
+		if s.settings.BoardManagerEnableUnsafeInstall() {
+			checks = resources.IntegrityCheckNone
+		}
+		if err := pme.DownloadAndInstallPlatformAndTools(ctx, platformRelease, tools, downloadCB, taskCB, req.GetSkipPostInstall(), req.GetSkipPreUninstall(), checks); err != nil {
 			return err
 		}
 

--- a/commands/service_platform_upgrade.go
+++ b/commands/service_platform_upgrade.go
@@ -21,6 +21,7 @@ import (
 	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/internal/arduino/cores"
 	"github.com/arduino/arduino-cli/internal/arduino/cores/packagemanager"
+	"github.com/arduino/arduino-cli/internal/arduino/resources"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
@@ -75,7 +76,11 @@ func (s *arduinoCoreServerImpl) PlatformUpgrade(req *rpc.PlatformUpgradeRequest,
 			Package:              req.GetPlatformPackage(),
 			PlatformArchitecture: req.GetArchitecture(),
 		}
-		platform, err := pme.DownloadAndInstallPlatformUpgrades(ctx, ref, downloadCB, taskCB, req.GetSkipPostInstall(), req.GetSkipPreUninstall())
+		checks := resources.IntegrityCheckFull
+		if s.settings.BoardManagerEnableUnsafeInstall() {
+			checks = resources.IntegrityCheckNone
+		}
+		platform, err := pme.DownloadAndInstallPlatformUpgrades(ctx, ref, downloadCB, taskCB, req.GetSkipPostInstall(), req.GetSkipPreUninstall(), checks)
 		if err != nil {
 			return platform, err
 		}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,8 @@
 
 - `board_manager`
   - `additional_urls` - the URLs to any additional Boards Manager package index files needed for your boards platforms.
+  - `enable_unsafe_install` - set to `true` to allow installation of packages that do not pass the checksum test. This
+    is considered an unsafe installation method and should be used only for development purposes.
 - `daemon` - options related to running Arduino CLI as a [gRPC] server.
   - `port` - TCP port used for gRPC client connections.
 - `directories` - directories used by Arduino CLI.

--- a/internal/arduino/cores/packageindex/index.go
+++ b/internal/arduino/cores/packageindex/index.go
@@ -17,14 +17,12 @@ package packageindex
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"slices"
 
 	"github.com/arduino/arduino-cli/internal/arduino/cores"
 	"github.com/arduino/arduino-cli/internal/arduino/resources"
 	"github.com/arduino/arduino-cli/internal/arduino/security"
-	"github.com/arduino/arduino-cli/internal/i18n"
 	"github.com/arduino/go-paths-helper"
 	easyjson "github.com/mailru/easyjson"
 	"github.com/sirupsen/logrus"
@@ -273,14 +271,15 @@ func (inPlatformRelease indexPlatformRelease) extractPlatformIn(outPackage *core
 		outPlatform.Deprecated = inPlatformRelease.Deprecated
 	}
 
-	size, err := inPlatformRelease.Size.Int64()
-	if err != nil {
-		return errors.New(i18n.Tr("invalid platform archive size: %s", err))
-	}
 	outPlatformRelease := outPlatform.GetOrCreateRelease(inPlatformRelease.Version)
 	outPlatformRelease.Name = inPlatformRelease.Name
 	outPlatformRelease.Category = inPlatformRelease.Category
 	outPlatformRelease.IsTrusted = trusted
+	size, err := inPlatformRelease.Size.Int64()
+	if err != nil {
+		logrus.Warningf("invalid platform %s archive size: %s", outPlatformRelease, err)
+		size = 0
+	}
 	outPlatformRelease.Resource = &resources.DownloadResource{
 		ArchiveFileName: inPlatformRelease.ArchiveFileName,
 		Checksum:        inPlatformRelease.Checksum,

--- a/internal/arduino/cores/packagemanager/profiles.go
+++ b/internal/arduino/cores/packagemanager/profiles.go
@@ -132,7 +132,7 @@ func (pmb *Builder) installMissingProfilePlatform(ctx context.Context, platformR
 
 	// Perform install
 	taskCB(&rpc.TaskProgress{Name: i18n.Tr("Installing platform %s", tmpPlatformRelease)})
-	if err := tmpPme.InstallPlatformInDirectory(tmpPlatformRelease, destDir); err != nil {
+	if err := tmpPme.InstallPlatformInDirectory(tmpPlatformRelease, destDir, resources.IntegrityCheckFull); err != nil {
 		taskCB(&rpc.TaskProgress{Name: i18n.Tr("Error installing platform %s", tmpPlatformRelease)})
 		return &cmderrors.FailedInstallError{Message: i18n.Tr("Error installing platform %s", tmpPlatformRelease), Cause: err}
 	}
@@ -183,7 +183,7 @@ func (pmb *Builder) installMissingProfileTool(ctx context.Context, toolRelease *
 
 	// Install tool
 	taskCB(&rpc.TaskProgress{Name: i18n.Tr("Installing tool %s", toolRelease)})
-	if err := toolResource.Install(pmb.DownloadDir, tmp, destDir); err != nil {
+	if err := toolResource.Install(pmb.DownloadDir, tmp, destDir, resources.IntegrityCheckFull); err != nil {
 		taskCB(&rpc.TaskProgress{Name: i18n.Tr("Error installing tool %s", toolRelease)})
 		return &cmderrors.FailedInstallError{Message: i18n.Tr("Error installing tool %s", toolRelease), Cause: err}
 	}

--- a/internal/arduino/resources/install.go
+++ b/internal/arduino/resources/install.go
@@ -26,18 +26,27 @@ import (
 	"go.bug.st/cleanup"
 )
 
+type IntegrityCheckMode int
+
+const (
+	IntegrityCheckFull IntegrityCheckMode = iota
+	IntegrityCheckNone
+)
+
 // Install installs the resource in three steps:
 // - the archive is unpacked in a temporary subdir of tempPath
 // - there should be only one root dir in the unpacked content
 // - the only root dir is moved/renamed to/as the destination directory
 // Note that tempPath and destDir must be on the same filesystem partition
 // otherwise the last step will fail.
-func (release *DownloadResource) Install(downloadDir, tempPath, destDir *paths.Path) error {
-	// Check the integrity of the package
-	if ok, err := release.TestLocalArchiveIntegrity(downloadDir); err != nil {
-		return errors.New(i18n.Tr("testing local archive integrity: %s", err))
-	} else if !ok {
-		return errors.New(i18n.Tr("checking local archive integrity"))
+func (release *DownloadResource) Install(downloadDir, tempPath, destDir *paths.Path, checks IntegrityCheckMode) error {
+	if checks != IntegrityCheckNone {
+		// Check the integrity of the package
+		if ok, err := release.TestLocalArchiveIntegrity(downloadDir); err != nil {
+			return errors.New(i18n.Tr("testing local archive integrity: %s", err))
+		} else if !ok {
+			return errors.New(i18n.Tr("checking local archive integrity"))
+		}
 	}
 
 	// Create a temporary dir to extract package

--- a/internal/arduino/resources/install_test.go
+++ b/internal/arduino/resources/install_test.go
@@ -44,7 +44,7 @@ func TestInstallPlatform(t *testing.T) {
 			Size:            157,
 		}
 
-		require.NoError(t, r.Install(downloadDir, tempPath, destDir))
+		require.NoError(t, r.Install(downloadDir, tempPath, destDir, IntegrityCheckFull))
 	})
 
 	tests := []struct {
@@ -82,7 +82,7 @@ func TestInstallPlatform(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, os.WriteFile(path.Join(downloadDir.String(), testFileName), origin, 0644))
 
-			err = test.downloadResource.Install(downloadDir, tempPath, destDir)
+			err = test.downloadResource.Install(downloadDir, tempPath, destDir, IntegrityCheckFull)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), test.error)
 		})

--- a/internal/cli/configuration/board_manager.go
+++ b/internal/cli/configuration/board_manager.go
@@ -21,3 +21,10 @@ func (settings *Settings) BoardManagerAdditionalUrls() []string {
 	}
 	return settings.Defaults.GetStringSlice("board_manager.additional_urls")
 }
+
+func (settings *Settings) BoardManagerEnableUnsafeInstall() bool {
+	if v, ok, _ := settings.GetBoolOk("board_manager.enable_unsafe_install"); ok {
+		return v
+	}
+	return settings.Defaults.GetBool("board_manager.enable_unsafe_install")
+}

--- a/internal/cli/configuration/configuration.schema.json
+++ b/internal/cli/configuration/configuration.schema.json
@@ -13,6 +13,10 @@
             "type": "string",
             "format": "uri"
           }
+        },
+        "enable_unsafe_install": {
+          "description": "set to `true` to allow installation of packages that do not pass the checksum test. This is considered an unsafe installation method and should be used only for development purposes.",
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/internal/cli/configuration/defaults.go
+++ b/internal/cli/configuration/defaults.go
@@ -41,6 +41,7 @@ func SetDefaults(settings *Settings) {
 
 	// Boards Manager
 	setDefaultValueAndKeyTypeSchema("board_manager.additional_urls", []string{})
+	setDefaultValueAndKeyTypeSchema("board_manager.enable_unsafe_install", false)
 
 	// arduino directories
 	setDefaultValueAndKeyTypeSchema("directories.data", getDefaultArduinoDataDir())

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -1366,3 +1366,20 @@ func TestCoreInstallWithWrongArchiveSize(t *testing.T) {
 	_, _, err = cli.Run("--additional-urls", "https://raw.githubusercontent.com/geolink/opentracker-arduino-board/bf6158ebab0402db217bfb02ea61461ddc6f2940/package_opentracker_index.json", "core", "install", "opentracker:sam@1.0.5")
 	require.NoError(t, err)
 }
+
+func TestCoreInstallWithMissingOrInvalidChecksumAndUnsafeInstallEnabled(t *testing.T) {
+	// See: https://github.com/arduino/arduino-cli/issues/1468
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	_, _, err := cli.Run("--additional-urls", "https://raw.githubusercontent.com/keyboardio/ArduinoCore-GD32-Keyboardio/refs/heads/main/package_gd32_index.json", "core", "update-index")
+	require.NoError(t, err)
+
+	_, _, err = cli.Run("--additional-urls", "https://raw.githubusercontent.com/keyboardio/ArduinoCore-GD32-Keyboardio/refs/heads/main/package_gd32_index.json", "core", "install", "GD32Community:gd32")
+	require.Error(t, err)
+
+	_, _, err = cli.RunWithCustomEnv(
+		map[string]string{"ARDUINO_BOARD_MANAGER_ENABLE_UNSAFE_INSTALL": "true"},
+		"--additional-urls", "https://raw.githubusercontent.com/keyboardio/ArduinoCore-GD32-Keyboardio/refs/heads/main/package_gd32_index.json", "core", "install", "GD32Community:gd32")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [X] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

We have added a new configuration option, `board_manager.enable_unsafe_install,` to allow the installation of platforms/tools that do not pass the checksum test. This option has been added to ease the platform's development phase, relieving the developer from having to regenerate the index every time, and is not intended for use in production environments.

## What is the current behavior?

If a platform fails the checksum test, it will not be installed:

```
$ arduino-cli core install GD32Community:gd32
Downloading packages...
[...]
Installing platform GD32Community:gd32@0.0.1...
Error during install: Cannot install platform: installing platform GD32Community:gd32@0.0.1: testing local archive integrity: testing archive checksum: missing checksum for: ArduinoCore-GD32-main.zip
$
```

## What is the new behavior?

The checksum test may be skipped:

```
$ ARDUINO_BOARD_MANAGER_ENABLE_UNSAFE_INSTALL=true arduino-cli core install GD32Community:gd32 
Tool GD32Community:xpack-arm-none-eabi-gcc@9.3.1-1.3 already installed
Tool GD32Community:xpack-openocd@0.11.0-1 already installed
Tool GD32Community:dfu-util@0.10.0-arduino1 already installed
Downloading packages...
GD32Community:gd32@0.0.1 downloaded                                                                                                                                                    
Installing platform GD32Community:gd32@0.0.1...
Configuring platform....
Platform GD32Community:gd32@0.0.1 installed
$
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #1468 
