### PR TITLE
[skip changelog] Only download required artifact in Windows Installer job of release workflows

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -201,8 +201,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ env.ARTIFACT_NAME }}-*
-          merge-multiple: true
+          name: ${{ env.ARTIFACT_NAME }}-Windows_64bit
           path: ${{ env.DIST_DIR }}
 
       - name: Prepare PATH

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -201,8 +201,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ env.ARTIFACT_NAME }}-*
-          merge-multiple: true
+          name: ${{ env.ARTIFACT_NAME }}-Windows_64bit
           path: ${{ env.DIST_DIR }}
 
       - name: Prepare PATH


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [s] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [s] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The project's nightly build and production release workflows generate a Windows Installer package of Arduino CLI. This is generated from the Windows x86-64 build, which is produced by a prior job. The builds are transferred between jobs by GitHub Actions workflow artifacts, one for each host architecture.

The `create-windows-installer` job that generates the Windows Installer package unnecessarily downloads all the build artifacts:

https://github.com/arduino/arduino-cli/blob/7ee4cf71c24798cd8400a54f2015bd7326062ad5/.github/workflows/publish-go-nightly-task.yml#L204

https://github.com/arduino/arduino-cli/blob/7ee4cf71c24798cd8400a54f2015bd7326062ad5/.github/workflows/release-go-task.yml#L204

This, even though it only requires the Windows x86-64 artifact. In addition to being inefficient, this was problematic because the `create-windows-installer` job is running in parallel with the `notarize-macos` job, which modifies the macOS artifacts. In order to fix a bug in the workflow, the `notarize-macos` job was recently changed (https://github.com/arduino/arduino-cli/pull/2732) to delete the non-notarized macOS artifacts after downloading them so that the job could replace those artifacts with the notarized builds:

https://github.com/arduino/arduino-cli/blob/7ee4cf71c24798cd8400a54f2015bd7326062ad5/.github/workflows/publish-go-nightly-task.yml#L102-L105

https://github.com/arduino/arduino-cli/blob/7ee4cf71c24798cd8400a54f2015bd7326062ad5/.github/workflows/release-go-task.yml#L102-L105

This caused the `create-windows-installer` job's download of the macOS artifacts to fail when it attempted to download them after the time the parallel `notarize-macos` job had deleted them (but before the `notarize-macos` job had uploaded the artifacts again):

https://github.com/arduino/arduino-cli/actions/runs/11647407075/job/32432652767#step:3:56

```text
Error: Unable to download artifact(s): Unable to download and extract artifact: Artifact download failed after 5 retries.
```

## What is the new behavior?

The proposed solution is to configure the `create-windows-installe`" job to only download the artifact it requires. This artifact is not modified by any parallel job so there is no danger of a conflict.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.

## Other information

In order to facilitate the review, I modified the workflows so that they would not publish a release (historically I would have performed a full release in my own fork to demonstrate such a proposal, but the workflows are now utterly hostile to testing by contributors due to the new Windows signing certificate system) and triggered a run of each:

### "Publish Nightly Build" workflow

https://github.com/arduino/arduino-cli/actions/runs/11648945583

The generated Windows Installer artifact can be downloaded from the "Artifacts" section of the page.

### "Release" workflow

https://github.com/arduino/arduino-cli/actions/runs/11648942575

In this run, the Windows Installer generation step failed spuriously due to the workflow not having been triggered by a tag as intended (I didn't want to push a tag to Arduino's repo so I configured the workflow to be triggered by the `push` event instead):

https://github.com/arduino/arduino-cli/actions/runs/11648942575/job/32435926970#step:5:37

```text
  C:\actions-runner\_work\arduino-cli\arduino-cli\installer\cli.wxs(19): error CNDL0108: The Product/@Version attribute's value, 'git', is not a valid version.  Legal version values should look like 'x.x.x.x' where x is an integer from 0 to 65534. [C:\actions-runner\_work\arduino-cli\arduino-cli\installer\cli.wixproj]
```

However, you can see that the previously failing "Download artifacts" is now successful:

https://github.com/arduino/arduino-cli/actions/runs/11648942575/job/32435926970#step:3:1
