### PR TITLE
Allow use of a dependency helper source file during library detection

### DIFF
--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -239,3 +239,14 @@ func (library *Library) SourceHeaders() ([]string, error) {
 	}
 	return library.sourceHeaders, nil
 }
+
+// DependencyHelper returns the path to the dependency helper file.
+func (library *Library) DependencyHelper() *paths.Path {
+	if c := library.SourceDir.Join("arduino_deps.c"); c.Exist() {
+		return c
+	}
+	if cpp := library.SourceDir.Join("arduino_deps.cpp"); cpp.Exist() {
+		return cpp
+	}
+	return nil
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This is a tentative implementation for a strategy to increase the speed of the library discovery phase.
The idea behind this PR is to add a helper file in a library, called `arduino_deps.cpp` (or `arduino_deps.c`), whose only purpose is to `#include` the required dependencies. If the Arduino CLI finds the helper the library detection process is performed only on that file, skipping all the other source files (that may be a lot...).

Advantages:
* It will correctly handle conditional includes (inside ifdefs).
* It must be maintained with the source code, otherwise, the library will fail to compile (differently from the `dependencies` field in the `library.properties` that may become outdated if the author is not precise).
* If a library has a lot of source files, the speed-up may be dramatic.

Disadvantages:
* It requires action from lib authors to write an `arduino_deps.cpp`.
* Writing a correct `arduino_deps.cpp` may be tricky.
* An incorrect `arduino_deps.cpp` may result in difficult-to-diagnose "missing include X.h" errors (that could be a workaround by including X.h in the user sketch)

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

This may be combined with #2625 for even better performance gain