### PR TITLE
Fixed protoc.zip release artifact missing `google/rpc/status.proto`

### DIFF
--- a/.github/workflows/check-protobuf-task.yml
+++ b/.github/workflows/check-protobuf-task.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: bufbuild/buf-action@v1
+      - name: Install buf
+        uses: bufbuild/buf-action@v1
         with:
           setup_only: true
 

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -265,6 +265,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install buf
+        uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+
       - name: Collect proto files
         env:
           NIGHTLY: true

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -127,6 +127,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install buf
+        uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+
       - name: Build
         run: |
           PACKAGE_NAME_PREFIX=${{ needs.package-name-prefix.outputs.prefix }}

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -265,6 +265,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install buf
+        uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+
       - name: Collect proto files
         run: task protoc:collect
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -258,10 +258,10 @@ tasks:
 
   protoc:collect:
     desc: Create a zip file containing all .proto files in DIST_DIR
-    dir: rpc
     cmds:
-      - mkdir --parents ../{{.DIST_DIR}}
-      - zip -r ../{{.DIST_DIR}}/{{.PROJECT_NAME}}_{{.VERSION}}_proto.zip  * -i \*.proto
+      - mkdir --parents {{.DIST_DIR}}
+      - buf export . -o {{.DIST_DIR}}/proto
+      - cd {{.DIST_DIR}}/proto && zip -r ../{{.PROJECT_NAME}}_{{.VERSION}}_proto.zip .
 
   protoc:format:
     desc: Perform formatting of the protobuf definitions


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

It uses the `buf export` function to produce the protoc.zip artifact content. `buf` will automatically include all the dependencies.

## What is the current behavior?

The export was missing the `google/rpc/status.proto`

## What is the new behavior?

Future exports will have the missing `google/rpc/status.proto` file again.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Fix #2755