### PR TITLE
Expose golang `fqbn` package for public use

### DIFF
--- a/commands/service_board_details.go
+++ b/commands/service_board_details.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/arduino/arduino-cli/commands/cmderrors"
 	"github.com/arduino/arduino-cli/commands/internal/instances"
-	"github.com/arduino/arduino-cli/internal/arduino/cores"
 	"github.com/arduino/arduino-cli/internal/arduino/utils"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
@@ -34,7 +34,7 @@ func (s *arduinoCoreServerImpl) BoardDetails(ctx context.Context, req *rpc.Board
 	}
 	defer release()
 
-	fqbn, err := cores.ParseFQBN(req.GetFqbn())
+	fqbn, err := fqbn.Parse(req.GetFqbn())
 	if err != nil {
 		return nil, &cmderrors.InvalidFQBNError{Cause: err}
 	}
@@ -48,7 +48,7 @@ func (s *arduinoCoreServerImpl) BoardDetails(ctx context.Context, req *rpc.Board
 	details.Name = board.Name()
 	details.Fqbn = board.FQBN()
 	details.PropertiesId = board.BoardID
-	details.Official = fqbn.Package == "arduino"
+	details.Official = fqbn.Packager == "arduino"
 	details.Version = board.PlatformRelease.Version.String()
 	details.IdentificationProperties = []*rpc.BoardIdentificationProperties{}
 	for _, p := range board.GetIdentificationProperties() {

--- a/commands/service_board_list.go
+++ b/commands/service_board_list.go
@@ -30,11 +30,11 @@ import (
 	"github.com/arduino/arduino-cli/commands/cmderrors"
 	"github.com/arduino/arduino-cli/commands/internal/instances"
 	f "github.com/arduino/arduino-cli/internal/algorithms"
-	"github.com/arduino/arduino-cli/internal/arduino/cores"
 	"github.com/arduino/arduino-cli/internal/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/internal/cli/configuration"
 	"github.com/arduino/arduino-cli/internal/i18n"
 	"github.com/arduino/arduino-cli/internal/inventory"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-properties-orderedmap"
 	discovery "github.com/arduino/pluggable-discovery-protocol-handler/v2"
@@ -148,7 +148,7 @@ func identify(pme *packagemanager.Explorer, port *discovery.Port, settings *conf
 	// first query installed cores through the Package Manager
 	logrus.Debug("Querying installed cores for board identification...")
 	for _, board := range pme.IdentifyBoard(port.Properties) {
-		fqbn, err := cores.ParseFQBN(board.FQBN())
+		fqbn, err := fqbn.Parse(board.FQBN())
 		if err != nil {
 			return nil, &cmderrors.InvalidFQBNError{Cause: err}
 		}
@@ -210,10 +210,10 @@ func (s *arduinoCoreServerImpl) BoardList(ctx context.Context, req *rpc.BoardLis
 	}
 	defer release()
 
-	var fqbnFilter *cores.FQBN
+	var fqbnFilter *fqbn.FQBN
 	if f := req.GetFqbn(); f != "" {
 		var err error
-		fqbnFilter, err = cores.ParseFQBN(f)
+		fqbnFilter, err = fqbn.Parse(f)
 		if err != nil {
 			return nil, &cmderrors.InvalidFQBNError{Cause: err}
 		}
@@ -247,9 +247,9 @@ func (s *arduinoCoreServerImpl) BoardList(ctx context.Context, req *rpc.BoardLis
 	}, nil
 }
 
-func hasMatchingBoard(b *rpc.DetectedPort, fqbnFilter *cores.FQBN) bool {
+func hasMatchingBoard(b *rpc.DetectedPort, fqbnFilter *fqbn.FQBN) bool {
 	for _, detectedBoard := range b.GetMatchingBoards() {
-		detectedFqbn, err := cores.ParseFQBN(detectedBoard.GetFqbn())
+		detectedFqbn, err := fqbn.Parse(detectedBoard.GetFqbn())
 		if err != nil {
 			continue
 		}

--- a/commands/service_compile.go
+++ b/commands/service_compile.go
@@ -28,13 +28,13 @@ import (
 	"github.com/arduino/arduino-cli/commands/cmderrors"
 	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/internal/arduino/builder"
-	"github.com/arduino/arduino-cli/internal/arduino/cores"
 	"github.com/arduino/arduino-cli/internal/arduino/libraries/librariesmanager"
 	"github.com/arduino/arduino-cli/internal/arduino/sketch"
 	"github.com/arduino/arduino-cli/internal/arduino/utils"
 	"github.com/arduino/arduino-cli/internal/buildcache"
 	"github.com/arduino/arduino-cli/internal/i18n"
 	"github.com/arduino/arduino-cli/internal/inventory"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	paths "github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
@@ -116,7 +116,7 @@ func (s *arduinoCoreServerImpl) Compile(req *rpc.CompileRequest, stream rpc.Ardu
 		return &cmderrors.MissingFQBNError{}
 	}
 
-	fqbn, err := cores.ParseFQBN(fqbnIn)
+	fqbn, err := fqbn.Parse(fqbnIn)
 	if err != nil {
 		return &cmderrors.InvalidFQBNError{Cause: err}
 	}
@@ -124,7 +124,7 @@ func (s *arduinoCoreServerImpl) Compile(req *rpc.CompileRequest, stream rpc.Ardu
 	if err != nil {
 		if targetPlatform == nil {
 			return &cmderrors.PlatformNotFoundError{
-				Platform: fmt.Sprintf("%s:%s", fqbn.Package, fqbn.PlatformArch),
+				Platform: fmt.Sprintf("%s:%s", fqbn.Packager, fqbn.Architecture),
 				Cause:    errors.New(i18n.Tr("platform not installed")),
 			}
 		}

--- a/commands/service_debug_config.go
+++ b/commands/service_debug_config.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/arduino/arduino-cli/commands/cmderrors"
 	"github.com/arduino/arduino-cli/commands/internal/instances"
-	"github.com/arduino/arduino-cli/internal/arduino/cores"
 	"github.com/arduino/arduino-cli/internal/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/internal/arduino/sketch"
 	"github.com/arduino/arduino-cli/internal/i18n"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
@@ -76,7 +76,7 @@ func (s *arduinoCoreServerImpl) IsDebugSupported(ctx context.Context, req *rpc.I
 
 	// Compute the minimum FQBN required to get the same debug configuration.
 	// (i.e. the FQBN cleaned up of the options that do not affect the debugger configuration)
-	minimumFQBN := cores.MustParseFQBN(req.GetFqbn())
+	minimumFQBN := fqbn.MustParse(req.GetFqbn())
 	for _, config := range minimumFQBN.Configs.Keys() {
 		checkFQBN := minimumFQBN.Clone()
 		checkFQBN.Configs.Remove(config)
@@ -127,7 +127,7 @@ func (s *arduinoCoreServerImpl) getDebugProperties(req *rpc.GetDebugConfigReques
 	if fqbnIn == "" {
 		return nil, &cmderrors.MissingFQBNError{}
 	}
-	fqbn, err := cores.ParseFQBN(fqbnIn)
+	fqbn, err := fqbn.Parse(fqbnIn)
 	if err != nil {
 		return nil, &cmderrors.InvalidFQBNError{Cause: err}
 	}

--- a/commands/service_monitor.go
+++ b/commands/service_monitor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/arduino/arduino-cli/internal/arduino/cores/packagemanager"
 	pluggableMonitor "github.com/arduino/arduino-cli/internal/arduino/monitor"
 	"github.com/arduino/arduino-cli/internal/i18n"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-properties-orderedmap"
 	"github.com/djherbis/buffer"
@@ -237,7 +238,7 @@ func (s *arduinoCoreServerImpl) Monitor(stream rpc.ArduinoCoreService_MonitorSer
 	return nil
 }
 
-func findMonitorAndSettingsForProtocolAndBoard(pme *packagemanager.Explorer, protocol, fqbn string) (*pluggableMonitor.PluggableMonitor, *properties.Map, error) {
+func findMonitorAndSettingsForProtocolAndBoard(pme *packagemanager.Explorer, protocol, fqbnIn string) (*pluggableMonitor.PluggableMonitor, *properties.Map, error) {
 	if protocol == "" {
 		return nil, nil, &cmderrors.MissingPortProtocolError{}
 	}
@@ -246,8 +247,8 @@ func findMonitorAndSettingsForProtocolAndBoard(pme *packagemanager.Explorer, pro
 	boardSettings := properties.NewMap()
 
 	// If a board is specified search the monitor in the board package first
-	if fqbn != "" {
-		fqbn, err := cores.ParseFQBN(fqbn)
+	if fqbnIn != "" {
+		fqbn, err := fqbn.Parse(fqbnIn)
 		if err != nil {
 			return nil, nil, &cmderrors.InvalidFQBNError{Cause: err}
 		}

--- a/commands/service_upload.go
+++ b/commands/service_upload.go
@@ -32,6 +32,7 @@ import (
 	"github.com/arduino/arduino-cli/internal/arduino/globals"
 	"github.com/arduino/arduino-cli/internal/arduino/sketch"
 	"github.com/arduino/arduino-cli/internal/i18n"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	paths "github.com/arduino/go-paths-helper"
 	properties "github.com/arduino/go-properties-orderedmap"
@@ -53,7 +54,7 @@ func (s *arduinoCoreServerImpl) SupportedUserFields(ctx context.Context, req *rp
 	}
 	defer release()
 
-	fqbn, err := cores.ParseFQBN(req.GetFqbn())
+	fqbn, err := fqbn.Parse(req.GetFqbn())
 	if err != nil {
 		return nil, &cmderrors.InvalidFQBNError{Cause: err}
 	}
@@ -61,7 +62,7 @@ func (s *arduinoCoreServerImpl) SupportedUserFields(ctx context.Context, req *rp
 	_, platformRelease, _, boardProperties, _, err := pme.ResolveFQBN(fqbn)
 	if platformRelease == nil {
 		return nil, &cmderrors.PlatformNotFoundError{
-			Platform: fmt.Sprintf("%s:%s", fqbn.Package, fqbn.PlatformArch),
+			Platform: fmt.Sprintf("%s:%s", fqbn.Packager, fqbn.Architecture),
 			Cause:    err,
 		}
 	} else if err != nil {
@@ -282,7 +283,7 @@ func (s *arduinoCoreServerImpl) runProgramAction(ctx context.Context, pme *packa
 		return nil, &cmderrors.MissingProgrammerError{}
 	}
 
-	fqbn, err := cores.ParseFQBN(fqbnIn)
+	fqbn, err := fqbn.Parse(fqbnIn)
 	if err != nil {
 		return nil, &cmderrors.InvalidFQBNError{Cause: err}
 	}
@@ -292,7 +293,7 @@ func (s *arduinoCoreServerImpl) runProgramAction(ctx context.Context, pme *packa
 	_, boardPlatform, board, boardProperties, buildPlatform, err := pme.ResolveFQBN(fqbn)
 	if boardPlatform == nil {
 		return nil, &cmderrors.PlatformNotFoundError{
-			Platform: fmt.Sprintf("%s:%s", fqbn.Package, fqbn.PlatformArch),
+			Platform: fmt.Sprintf("%s:%s", fqbn.Packager, fqbn.Architecture),
 			Cause:    err,
 		}
 	} else if err != nil {

--- a/commands/service_upload_list_programmers.go
+++ b/commands/service_upload_list_programmers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/arduino/arduino-cli/commands/cmderrors"
 	"github.com/arduino/arduino-cli/commands/internal/instances"
 	"github.com/arduino/arduino-cli/internal/arduino/cores"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 )
 
@@ -36,7 +37,7 @@ func (s *arduinoCoreServerImpl) ListProgrammersAvailableForUpload(ctx context.Co
 	if fqbnIn == "" {
 		return nil, &cmderrors.MissingFQBNError{}
 	}
-	fqbn, err := cores.ParseFQBN(fqbnIn)
+	fqbn, err := fqbn.Parse(fqbnIn)
 	if err != nil {
 		return nil, &cmderrors.InvalidFQBNError{Cause: err}
 	}

--- a/commands/service_upload_test.go
+++ b/commands/service_upload_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/arduino/arduino-cli/internal/arduino/cores"
 	"github.com/arduino/arduino-cli/internal/arduino/cores/packagemanager"
 	"github.com/arduino/arduino-cli/internal/arduino/sketch"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	paths "github.com/arduino/go-paths-helper"
 	properties "github.com/arduino/go-properties-orderedmap"
@@ -60,7 +61,7 @@ func TestDetermineBuildPathAndSketchName(t *testing.T) {
 		importFile    string
 		importDir     string
 		sketch        *sketch.Sketch
-		fqbn          *cores.FQBN
+		fqbn          *fqbn.FQBN
 		resBuildPath  string
 		resSketchName string
 	}
@@ -68,7 +69,7 @@ func TestDetermineBuildPathAndSketchName(t *testing.T) {
 	blonk, err := sketch.New(paths.New("testdata/upload/Blonk"))
 	require.NoError(t, err)
 
-	fqbn, err := cores.ParseFQBN("arduino:samd:mkr1000")
+	fqbn, err := fqbn.Parse("arduino:samd:mkr1000")
 	require.NoError(t, err)
 
 	srv := NewArduinoCoreServer().(*arduinoCoreServerImpl)

--- a/internal/arduino/builder/build_options_manager.go
+++ b/internal/arduino/builder/build_options_manager.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 
 	"github.com/arduino/arduino-cli/internal/arduino/builder/internal/utils"
-	"github.com/arduino/arduino-cli/internal/arduino/cores"
 	"github.com/arduino/arduino-cli/internal/arduino/sketch"
 	"github.com/arduino/arduino-cli/internal/i18n"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	"github.com/arduino/go-paths-helper"
 	properties "github.com/arduino/go-properties-orderedmap"
 )
@@ -51,7 +51,7 @@ func newBuildOptions(
 	builtInLibrariesDirs, buildPath *paths.Path,
 	sketch *sketch.Sketch,
 	customBuildProperties []string,
-	fqbn *cores.FQBN,
+	fqbn *fqbn.FQBN,
 	clean bool,
 	compilerOptimizationFlags string,
 	runtimePlatformPath, buildCorePath *paths.Path,

--- a/internal/arduino/builder/builder.go
+++ b/internal/arduino/builder/builder.go
@@ -35,6 +35,7 @@ import (
 	"github.com/arduino/arduino-cli/internal/arduino/libraries/librariesmanager"
 	"github.com/arduino/arduino-cli/internal/arduino/sketch"
 	"github.com/arduino/arduino-cli/internal/i18n"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
@@ -127,7 +128,7 @@ func NewBuilder(
 	requestBuildProperties []string,
 	hardwareDirs, otherLibrariesDirs paths.PathList,
 	builtInLibrariesDirs *paths.Path,
-	fqbn *cores.FQBN,
+	fqbn *fqbn.FQBN,
 	clean bool,
 	sourceOverrides map[string]string,
 	onlyUpdateCompilationDatabase bool,

--- a/internal/arduino/cores/board.go
+++ b/internal/arduino/cores/board.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/arduino/arduino-cli/internal/i18n"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	"github.com/arduino/go-properties-orderedmap"
 )
 
@@ -124,7 +125,7 @@ func (b *Board) GetConfigOptionValues(option string) *properties.Map {
 
 // GetBuildProperties returns the build properties and the build
 // platform for the Board with the configuration passed as parameter.
-func (b *Board) GetBuildProperties(fqbn *FQBN) (*properties.Map, error) {
+func (b *Board) GetBuildProperties(fqbn *fqbn.FQBN) (*properties.Map, error) {
 	b.buildConfigOptionsStructures()
 
 	// Override default configs with user configs
@@ -161,7 +162,7 @@ func (b *Board) GetBuildProperties(fqbn *FQBN) (*properties.Map, error) {
 // "cpu=atmega2560".
 // FIXME: deprecated, use GetBuildProperties instead
 func (b *Board) GeneratePropertiesForConfiguration(config string) (*properties.Map, error) {
-	fqbn, err := ParseFQBN(b.String() + ":" + config)
+	fqbn, err := fqbn.Parse(b.String() + ":" + config)
 	if err != nil {
 		return nil, errors.New(i18n.Tr("parsing fqbn: %s", err))
 	}

--- a/internal/arduino/cores/packagemanager/package_manager_test.go
+++ b/internal/arduino/cores/packagemanager/package_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/arduino/arduino-cli/internal/arduino/cores"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
 	"github.com/stretchr/testify/require"
@@ -69,7 +70,7 @@ func TestResolveFQBN(t *testing.T) {
 
 	t.Run("NormalizeFQBN", func(t *testing.T) {
 		testNormalization := func(in, expected string) {
-			fqbn, err := cores.ParseFQBN(in)
+			fqbn, err := fqbn.Parse(in)
 			require.Nil(t, err)
 			require.NotNil(t, fqbn)
 			normalized, err := pme.NormalizeFQBN(fqbn)
@@ -92,7 +93,7 @@ func TestResolveFQBN(t *testing.T) {
 	})
 
 	t.Run("BoardAndBuildPropertiesArduinoUno", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("arduino:avr:uno")
+		fqbn, err := fqbn.Parse("arduino:avr:uno")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -113,7 +114,7 @@ func TestResolveFQBN(t *testing.T) {
 	})
 
 	t.Run("BoardAndBuildPropertiesArduinoMega", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("arduino:avr:mega")
+		fqbn, err := fqbn.Parse("arduino:avr:mega")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -129,7 +130,7 @@ func TestResolveFQBN(t *testing.T) {
 	})
 
 	t.Run("BoardAndBuildPropertiesArduinoMegaWithNonDefaultCpuOption", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("arduino:avr:mega:cpu=atmega1280")
+		fqbn, err := fqbn.Parse("arduino:avr:mega:cpu=atmega1280")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -147,7 +148,7 @@ func TestResolveFQBN(t *testing.T) {
 	})
 
 	t.Run("BoardAndBuildPropertiesArduinoMegaWithDefaultCpuOption", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("arduino:avr:mega:cpu=atmega2560")
+		fqbn, err := fqbn.Parse("arduino:avr:mega:cpu=atmega2560")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -167,7 +168,7 @@ func TestResolveFQBN(t *testing.T) {
 
 	t.Run("BoardAndBuildPropertiesForReferencedArduinoUno", func(t *testing.T) {
 		// Test a board referenced from the main AVR arduino platform
-		fqbn, err := cores.ParseFQBN("referenced:avr:uno")
+		fqbn, err := fqbn.Parse("referenced:avr:uno")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -185,7 +186,7 @@ func TestResolveFQBN(t *testing.T) {
 	})
 
 	t.Run("BoardAndBuildPropertiesForArduinoDue", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("arduino:sam:arduino_due_x")
+		fqbn, err := fqbn.Parse("arduino:sam:arduino_due_x")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -200,7 +201,7 @@ func TestResolveFQBN(t *testing.T) {
 	})
 
 	t.Run("BoardAndBuildPropertiesForCustomArduinoYun", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("my_avr_platform:avr:custom_yun")
+		fqbn, err := fqbn.Parse("my_avr_platform:avr:custom_yun")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -216,7 +217,7 @@ func TestResolveFQBN(t *testing.T) {
 	})
 
 	t.Run("BoardAndBuildPropertiesForWatterotCore", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("watterott:avr:attiny841:core=spencekonde,info=info")
+		fqbn, err := fqbn.Parse("watterott:avr:attiny841:core=spencekonde,info=info")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -234,7 +235,7 @@ func TestResolveFQBN(t *testing.T) {
 	t.Run("BoardAndBuildPropertiesForReferencedFeatherM0", func(t *testing.T) {
 		// Test a board referenced from the Adafruit SAMD core (this tests
 		// deriving where the package and core name are different)
-		fqbn, err := cores.ParseFQBN("referenced:samd:feather_m0")
+		fqbn, err := fqbn.Parse("referenced:samd:feather_m0")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -253,7 +254,7 @@ func TestResolveFQBN(t *testing.T) {
 
 	t.Run("BoardAndBuildPropertiesForNonExistentPackage", func(t *testing.T) {
 		// Test a board referenced from a non-existent package
-		fqbn, err := cores.ParseFQBN("referenced:avr:dummy_invalid_package")
+		fqbn, err := fqbn.Parse("referenced:avr:dummy_invalid_package")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -270,7 +271,7 @@ func TestResolveFQBN(t *testing.T) {
 
 	t.Run("BoardAndBuildPropertiesForNonExistentArchitecture", func(t *testing.T) {
 		// Test a board referenced from a non-existent platform/architecture
-		fqbn, err := cores.ParseFQBN("referenced:avr:dummy_invalid_platform")
+		fqbn, err := fqbn.Parse("referenced:avr:dummy_invalid_platform")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -288,7 +289,7 @@ func TestResolveFQBN(t *testing.T) {
 	t.Run("BoardAndBuildPropertiesForNonExistentCore", func(t *testing.T) {
 		// Test a board referenced from a non-existent core
 		// Note that ResolveFQBN does not actually check this currently
-		fqbn, err := cores.ParseFQBN("referenced:avr:dummy_invalid_core")
+		fqbn, err := fqbn.Parse("referenced:avr:dummy_invalid_core")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -306,7 +307,7 @@ func TestResolveFQBN(t *testing.T) {
 	})
 
 	t.Run("AddBuildBoardPropertyIfMissing", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("my_avr_platform:avr:mymega")
+		fqbn, err := fqbn.Parse("my_avr_platform:avr:mymega")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -324,7 +325,7 @@ func TestResolveFQBN(t *testing.T) {
 	})
 
 	t.Run("AddBuildBoardPropertyIfNotMissing", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("my_avr_platform:avr:mymega:cpu=atmega1280")
+		fqbn, err := fqbn.Parse("my_avr_platform:avr:mymega:cpu=atmega1280")
 		require.Nil(t, err)
 		require.NotNil(t, fqbn)
 		pkg, platformRelease, board, props, buildPlatformRelease, err := pme.ResolveFQBN(fqbn)
@@ -813,7 +814,7 @@ func TestLegacyPackageConversionToPluggableDiscovery(t *testing.T) {
 	defer release()
 
 	{
-		fqbn, err := cores.ParseFQBN("esp32:esp32:esp32")
+		fqbn, err := fqbn.Parse("esp32:esp32:esp32")
 		require.NoError(t, err)
 		require.NotNil(t, fqbn)
 		_, platformRelease, board, _, _, err := pme.ResolveFQBN(fqbn)
@@ -836,7 +837,7 @@ func TestLegacyPackageConversionToPluggableDiscovery(t *testing.T) {
 		require.Equal(t, "{network_cmd} -i \"{upload.port.address}\" -p \"{upload.port.properties.port}\" \"--auth={upload.field.password}\" -f \"{build.path}/{build.project_name}.bin\"", platformProps.Get("tools.esptool__pluggable_network.upload.pattern"))
 	}
 	{
-		fqbn, err := cores.ParseFQBN("esp8266:esp8266:generic")
+		fqbn, err := fqbn.Parse("esp8266:esp8266:generic")
 		require.NoError(t, err)
 		require.NotNil(t, fqbn)
 		_, platformRelease, board, _, _, err := pme.ResolveFQBN(fqbn)
@@ -858,7 +859,7 @@ func TestLegacyPackageConversionToPluggableDiscovery(t *testing.T) {
 		require.Equal(t, "\"{network_cmd}\" -I \"{runtime.platform.path}/tools/espota.py\" -i \"{upload.port.address}\" -p \"{upload.port.properties.port}\" \"--auth={upload.field.password}\" -f \"{build.path}/{build.project_name}.bin\"", platformProps.Get("tools.esptool__pluggable_network.upload.pattern"))
 	}
 	{
-		fqbn, err := cores.ParseFQBN("arduino:avr:uno")
+		fqbn, err := fqbn.Parse("arduino:avr:uno")
 		require.NoError(t, err)
 		require.NotNil(t, fqbn)
 		_, platformRelease, board, _, _, err := pme.ResolveFQBN(fqbn)
@@ -888,7 +889,7 @@ func TestVariantAndCoreSelection(t *testing.T) {
 
 	// build.core test suite
 	t.Run("CoreWithoutSubstitutions", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("test2:avr:test")
+		fqbn, err := fqbn.Parse("test2:avr:test")
 		require.NoError(t, err)
 		require.NotNil(t, fqbn)
 		_, _, _, buildProps, _, err := pme.ResolveFQBN(fqbn)
@@ -897,7 +898,7 @@ func TestVariantAndCoreSelection(t *testing.T) {
 		requireSameFile(buildProps.GetPath("build.core.path"), dataDir1.Join("packages", "test2", "hardware", "avr", "1.0.0", "cores", "arduino"))
 	})
 	t.Run("CoreWithSubstitutions", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("test2:avr:test2")
+		fqbn, err := fqbn.Parse("test2:avr:test2")
 		require.NoError(t, err)
 		require.NotNil(t, fqbn)
 		_, _, _, buildProps, _, err := pme.ResolveFQBN(fqbn)
@@ -907,7 +908,7 @@ func TestVariantAndCoreSelection(t *testing.T) {
 		requireSameFile(buildProps.GetPath("build.core.path"), dataDir1.Join("packages", "test2", "hardware", "avr", "1.0.0", "cores", "arduino"))
 	})
 	t.Run("CoreWithSubstitutionsAndDefaultOption", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("test2:avr:test3")
+		fqbn, err := fqbn.Parse("test2:avr:test3")
 		require.NoError(t, err)
 		require.NotNil(t, fqbn)
 		_, _, _, buildProps, _, err := pme.ResolveFQBN(fqbn)
@@ -917,7 +918,7 @@ func TestVariantAndCoreSelection(t *testing.T) {
 		requireSameFile(buildProps.GetPath("build.core.path"), dataDir1.Join("packages", "test2", "hardware", "avr", "1.0.0", "cores", "arduino"))
 	})
 	t.Run("CoreWithSubstitutionsAndNonDefaultOption", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("test2:avr:test3:core=referenced")
+		fqbn, err := fqbn.Parse("test2:avr:test3:core=referenced")
 		require.NoError(t, err)
 		require.NotNil(t, fqbn)
 		_, _, _, buildProps, _, err := pme.ResolveFQBN(fqbn)
@@ -929,7 +930,7 @@ func TestVariantAndCoreSelection(t *testing.T) {
 
 	// build.variant test suite
 	t.Run("VariantWithoutSubstitutions", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("test2:avr:test4")
+		fqbn, err := fqbn.Parse("test2:avr:test4")
 		require.NoError(t, err)
 		require.NotNil(t, fqbn)
 		_, _, _, buildProps, _, err := pme.ResolveFQBN(fqbn)
@@ -938,7 +939,7 @@ func TestVariantAndCoreSelection(t *testing.T) {
 		requireSameFile(buildProps.GetPath("build.variant.path"), dataDir1.Join("packages", "test2", "hardware", "avr", "1.0.0", "variants", "standard"))
 	})
 	t.Run("VariantWithSubstitutions", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("test2:avr:test5")
+		fqbn, err := fqbn.Parse("test2:avr:test5")
 		require.NoError(t, err)
 		require.NotNil(t, fqbn)
 		_, _, _, buildProps, _, err := pme.ResolveFQBN(fqbn)
@@ -948,7 +949,7 @@ func TestVariantAndCoreSelection(t *testing.T) {
 		requireSameFile(buildProps.GetPath("build.variant.path"), dataDir1.Join("packages", "test2", "hardware", "avr", "1.0.0", "variants", "standard"))
 	})
 	t.Run("VariantWithSubstitutionsAndDefaultOption", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("test2:avr:test6")
+		fqbn, err := fqbn.Parse("test2:avr:test6")
 		require.NoError(t, err)
 		require.NotNil(t, fqbn)
 		_, _, _, buildProps, _, err := pme.ResolveFQBN(fqbn)
@@ -958,7 +959,7 @@ func TestVariantAndCoreSelection(t *testing.T) {
 		requireSameFile(buildProps.GetPath("build.variant.path"), dataDir1.Join("packages", "test2", "hardware", "avr", "1.0.0", "variants", "standard"))
 	})
 	t.Run("VariantWithSubstitutionsAndNonDefaultOption", func(t *testing.T) {
-		fqbn, err := cores.ParseFQBN("test2:avr:test6:variant=referenced")
+		fqbn, err := fqbn.Parse("test2:avr:test6:variant=referenced")
 		require.NoError(t, err)
 		require.NotNil(t, fqbn)
 		_, _, _, buildProps, _, err := pme.ResolveFQBN(fqbn)

--- a/internal/cli/board/list.go
+++ b/internal/cli/board/list.go
@@ -24,13 +24,13 @@ import (
 
 	"github.com/arduino/arduino-cli/commands"
 	"github.com/arduino/arduino-cli/commands/cmderrors"
-	"github.com/arduino/arduino-cli/internal/arduino/cores"
 	"github.com/arduino/arduino-cli/internal/cli/arguments"
 	"github.com/arduino/arduino-cli/internal/cli/feedback"
 	"github.com/arduino/arduino-cli/internal/cli/feedback/result"
 	"github.com/arduino/arduino-cli/internal/cli/feedback/table"
 	"github.com/arduino/arduino-cli/internal/cli/instance"
 	"github.com/arduino/arduino-cli/internal/i18n"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -159,9 +159,9 @@ func (dr listResult) String() string {
 				// to improve the user experience, show on a dedicated column
 				// the name of the core supporting the board detected
 				var coreName = ""
-				fqbn, err := cores.ParseFQBN(b.Fqbn)
+				fqbn, err := fqbn.Parse(b.Fqbn)
 				if err == nil {
-					coreName = fmt.Sprintf("%s:%s", fqbn.Package, fqbn.PlatformArch)
+					coreName = fmt.Sprintf("%s:%s", fqbn.Packager, fqbn.Architecture)
 				}
 
 				t.AddRow(address, protocol, protocolLabel, board, fqbn, coreName)
@@ -215,9 +215,9 @@ func (dr watchEventResult) String() string {
 			// to improve the user experience, show on a dedicated column
 			// the name of the core supporting the board detected
 			var coreName = ""
-			fqbn, err := cores.ParseFQBN(b.Fqbn)
+			fqbn, err := fqbn.Parse(b.Fqbn)
 			if err == nil {
-				coreName = fmt.Sprintf("%s:%s", fqbn.Package, fqbn.PlatformArch)
+				coreName = fmt.Sprintf("%s:%s", fqbn.Packager, fqbn.Architecture)
 			}
 
 			t.AddRow(address, protocol, event, board, fqbn, coreName)

--- a/pkg/fqbn/fqbn_test.go
+++ b/pkg/fqbn/fqbn_test.go
@@ -13,67 +13,68 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-package cores
+package fqbn_test
 
 import (
 	"testing"
 
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFQBN(t *testing.T) {
-	a, err := ParseFQBN("arduino:avr:uno")
+	a, err := fqbn.Parse("arduino:avr:uno")
 	require.Equal(t, "arduino:avr:uno", a.String())
 	require.NoError(t, err)
-	require.Equal(t, a.Package, "arduino")
-	require.Equal(t, a.PlatformArch, "avr")
+	require.Equal(t, a.Packager, "arduino")
+	require.Equal(t, a.Architecture, "avr")
 	require.Equal(t, a.BoardID, "uno")
 	require.Zero(t, a.Configs.Size())
 
 	// Allow empty platforms or packages (aka. vendors + architectures)
-	b1, err := ParseFQBN("arduino::uno")
+	b1, err := fqbn.Parse("arduino::uno")
 	require.Equal(t, "arduino::uno", b1.String())
 	require.NoError(t, err)
-	require.Equal(t, b1.Package, "arduino")
-	require.Equal(t, b1.PlatformArch, "")
+	require.Equal(t, b1.Packager, "arduino")
+	require.Equal(t, b1.Architecture, "")
 	require.Equal(t, b1.BoardID, "uno")
 	require.Zero(t, b1.Configs.Size())
 
-	b2, err := ParseFQBN(":avr:uno")
+	b2, err := fqbn.Parse(":avr:uno")
 	require.Equal(t, ":avr:uno", b2.String())
 	require.NoError(t, err)
-	require.Equal(t, b2.Package, "")
-	require.Equal(t, b2.PlatformArch, "avr")
+	require.Equal(t, b2.Packager, "")
+	require.Equal(t, b2.Architecture, "avr")
 	require.Equal(t, b2.BoardID, "uno")
 	require.Zero(t, b2.Configs.Size())
 
-	b3, err := ParseFQBN("::uno")
+	b3, err := fqbn.Parse("::uno")
 	require.Equal(t, "::uno", b3.String())
 	require.NoError(t, err)
-	require.Equal(t, b3.Package, "")
-	require.Equal(t, b3.PlatformArch, "")
+	require.Equal(t, b3.Packager, "")
+	require.Equal(t, b3.Architecture, "")
 	require.Equal(t, b3.BoardID, "uno")
 	require.Zero(t, b3.Configs.Size())
 
 	// Do not allow missing board identifier
-	_, err = ParseFQBN("arduino:avr:")
+	_, err = fqbn.Parse("arduino:avr:")
 	require.Error(t, err)
 
 	// Do not allow partial fqbn
-	_, err = ParseFQBN("arduino")
+	_, err = fqbn.Parse("arduino")
 	require.Error(t, err)
-	_, err = ParseFQBN("arduino:avr")
+	_, err = fqbn.Parse("arduino:avr")
 	require.Error(t, err)
 
 	// Keeps the config keys order
-	s1, err := ParseFQBN("arduino:avr:uno:d=x,b=x,a=x,e=x,c=x")
+	s1, err := fqbn.Parse("arduino:avr:uno:d=x,b=x,a=x,e=x,c=x")
 	require.NoError(t, err)
 	require.Equal(t, "arduino:avr:uno:d=x,b=x,a=x,e=x,c=x", s1.String())
 	require.Equal(t,
 		"properties.Map{\n  \"d\": \"x\",\n  \"b\": \"x\",\n  \"a\": \"x\",\n  \"e\": \"x\",\n  \"c\": \"x\",\n}",
 		s1.Configs.Dump())
 
-	s2, err := ParseFQBN("arduino:avr:uno:a=x,b=x,c=x,d=x,e=x")
+	s2, err := fqbn.Parse("arduino:avr:uno:a=x,b=x,c=x,d=x,e=x")
 	require.NoError(t, err)
 	require.Equal(t, "arduino:avr:uno:a=x,b=x,c=x,d=x,e=x", s2.String())
 	require.Equal(t,
@@ -85,53 +86,53 @@ func TestFQBN(t *testing.T) {
 	require.NotEqual(t, s1.String(), s2.String())
 
 	// Test configs
-	c, err := ParseFQBN("arduino:avr:uno:cpu=atmega")
+	c, err := fqbn.Parse("arduino:avr:uno:cpu=atmega")
 	require.Equal(t, "arduino:avr:uno:cpu=atmega", c.String())
 	require.NoError(t, err)
-	require.Equal(t, c.Package, "arduino")
-	require.Equal(t, c.PlatformArch, "avr")
+	require.Equal(t, c.Packager, "arduino")
+	require.Equal(t, c.Architecture, "avr")
 	require.Equal(t, c.BoardID, "uno")
 	require.Equal(t, "properties.Map{\n  \"cpu\": \"atmega\",\n}", c.Configs.Dump())
 
-	d, err := ParseFQBN("arduino:avr:uno:cpu=atmega,speed=1000")
+	d, err := fqbn.Parse("arduino:avr:uno:cpu=atmega,speed=1000")
 	require.Equal(t, "arduino:avr:uno:cpu=atmega,speed=1000", d.String())
 	require.NoError(t, err)
-	require.Equal(t, d.Package, "arduino")
-	require.Equal(t, d.PlatformArch, "avr")
+	require.Equal(t, d.Packager, "arduino")
+	require.Equal(t, d.Architecture, "avr")
 	require.Equal(t, d.BoardID, "uno")
 	require.Equal(t, "properties.Map{\n  \"cpu\": \"atmega\",\n  \"speed\": \"1000\",\n}", d.Configs.Dump())
 
 	// Do not allow empty keys or missing values in config
-	_, err = ParseFQBN("arduino:avr:uno:")
+	_, err = fqbn.Parse("arduino:avr:uno:")
 	require.Error(t, err)
-	_, err = ParseFQBN("arduino:avr:uno,")
+	_, err = fqbn.Parse("arduino:avr:uno,")
 	require.Error(t, err)
-	_, err = ParseFQBN("arduino:avr:uno:cpu")
+	_, err = fqbn.Parse("arduino:avr:uno:cpu")
 	require.Error(t, err)
-	_, err = ParseFQBN("arduino:avr:uno:=atmega")
+	_, err = fqbn.Parse("arduino:avr:uno:=atmega")
 	require.Error(t, err)
-	_, err = ParseFQBN("arduino:avr:uno:cpu=atmega,")
+	_, err = fqbn.Parse("arduino:avr:uno:cpu=atmega,")
 	require.Error(t, err)
-	_, err = ParseFQBN("arduino:avr:uno:cpu=atmega,speed")
+	_, err = fqbn.Parse("arduino:avr:uno:cpu=atmega,speed")
 	require.Error(t, err)
-	_, err = ParseFQBN("arduino:avr:uno:cpu=atmega,=1000")
+	_, err = fqbn.Parse("arduino:avr:uno:cpu=atmega,=1000")
 	require.Error(t, err)
 
 	// Allow keys with empty values
-	e, err := ParseFQBN("arduino:avr:uno:cpu=")
+	e, err := fqbn.Parse("arduino:avr:uno:cpu=")
 	require.Equal(t, "arduino:avr:uno:cpu=", e.String())
 	require.NoError(t, err)
-	require.Equal(t, e.Package, "arduino")
-	require.Equal(t, e.PlatformArch, "avr")
+	require.Equal(t, e.Packager, "arduino")
+	require.Equal(t, e.Architecture, "avr")
 	require.Equal(t, e.BoardID, "uno")
 	require.Equal(t, "properties.Map{\n  \"cpu\": \"\",\n}", e.Configs.Dump())
 
 	// Allow "=" in config values
-	f, err := ParseFQBN("arduino:avr:uno:cpu=atmega,speed=1000,extra=core=arduino")
+	f, err := fqbn.Parse("arduino:avr:uno:cpu=atmega,speed=1000,extra=core=arduino")
 	require.Equal(t, "arduino:avr:uno:cpu=atmega,speed=1000,extra=core=arduino", f.String())
 	require.NoError(t, err)
-	require.Equal(t, f.Package, "arduino")
-	require.Equal(t, f.PlatformArch, "avr")
+	require.Equal(t, f.Packager, "arduino")
+	require.Equal(t, f.Architecture, "avr")
 	require.Equal(t, f.BoardID, "uno")
 	require.Equal(t,
 		"properties.Map{\n  \"cpu\": \"atmega\",\n  \"speed\": \"1000\",\n  \"extra\": \"core=arduino\",\n}",
@@ -148,9 +149,9 @@ func TestMatch(t *testing.T) {
 	}
 
 	for _, pair := range expectedMatches {
-		a, err := ParseFQBN(pair[0])
+		a, err := fqbn.Parse(pair[0])
 		require.NoError(t, err)
-		b, err := ParseFQBN(pair[1])
+		b, err := fqbn.Parse(pair[1])
 		require.NoError(t, err)
 		require.True(t, b.Match(a))
 	}
@@ -164,9 +165,9 @@ func TestMatch(t *testing.T) {
 	}
 
 	for _, pair := range expectedMismatches {
-		a, err := ParseFQBN(pair[0])
+		a, err := fqbn.Parse(pair[0])
 		require.NoError(t, err)
-		b, err := ParseFQBN(pair[1])
+		b, err := fqbn.Parse(pair[1])
 		require.NoError(t, err)
 		require.False(t, b.Match(a))
 	}
@@ -175,14 +176,14 @@ func TestMatch(t *testing.T) {
 func TestValidCharacters(t *testing.T) {
 	// These FQBNs contain valid characters
 	validFqbns := []string{"ardui_no:av_r:un_o", "arduin.o:av.r:un.o", "arduin-o:av-r:un-o", "arduin-o:av-r:un-o:a=b=c=d"}
-	for _, fqbn := range validFqbns {
-		_, err := ParseFQBN(fqbn)
+	for _, validFqbn := range validFqbns {
+		_, err := fqbn.Parse(validFqbn)
 		require.NoError(t, err)
 	}
 	// These FQBNs contain invalid characters
 	invalidFqbns := []string{"arduin-o:av-r:un=o", "arduin?o:av-r:uno", "arduino:av*r:uno"}
-	for _, fqbn := range invalidFqbns {
-		_, err := ParseFQBN(fqbn)
+	for _, validFqbn := range invalidFqbns {
+		_, err := fqbn.Parse(validFqbn)
 		require.Error(t, err)
 	}
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This is a tentative design for exporting some of the internals of the Arduino CLI for reuse in other projects.

## What is the current behavior?

The `FQBN` struct is not exported.

## What is the new behavior?

The `FQBN` struct is exported through a public `fqbn` package.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

