### PR TITLE
improved regexp to also parse error messages with single quotes around header file name

### DIFF
--- a/internal/arduino/builder/internal/detector/detector.go
+++ b/internal/arduino/builder/internal/detector/detector.go
@@ -478,7 +478,7 @@ func (l *SketchLibrariesDetector) failIfImportedLibraryIsWrong() error {
 }
 
 // includeRegexp fixdoc
-var includeRegexp = regexp.MustCompile("(?ms)^\\s*#[ \t]*include\\s*[<\"](\\S+)[\">]")
+var includeRegexp = regexp.MustCompile(`(?ms)[<"'](\S+)[">']`)
 
 // IncludesFinderWithRegExp fixdoc
 func IncludesFinderWithRegExp(source string) string {


### PR DESCRIPTION
## What kind of change does this PR introduce?

this change improves the behavior of function `IncludesFinderWithRegExp` in `detector.go` by changing the regexp to also extract a library header file name. even when it is surrounded by single quotes.

background: when working on a board definition that uses the desktop gcc compiler, we found that the error message emitted, which is used to deduce a library header file name, failed to produce the desired result with the current regular expression. the desktop gcc compiler emits the error message surrounding the header file name with single quotes like this:

`g++`:

```
... fatal error: 'Foobar.h' file not found
    2 | #include <Foobar.h>
```

while other compilers, currently used in arduino board definitions, omit the single quotes and therefore can be processed correctly:

`avr-g++`:

```
... fatal error: Foobar.h: No such file or directory
 #include <Foobar.h>
```

`arm-none-eabi-g++`:

```
... fatal error: Foobar.h: No such file or directory
    2 | #include <Foobar.h>
```

riscv32-esp-elf-g++`:

```
... fatal error: Foobar.h: No such file or directory
    2 | #include <Foobar.h>
``` 

in order to address this issues we have changed the regular expression to the following:

```
var includeRegexp = regexp.MustCompile(`(?ms)[<"'](\S+)[">']`)
```

with this change error messages from all compilers are parsed correctly. 

this issues has been encountered with desktop gcc compiler on macOS :

```
$ gcc --version
Apple clang version 16.0.0 (clang-1600.0.26.6)
Target: arm64-apple-darwin24.1.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

as far as we know this PR does not introduce a breaking change. however, only four compilers have been tested.

PS the old regexp used to work on macOS until recently. apparently the error message emitted by desktop gcc on macOS has been changed, which broke the arduino header file name detection …