### PR TITLE
Add metadata retrieved from the `context` to the user agent when a new HTTP client is created

### DIFF
--- a/commands/instances.go
+++ b/commands/instances.go
@@ -43,6 +43,7 @@ import (
 	paths "github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -63,6 +64,11 @@ func installTool(ctx context.Context, pm *packagemanager.PackageManager, tool *c
 
 // Create a new Instance ready to be initialized, supporting directories are also created.
 func (s *arduinoCoreServerImpl) Create(ctx context.Context, req *rpc.CreateRequest) (*rpc.CreateResponse, error) {
+	var userAgent string
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		userAgent = strings.Join(md.Get("user-agent"), " ")
+	}
+
 	// Setup downloads directory
 	downloadsDir := s.settings.DownloadsDir()
 	if downloadsDir.NotExist() {
@@ -87,7 +93,7 @@ func (s *arduinoCoreServerImpl) Create(ctx context.Context, req *rpc.CreateReque
 	if err != nil {
 		return nil, err
 	}
-	inst, err := instances.Create(dataDir, packagesDir, userPackagesDir, downloadsDir, "", config)
+	inst, err := instances.Create(dataDir, packagesDir, userPackagesDir, downloadsDir, userAgent, config)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/service_board_identify_test.go
+++ b/commands/service_board_identify_test.go
@@ -16,6 +16,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func TestGetByVidPid(t *testing.T) {
 
 	vidPidURL = ts.URL
 	settings := configuration.NewSettings()
-	res, err := apiByVidPid("0xf420", "0XF069", settings)
+	res, err := apiByVidPid(context.Background(), "0xf420", "0XF069", settings)
 	require.Nil(t, err)
 	require.Len(t, res, 1)
 	require.Equal(t, "Arduino/Genuino MKR1000", res[0].GetName())
@@ -56,7 +57,7 @@ func TestGetByVidPid(t *testing.T) {
 
 	// wrong vid (too long), wrong pid (not an hex value)
 
-	_, err = apiByVidPid("0xfffff", "0xDEFG", settings)
+	_, err = apiByVidPid(context.Background(), "0xfffff", "0xDEFG", settings)
 	require.NotNil(t, err)
 }
 
@@ -69,7 +70,7 @@ func TestGetByVidPidNotFound(t *testing.T) {
 	defer ts.Close()
 
 	vidPidURL = ts.URL
-	res, err := apiByVidPid("0x0420", "0x0069", settings)
+	res, err := apiByVidPid(context.Background(), "0x0420", "0x0069", settings)
 	require.NoError(t, err)
 	require.Empty(t, res)
 }
@@ -84,7 +85,7 @@ func TestGetByVidPid5xx(t *testing.T) {
 	defer ts.Close()
 
 	vidPidURL = ts.URL
-	res, err := apiByVidPid("0x0420", "0x0069", settings)
+	res, err := apiByVidPid(context.Background(), "0x0420", "0x0069", settings)
 	require.NotNil(t, err)
 	require.Equal(t, "the server responded with status 500 Internal Server Error", err.Error())
 	require.Len(t, res, 0)
@@ -99,7 +100,7 @@ func TestGetByVidPidMalformedResponse(t *testing.T) {
 	defer ts.Close()
 
 	vidPidURL = ts.URL
-	res, err := apiByVidPid("0x0420", "0x0069", settings)
+	res, err := apiByVidPid(context.Background(), "0x0420", "0x0069", settings)
 	require.NotNil(t, err)
 	require.Equal(t, "wrong format in server response", err.Error())
 	require.Len(t, res, 0)
@@ -107,7 +108,7 @@ func TestGetByVidPidMalformedResponse(t *testing.T) {
 
 func TestBoardDetectionViaAPIWithNonUSBPort(t *testing.T) {
 	settings := configuration.NewSettings()
-	items, err := identifyViaCloudAPI(properties.NewMap(), settings)
+	items, err := identifyViaCloudAPI(context.Background(), properties.NewMap(), settings)
 	require.NoError(t, err)
 	require.Empty(t, items)
 }
@@ -156,7 +157,7 @@ func TestBoardIdentifySorting(t *testing.T) {
 	defer release()
 
 	settings := configuration.NewSettings()
-	res, err := identify(pme, idPrefs, settings, true)
+	res, err := identify(context.Background(), pme, idPrefs, settings, true)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Len(t, res, 4)

--- a/commands/service_check_for_updates.go
+++ b/commands/service_check_for_updates.go
@@ -43,7 +43,7 @@ func (s *arduinoCoreServerImpl) CheckForArduinoCLIUpdates(ctx context.Context, r
 		inventory.WriteStore()
 	}()
 
-	latestVersion, err := semver.Parse(s.getLatestRelease())
+	latestVersion, err := semver.Parse(s.getLatestRelease(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ func (s *arduinoCoreServerImpl) shouldCheckForUpdate(currentVersion *semver.Vers
 
 // getLatestRelease queries the official Arduino download server for the latest release,
 // if there are no errors or issues a version string is returned, in all other case an empty string.
-func (s *arduinoCoreServerImpl) getLatestRelease() string {
-	client, err := s.settings.NewHttpClient()
+func (s *arduinoCoreServerImpl) getLatestRelease(ctx context.Context) string {
+	client, err := s.settings.NewHttpClient(ctx)
 	if err != nil {
 		return ""
 	}

--- a/commands/service_library_download.go
+++ b/commands/service_library_download.go
@@ -82,11 +82,15 @@ func (s *arduinoCoreServerImpl) LibraryDownload(req *rpc.LibraryDownloadRequest,
 	})
 }
 
-func downloadLibrary(ctx context.Context, downloadsDir *paths.Path, libRelease *librariesindex.Release,
-	downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB, queryParameter string, settings *configuration.Settings) error {
-
+func downloadLibrary(
+	ctx context.Context,
+	downloadsDir *paths.Path, libRelease *librariesindex.Release,
+	downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB,
+	queryParameter string,
+	settings *configuration.Settings,
+) error {
 	taskCB(&rpc.TaskProgress{Name: i18n.Tr("Downloading %s", libRelease)})
-	config, err := settings.DownloaderConfig()
+	config, err := settings.DownloaderConfig(ctx)
 	if err != nil {
 		return &cmderrors.FailedDownloadError{Message: i18n.Tr("Can't download library"), Cause: err}
 	}

--- a/internal/arduino/resources/helpers_test.go
+++ b/internal/arduino/resources/helpers_test.go
@@ -55,7 +55,7 @@ func TestDownloadApplyUserAgentHeaderUsingConfig(t *testing.T) {
 
 	settings := configuration.NewSettings()
 	settings.Set("network.user_agent_ext", goldUserAgentValue)
-	config, err := settings.DownloaderConfig()
+	config, err := settings.DownloaderConfig(context.Background())
 	require.NoError(t, err)
 	err = r.Download(context.Background(), tmp, config, "", func(progress *rpc.DownloadProgress) {}, "")
 	require.NoError(t, err)

--- a/internal/cli/configuration/network_test.go
+++ b/internal/cli/configuration/network_test.go
@@ -16,6 +16,7 @@
 package configuration_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,7 +36,7 @@ func TestUserAgentHeader(t *testing.T) {
 
 	settings := configuration.NewSettings()
 	require.NoError(t, settings.Set("network.user_agent_ext", "test-user-agent"))
-	client, err := settings.NewHttpClient()
+	client, err := settings.NewHttpClient(context.Background())
 	require.NoError(t, err)
 
 	request, err := http.NewRequest("GET", ts.URL, nil)
@@ -59,7 +60,7 @@ func TestProxy(t *testing.T) {
 
 	settings := configuration.NewSettings()
 	settings.Set("network.proxy", ts.URL)
-	client, err := settings.NewHttpClient()
+	client, err := settings.NewHttpClient(context.Background())
 	require.NoError(t, err)
 
 	request, err := http.NewRequest("GET", "http://arduino.cc", nil)
@@ -83,7 +84,7 @@ func TestConnectionTimeout(t *testing.T) {
 		if timeout != 0 {
 			require.NoError(t, settings.Set("network.connection_timeout", "2s"))
 		}
-		client, err := settings.NewHttpClient()
+		client, err := settings.NewHttpClient(context.Background())
 		require.NoError(t, err)
 
 		request, err := http.NewRequest("GET", "http://arduino.cc", nil)

--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -123,13 +123,6 @@ func NewArduinoCliWithinEnvironment(env *Environment, config *ArduinoCLIConfig) 
 // It returns a testsuite.Environment and an ArduinoCLI client to perform the integration tests.
 // The Environment must be disposed by calling the CleanUp method via defer.
 func CreateEnvForDaemon(t *testing.T) (*Environment, *ArduinoCLI) {
-	return CreateEnvForDaemonWithUserAgent(t, "cli-test/0.0.0")
-}
-
-// CreateEnvForDaemonWithUserAgent performs the minimum required operations to start the arduino-cli daemon.
-// It returns a testsuite.Environment and an ArduinoCLI client to perform the integration tests.
-// The Environment must be disposed by calling the CleanUp method via defer.
-func CreateEnvForDaemonWithUserAgent(t *testing.T, userAgent string) (*Environment, *ArduinoCLI) {
 	env := NewEnvironment(t)
 
 	cli := NewArduinoCliWithinEnvironment(env, &ArduinoCLIConfig{
@@ -137,7 +130,7 @@ func CreateEnvForDaemonWithUserAgent(t *testing.T, userAgent string) (*Environme
 		UseSharedStagingFolder: true,
 	})
 
-	_ = cli.StartDaemon(false, userAgent)
+	_ = cli.StartDaemon(false)
 	return env, cli
 }
 
@@ -417,7 +410,7 @@ func (cli *ArduinoCLI) run(stdoutBuff, stderrBuff io.Writer, stdinBuff io.Reader
 }
 
 // StartDaemon starts the Arduino CLI daemon. It returns the address of the daemon.
-func (cli *ArduinoCLI) StartDaemon(verbose bool, userAgent string) string {
+func (cli *ArduinoCLI) StartDaemon(verbose bool) string {
 	args := []string{"daemon", "--json"}
 	if cli.cliConfigPath != nil {
 		args = append([]string{"--config-file", cli.cliConfigPath.String()}, args...)
@@ -460,7 +453,7 @@ func (cli *ArduinoCLI) StartDaemon(verbose bool, userAgent string) string {
 		conn, err := grpc.NewClient(
 			cli.daemonAddr,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithUserAgent(userAgent),
+			grpc.WithUserAgent("cli-test/0.0.0"),
 		)
 		if err != nil {
 			connErr = err

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -69,7 +69,7 @@ func TestCoreSearch(t *testing.T) {
 
 	// Set up an http server to serve our custom index file
 	test_index := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, test_index)
+	url := env.HTTPServeFile(8000, test_index, false)
 
 	// Run update-index with our test index
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -161,7 +161,7 @@ func TestCoreSearchNoArgs(t *testing.T) {
 
 	// Set up an http server to serve our custom index file
 	testIndex := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, testIndex)
+	url := env.HTTPServeFile(8000, testIndex, false)
 
 	// update custom index and install test core (installed cores affect `core search`)
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -749,7 +749,7 @@ func TestCoreSearchSortedResults(t *testing.T) {
 
 	// Set up the server to serve our custom index file
 	testIndex := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, testIndex)
+	url := env.HTTPServeFile(8000, testIndex, false)
 
 	// update custom index
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -821,7 +821,7 @@ func TestCoreListSortedResults(t *testing.T) {
 
 	// Set up the server to serve our custom index file
 	testIndex := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, testIndex)
+	url := env.HTTPServeFile(8000, testIndex, false)
 
 	// update custom index
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -892,7 +892,7 @@ func TestCoreListDeprecatedPlatformWithInstalledJson(t *testing.T) {
 
 	// Set up the server to serve our custom index file
 	testIndex := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, testIndex)
+	url := env.HTTPServeFile(8000, testIndex, false)
 
 	// update custom index
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -1110,8 +1110,8 @@ func TestCoreInstallRunsToolPostInstallScript(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
-	url := env.HTTPServeFile(8080, paths.New("testdata", "package_with_postinstall_index.json"))
-	env.HTTPServeFile(8081, paths.New("testdata", "core_with_postinst.zip"))
+	url := env.HTTPServeFile(8080, paths.New("testdata", "package_with_postinstall_index.json"), false)
+	env.HTTPServeFile(8081, paths.New("testdata", "core_with_postinst.zip"), false)
 
 	_, _, err := cli.Run("core", "update-index", "--additional-urls", url.String())
 	require.NoError(t, err)
@@ -1129,7 +1129,7 @@ func TestCoreBrokenDependency(t *testing.T) {
 
 	// Set up an http server to serve our custom index file
 	test_index := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, test_index)
+	url := env.HTTPServeFile(8000, test_index, false)
 
 	// Run update-index with our test index
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -1145,7 +1145,7 @@ func TestCoreUpgradeWarningWithPackageInstalledButNotIndexed(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
-	url := env.HTTPServeFile(8000, paths.New("..", "testdata", "test_index.json")).String()
+	url := env.HTTPServeFile(8000, paths.New("..", "testdata", "test_index.json"), false).String()
 
 	t.Run("missing additional-urls", func(t *testing.T) {
 		// update index
@@ -1187,7 +1187,7 @@ func TestCoreHavingIncompatibleDepTools(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
-	url := env.HTTPServeFile(8000, paths.New("..", "testdata", "test_index.json")).String()
+	url := env.HTTPServeFile(8000, paths.New("..", "testdata", "test_index.json"), false).String()
 	additionalURLs := "--additional-urls=" + url
 
 	_, _, err := cli.Run("core", "update-index", additionalURLs)

--- a/internal/integrationtest/core/core_test.go
+++ b/internal/integrationtest/core/core_test.go
@@ -69,7 +69,7 @@ func TestCoreSearch(t *testing.T) {
 
 	// Set up an http server to serve our custom index file
 	test_index := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, test_index, false)
+	url := env.HTTPServeFile(8000, test_index)
 
 	// Run update-index with our test index
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -161,7 +161,7 @@ func TestCoreSearchNoArgs(t *testing.T) {
 
 	// Set up an http server to serve our custom index file
 	testIndex := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, testIndex, false)
+	url := env.HTTPServeFile(8000, testIndex)
 
 	// update custom index and install test core (installed cores affect `core search`)
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -749,7 +749,7 @@ func TestCoreSearchSortedResults(t *testing.T) {
 
 	// Set up the server to serve our custom index file
 	testIndex := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, testIndex, false)
+	url := env.HTTPServeFile(8000, testIndex)
 
 	// update custom index
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -821,7 +821,7 @@ func TestCoreListSortedResults(t *testing.T) {
 
 	// Set up the server to serve our custom index file
 	testIndex := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, testIndex, false)
+	url := env.HTTPServeFile(8000, testIndex)
 
 	// update custom index
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -892,7 +892,7 @@ func TestCoreListDeprecatedPlatformWithInstalledJson(t *testing.T) {
 
 	// Set up the server to serve our custom index file
 	testIndex := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, testIndex, false)
+	url := env.HTTPServeFile(8000, testIndex)
 
 	// update custom index
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -1110,8 +1110,8 @@ func TestCoreInstallRunsToolPostInstallScript(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
-	url := env.HTTPServeFile(8080, paths.New("testdata", "package_with_postinstall_index.json"), false)
-	env.HTTPServeFile(8081, paths.New("testdata", "core_with_postinst.zip"), false)
+	url := env.HTTPServeFile(8080, paths.New("testdata", "package_with_postinstall_index.json"))
+	env.HTTPServeFile(8081, paths.New("testdata", "core_with_postinst.zip"))
 
 	_, _, err := cli.Run("core", "update-index", "--additional-urls", url.String())
 	require.NoError(t, err)
@@ -1129,7 +1129,7 @@ func TestCoreBrokenDependency(t *testing.T) {
 
 	// Set up an http server to serve our custom index file
 	test_index := paths.New("..", "testdata", "test_index.json")
-	url := env.HTTPServeFile(8000, test_index, false)
+	url := env.HTTPServeFile(8000, test_index)
 
 	// Run update-index with our test index
 	_, _, err := cli.Run("core", "update-index", "--additional-urls="+url.String())
@@ -1145,7 +1145,7 @@ func TestCoreUpgradeWarningWithPackageInstalledButNotIndexed(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
-	url := env.HTTPServeFile(8000, paths.New("..", "testdata", "test_index.json"), false).String()
+	url := env.HTTPServeFile(8000, paths.New("..", "testdata", "test_index.json")).String()
 
 	t.Run("missing additional-urls", func(t *testing.T) {
 		// update index
@@ -1187,7 +1187,7 @@ func TestCoreHavingIncompatibleDepTools(t *testing.T) {
 	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
 	defer env.CleanUp()
 
-	url := env.HTTPServeFile(8000, paths.New("..", "testdata", "test_index.json"), false).String()
+	url := env.HTTPServeFile(8000, paths.New("..", "testdata", "test_index.json")).String()
 	additionalURLs := "--additional-urls=" + url
 
 	_, _, err := cli.Run("core", "update-index", additionalURLs)

--- a/internal/integrationtest/http_server.go
+++ b/internal/integrationtest/http_server.go
@@ -26,18 +26,11 @@ import (
 
 // HTTPServeFile spawn an http server that serve a single file. The server
 // is started on the given port. The URL to the file and a cleanup function are returned.
-func (env *Environment) HTTPServeFile(port uint16, path *paths.Path, isDaemon bool) *url.URL {
+func (env *Environment) HTTPServeFile(port uint16, path *paths.Path) *url.URL {
 	t := env.T()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/"+path.Base(), func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, path.String())
-		if isDaemon {
-			// Test that the user-agent contains metadata from the context when the CLI is in daemon mode
-			userAgent := r.Header.Get("User-Agent")
-			require.Contains(t, userAgent, "arduino-cli/git-snapshot")
-			require.Contains(t, userAgent, "cli-test/0.0.0")
-			require.Contains(t, userAgent, "grpc-go")
-		}
 	})
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),

--- a/internal/integrationtest/http_server.go
+++ b/internal/integrationtest/http_server.go
@@ -33,7 +33,10 @@ func (env *Environment) HTTPServeFile(port uint16, path *paths.Path, isDaemon bo
 		http.ServeFile(w, r, path.String())
 		if isDaemon {
 			// Test that the user-agent contains metadata from the context when the CLI is in daemon mode
-			require.Contains(t, r.Header.Get("User-Agent"), "arduino-cli/git-snapshot grpc-go")
+			userAgent := r.Header.Get("User-Agent")
+			require.Contains(t, userAgent, "arduino-cli/git-snapshot")
+			require.Contains(t, userAgent, "cli-test/0.0.0")
+			require.Contains(t, userAgent, "grpc-go")
 		}
 	})
 	server := &http.Server{


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?
Bug fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
The user agent does not specify if the CLI runs in daemon mode. It is always something like `arduino-cli/git-snapshot (amd64; windows; go1.23.2) Commit:84fc413a`.
<!-- You can also link to an open issue here -->

## What is the new behavior?
The user agent obtained from the context metadata is propagated to the`network.user_agent_ext` if it's empty and the CLI runs in daemon mode. The complete user agent is `arduino-cli/git-snapshot arduino-ide/2.3.4 grpc-node-js/1.9.5 daemon (amd64; windows; go1.23.4) Commit:f3dc127e`.
<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
