### PR TITLE
fix: Sketch preprocessing errors were displayed on stdout instead of stderr

### DIFF
--- a/internal/arduino/builder/preprocess_sketch.go
+++ b/internal/arduino/builder/preprocess_sketch.go
@@ -32,7 +32,7 @@ func (b *Builder) preprocessSketch(includes paths.PathList) error {
 		if b.logger.Verbose() {
 			b.logger.WriteStdout(result.Stdout())
 		}
-		b.logger.WriteStdout(result.Stderr())
+		b.logger.WriteStderr(result.Stderr())
 		b.diagnosticStore.Parse(result.Args(), result.Stderr())
 	}
 

--- a/internal/integrationtest/compile_3/compile_test.go
+++ b/internal/integrationtest/compile_3/compile_test.go
@@ -107,7 +107,7 @@ func TestCompilerErrOutput(t *testing.T) {
 	_, _, err := cli.Run("core", "install", "arduino:avr@1.8.5")
 	require.NoError(t, err)
 
-	{
+	t.Run("Diagnostics", func(t *testing.T) {
 		// prepare sketch
 		sketch, err := paths.New("testdata", "blink_with_wrong_cpp").Abs()
 		require.NoError(t, err)
@@ -126,10 +126,11 @@ func TestCompilerErrOutput(t *testing.T) {
 			  "context": [ { "message": "In function 'void wrong()':" } ]
 			}
 		]`)
-	}
+	})
 
-	// Test the preprocessor errors are present in the diagnostics
-	{
+	t.Run("PreprocessorDiagnostics", func(t *testing.T) {
+		// Test the preprocessor errors are present in the diagnostics
+
 		// prepare sketch
 		sketch, err := paths.New("testdata", "blink_with_wrong_include").Abs()
 		require.NoError(t, err)
@@ -148,14 +149,15 @@ func TestCompilerErrOutput(t *testing.T) {
 			  "message": "invalid preprocessing directive #wrong\n #wrong\n  ^~~~~",
 			}
 		]`)
-	}
+	})
 
-	// Test the preprocessor errors are present in the diagnostics.
-	// In case we have 2 libraries:
-	// 1. one is missing
-	// 2. the other one is missing only from the first GCC run
-	// The diagnostics should report only 1 missing library.
-	{
+	t.Run("PreprocessorDiagnosticsWithLibErrors", func(t *testing.T) {
+		// Test the preprocessor errors are present in the diagnostics.
+		// In case we have 2 libraries:
+		// 1. one is missing
+		// 2. the other one is missing only from the first GCC run
+		// The diagnostics should report only 1 missing library.
+
 		// prepare sketch
 		sketch, err := paths.New("testdata", "using_Wire_with_missing_lib").Abs()
 		require.NoError(t, err)
@@ -175,11 +177,12 @@ func TestCompilerErrOutput(t *testing.T) {
 			  "column": 10,
 			}
 		]`)
-	}
+	})
 
-	// Check that library discover do not generate false errors
-	// https://github.com/arduino/arduino-cli/issues/2263
-	{
+	t.Run("LibraryDiscoverFalseErrors", func(t *testing.T) {
+		// Check that library discover do not generate false errors
+		// https://github.com/arduino/arduino-cli/issues/2263
+
 		// prepare sketch
 		sketch, err := paths.New("testdata", "using_Wire").Abs()
 		require.NoError(t, err)
@@ -191,7 +194,7 @@ func TestCompilerErrOutput(t *testing.T) {
 		jsonOut.Query(".compiler_out").MustNotContain(`"fatal error"`)
 		jsonOut.Query(".compiler_err").MustNotContain(`"fatal error"`)
 		jsonOut.MustNotContain(`{ "diagnostics" : [] }`)
-	}
+	})
 }
 
 func TestCompileRelativeLibraryPath(t *testing.T) {

--- a/internal/integrationtest/compile_3/testdata/blink_with_error_directive/blink_with_error_directive.ino
+++ b/internal/integrationtest/compile_3/testdata/blink_with_error_directive/blink_with_error_directive.ino
@@ -1,0 +1,1 @@
+#error void setup(){} void loop(){}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fix the error output during sketch preprocessing wrongly redirected to stdout instead of stderr.

## What is the current behavior?

```
$ arduino-cli compile -b arduino:avr:uno 
/home/megabug/Arduino/Blink/Blink.ino:1:2: error: #error eeee
 #error eeee
  ^~~~~
$ arduino-cli compile -b arduino:avr:uno 1> /dev/null 
Error during build: exit status 1
```

## What is the new behavior?

```
$ arduino-cli compile -b arduino:avr:uno 
/home/megabug/Arduino/Blink/Blink.ino:1:2: error: #error eeee
 #error eeee
  ^~~~~
$ arduino-cli compile -b arduino:avr:uno 1> /dev/null 
/home/megabug/Arduino/Blink/Blink.ino:1:2: error: #error eeee
 #error eeee
  ^~~~~
Error during build: exit status 1
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
