### PR TITLE
Fixed panic if malformed 3rd party url is specified

### DIFF
--- a/commands/instances.go
+++ b/commands/instances.go
@@ -534,9 +534,9 @@ func (s *arduinoCoreServerImpl) UpdateIndex(req *rpc.UpdateIndexRequest, stream 
 		return &cmderrors.InvalidInstanceError{}
 	}
 
-	report := func(indexURL *url.URL, status rpc.IndexUpdateReport_Status) *rpc.IndexUpdateReport {
+	report := func(indexURL string, status rpc.IndexUpdateReport_Status) *rpc.IndexUpdateReport {
 		return &rpc.IndexUpdateReport{
-			IndexUrl: indexURL.String(),
+			IndexUrl: indexURL,
 			Status:   status,
 		}
 	}
@@ -564,7 +564,7 @@ func (s *arduinoCoreServerImpl) UpdateIndex(req *rpc.UpdateIndexRequest, stream 
 			downloadCB.Start(u, i18n.Tr("Downloading index: %s", u))
 			downloadCB.End(false, msg)
 			failed = true
-			result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(URL, rpc.IndexUpdateReport_STATUS_FAILED))
+			result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(u, rpc.IndexUpdateReport_STATUS_FAILED))
 			continue
 		}
 
@@ -582,9 +582,9 @@ func (s *arduinoCoreServerImpl) UpdateIndex(req *rpc.UpdateIndexRequest, stream 
 				downloadCB.Start(u, i18n.Tr("Downloading index: %s", filepath.Base(URL.Path)))
 				downloadCB.End(false, msg)
 				failed = true
-				result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(URL, rpc.IndexUpdateReport_STATUS_FAILED))
+				result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(u, rpc.IndexUpdateReport_STATUS_FAILED))
 			} else {
-				result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(URL, rpc.IndexUpdateReport_STATUS_SKIPPED))
+				result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(u, rpc.IndexUpdateReport_STATUS_SKIPPED))
 			}
 			continue
 		}
@@ -596,14 +596,14 @@ func (s *arduinoCoreServerImpl) UpdateIndex(req *rpc.UpdateIndexRequest, stream 
 			downloadCB.Start(u, i18n.Tr("Downloading index: %s", filepath.Base(URL.Path)))
 			downloadCB.End(false, i18n.Tr("Invalid index URL: %s", err))
 			failed = true
-			result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(URL, rpc.IndexUpdateReport_STATUS_FAILED))
+			result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(u, rpc.IndexUpdateReport_STATUS_FAILED))
 			continue
 		}
 		indexFile := indexpath.Join(indexFileName)
 		if info, err := indexFile.Stat(); err == nil {
 			ageSecs := int64(time.Since(info.ModTime()).Seconds())
 			if ageSecs < req.GetUpdateIfOlderThanSecs() {
-				result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(URL, rpc.IndexUpdateReport_STATUS_ALREADY_UP_TO_DATE))
+				result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(u, rpc.IndexUpdateReport_STATUS_ALREADY_UP_TO_DATE))
 				continue
 			}
 		}
@@ -622,9 +622,9 @@ func (s *arduinoCoreServerImpl) UpdateIndex(req *rpc.UpdateIndexRequest, stream 
 		}
 		if err := indexResource.Download(stream.Context(), indexpath, downloadCB, config); err != nil {
 			failed = true
-			result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(URL, rpc.IndexUpdateReport_STATUS_FAILED))
+			result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(u, rpc.IndexUpdateReport_STATUS_FAILED))
 		} else {
-			result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(URL, rpc.IndexUpdateReport_STATUS_UPDATED))
+			result.UpdatedIndexes = append(result.GetUpdatedIndexes(), report(u, rpc.IndexUpdateReport_STATUS_UPDATED))
 		}
 	}
 	syncSend.Send(&rpc.UpdateIndexResponse{

--- a/internal/integrationtest/config/config_test.go
+++ b/internal/integrationtest/config/config_test.go
@@ -944,3 +944,18 @@ func TestI18N(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(out), "Available Commands")
 }
+
+func TestCoreUpdateWithInvalidIndexURL(t *testing.T) {
+	// https://github.com/arduino/arduino-cli/issues/2786
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	t.Cleanup(env.CleanUp)
+
+	_, _, err := cli.Run("config", "init")
+	require.NoError(t, err)
+	_, _, err = cli.Run("config", "set", "board_manager.additional_urls", "foo=https://espressif.github.io/arduino-esp32/package_esp32_index.json")
+	require.NoError(t, err)
+	_, stdErr, err := cli.Run("core", "update-index")
+	require.Error(t, err)
+	require.Contains(t, string(stdErr), `Error initializing instance: Some indexes could not be updated.`)
+	require.Contains(t, string(stdErr), `Invalid additional URL: parse "foo=https://espressif.github.io/arduino-esp32/package_esp32_index.json"`)
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fix the panic reported in #2786

## What is the current behavior?

The `arduino-cli` panics by reproducing the steps described in #2786 

## What is the new behavior?

```
$ arduino-cli update-index
Error initializing instance: Invalid additional URL: parse "foo=https://arduino.esp8266.com/stable/package_esp8266com_index.json": first path segment in URL cannot contain colon
Downloading index: package_index.tar.bz2 downloaded                                                                                                                           
Downloading index: foo=https://espressif.github.io/arduino-esp32/package_esp32_index.json Unable to parse URL: parse "foo=https://espressif.github.io/arduino-esp32/package_esp32_index.json": first path segment in URL cannot contain colon
Some indexes could not be updated.
$
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Fix #2786 
