### PR TITLE
Fixed library install from git-url when reference points to a git branch

### DIFF
--- a/internal/integrationtest/lib/lib_test.go
+++ b/internal/integrationtest/lib/lib_test.go
@@ -698,7 +698,7 @@ func TestInstallWithGitUrlFragmentAsBranch(t *testing.T) {
 		// https://github.com/arduino-libraries/ArduinoCloud/commit/d098d4647967b3aeb4520e7baf279e4225254dd2
 		fileToTest, err := libInstallDir.Join("src", "ArduinoCloudThingBase.h").ReadFile()
 		require.NoError(t, err)
-		require.Contains(t, string(fileToTest), `#define LENGHT_M "meters"`)
+		require.Contains(t, string(fileToTest), `#define LENGHT_M "meters"`) // nolint:misspell
 	})
 }
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fixes library install from git-url when reference points to a git branch.

## What is the current behavior?

Using the `--git-url` option with a specific branch gives error

```
Error installing Git Library: Library install failed: reference not found
```

## What is the new behavior?

Library installs correctly

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2825
