### PR TITLE
Investigate some integration-test failures

### DIFF
--- a/internal/integrationtest/daemon/daemon_test.go
+++ b/internal/integrationtest/daemon/daemon_test.go
@@ -618,6 +618,7 @@ func analyzeUpdateIndexClient(t *testing.T, cl commands.ArduinoCoreService_Updat
 	analyzer := NewDownloadProgressAnalyzer(t)
 	for {
 		msg, err := cl.Recv()
+		fmt.Println("UPDATE>", msg, err)
 		if errors.Is(err, io.EOF) {
 			return analyzer.Results, nil
 		}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

It's a debugging of an intermittent integration-test failure.

## What is the current behavior?

The following test fails:
```
=== RUN   TestDaemonUserAgent
{
  "IP": "127.0.0.1",
  "Port": "50051"
}
>>> Create() -> instance:{id:1}
>>> Init(instance:{id:1})
INIT> &{download_progress:{start:{url:"https://downloads.arduino.cc/libraries/library_index.tar.bz2"  label:"Downloading index: library_index.tar.bz2"}}}
INIT> &{download_progress:{update:{downloaded:3397585  total_size:3397585}}}
INIT> &{download_progress:{end:{success:true}}}
INIT> &{download_progress:{start:{url:"https://downloads.arduino.cc/packages/package_index.tar.bz2"  label:"Downloading index: package_index.tar.bz2"}}}
INIT> &{download_progress:{update:{downloaded:79774  total_size:79774}}}
INIT> &{download_progress:{end:{success:true}}}
INIT> &{task_progress:{name:"Downloading missing tool builtin:dfu-discovery@0.1.2"}}
INIT> &{download_progress:{start:{url:"https://downloads.arduino.cc/discovery/dfu-discovery/dfu-discovery_v0.1.2_Windows_64bit.zip"  label:"builtin:dfu-discovery@0.1.2"}}}
INIT> &{download_progress:{end:{success:true  message:"builtin:dfu-discovery@0.1.2 already downloaded"}}}
INIT> &{task_progress:{completed:true}}
INIT> &{task_progress:{name:"Installing builtin:dfu-discovery@0.1.2"}}
INIT> &{task_progress:{message:"Skipping tool configuration."}}
INIT> &{task_progress:{message:"builtin:dfu-discovery@0.1.2 installed"  completed:true}}
INIT> &{task_progress:{name:"Downloading missing tool builtin:mdns-discovery@1.0.9"}}
INIT> &{download_progress:{start:{url:"https://downloads.arduino.cc/discovery/mdns-discovery/mdns-discovery_v1.0.9_Windows_64bit.zip"  label:"builtin:mdns-discovery@1.0.9"}}}
INIT> &{download_progress:{end:{success:true  message:"builtin:mdns-discovery@1.0.9 already downloaded"}}}
INIT> &{task_progress:{completed:true}}
INIT> &{task_progress:{name:"Installing builtin:mdns-discovery@1.0.9"}}
INIT> &{task_progress:{message:"Skipping tool configuration."}}
INIT> &{task_progress:{message:"builtin:mdns-discovery@1.0.9 installed"  completed:true}}
INIT> &{task_progress:{name:"Downloading missing tool builtin:serial-discovery@1.4.1"}}
INIT> &{download_progress:{start:{url:"https://downloads.arduino.cc/discovery/serial-discovery/serial-discovery_v1.4.1_Windows_64bit.zip"  label:"builtin:serial-discovery@1.4.1"}}}
INIT> &{download_progress:{end:{success:true  message:"builtin:serial-discovery@1.4.1 already downloaded"}}}
INIT> &{task_progress:{completed:true}}
INIT> &{task_progress:{name:"Installing builtin:serial-discovery@1.4.1"}}
INIT> &{task_progress:{message:"Skipping tool configuration."}}
INIT> &{task_progress:{message:"builtin:serial-discovery@1.4.1 installed"  completed:true}}
INIT> &{task_progress:{name:"Downloading missing tool builtin:serial-monitor@0.14.1"}}
INIT> &{download_progress:{start:{url:"https://downloads.arduino.cc/monitor/serial-monitor/serial-monitor_v0.14.1_Windows_64bit.zip"  label:"builtin:serial-monitor@0.14.1"}}}
INIT> &{download_progress:{end:{success:true  message:"builtin:serial-monitor@0.14.1 already downloaded"}}}
INIT> &{task_progress:{completed:true}}
INIT> &{task_progress:{name:"Installing builtin:serial-monitor@0.14.1"}}
INIT> &{task_progress:{message:"Skipping tool configuration."}}
INIT> &{task_progress:{message:"builtin:serial-monitor@0.14.1 installed"  completed:true}}
INIT> &{task_progress:{name:"Downloading missing tool builtin:ctags@5.8-arduino11"}}
INIT> &{download_progress:{start:{url:"https://downloads.arduino.cc/tools/ctags-5.8-arduino11-pm-i686-mingw32.zip"  label:"builtin:ctags@5.8-arduino11"}}}
INIT> &{download_progress:{end:{success:true  message:"builtin:ctags@5.8-arduino11 already downloaded"}}}
INIT> &{task_progress:{completed:true}}
INIT> &{task_progress:{name:"Installing builtin:ctags@5.8-arduino11"}}
INIT> &{task_progress:{message:"Skipping tool configuration."}}
INIT> &{task_progress:{message:"builtin:ctags@5.8-arduino11 installed"  completed:true}}
<<< Init EOF
>>> SetValue(key:"board_manager.additional_urls"  encoded_value:"[\"[http://127.0.0.1:52938/test_index.json\](http://127.0.0.1:52938/test_index.json/)"]")
>>> UpdateIndex(instance:{id:1})
    daemon_test.go:577: 
        	Error Trace:	D:/a/arduino-cli/arduino-cli/internal/integrationtest/daemon/daemon_test.go:577
        	            				C:/hostedtoolcache/windows/go/1.23.6/x64/src/net/http/server.go:2220
        	            				C:/hostedtoolcache/windows/go/1.23.6/x64/src/net/http/server.go:3210
        	            				C:/hostedtoolcache/windows/go/1.23.6/x64/src/net/http/server.go:2092
        	            				C:/hostedtoolcache/windows/go/1.23.6/x64/src/runtime/asm_amd64.s:1700
        	Error:      	Condition failed!
        	Test:       	TestDaemonUserAgent
    daemon_test.go:611: 
        	Error Trace:	D:/a/arduino-cli/arduino-cli/internal/integrationtest/daemon/daemon_test.go:611
        	Error:      	Received unexpected error:
        	            	rpc error: code = Internal desc = Some indexes could not be updated.
        	Test:       	TestDaemonUserAgent
--- FAIL: TestDaemonUserAgent (3.21s)
```

## What is the new behavior?

My suspect is that the local webserver (that is started under a go-routine) sometimes is too slow to start, and the UpdateIndex operation fails due to a "connection refused". BTW my try to show the error is probably enough to slow down the test a bit to allow the webserver to go live and make the test pass.
I will keep this debug-print enabled to see the root cause of the failure the next time the test will fail.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
