### PR TITLE
bugfix: `compile ... --dump-profile` now produces a clean output

### DIFF
--- a/internal/cli/feedback/feedback.go
+++ b/internal/cli/feedback/feedback.go
@@ -84,8 +84,8 @@ func reset() {
 	stdErr = os.Stderr
 	feedbackOut = os.Stdout
 	feedbackErr = os.Stderr
-	bufferOut = &bytes.Buffer{}
-	bufferErr = &bytes.Buffer{}
+	bufferOut = bytes.NewBuffer(nil)
+	bufferErr = bytes.NewBuffer(nil)
 	bufferWarnings = nil
 	format = Text
 	formatSelected = false

--- a/internal/cli/feedback/stdio.go
+++ b/internal/cli/feedback/stdio.go
@@ -68,7 +68,7 @@ func OutputStreams() (io.Writer, io.Writer, func() *OutputStreamsResult) {
 // object that can be used as a Result or to retrieve the accumulated output
 // to embed it in another object.
 func NewBufferedStreams() (io.Writer, io.Writer, func() *OutputStreamsResult) {
-	out, err := &bytes.Buffer{}, &bytes.Buffer{}
+	out, err := bytes.NewBuffer(nil), bytes.NewBuffer(nil)
 	return out, err, func() *OutputStreamsResult {
 		return &OutputStreamsResult{
 			Stdout: out.String(),

--- a/internal/integrationtest/compile_4/dump_profile_test.go
+++ b/internal/integrationtest/compile_4/dump_profile_test.go
@@ -1,0 +1,71 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2023 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package compile_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/arduino/arduino-cli/internal/integrationtest"
+	"github.com/arduino/go-paths-helper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDumpProfileClean(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	t.Cleanup(env.CleanUp)
+
+	// Install Arduino AVR Boards
+	_, _, err := cli.Run("core", "install", "arduino:avr@1.8.6")
+	require.NoError(t, err)
+
+	validSketchPath, err := paths.New("testdata", "ValidSketch").Abs()
+	require.NoError(t, err)
+	invalidSketchPath, err := paths.New("testdata", "InvalidSketch").Abs()
+	require.NoError(t, err)
+
+	validProfile := `profiles:
+  uno:
+    fqbn: arduino:avr:uno
+    platforms:
+      - platform: arduino:avr (1.8.6)`
+	t.Run("NoVerbose", func(t *testing.T) {
+		stdout, stderr, err := cli.Run("compile", "-b", "arduino:avr:uno", validSketchPath.String(), "--dump-profile")
+		require.NoError(t, err)
+		require.Empty(t, stderr)
+		profile := strings.TrimSpace(string(stdout))
+		require.Equal(t, validProfile, profile)
+	})
+	t.Run("Verbose", func(t *testing.T) {
+		stdout, stderr, err := cli.Run("compile", "-b", "arduino:avr:uno", validSketchPath.String(), "--dump-profile", "--verbose")
+		require.NoError(t, err)
+		require.Empty(t, stderr)
+		profile := strings.TrimSpace(string(stdout))
+		require.Equal(t, validProfile, profile)
+	})
+	t.Run("ErrorNoVerbose", func(t *testing.T) {
+		stdout, stderr, err := cli.Run("compile", "-b", "arduino:avr:uno", invalidSketchPath.String(), "--dump-profile")
+		require.Error(t, err)
+		require.NotEmpty(t, stderr)
+		require.NotContains(t, string(stdout), validProfile)
+	})
+	t.Run("ErrorVerbose", func(t *testing.T) {
+		stdout, stderr, err := cli.Run("compile", "-b", "arduino:avr:uno", invalidSketchPath.String(), "--dump-profile", "--verbose")
+		require.Error(t, err)
+		require.NotEmpty(t, stderr)
+		require.NotContains(t, string(stdout), validProfile)
+	})
+}

--- a/internal/integrationtest/compile_4/testdata/InvalidSketch/InvalidSketch.ino
+++ b/internal/integrationtest/compile_4/testdata/InvalidSketch/InvalidSketch.ino
@@ -1,0 +1,3 @@
+void setup() {}
+void loop() {}
+aaaaaa

--- a/internal/integrationtest/compile_4/testdata/ValidSketch/ValidSketch.ino
+++ b/internal/integrationtest/compile_4/testdata/ValidSketch/ValidSketch.ino
@@ -1,0 +1,2 @@
+void setup() {}
+void loop() {}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

When a `compile --dump-profile` is performed, the output is the clean profile that could be redirected in a file.

## What is the current behavior?

A regression in the Arduino CLI 1.2.0 made the profile disappear from the non-verbose output:
```
$ arduino-cli compile -b arduino:avr:uno --dump-profile
Lo sketch usa 444 byte (1%) dello spazio disponibile per i programmi. Il massimo è 32256 byte.
Le variabili globali usano 9 byte (0%) di memoria dinamica, lasciando altri 2039 byte liberi per le variabili locali. Il massimo è 2048 byte.
```

the only way to get the profile with --dump-profile is to enable verbose -v, but this is really inconvenient:
```
$ arduino-cli compile -b arduino:avr:uno --dump-profile -v
FQBN: arduino:avr:uno
Utilizzo della scheda 'uno' dalla piattaforma nella cartella: /home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.6
Utilizzo del core 'arduino' dalla piattaforma nella cartella: /home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.6

Rilevamento delle librerie utilizzate in corso...
/home/megabug/.arduino15/packages/arduino/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7/bin/avr-g++ -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -flto -w -x c++ -E -CC -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.6/cores/arduino -I/home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.6/variants/standard /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/sketch/Blink.ino.cpp -o /dev/null
Sto generando i prototipi di funzione...
/home/megabug/.arduino15/packages/arduino/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7/bin/avr-g++ -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -flto -w -x c++ -E -CC -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.6/cores/arduino -I/home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.6/variants/standard /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/sketch/Blink.ino.cpp -o /tmp/709592250/sketch_merged.cpp
/home/megabug/.arduino15/packages/builtin/tools/ctags/5.8-arduino11/ctags -u --language-force=c++ -f - --c++-kinds=svpf --fields=KSTtzns --line-directives /tmp/709592250/sketch_merged.cpp

Compilazione dello sketch in corso...
/home/megabug/.arduino15/packages/arduino/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7/bin/avr-g++ -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.6/cores/arduino -I/home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.6/variants/standard /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/sketch/Blink.ino.cpp -o /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/sketch/Blink.ino.cpp.o
Compilazione delle librerie in corso...
Compilazione del core in corso...
Utilizzo del core precompilato: /home/megabug/.cache/arduino/cores/arduino_avr_uno_12e4cfbdc0590d50ab9cd20e50a4c3c5/core.a
Collegare tutto insieme...
/home/megabug/.arduino15/packages/arduino/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7/bin/avr-gcc -w -Os -g -flto -fuse-linker-plugin -Wl,--gc-sections -mmcu=atmega328p -o /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/Blink.ino.elf /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/sketch/Blink.ino.cpp.o /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/../../cores/arduino_avr_uno_12e4cfbdc0590d50ab9cd20e50a4c3c5/core.a -L/home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3 -lm
/home/megabug/.arduino15/packages/arduino/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7/bin/avr-objcopy -O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0 /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/Blink.ino.elf /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/Blink.ino.eep
/home/megabug/.arduino15/packages/arduino/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7/bin/avr-objcopy -O ihex -R .eeprom /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/Blink.ino.elf /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/Blink.ino.hex
/home/megabug/.arduino15/packages/arduino/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7/bin/avr-size -A /home/megabug/.cache/arduino/sketches/002050EAA7EFB9A4FC451CDFBC0FA2D3/Blink.ino.elf
Lo sketch usa 444 byte (1%) dello spazio disponibile per i programmi. Il massimo è 32256 byte.
Le variabili globali usano 9 byte (0%) di memoria dinamica, lasciando altri 2039 byte liberi per le variabili locali. Il massimo è 2048 byte.

Piattaforma utilizzata Versione Percorso
arduino:avr            1.8.6    /home/megabug/.arduino15/packages/arduino/hardware/avr/1.8.6

profiles:
  uno:
    fqbn: arduino:avr:uno
    platforms:
      - platform: arduino:avr (1.8.6)
```


## What is the new behavior?

```
$ arduino-cli compile -b arduino:avr:uno --dump-profile
profiles:
  uno:
    fqbn: arduino:avr:uno
    platforms:
      - platform: arduino:avr (1.8.6)


$
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Fix #2848