### PR TITLE
Fix NewSketch crash when directories.user is not set

### DIFF
--- a/commands/service_sketch_new.go
+++ b/commands/service_sketch_new.go
@@ -48,7 +48,7 @@ func (s *arduinoCoreServerImpl) NewSketch(ctx context.Context, req *rpc.NewSketc
 	if len(req.GetSketchDir()) > 0 {
 		sketchesDir = req.GetSketchDir()
 	} else {
-		sketchesDir = s.settings.GetString("directories.User")
+		sketchesDir = s.settings.UserDir().String()
 	}
 
 	if err := validateSketchName(req.GetSketchName()); err != nil {

--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -710,3 +710,14 @@ func (inst *ArduinoCLIInstance) BoardIdentify(ctx context.Context, props map[str
 	resp, err := inst.cli.daemonClient.BoardIdentify(ctx, req)
 	return resp, err
 }
+
+// NewSketch calls the "NewSketch" gRPC method.
+func (inst *ArduinoCLIInstance) NewSketch(ctx context.Context, sketchName, sketchDir string, overwrite bool) (*commands.NewSketchResponse, error) {
+	req := &commands.NewSketchRequest{
+		SketchName: sketchName,
+		SketchDir:  sketchDir,
+		Overwrite:  overwrite,
+	}
+	logCallf(">>> NewSketch(%+v)\n", req)
+	return inst.cli.daemonClient.NewSketch(ctx, req)
+}

--- a/internal/integrationtest/daemon/daemon_test.go
+++ b/internal/integrationtest/daemon/daemon_test.go
@@ -614,6 +614,22 @@ func TestDaemonUserAgent(t *testing.T) {
 	}
 }
 
+func TestDaemonCreateSketch(t *testing.T) {
+	// https://github.com/arduino/arduino-cli/issues/2861
+
+	env, cli := integrationtest.CreateEnvForDaemon(t)
+	defer env.CleanUp()
+
+	grpcInst := cli.Create()
+	require.NoError(t, grpcInst.Init("", "", func(ir *commands.InitResponse) {
+		fmt.Printf("INIT> %v\n", ir.GetMessage())
+	}))
+
+	sketchName := "test_sketch.ino"
+	_, err := grpcInst.NewSketch(context.Background(), sketchName, "", false)
+	require.NoError(t, err)
+}
+
 func analyzeUpdateIndexClient(t *testing.T, cl commands.ArduinoCoreService_UpdateIndexClient) (map[string]*commands.DownloadProgressEnd, error) {
 	analyzer := NewDownloadProgressAnalyzer(t)
 	for {


### PR DESCRIPTION

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fix a nil pointer 

## What is the current behavior?

When the `directories.user` is not set by the user, an empty string is returned instead of using the default value. This leads to a panic

## What is the new behavior?

Use the `UserDir` function that correctly fallback to default dir in case of empty string.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
