### PR TITLE
fix: allow lib-install from git using revision hash as a reference

### DIFF
--- a/internal/arduino/libraries/librariesmanager/install.go
+++ b/internal/arduino/libraries/librariesmanager/install.go
@@ -232,7 +232,9 @@ func (lmi *Installer) InstallGitLib(argURL string, overwrite bool) error {
 			return err
 		} else if w, err := repo.Worktree(); err != nil {
 			return err
-		} else if err := w.Checkout(&git.CheckoutOptions{Hash: plumbing.NewHash(h.String())}); err != nil {
+		} else if err := w.Checkout(&git.CheckoutOptions{
+			Force: true, // workaround for: https://github.com/go-git/go-git/issues/1411
+			Hash:  plumbing.NewHash(h.String())}); err != nil {
 			return err
 		}
 	}

--- a/internal/arduino/libraries/librariesmanager/install.go
+++ b/internal/arduino/libraries/librariesmanager/install.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/arduino/arduino-cli/commands/cmderrors"
@@ -215,17 +214,27 @@ func (lmi *Installer) InstallGitLib(argURL string, overwrite bool) error {
 	defer tmp.RemoveAll()
 	tmpInstallPath := tmp.Join(libraryName)
 
-	depth := 1
-	if ref != "" {
-		depth = 0
-	}
 	if _, err := git.PlainClone(tmpInstallPath.String(), false, &git.CloneOptions{
 		URL:           gitURL,
-		Depth:         depth,
-		Progress:      os.Stdout,
-		ReferenceName: ref,
+		ReferenceName: plumbing.ReferenceName(ref),
 	}); err != nil {
-		return err
+		if err.Error() != "reference not found" {
+			return err
+		}
+
+		// We did not find the requested reference, let's do a PlainClone and use
+		// "ResolveRevision" to find and checkout the requested revision
+		if repo, err := git.PlainClone(tmpInstallPath.String(), false, &git.CloneOptions{
+			URL: gitURL,
+		}); err != nil {
+			return err
+		} else if h, err := repo.ResolveRevision(plumbing.Revision(ref)); err != nil {
+			return err
+		} else if w, err := repo.Worktree(); err != nil {
+			return err
+		} else if err := w.Checkout(&git.CheckoutOptions{Hash: plumbing.NewHash(h.String())}); err != nil {
+			return err
+		}
 	}
 
 	// We don't want the installed library to be a git repository thus we delete this folder
@@ -241,7 +250,7 @@ func (lmi *Installer) InstallGitLib(argURL string, overwrite bool) error {
 
 // parseGitArgURL tries to recover a library name from a git URL.
 // Returns an error in case the URL is not a valid git URL.
-func parseGitArgURL(argURL string) (string, string, plumbing.ReferenceName, error) {
+func parseGitArgURL(argURL string) (string, string, string, error) {
 	// On Windows handle paths with backslashes in the form C:\Path\to\library
 	if path := paths.New(argURL); path != nil && path.Exist() {
 		return path.Base(), argURL, "", nil
@@ -279,7 +288,7 @@ func parseGitArgURL(argURL string) (string, string, plumbing.ReferenceName, erro
 		return "", "", "", errors.New(i18n.Tr("invalid git url"))
 	}
 	// fragment == "1.0.3"
-	rev := plumbing.ReferenceName(parsedURL.Fragment)
+	rev := parsedURL.Fragment
 	// gitURL == "https://github.com/arduino-libraries/SigFox.git"
 	parsedURL.Fragment = ""
 	gitURL := parsedURL.String()


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

A previous "fix" allowed the installation of a library from git by specifying a branch, but introduced a regression, making it impossible to install from git by specifying a revision hash.

## What is the current behavior?

A library can not be installed from git using a revision hash, see https://github.com/arduino/arduino-cli/issues/2860 for details

## What is the new behavior?

It is now allowed to install from git using a revision hash.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Fix https://github.com/arduino/arduino-cli/issues/2860
