### PR TITLE
bugfix: Kill compile processes that generates too much output

### DIFF
--- a/internal/arduino/builder/internal/preprocessor/gcc.go
+++ b/internal/arduino/builder/internal/preprocessor/gcc.go
@@ -90,8 +90,8 @@ func GCC(
 		n, err := stderr.Write(p)
 		count += n
 		if count > 100*1024 {
-			cancel()
 			fmt.Fprintln(stderr, i18n.Tr("Compiler error output has been truncated."))
+			cancel()
 		}
 		return n, err
 	})

--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"runtime"
 	"strings"
@@ -199,9 +200,7 @@ func (cli *ArduinoCLI) RunWithContext(ctx context.Context, args ...string) ([]by
 // GetDefaultEnv returns a copy of the default execution env used with the Run method.
 func (cli *ArduinoCLI) GetDefaultEnv() map[string]string {
 	res := map[string]string{}
-	for k, v := range cli.cliEnvVars {
-		res[k] = v
-	}
+	maps.Copy(res, cli.cliEnvVars)
 	return res
 }
 

--- a/internal/integrationtest/compile_5/recusive_include_test.go
+++ b/internal/integrationtest/compile_5/recusive_include_test.go
@@ -1,0 +1,44 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2025 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package compile_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arduino/arduino-cli/internal/integrationtest"
+	"github.com/arduino/go-paths-helper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileWithInfiniteMultipleIncludeRecursion(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	t.Cleanup(env.CleanUp)
+
+	// Install Arduino AVR Boards
+	_, _, err := cli.Run("core", "install", "arduino:avr@1.8.6")
+	require.NoError(t, err)
+
+	sketch, err := paths.New("testdata", "SketchWithRecursiveIncludes").Abs()
+	require.NoError(t, err)
+
+	// Time-limited test to prevent OOM
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	t.Cleanup(cancel)
+	_, _, _ = cli.RunWithContext(ctx, "compile", "-b", "arduino:avr:uno", sketch.String())
+	require.NotErrorIs(t, ctx.Err(), context.DeadlineExceeded, "compilation should not hang")
+}

--- a/internal/integrationtest/compile_5/testdata/SketchWithRecursiveIncludes/SketchWithRecursiveIncludes.ino
+++ b/internal/integrationtest/compile_5/testdata/SketchWithRecursiveIncludes/SketchWithRecursiveIncludes.ino
@@ -1,0 +1,1 @@
+#include "a.h"

--- a/internal/integrationtest/compile_5/testdata/SketchWithRecursiveIncludes/a.h
+++ b/internal/integrationtest/compile_5/testdata/SketchWithRecursiveIncludes/a.h
@@ -1,0 +1,2 @@
+#include "a.h"
+#include "a.h"


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Previously, compiling a sketch containing an include loop could generate a lot of output and crash the Arduino CLI with an out-of-memory error. This is due to the library-discovery process that buffers the stderr output of the compiler for analysis after the process exits.

To fix this problem, a limit to the compiler output has been set to 100KB of data.

## What is the current behavior?

```
$ cat sketch.ino
#include <a.h>
$ cat a.h
#include <a.h>
#include <a.h>
#include <a.h>
$ arduino-cli compile -b arduino:avr:uno
```
The process never terminates, and it's killed for OOM later by the kernel.

## What is the new behavior?

```
$ cat sketch.ino
#include <a.h>
$ cat a.h
#include <a.h>
#include <a.h>
#include <a.h>
$ arduino-cli compile -b arduino:avr:uno
[...a lot of output truncated...]
In file included from /home/cmaglie/sketch/a.h:1:0,
                 from /home/cmaglie/sketch/a.h:2,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:2,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/a.h:1,
                 from /home/cmaglie/sketch/sketch.ino:1:
/home/cmaglie/sketch/a.h:1:15: error: #include nested too deeply
/home/cmaglie/sketch/a.h:2:15: error: #include nested too deeply
Compiler error output has been truncated.

Used platform Version Path
arduino:avr   1.6.22  /home/cmaglie/.arduino15/packages/arduino/hardware/avr/1.6.22
Error during build: signal: killed
$
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

A legitimate sketch may produce a lot of warnings **from a single file**, going over 100KB. In that extreme case, the sketch could not be compiled anymore with Arduino CLI.

100KB looks like a reasonable limit. By the way, there are no specific stats available about this, so we have to deploy this fix, get feedback from the user, and be ready to increase this limit if needed.

## Other information

<!-- Any additional information that could help the review process -->
