### PR TITLE
 Fix user network config being ignored in package manger operations

### DIFF
--- a/internal/arduino/cores/packagemanager/package_manager.go
+++ b/internal/arduino/cores/packagemanager/package_manager.go
@@ -124,6 +124,7 @@ func (pmb *Builder) Build() *PackageManager {
 		profile:                        pmb.profile,
 		discoveryManager:               pmb.discoveryManager,
 		userAgent:                      pmb.userAgent,
+		downloaderConfig:               pmb.downloaderConfig,
 	}
 }
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

We correctly pass the downloader config during the `Build()` of the package manager

## What is the current behavior?

Currently, the downloader config is not passed when building the final package manager. This led to ignoring user network configs.

## What is the new behavior?

We correctly pass the downloader configs. 

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
