### PR TITLE
Fixed integration test

### DIFF
--- a/internal/integrationtest/compile_1/compile_test.go
+++ b/internal/integrationtest/compile_1/compile_test.go
@@ -850,7 +850,9 @@ func TestCompileWithArchivesAndLongPaths(t *testing.T) {
 	require.NoError(t, err)
 
 	// Install test library
-	_, _, err = cli.Run("lib", "install", "ArduinoIoTCloud", "--config-file", "arduino-cli.yaml")
+	// (We must use ArduinoIOTCloud@2.4.1 because it has a folder with a lot of files
+	// that will trigger the creation of an objs.a archive)
+	_, _, err = cli.Run("lib", "install", "ArduinoIoTCloud@2.4.1", "--config-file", "arduino-cli.yaml")
 	require.NoError(t, err)
 
 	stdout, _, err := cli.Run("lib", "examples", "ArduinoIoTCloud", "--json", "--config-file", "arduino-cli.yaml")
@@ -859,12 +861,10 @@ func TestCompileWithArchivesAndLongPaths(t *testing.T) {
 	sketchPath := paths.New(libOutput)
 	sketchPath = sketchPath.Join("examples", "ArduinoIoTCloud-Advanced")
 
-	t.Run("Compile", func(t *testing.T) {
+	t.Run("CheckCachingOfFolderArchives", func(t *testing.T) {
 		_, _, err = cli.Run("compile", "-b", "esp8266:esp8266:huzzah", sketchPath.String(), "--config-file", "arduino-cli.yaml")
 		require.NoError(t, err)
-	})
 
-	t.Run("CheckCachingOfFolderArchives", func(t *testing.T) {
 		// Run compile again and check if the archive is re-used (cached)
 		out, _, err := cli.Run("compile", "-b", "esp8266:esp8266:huzzah", sketchPath.String(), "--config-file", "arduino-cli.yaml", "-v")
 		require.NoError(t, err)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

1. Fix ArduinoIoTCloud version to 2.4.1 (the latest versions have fewer files and do not trigger the objs.a creation)
2. Merge two parallel tests because they actually need to be performed sequentially since we are checking that the compiled artifacts on the former are reused on the latter.

## What is the current behavior?

CI is failing

## What is the new behavior?

CI is green

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
