### PR TITLE
[skip changelog] Fixed release workflow build

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -20,20 +20,29 @@ jobs:
   create-release-artifacts:
     outputs:
       version: ${{ steps.get-version.outputs.version }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.env.runner }}
 
     strategy:
       matrix:
-        os:
-          - Windows_32bit
-          - Windows_64bit
-          - Linux_32bit
-          - Linux_64bit
-          - Linux_ARMv6
-          - Linux_ARMv7
-          - Linux_ARM64
-          - macOS_64bit
-          - macOS_ARM64
+        env:
+          - os: Windows_32bit
+            runner: ubuntu-latest
+          - os: Windows_64bit
+            runner: ubuntu-latest
+          - os: Linux_32bit
+            runner: ubuntu-latest
+          - os: Linux_64bit
+            runner: ubuntu-latest
+          - os: Linux_ARMv6
+            runner: ubuntu-latest
+          - os: Linux_ARMv7
+            runner: ubuntu-latest
+          - os: Linux_ARM64
+            runner: ubuntu-latest
+          - os: macOS_64bit
+            runner: ubuntu-latest
+          - os: macOS_ARM64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout repository
@@ -43,7 +52,7 @@ jobs:
 
       - name: Create changelog
         # Avoid creating the same changelog for each os
-        if: matrix.os == 'Windows_32bit'
+        if: matrix.env.os == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
           tag-regex: '^v[0-9]+\.[0-9]+\.[0-9]+.*$'
@@ -58,7 +67,7 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:${{ matrix.os }}
+        run: task dist:${{ matrix.env.os }}
 
       - name: Output Version
         id: get-version
@@ -68,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}-${{ matrix.os }}
+          name: ${{ env.ARTIFACT_NAME }}-${{ matrix.env.os }}
           path: ${{ env.DIST_DIR }}
 
   notarize-macos:


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

The `task dist:macos_ARM64` requires an arm64-based runner.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

This change should fix the build task on the release workflow.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Related to #2850 
https://github.com/arduino/arduino-cli/pull/2850/files#diff-6b9acae2ec2dd8380951f75b0526e9c2f71976d513236d60e40d0f3dba275654