### PR TITLE
[skip changelog] Revert "Disable internal anchor checks by link checker tool (#1692)"

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,9 +5,6 @@
   "aliveStatusCodes": [200, 206],
   "ignorePatterns": [
     {
-      "pattern": "^#"
-    },
-    {
       "pattern": "https?://localhost:\\d*/"
     },
     {


### PR DESCRIPTION
This reverts commit f470f407a3afca82e30c6503b421ddde694c7b6d.

This configuration entry was previously required in order to work around a bug in the [**markdown-link-check**](https://github.com/tcort/markdown-link-check) tool (https://github.com/tcort/markdown-link-check/issues/202) that resulted in false positives for links to anchors created by HTML anchor tags.

The bug in the "markdown-link-check" tool has since been fixed (https://github.com/tcort/markdown-link-check/pull/331), and this project updated to use the version of the tool with that fix (https://github.com/arduino/arduino-cli/pull/2898). So this configuration entry is no longer required.

The now superfluous configuration entry is hereby removed in order to ensure more comprehensive link check coverage.