### PR TITLE
[skip changelog] Correct configuration key name in documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,8 +64,8 @@ configuration file.
   - on Windows is: `{HOME}/AppData/Local/Arduino15`
   - on MacOS is: `{HOME}/Library/Arduino15`
 
-- The `directories.download` default is `{directories.data}/staging`. If the value of `{directories.data}` is changed in
-  the configuration the user-specified value will be used.
+- The `directories.downloads` default is `{directories.data}/staging`. If the value of `{directories.data}` is changed
+  in the configuration the user-specified value will be used.
 
 - The `directories.user` default is OS-dependent:
   - on Linux (and other Unix-based OS) is: `{HOME}/Arduino`


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

A reference to Arduino CLI's `directories.downloads` configuration key in the documentation is misspelled as "directories.download".

## What is the new behavior?

The configuration key name is correctly spelled.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change

## Other information

Originally reported at https://forum.arduino.cc/t/configuration-file/1378100/7
