### PR TITLE
[skip changelog] Add missing pages to website navigation panel

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - config init: commands/arduino-cli_config_init.md
       - config add: commands/arduino-cli_config_add.md
       - config delete: commands/arduino-cli_config_delete.md
+      - config get: commands/arduino-cli_config_get.md
       - config remove: commands/arduino-cli_config_remove.md
       - config set: commands/arduino-cli_config_set.md
       - core: commands/arduino-cli_core.md
@@ -79,6 +80,7 @@ nav:
       - core upgrade: commands/arduino-cli_core_upgrade.md
       - daemon: commands/arduino-cli_daemon.md
       - debug: commands/arduino-cli_debug.md
+      - debug check: commands/arduino-cli_debug_check.md
       - lib: commands/arduino-cli_lib.md
       - lib deps: commands/arduino-cli_lib_deps.md
       - lib download: commands/arduino-cli_lib_download.md


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The project is supplemented by [a documentation website](https://arduino.github.io/arduino-cli/latest/) which is generated by the [**MkDocs**](https://www.mkdocs.org/) static site generator. The site contains a navigation panel which lists the available documentation pages.

Rather than being [automatically generated](https://www.mkdocs.org/user-guide/configuration/#nav:~:text=local%20MkDocs%20page.-,default,-%3A%20By%20default%20nav) from the contents of the `docs` folder, the contents of the navigation panel have been [explicitly defined](https://www.mkdocs.org/user-guide/configuration/#nav) via the **MkDocs** configuration file. This means that the project contributors must remember to update the configuration file when development work results in the addition or removal of web pages.

This was not done when the `config get` and `debug check` commands were added. The web pages for those commands are generated as expected, but the missing configuration file entries means that a visitor to the website would never know of their existence, and can only access them by hacking the URL.

## What is the new behavior?

Entries for all documentation pages are present in the MkDocs configuration file, which results in all pages being listed in the navigation panel of the website.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.