### PR TITLE
[skip changelog] Correct documentation re: default for `build_cache.path` configuration key

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@
 - `updater` - configuration options related to Arduino CLI updates
   - `enable_notification` - set to `false` to disable notifications of new Arduino CLI releases, defaults to `true`
 - `build_cache` configuration options related to the compilation cache
-  - `path` - the path to the build cache, default is `$TMP/arduino`.
+  - `path` - the path to the folder under which build caches are stored.
   - `extra_paths` - a list of paths to look for precompiled artifacts if not found on `build_cache.path` setting.
   - `compilations_before_purge` - interval, in number of compilations, at which the cache is purged, defaults to `10`.
     When `0` the cache is never purged.
@@ -57,6 +57,14 @@
 
 The following are the default directories selected by the Arduino CLI if alternatives are not specified in the
 configuration file.
+
+- The `build_cache.path` default is OS-dependent:
+
+  - on Linux (and other Unix-based OS) is: if
+    [`$XDG_CACHE_HOME`](https://specifications.freedesktop.org/basedir-spec/latest/#variables) is defined,
+    `$XDG_CACHE_HOME/arduino`. Otherwise `{HOME}/.config/arduino`.
+  - on Windows is: `{HOME}/AppData/Local/arduino`
+  - on MacOS is: `{HOME}/Library/Caches/arduino`
 
 - The `directories.data` default is OS-dependent:
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Docs fix

## What is the current behavior?

The "Configuration" documentation page includes information on the default values of the configuration keys.

The default value of the build_cache.path configuration key was recently changed (https://github.com/arduino/arduino-cli/pull/2673), but the documentation was not updated accordingly so it provides incorrect information regarding the default build cache location.

## What is the new behavior?

The documentation is updated to provide the correct information regarding the default value of the `build_cache.path` configuration key.

Previously, the information was provided in the list of keys. That is a non-standard location for the information as there is an established convention of instead providing this information in the separate section of the page dedicated to documenting default paths. In addition. the location in the keys list became more problematic for the new default since it is operating system-specific and thus the increased volume of documentation content would be awkward to fit into the nested list of keys. For these reasons, the documentation content was moved to the standardized location under the "Default directories" section of the page.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.
