### PR TITLE
build_cache.path correction

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,9 +62,11 @@ configuration file.
 
   - on Linux (and other Unix-based OS) is: if
     [`$XDG_CACHE_HOME`](https://specifications.freedesktop.org/basedir-spec/latest/#variables) is defined,
-    `$XDG_CACHE_HOME/arduino`. Otherwise `{HOME}/.config/arduino`.
-  - on Windows is: `{HOME}/AppData/Local/arduino`
-  - on MacOS is: `{HOME}/Library/Caches/arduino`
+    `$XDG_CACHE_HOME/arduino`. Otherwise `${HOME}/.cache/arduino`.
+  - on Windows is: `%LocalAppData%/arduino`
+  - on MacOS is: `${HOME}/Library/Caches/arduino`
+
+  If neither `$HOME` or `$XDG_CACHE_HOME` are defined, a temporary directory will be used.
 
 - The `directories.data` default is OS-dependent:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,11 +62,11 @@ configuration file.
 
   - on Linux (and other Unix-based OS) is: if
     [`$XDG_CACHE_HOME`](https://specifications.freedesktop.org/basedir-spec/latest/#variables) is defined,
-    `$XDG_CACHE_HOME/arduino`. Otherwise `${HOME}/.cache/arduino`.
+    `$XDG_CACHE_HOME/arduino`. Otherwise `$HOME/.cache/arduino`.
   - on Windows is: `%LocalAppData%/arduino`
-  - on MacOS is: `${HOME}/Library/Caches/arduino`
+  - on MacOS is: `$HOME/Library/Caches/arduino`
 
-  If neither `$HOME` or `$XDG_CACHE_HOME` are defined, a temporary directory will be used.
+  If neither `$HOME` nor `$XDG_CACHE_HOME` are defined, a temporary directory will be used.
 
 - The `directories.data` default is OS-dependent:
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Correction for #2919 and using `$VAR`

These are values from Go docs
https://pkg.go.dev/os#UserCacheDir

Actual CLI code falls back to /tmp when neither $HOME or XDG variables are available 
https://github.com/arduino/arduino-cli/blob/55f86b541026aad880fcb27bc49e3fe1facb223b/internal/cli/configuration/defaults.go#L56
https://github.com/arduino/arduino-cli/blob/55f86b541026aad880fcb27bc49e3fe1facb223b/internal/cli/configuration/configuration.go#L105-L114

## What is the current behavior?

-

## What is the new behavior?

-

## Does this PR introduce a breaking change, and is [titled accordingly]

-

## Other information

-