### PR TITLE
ctags: filterSketchSource: enlarge buffer size to handle long lines

### DIFF
--- a/internal/arduino/builder/internal/preprocessor/ctags.go
+++ b/internal/arduino/builder/internal/preprocessor/ctags.go
@@ -235,7 +235,7 @@ func filterSketchSource(sketch *sketch.Sketch, source io.Reader, removeLineMarke
 			filtered += line + "\n"
 		}
 	}
-	if scanner.Err() == bufio.ErrTooLong {
+	if errors.Is(scanner.Err(), bufio.ErrTooLong) {
 		fmt.Fprintf(stderr, "%s: %s",
 			i18n.Tr("An error occurred adding prototypes"),
 			i18n.Tr("line too long\n"))

--- a/internal/arduino/builder/internal/preprocessor/ctags_test.go
+++ b/internal/arduino/builder/internal/preprocessor/ctags_test.go
@@ -1,0 +1,42 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2025 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package preprocessor
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/arduino/arduino-cli/internal/arduino/sketch"
+	"github.com/arduino/go-paths-helper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCtagsSketchFilter(t *testing.T) {
+	sourcePath := paths.New("testdata", "sketch_merged.cpp")
+	f, err := sourcePath.Open()
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+
+	sketch := &sketch.Sketch{
+		MainFile: paths.New("/home/megabug/Arduino/Test/Test.ino"),
+	}
+	stderr := bytes.NewBuffer(nil)
+	res := filterSketchSource(sketch, f, false, stderr)
+	require.Empty(t, stderr)
+	require.NotEmpty(t, res)
+	fmt.Println(res)
+}


### PR DESCRIPTION
Fixes https://github.com/arduino/ArduinoCore-zephyr/issues/140

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

When parsing the preprocessed file, only the lines relevant for the sketch are preserved.
However, golang's `scanner` fails if a line is too long for its buffer.
Overcome the issue by adding a 1MB buffer (extremely conservative) and a non-fatal error message in case it's still not enough.
 
## What is the current behavior?

Compiling any sketch from https://github.com/arduino/ArduinoCore-zephyr fails to create prototypes due to `analogPins` macro, which expands into a ~90K characters line

## What is the new behavior?

The prototypes are created correctly

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change

## Other information

<!-- Any additional information that could help the review process -->
