### PR TITLE
Allow platforms without fixed version in profiles.

### DIFF
--- a/commands/instances.go
+++ b/commands/instances.go
@@ -243,8 +243,13 @@ func (s *arduinoCoreServerImpl) Init(req *rpc.InitRequest, stream rpc.ArduinoCor
 		}
 
 		// Load Platforms
-		if profile == nil || profile.RequireSystemInstalledPlatform() {
+		if profile == nil {
 			for _, err := range pmb.LoadHardware() {
+				s := &cmderrors.PlatformLoadingError{Cause: err}
+				responseError(s.GRPCStatus())
+			}
+		} else if profile.RequireSystemInstalledPlatform() {
+			for _, err := range pmb.LoadGlobalHardwareForProfile(profile) {
 				s := &cmderrors.PlatformLoadingError{Cause: err}
 				responseError(s.GRPCStatus())
 			}

--- a/commands/instances.go
+++ b/commands/instances.go
@@ -243,7 +243,7 @@ func (s *arduinoCoreServerImpl) Init(req *rpc.InitRequest, stream rpc.ArduinoCor
 		}
 
 		// Load Platforms
-		if profile == nil {
+		if profile == nil || profile.RequireSystemInstalledPlatform() {
 			for _, err := range pmb.LoadHardware() {
 				s := &cmderrors.PlatformLoadingError{Cause: err}
 				responseError(s.GRPCStatus())

--- a/docs/sketch-project-file.md
+++ b/docs/sketch-project-file.md
@@ -28,9 +28,9 @@ profiles:
     fqbn: <FQBN>
     programmer: <PROGRAMMER>
     platforms:
-      - platform: <PLATFORM> (<PLATFORM_VERSION>)
+      - platform: <PLATFORM> [(<PLATFORM_VERSION>)]
         platform_index_url: <3RD_PARTY_PLATFORM_URL>
-      - platform: <PLATFORM_DEPENDENCY> (<PLATFORM_DEPENDENCY_VERSION>)
+      - platform: <PLATFORM_DEPENDENCY> [(<PLATFORM_DEPENDENCY_VERSION>)]
         platform_index_url: <3RD_PARTY_PLATFORM_DEPENDENCY_URL>
     libraries:
       - <INDEX_LIB_NAME> (<INDEX_LIB_VERSION>)
@@ -72,6 +72,14 @@ The following fields are available since Arduino CLI 1.1.0:
   used in the `monitor` command. Typically is used to set the baudrate for the serial port (for example
   `baudrate: 115200`) but any setting/value can be specified. Multiple settings can be set. These fields are optional.
 - `<PORT_PROTOCOL>` is the protocol for the port used to upload and monitor the board. This field is optional.
+
+#### Using a system-installed platform.
+
+The fields `<PLATFORM_VERSION>` and `<PLATFORM_DEPENDENCY_VERSION>` are optional, if they are omitted, the sketch
+compilation will use the platforms installed system-wide. This could be helpful during the development of a platform
+(where a specific release is not yet available), or if a specific version of a platform is not a strict requirement.
+
+#### An example of a complete project file.
 
 A complete example of a sketch project file may be the following:
 

--- a/internal/arduino/cores/packagemanager/profiles.go
+++ b/internal/arduino/cores/packagemanager/profiles.go
@@ -33,6 +33,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// LoadGlobalHardwareForProfile loads the hardware platforms for the given profile.
+// It uses the global package manager and does not download or install any missing tools or platforms.
+func (pmb *Builder) LoadGlobalHardwareForProfile(p *sketch.Profile) []error {
+	pmb.profile = p
+	return pmb.LoadHardware()
+}
+
 // LoadHardwareForProfile load the hardware platforms for the given profile.
 // If installMissing is true then possibly missing tools and platforms will be downloaded and installed.
 func (pmb *Builder) LoadHardwareForProfile(ctx context.Context, p *sketch.Profile, installMissing bool, downloadCB rpc.DownloadProgressCB, taskCB rpc.TaskProgressCB, settings *configuration.Settings) []error {

--- a/internal/arduino/sketch/profiles.go
+++ b/internal/arduino/sketch/profiles.go
@@ -187,6 +187,20 @@ func (p *ProfileRequiredPlatforms) AsYaml() string {
 	return res
 }
 
+func (p *ProfileRequiredPlatforms) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	_p := (*[]*ProfilePlatformReference)(p)
+	if err := unmarshal(_p); err != nil {
+		return err
+	}
+	requireSystemPlatform := (*_p)[0].RequireSystemInstalledPlatform()
+	for _, platform := range *_p {
+		if platform.RequireSystemInstalledPlatform() != requireSystemPlatform {
+			return errors.New(i18n.Tr("all platforms in a profile must either require a specific version or not"))
+		}
+	}
+	return nil
+}
+
 // ProfileRequiredLibraries is a list of ProfileLibraryReference (libraries
 // required to build the sketch using this profile)
 type ProfileRequiredLibraries []*ProfileLibraryReference

--- a/internal/arduino/sketch/profiles_test.go
+++ b/internal/arduino/sketch/profiles_test.go
@@ -47,4 +47,9 @@ func TestProjectFileLoading(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, string(golden), proj.AsYaml())
 	}
+	{
+		sketchProj := paths.New("testdata", "profiles", "bad_profile_1.yml")
+		_, err := LoadProjectFile(sketchProj)
+		require.Error(t, err)
+	}
 }

--- a/internal/arduino/sketch/profiles_test.go
+++ b/internal/arduino/sketch/profiles_test.go
@@ -39,4 +39,12 @@ func TestProjectFileLoading(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, proj.AsYaml(), string(golden))
 	}
+	{
+		sketchProj := paths.New("testdata", "profiles", "profile_1.yml")
+		proj, err := LoadProjectFile(sketchProj)
+		require.NoError(t, err)
+		golden, err := sketchProj.ReadFile()
+		require.NoError(t, err)
+		require.Equal(t, string(golden), proj.AsYaml())
+	}
 }

--- a/internal/arduino/sketch/testdata/profiles/bad_profile_1.yml
+++ b/internal/arduino/sketch/testdata/profiles/bad_profile_1.yml
@@ -1,0 +1,9 @@
+profiles:
+  tiny:
+    notes: Invalid profile mixing versioned and non-versioned platforms.
+    fqbn: attiny:avr:ATtinyX5:cpu=attiny85,clock=internal16
+    platforms:
+      - platform: attiny:avr
+        platform_index_url: http://raw.githubusercontent.com/damellis/attiny/ide-1.6.x-boards-manager/package_damellis_attiny_index.json
+      - platform: arduino:avr (1.8.3)
+

--- a/internal/arduino/sketch/testdata/profiles/profile_1.yml
+++ b/internal/arduino/sketch/testdata/profiles/profile_1.yml
@@ -1,0 +1,12 @@
+profiles:
+  giga:
+    fqbn: arduino:mbed_giga:giga
+    platforms:
+      - platform: arduino:mbed_giga (4.3.1)
+
+  giga_any:
+    fqbn: arduino:mbed_giga:giga
+    platforms:
+      - platform: arduino:mbed_giga
+
+default_profile: giga_any


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

The idea is to allow in the `sketch.yml` platforms without a specific version, like the following `giga_any`:

```yaml
profiles:
  giga:
    fqbn: arduino:mbed_giga:giga
    platforms:
      - platform: arduino:mbed_giga (4.3.1)

  giga_any:
    fqbn: arduino:mbed_giga:giga
    platforms:
      - platform: arduino:mbed_giga      # this does not specify a version
      # no need to specify index_url either

default_profile: giga_any
```

In this case, the Arduino CLI will not download the platform to the internal space, but it will use the globally installed platform.

## What is the current behavior?

You must specify a version in the `platform` directive of the `sketch.yml`

## What is the new behavior?

You can omit a version in the `platform` directive of the `sketch.yml`, in this case the Arduino CLI will use the globally installed platform.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

<!-- Any additional information that could help the review process -->
