### PR TITLE
Updated formatting to new prettier standard

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -2742,7 +2742,6 @@ changes are trivial and falls into the following categories:
 Consumers of the JSON output of the CLI must update their clients if they use one of the following commands:
 
 - in `core search` command the following fields have been renamed:
-
   - `Boards` -> `boards`
   - `Email` -> `email`
   - `ID` -> `id`
@@ -2778,7 +2777,6 @@ Consumers of the JSON output of the CLI must update their clients if they use on
   ```
 
 - in `board details` command the following fields have been renamed:
-
   - `identification_pref` -> `identification_prefs`
   - `usbID` -> `usb_id`
   - `PID` -> `pid`
@@ -2856,7 +2854,6 @@ Consumers of the JSON output of the CLI must update their clients if they use on
   ```
 
 - in `board listall` command the following fields have been renamed:
-
   - `FQBN` -> `fqbn`
   - `Email` -> `email`
   - `ID` -> `id`
@@ -2890,7 +2887,6 @@ Consumers of the JSON output of the CLI must update their clients if they use on
   ```
 
 - in `board search` command the following fields have been renamed:
-
   - `FQBN` -> `fqbn`
   - `Email` -> `email`
   - `ID` -> `id`
@@ -2922,7 +2918,6 @@ Consumers of the JSON output of the CLI must update their clients if they use on
   ```
 
 - in `lib deps` command the following fields have been renamed:
-
   - `versionRequired` -> `version_required`
   - `versionInstalled` -> `version_installed`
 
@@ -2947,7 +2942,6 @@ Consumers of the JSON output of the CLI must update their clients if they use on
   ```
 
 - in `lib search` command the following fields have been renamed:
-
   - `archivefilename` -> `archive_filename`
   - `cachepath` -> `cache_path`
 
@@ -3016,7 +3010,6 @@ Consumers of the JSON output of the CLI must update their clients if they use on
   ```
 
 - in `board list` command the following fields have been renamed:
-
   - `FQBN` -> `fqbn`
   - `VID` -> `vid`
   - `PID` -> `pid`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,6 @@ The following are the default directories selected by the Arduino CLI if alterna
 configuration file.
 
 - The `build_cache.path` default is OS-dependent:
-
   - on Linux (and other Unix-based OS) is: if
     [`$XDG_CACHE_HOME`](https://specifications.freedesktop.org/basedir-spec/latest/#variables) is defined,
     `$XDG_CACHE_HOME/arduino`. Otherwise `{HOME}/.config/arduino`.
@@ -67,7 +66,6 @@ configuration file.
   - on MacOS is: `{HOME}/Library/Caches/arduino`
 
 - The `directories.data` default is OS-dependent:
-
   - on Linux (and other Unix-based OS) is: `{HOME}/.arduino15`
   - on Windows is: `{HOME}/AppData/Local/Arduino15`
   - on MacOS is: `{HOME}/Library/Arduino15`

--- a/docs/package_index_json-specification.md
+++ b/docs/package_index_json-specification.md
@@ -318,7 +318,6 @@ In general the same tool may be provided by different packagers (for example the
 are as follows:
 
 - The property `{runtime.tools.TOOLNAME.path}` points, in order of priority, to:
-
   1. the tool, version and packager specified via `toolsDependencies` in the `package_index.json`
   1. the highest version of the tool provided by the packager of the current platform
   1. the highest version of the tool provided by the packager of the referenced platform used for compile (see


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Updated formatting of .md files to new `prettier@3.6.2` standard.

## What is the current behavior?

CI fails.

## What is the new behavior?

CI pass (hopefully :-)

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
