### PR TITLE
Some bugfix in profile parsing / Better support for platforms having tools dependencies on other platforms.

### DIFF
--- a/internal/arduino/cores/packageindex/index_test.go
+++ b/internal/arduino/cores/packageindex/index_test.go
@@ -40,7 +40,215 @@ func TestIndexParsing(t *testing.T) {
 }
 
 func TestIndexFromPlatformRelease(t *testing.T) {
-	pr := &cores.PlatformRelease{
+	arduinoTools := map[string]*cores.Tool{
+		"serial-discovery": {
+			Name: "serial-discovery",
+			Releases: map[semver.NormalizedString]*cores.ToolRelease{
+				"1.0.0": {
+					Version: semver.ParseRelaxed("1.0.0"),
+					Flavors: []*cores.Flavor{
+						{
+							OS: "arm-linux-gnueabihf",
+							Resource: &resources.DownloadResource{
+								URL:             "some-serial-discovery-1.0.0-url",
+								ArchiveFileName: "serial-discovery-1.0.0.tar.bz2",
+								Checksum:        "SHA-256:some-serial-discovery-1.0.0-sha",
+								Size:            201341,
+							},
+						},
+						{
+							OS: "i686-mingw32",
+							Resource: &resources.DownloadResource{
+								URL:             "some-serial-discovery-1.0.0-other-url",
+								ArchiveFileName: "serial-discovery-1.0.0.tar.gz",
+								Checksum:        "SHA-256:some-serial-discovery-1.0.0-other-sha",
+								Size:            222918,
+							},
+						},
+					},
+				},
+				"0.1.0": {
+					Version: semver.ParseRelaxed("0.1.0"),
+					Flavors: []*cores.Flavor{
+						{
+							OS: "arm-linux-gnueabihf",
+							Resource: &resources.DownloadResource{
+								URL:             "some-serial-discovery-0.1.0-url",
+								ArchiveFileName: "serial-discovery-0.1.0.tar.bz2",
+								Checksum:        "SHA-256:some-serial-discovery-0.1.0-sha",
+								Size:            201341,
+							},
+						},
+						{
+							OS: "i686-mingw32",
+							Resource: &resources.DownloadResource{
+								URL:             "some-serial-discovery-0.1.0-other-url",
+								ArchiveFileName: "serial-discovery-0.1.0.tar.gz",
+								Checksum:        "SHA-256:some-serial-discovery-0.1.0-other-sha",
+								Size:            222918,
+							},
+						},
+					},
+				},
+			},
+		},
+		"ble-discovery": {
+			Name: "ble-discovery",
+			Releases: map[semver.NormalizedString]*cores.ToolRelease{
+				"1.0.0": {
+					Version: semver.ParseRelaxed("1.0.0"),
+					Flavors: []*cores.Flavor{
+						{
+							OS: "arm-linux-gnueabihf",
+							Resource: &resources.DownloadResource{
+								URL:             "some-ble-discovery-1.0.0-url",
+								ArchiveFileName: "ble-discovery-1.0.0.tar.bz2",
+								Checksum:        "SHA-256:some-ble-discovery-1.0.0-sha",
+								Size:            201341,
+							},
+						},
+						{
+							OS: "i686-mingw32",
+							Resource: &resources.DownloadResource{
+								URL:             "some-ble-discovery-1.0.0-other-url",
+								ArchiveFileName: "ble-discovery-1.0.0.tar.gz",
+								Checksum:        "SHA-256:some-ble-discovery-1.0.0-other-sha",
+								Size:            222918,
+							},
+						},
+					},
+				},
+				"0.1.0": {
+					Version: semver.ParseRelaxed("0.1.0"),
+					Flavors: []*cores.Flavor{
+						{
+							OS: "arm-linux-gnueabihf",
+							Resource: &resources.DownloadResource{
+								URL:             "some-ble-discovery-0.1.0-url",
+								ArchiveFileName: "ble-discovery-0.1.0.tar.bz2",
+								Checksum:        "SHA-256:some-ble-discovery-0.1.0-sha",
+								Size:            201341,
+							},
+						},
+
+						{
+							OS: "i686-mingw32",
+							Resource: &resources.DownloadResource{
+								URL:             "some-ble-discovery-0.1.0-other-url",
+								ArchiveFileName: "ble-discovery-0.1.0.tar.gz",
+								Checksum:        "SHA-256:some-ble-discovery-0.1.0-other-sha",
+								Size:            222918,
+							},
+						},
+					},
+				},
+			},
+		},
+		"bossac": {
+			Name: "bossac",
+			Releases: map[semver.NormalizedString]*cores.ToolRelease{
+				"1.6.1-arduino": {
+					Version: semver.ParseRelaxed("1.6.1-arduino"),
+					Flavors: []*cores.Flavor{
+						{
+							OS: "arm-linux-gnueabihf",
+							Resource: &resources.DownloadResource{
+								URL:             "http://downloads.arduino.cc/bossac-1.6.1-arduino-arm-linux-gnueabihf.tar.bz2",
+								ArchiveFileName: "bossac-1.6.1-arduino-arm-linux-gnueabihf.tar.bz2",
+								Checksum:        "SHA-256:8c4e63db982178919c824e7a35580dffc95c3426afa7285de3eb583982d4d391",
+								Size:            201341,
+							},
+						},
+						{
+							OS: "i686-mingw32",
+							Resource: &resources.DownloadResource{
+								URL:             "http://downloads.arduino.cc/bossac-1.6.1-arduino-mingw32.tar.gz",
+								ArchiveFileName: "bossac-1.6.1-arduino-mingw32.tar.gz",
+								Checksum:        "SHA-256:d59f43e2e83a337d04c4ae88b195a4ee175b8d87fff4c43144d23412a4a9513b",
+								Size:            222918,
+							},
+						},
+					},
+				},
+				"1.7.0": {
+					Version: semver.ParseRelaxed("1.7.0"),
+					Flavors: []*cores.Flavor{
+						{
+							OS: "i686-mingw32",
+							Resource: &resources.DownloadResource{
+								URL:             "http://downloads.arduino.cc/bossac-1.7.0-arduino-mingw32.tar.bz2",
+								ArchiveFileName: "bossac-1.7.0-arduino-mingw32.tar.bz2",
+								Checksum:        "SHA-256:9ef7d11b4fabca0adc17102a0290957d5cc26ce46b422c3a5344722c80acc7b2",
+								Size:            243066,
+							},
+						},
+						{
+							OS: "x86_64-apple-darwin",
+							Resource: &resources.DownloadResource{
+								URL:             "http://downloads.arduino.cc/bossac-1.7.0-arduino-x86_64-apple-darwin.tar.bz2",
+								ArchiveFileName: "bossac-1.7.0-arduino-x86_64-apple-darwin.tar.bz2",
+								Checksum:        "SHA-256:feac36ab38876c163dcf51bdbcfbed01554eede3d41c59a0e152e170fe5164d2",
+								Size:            63822,
+							},
+						},
+					},
+				},
+			},
+		},
+		"arm-none-eabi-gcc": {
+			Name: "arm-none-eabi-gcc",
+			Releases: map[semver.NormalizedString]*cores.ToolRelease{
+				"4.8.3-2014q1": {
+					Version: semver.ParseRelaxed("4.8.3-2014q1"),
+					Flavors: []*cores.Flavor{
+						{
+							OS: "arm-linux-gnueabihf",
+							Resource: &resources.DownloadResource{
+								URL:             "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
+								ArchiveFileName: "gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
+								Checksum:        "SHA-256:ebe96b34c4f434667cab0187b881ed585e7c7eb990fe6b69be3c81ec7e11e845",
+								Size:            44423906,
+							},
+						},
+						{
+							OS: "i686-mingw32",
+							Resource: &resources.DownloadResource{
+								URL:             "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-windows.tar.gz",
+								ArchiveFileName: "gcc-arm-none-eabi-4.8.3-2014q1-windows.tar.gz",
+								Checksum:        "SHA-256:fd8c111c861144f932728e00abd3f7d1107e186eb9cd6083a54c7236ea78b7c2",
+								Size:            84537449,
+							},
+						},
+					},
+				},
+				"7-2017q4": {
+					Version: semver.ParseRelaxed("7-2017q4"),
+					Flavors: []*cores.Flavor{
+						{
+							OS: "arm-linux-gnueabihf",
+							Resource: &resources.DownloadResource{
+								URL:             "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
+								ArchiveFileName: "gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
+								Checksum:        "SHA-256:ebe96b34c4f434667cab0187b881ed585e7c7eb990fe6b69be3c81ec7e11e845",
+								Size:            44423906,
+							},
+						},
+						{
+							OS: "aarch64-linux-gnu",
+							Resource: &resources.DownloadResource{
+								URL:             "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
+								ArchiveFileName: "gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
+								Checksum:        "SHA-256:6fb5752fb4d11012bd0a1ceb93a19d0641ff7cf29d289b3e6b86b99768e66f76",
+								Size:            99558726,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	avrPlatformRelease := &cores.PlatformRelease{
 		Resource: &resources.DownloadResource{
 			URL:             "http://downloads.arduino.cc/cores/avr-1.6.23.tar.bz2",
 			ArchiveFileName: "avr-1.6.23.tar.bz2",
@@ -55,263 +263,42 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 			{Name: "Arduino Uno WiFi"},
 		},
 		ToolDependencies: cores.ToolDependencies{
-			{
-				ToolPackager: "arduino",
-				ToolName:     "avr-gcc",
-				ToolVersion:  semver.ParseRelaxed("5.4.0-atmel3.6.1-arduino2"),
-			},
-			{
-				ToolPackager: "arduino",
-				ToolName:     "avrdude",
-				ToolVersion:  semver.ParseRelaxed("6.3.0-arduino14"),
-			},
-			{
-				ToolPackager: "arduino",
-				ToolName:     "arduinoOTA",
-				ToolVersion:  semver.ParseRelaxed("1.2.1"),
-			},
+			{ToolPackager: "arduino", ToolName: "avr-gcc", ToolVersion: semver.ParseRelaxed("5.4.0-atmel3.6.1-arduino2")},
+			{ToolPackager: "arduino", ToolName: "avrdude", ToolVersion: semver.ParseRelaxed("6.3.0-arduino14")},
+			{ToolPackager: "arduino", ToolName: "arduinoOTA", ToolVersion: semver.ParseRelaxed("1.2.1")},
 		},
 		DiscoveryDependencies: cores.DiscoveryDependencies{
-			{
-				Packager: "arduino",
-				Name:     "ble-discovery",
-			},
-			{
-				Packager: "arduino",
-				Name:     "serial-discovery",
-			},
+			{Packager: "arduino", Name: "ble-discovery"},
+			{Packager: "arduino", Name: "serial-discovery"},
 		},
 		MonitorDependencies: cores.MonitorDependencies{
-			{
-				Packager: "arduino",
-				Name:     "ble-monitor",
-			},
-			{
-				Packager: "arduino",
-				Name:     "serial-monitor",
-			},
+			{Packager: "arduino", Name: "ble-monitor"},
+			{Packager: "arduino", Name: "serial-monitor"},
 		},
 		Name:     "Arduino AVR Boards",
 		Category: "Arduino",
-		Platform: &cores.Platform{
-			Architecture: "avr",
-			Package: &cores.Package{
-				Name:       "arduino",
-				Maintainer: "Arduino",
-				WebsiteURL: "https://arduino.cc/",
-				URL:        "",
-				Email:      "packages@arduino.cc",
-				Help:       cores.PackageHelp{Online: "http://www.arduino.cc/en/Reference/HomePage"},
-				Tools: map[string]*cores.Tool{
-					"serial-discovery": {
-						Name: "serial-discovery",
-						Releases: map[semver.NormalizedString]*cores.ToolRelease{
-							"1.0.0": {
-								Version: semver.ParseRelaxed("1.0.0"),
-								Flavors: []*cores.Flavor{
-									{
-										OS: "arm-linux-gnueabihf",
-										Resource: &resources.DownloadResource{
-											URL:             "some-serial-discovery-1.0.0-url",
-											ArchiveFileName: "serial-discovery-1.0.0.tar.bz2",
-											Checksum:        "SHA-256:some-serial-discovery-1.0.0-sha",
-											Size:            201341,
-										},
-									},
-									{
-										OS: "i686-mingw32",
-										Resource: &resources.DownloadResource{
-											URL:             "some-serial-discovery-1.0.0-other-url",
-											ArchiveFileName: "serial-discovery-1.0.0.tar.gz",
-											Checksum:        "SHA-256:some-serial-discovery-1.0.0-other-sha",
-											Size:            222918,
-										},
-									},
-								},
-							},
-							"0.1.0": {
-								Version: semver.ParseRelaxed("0.1.0"),
-								Flavors: []*cores.Flavor{
-									{
-										OS: "arm-linux-gnueabihf",
-										Resource: &resources.DownloadResource{
-											URL:             "some-serial-discovery-0.1.0-url",
-											ArchiveFileName: "serial-discovery-0.1.0.tar.bz2",
-											Checksum:        "SHA-256:some-serial-discovery-0.1.0-sha",
-											Size:            201341,
-										},
-									},
-									{
-										OS: "i686-mingw32",
-										Resource: &resources.DownloadResource{
-											URL:             "some-serial-discovery-0.1.0-other-url",
-											ArchiveFileName: "serial-discovery-0.1.0.tar.gz",
-											Checksum:        "SHA-256:some-serial-discovery-0.1.0-other-sha",
-											Size:            222918,
-										},
-									},
-								},
-							},
-						},
-					},
-					"ble-discovery": {
-						Name: "ble-discovery",
-						Releases: map[semver.NormalizedString]*cores.ToolRelease{
-							"1.0.0": {
-								Version: semver.ParseRelaxed("1.0.0"),
-								Flavors: []*cores.Flavor{
-									{
-										OS: "arm-linux-gnueabihf",
-										Resource: &resources.DownloadResource{
-											URL:             "some-ble-discovery-1.0.0-url",
-											ArchiveFileName: "ble-discovery-1.0.0.tar.bz2",
-											Checksum:        "SHA-256:some-ble-discovery-1.0.0-sha",
-											Size:            201341,
-										},
-									},
-									{
-										OS: "i686-mingw32",
-										Resource: &resources.DownloadResource{
-											URL:             "some-ble-discovery-1.0.0-other-url",
-											ArchiveFileName: "ble-discovery-1.0.0.tar.gz",
-											Checksum:        "SHA-256:some-ble-discovery-1.0.0-other-sha",
-											Size:            222918,
-										},
-									},
-								},
-							},
-							"0.1.0": {
-								Version: semver.ParseRelaxed("0.1.0"),
-								Flavors: []*cores.Flavor{
-									{
-										OS: "arm-linux-gnueabihf",
-										Resource: &resources.DownloadResource{
-											URL:             "some-ble-discovery-0.1.0-url",
-											ArchiveFileName: "ble-discovery-0.1.0.tar.bz2",
-											Checksum:        "SHA-256:some-ble-discovery-0.1.0-sha",
-											Size:            201341,
-										},
-									},
-
-									{
-										OS: "i686-mingw32",
-										Resource: &resources.DownloadResource{
-											URL:             "some-ble-discovery-0.1.0-other-url",
-											ArchiveFileName: "ble-discovery-0.1.0.tar.gz",
-											Checksum:        "SHA-256:some-ble-discovery-0.1.0-other-sha",
-											Size:            222918,
-										},
-									},
-								},
-							},
-						},
-					},
-					"bossac": {
-						Name: "bossac",
-						Releases: map[semver.NormalizedString]*cores.ToolRelease{
-							"1.6.1-arduino": {
-								Version: semver.ParseRelaxed("1.6.1-arduino"),
-								Flavors: []*cores.Flavor{
-									{
-										OS: "arm-linux-gnueabihf",
-										Resource: &resources.DownloadResource{
-											URL:             "http://downloads.arduino.cc/bossac-1.6.1-arduino-arm-linux-gnueabihf.tar.bz2",
-											ArchiveFileName: "bossac-1.6.1-arduino-arm-linux-gnueabihf.tar.bz2",
-											Checksum:        "SHA-256:8c4e63db982178919c824e7a35580dffc95c3426afa7285de3eb583982d4d391",
-											Size:            201341,
-										},
-									},
-									{
-										OS: "i686-mingw32",
-										Resource: &resources.DownloadResource{
-											URL:             "http://downloads.arduino.cc/bossac-1.6.1-arduino-mingw32.tar.gz",
-											ArchiveFileName: "bossac-1.6.1-arduino-mingw32.tar.gz",
-											Checksum:        "SHA-256:d59f43e2e83a337d04c4ae88b195a4ee175b8d87fff4c43144d23412a4a9513b",
-											Size:            222918,
-										},
-									},
-								},
-							},
-							"1.7.0": {
-								Version: semver.ParseRelaxed("1.7.0"),
-								Flavors: []*cores.Flavor{
-									{
-										OS: "i686-mingw32",
-										Resource: &resources.DownloadResource{
-											URL:             "http://downloads.arduino.cc/bossac-1.7.0-arduino-mingw32.tar.bz2",
-											ArchiveFileName: "bossac-1.7.0-arduino-mingw32.tar.bz2",
-											Checksum:        "SHA-256:9ef7d11b4fabca0adc17102a0290957d5cc26ce46b422c3a5344722c80acc7b2",
-											Size:            243066,
-										},
-									},
-									{
-										OS: "x86_64-apple-darwin",
-										Resource: &resources.DownloadResource{
-											URL:             "http://downloads.arduino.cc/bossac-1.7.0-arduino-x86_64-apple-darwin.tar.bz2",
-											ArchiveFileName: "bossac-1.7.0-arduino-x86_64-apple-darwin.tar.bz2",
-											Checksum:        "SHA-256:feac36ab38876c163dcf51bdbcfbed01554eede3d41c59a0e152e170fe5164d2",
-											Size:            63822,
-										},
-									},
-								},
-							},
-						},
-					},
-					"arm-none-eabi-gcc": {
-						Name: "arm-none-eabi-gcc",
-						Releases: map[semver.NormalizedString]*cores.ToolRelease{
-							"4.8.3-2014q1": {
-								Version: semver.ParseRelaxed("4.8.3-2014q1"),
-								Flavors: []*cores.Flavor{
-									{
-										OS: "arm-linux-gnueabihf",
-										Resource: &resources.DownloadResource{
-											URL:             "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
-											ArchiveFileName: "gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
-											Checksum:        "SHA-256:ebe96b34c4f434667cab0187b881ed585e7c7eb990fe6b69be3c81ec7e11e845",
-											Size:            44423906,
-										},
-									},
-									{
-										OS: "i686-mingw32",
-										Resource: &resources.DownloadResource{
-											URL:             "http://downloads.arduino.cc/gcc-arm-none-eabi-4.8.3-2014q1-windows.tar.gz",
-											ArchiveFileName: "gcc-arm-none-eabi-4.8.3-2014q1-windows.tar.gz",
-											Checksum:        "SHA-256:fd8c111c861144f932728e00abd3f7d1107e186eb9cd6083a54c7236ea78b7c2",
-											Size:            84537449,
-										},
-									},
-								},
-							},
-							"7-2017q4": {
-								Version: semver.ParseRelaxed("7-2017q4"),
-								Flavors: []*cores.Flavor{
-									{
-										OS: "arm-linux-gnueabihf",
-										Resource: &resources.DownloadResource{
-											URL:             "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
-											ArchiveFileName: "gcc-arm-none-eabi-4.8.3-2014q1-arm.tar.bz2",
-											Checksum:        "SHA-256:ebe96b34c4f434667cab0187b881ed585e7c7eb990fe6b69be3c81ec7e11e845",
-											Size:            44423906,
-										},
-									},
-									{
-										OS: "aarch64-linux-gnu",
-										Resource: &resources.DownloadResource{
-											URL:             "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
-											ArchiveFileName: "gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
-											Checksum:        "SHA-256:6fb5752fb4d11012bd0a1ceb93a19d0641ff7cf29d289b3e6b86b99768e66f76",
-											Size:            99558726,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+	}
+	avrPlatform := &cores.Platform{
+		Architecture: "avr",
+		Releases: map[semver.NormalizedString]*cores.PlatformRelease{
+			avrPlatformRelease.Version.NormalizedString(): avrPlatformRelease,
 		},
 	}
+	avrPlatformRelease.Platform = avrPlatform
+
+	arduinoPackage := &cores.Package{
+		Name:       "arduino",
+		Maintainer: "Arduino",
+		WebsiteURL: "https://arduino.cc/",
+		URL:        "",
+		Email:      "packages@arduino.cc",
+		Help:       cores.PackageHelp{Online: "http://www.arduino.cc/en/Reference/HomePage"},
+		Tools:      arduinoTools,
+		Platforms: map[string]*cores.Platform{
+			"avr": avrPlatform,
+		},
+	}
+	avrPlatform.Package = arduinoPackage
 
 	expectedIndex := Index{
 		IsTrusted: false,
@@ -338,41 +325,17 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 				},
 				Help: indexHelp{Online: "http://www.arduino.cc/en/Reference/HomePage"},
 				ToolDependencies: []indexToolDependency{
-					{
-						Packager: "arduino",
-						Name:     "avr-gcc",
-						Version:  semver.ParseRelaxed("5.4.0-atmel3.6.1-arduino2"),
-					},
-					{
-						Packager: "arduino",
-						Name:     "avrdude",
-						Version:  semver.ParseRelaxed("6.3.0-arduino14"),
-					},
-					{
-						Packager: "arduino",
-						Name:     "arduinoOTA",
-						Version:  semver.ParseRelaxed("1.2.1"),
-					},
+					{Packager: "arduino", Name: "avr-gcc", Version: semver.ParseRelaxed("5.4.0-atmel3.6.1-arduino2")},
+					{Packager: "arduino", Name: "avrdude", Version: semver.ParseRelaxed("6.3.0-arduino14")},
+					{Packager: "arduino", Name: "arduinoOTA", Version: semver.ParseRelaxed("1.2.1")},
 				},
 				DiscoveryDependencies: []indexDiscoveryDependency{
-					{
-						Packager: "arduino",
-						Name:     "ble-discovery",
-					},
-					{
-						Packager: "arduino",
-						Name:     "serial-discovery",
-					},
+					{Packager: "arduino", Name: "ble-discovery"},
+					{Packager: "arduino", Name: "serial-discovery"},
 				},
 				MonitorDependencies: []indexMonitorDependency{
-					{
-						Packager: "arduino",
-						Name:     "ble-monitor",
-					},
-					{
-						Packager: "arduino",
-						Name:     "serial-monitor",
-					},
+					{Packager: "arduino", Name: "ble-monitor"},
+					{Packager: "arduino", Name: "serial-monitor"},
 				},
 			}},
 			Tools: []*indexToolRelease{
@@ -540,7 +503,7 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 		}},
 	}
 
-	in := IndexFromPlatformRelease(pr)
+	in := IndexFromPlatformRelease(avrPlatformRelease)
 	require.Equal(t, expectedIndex.IsTrusted, in.IsTrusted)
 	require.Equal(t, len(expectedIndex.Packages), len(in.Packages))
 

--- a/internal/arduino/cores/packageindex/index_test.go
+++ b/internal/arduino/cores/packageindex/index_test.go
@@ -270,6 +270,7 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 		DiscoveryDependencies: cores.DiscoveryDependencies{
 			{Packager: "arduino", Name: "ble-discovery"},
 			{Packager: "arduino", Name: "serial-discovery"},
+			{Packager: "dev", Name: "dev-discovery"},
 		},
 		MonitorDependencies: cores.MonitorDependencies{
 			{Packager: "arduino", Name: "ble-monitor"},
@@ -299,6 +300,51 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 		},
 	}
 	avrPlatform.Package = arduinoPackage
+
+	dependentPackage := &cores.Package{
+		Name:       "dev",
+		Maintainer: "Arduino Dev",
+		WebsiteURL: "https://arduino.cc/",
+		URL:        "",
+		Email:      "packages@arduino.cc",
+		Help:       cores.PackageHelp{Online: "http://www.arduino.cc/en/Reference/HomePage"},
+		Tools: map[string]*cores.Tool{
+			"dev-discovery": {
+				Name: "dev-discovery",
+				Releases: map[semver.NormalizedString]*cores.ToolRelease{
+					"1.0.0": {
+						Version: semver.ParseRelaxed("1.0.0"),
+						Flavors: []*cores.Flavor{
+							{
+								OS: "arm-linux-gnueabihf",
+								Resource: &resources.DownloadResource{
+									URL:             "dev-discovery-1.0.0-url",
+									ArchiveFileName: "dev-discovery-1.0.0.tar.bz2",
+									Checksum:        "SHA-256:dev-discovery-1.0.0-sha",
+									Size:            201341,
+								},
+							},
+							{
+								OS: "i686-mingw32",
+								Resource: &resources.DownloadResource{
+									URL:             "dev-discovery-1.0.0-other-url",
+									ArchiveFileName: "dev-discovery-1.0.0.tar.gz",
+									Checksum:        "SHA-256:dev-discovery-1.0.0-other-sha",
+									Size:            222918,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	packages := cores.NewPackages()
+	packages[arduinoPackage.Name] = arduinoPackage
+	arduinoPackage.Packages = packages
+	packages[dependentPackage.Name] = dependentPackage
+	dependentPackage.Packages = packages
 
 	expectedIndex := Index{
 		IsTrusted: false,
@@ -332,6 +378,7 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 				DiscoveryDependencies: []indexDiscoveryDependency{
 					{Packager: "arduino", Name: "ble-discovery"},
 					{Packager: "arduino", Name: "serial-discovery"},
+					{Packager: "dev", Name: "dev-discovery"},
 				},
 				MonitorDependencies: []indexMonitorDependency{
 					{Packager: "arduino", Name: "ble-monitor"},
@@ -496,6 +543,35 @@ func TestIndexFromPlatformRelease(t *testing.T) {
 							ArchiveFileName: "gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
 							Size:            "99558726",
 							Checksum:        "SHA-256:6fb5752fb4d11012bd0a1ceb93a19d0641ff7cf29d289b3e6b86b99768e66f76",
+						},
+					},
+				},
+			},
+		}, {
+			Name:       "dev",
+			Maintainer: "Arduino Dev",
+			WebsiteURL: "https://arduino.cc/",
+			URL:        "",
+			Email:      "packages@arduino.cc",
+			Help:       indexHelp{Online: "http://www.arduino.cc/en/Reference/HomePage"},
+			Tools: []*indexToolRelease{
+				{
+					Name:    "dev-discovery",
+					Version: semver.ParseRelaxed("1.0.0"),
+					Systems: []indexToolReleaseFlavour{
+						{
+							OS:              "arm-linux-gnueabihf",
+							URL:             "dev-discovery-1.0.0-url",
+							ArchiveFileName: "dev-discovery-1.0.0.tar.bz2",
+							Checksum:        "SHA-256:dev-discovery-1.0.0-sha",
+							Size:            "201341",
+						},
+						{
+							OS:              "i686-mingw32",
+							URL:             "dev-discovery-1.0.0-other-url",
+							ArchiveFileName: "dev-discovery-1.0.0.tar.gz",
+							Checksum:        "SHA-256:dev-discovery-1.0.0-other-sha",
+							Size:            "222918",
 						},
 					},
 				},

--- a/internal/arduino/cores/status.go
+++ b/internal/arduino/cores/status.go
@@ -50,6 +50,13 @@ type Package struct {
 	Packages   Packages             `json:"-"`
 }
 
+// GetPackage returns the specified Package if it exists
+// and a boolean indicating whether it was found or not.
+func (packages Packages) GetPackage(packager string) (*Package, bool) {
+	targetPackage, ok := packages[packager]
+	return targetPackage, ok
+}
+
 // GetOrCreatePackage returns the specified Package or creates an empty one
 // filling all the cross-references
 func (packages Packages) GetOrCreatePackage(packager string) *Package {

--- a/internal/arduino/sketch/profiles.go
+++ b/internal/arduino/sketch/profiles.go
@@ -187,6 +187,9 @@ type ProfileRequiredLibraries []*ProfileLibraryReference
 
 // AsYaml outputs the required libraries as Yaml
 func (p *ProfileRequiredLibraries) AsYaml() string {
+	if len(*p) == 0 {
+		return ""
+	}
 	res := "    libraries:\n"
 	for _, lib := range *p {
 		res += lib.AsYaml()

--- a/internal/arduino/sketch/profiles_test.go
+++ b/internal/arduino/sketch/profiles_test.go
@@ -16,7 +16,6 @@
 package sketch
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/arduino/go-paths-helper"
@@ -28,7 +27,6 @@ func TestProjectFileLoading(t *testing.T) {
 		sketchProj := paths.New("testdata", "SketchWithProfiles", "sketch.yml")
 		proj, err := LoadProjectFile(sketchProj)
 		require.NoError(t, err)
-		fmt.Println(proj)
 		golden, err := sketchProj.ReadFile()
 		require.NoError(t, err)
 		require.Equal(t, proj.AsYaml(), string(golden))
@@ -37,7 +35,6 @@ func TestProjectFileLoading(t *testing.T) {
 		sketchProj := paths.New("testdata", "SketchWithDefaultFQBNAndPort", "sketch.yml")
 		proj, err := LoadProjectFile(sketchProj)
 		require.NoError(t, err)
-		fmt.Println(proj)
 		golden, err := sketchProj.ReadFile()
 		require.NoError(t, err)
 		require.Equal(t, proj.AsYaml(), string(golden))

--- a/internal/arduino/sketch/testdata/SketchWithProfiles/sketch.yml
+++ b/internal/arduino/sketch/testdata/SketchWithProfiles/sketch.yml
@@ -9,6 +9,12 @@ profiles:
       - Arduino_ConnectionHandler (0.6.4)
       - TinyDHT sensor library (1.1.0)
 
+  nanorp_nolib:
+    fqbn: arduino:mbed_nano:nanorp2040connect
+    programmer: p1
+    platforms:
+      - platform: arduino:mbed_nano (2.1.0)
+
   another_profile_name:
     notes: testing the limit of the AVR platform, may be unstable
     fqbn: arduino:avr:uno


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

1. Fix a profile `sketch.yml` rendering bug.
2. Fix a bug that prevents extracting all the needed information in `installed.json`.

## What is the current behavior?

1. It will print an empty `libraries:` YAML object when the profile has no libraries. This is invalid YAML.
2. If the installed platform depends on a tool from another platform, the tool metadata is not extracted in the `installed.json` file. This would eventually make the platform unusable if the original index is removed.

## What is the new behavior?

1. The `libraries:` field is not printed if there are no libraries in the profile.
2. The `installed.json` now has all the necessary metadata.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information


