### PR TITLE
Do not use crossbuild container when CGO=0

### DIFF
--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -24,57 +24,41 @@ vars:
 tasks:
   Windows_32bit:
     desc: Builds Windows 32 bit binaries
-    dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        CGO_ENABLED=0 GOOS=windows GOARCH=386 {{.BUILD_COMMAND}}
 
+        cd {{.DIST_DIR}}
         zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_386"
       BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}"
-      BUILD_PLATFORM: "windows/386"
-      CONTAINER_TAG: "{{.GO_VERSION}}-main"
       PACKAGE_PLATFORM: "Windows_32bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
 
   Windows_64bit:
     desc: Builds Windows 64 bit binaries
-    dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        CGO_ENABLED=0 GOOS=windows GOARCH=amd64 {{.BUILD_COMMAND}}
 
+        cd {{.DIST_DIR}}
         zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_amd64"
       BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}"
-      BUILD_PLATFORM: "windows/amd64"
-      CONTAINER_TAG: "{{.GO_VERSION}}-main"
       PACKAGE_PLATFORM: "Windows_64bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
 
   Linux_32bit:
     desc: Builds Linux 32 bit binaries
-    dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        CGO_ENABLED=0 GOOS=linux GOARCH=386 {{.BUILD_COMMAND}}
 
+        cd {{.DIST_DIR}}
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
       - task: build_deb
         vars:
@@ -84,22 +68,16 @@ tasks:
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd32"
       BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
-      BUILD_PLATFORM: "linux/386"
-      CONTAINER_TAG: "{{.GO_VERSION}}-main"
       PACKAGE_PLATFORM: "Linux_32bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
   Linux_64bit:
     desc: Builds Linux 64 bit binaries
-    dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 {{.BUILD_COMMAND}}
 
+        cd {{.DIST_DIR}}
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
       - task: build_deb
         vars:
@@ -109,22 +87,16 @@ tasks:
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd64"
       BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
-      BUILD_PLATFORM: "linux/amd64"
-      CONTAINER_TAG: "{{.GO_VERSION}}-main"
       PACKAGE_PLATFORM: "Linux_64bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
   Linux_ARMv7:
     desc: Builds Linux ARMv7 binaries
-    dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        CGO_ENABLED=0 GOOS=linux GOARM=7 GOARCH=arm {{.BUILD_COMMAND}}
 
+        cd {{.DIST_DIR}}
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
       - task: build_deb
         vars:
@@ -134,22 +106,16 @@ tasks:
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
       BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
-      BUILD_PLATFORM: "linux/armv7"
-      CONTAINER_TAG: "{{.GO_VERSION}}-armhf"
       PACKAGE_PLATFORM: "Linux_ARMv7"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
   Linux_ARMv6:
     desc: Builds Linux ARMv6 binaries
-    dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        CGO_ENABLED=0 GOOS=linux GOARM=6 GOARCH=arm {{.BUILD_COMMAND}}
 
+        cd {{.DIST_DIR}}
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
       - task: build_deb
         vars:
@@ -159,22 +125,16 @@ tasks:
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
       BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
-      BUILD_PLATFORM: "linux/armv6"
-      CONTAINER_TAG: "{{.GO_VERSION}}-armel-debian12"
       PACKAGE_PLATFORM: "Linux_ARMv6"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
   Linux_ARM64:
     desc: Builds Linux ARM64 binaries
-    dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 {{.BUILD_COMMAND}}
 
+        cd {{.DIST_DIR}}
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
       - task: build_deb
         vars:
@@ -184,8 +144,6 @@ tasks:
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
       BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
-      BUILD_PLATFORM: "linux/arm64"
-      CONTAINER_TAG: "{{.GO_VERSION}}-arm-debian12"
       PACKAGE_PLATFORM: "Linux_ARM64"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Golang supports cross-building by default. With this PR I propose not to use the crossbuild container of Elastic, when we are building without cgo. This will make our build process faster, and we minimize the dependency on Elastic Container at the bare minimum.

The trigger of this PR is that Elastic seem to have broke the manifest of arm images, and we are now blocked by bumping our go version.

## What is the current behavior?

We are always using the elastic crossbuild container 

## What is the new behavior?

When building without CGO use native golang cross build capabilities 

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
