### PR TITLE
Added missing token in CI

### DIFF
--- a/.github/workflows/check-protobuf-task.yml
+++ b/.github/workflows/check-protobuf-task.yml
@@ -86,6 +86,7 @@ jobs:
 
       - uses: bufbuild/buf-action@v1
         with:
+          token: ${{ secrets.BUF_TOKEN }}
           pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
           lint: ${{ github.event_name == 'pull_request' }}
           format: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Added a missing token to avoid CI failures:

```
Run bufbuild/buf-action@v1
  with:
    pr_comment: false
    lint: false
    format: false
    breaking: false
    breaking_against: .git#branch=origin/master,subdir=rpc
    domain: buf.build
    github_actor: cmaglie
    github_token: ***
    setup_only: false
    exclude_imports: false
    breaking_against_registry: false
    push: true
    push_disable_create: false
    archive: false
  env:
    GO_VERSION: 1.24
Using the latest release of buf: 1.55.1
Downloading buf (1.55.1)
Setup buf (1.55.1) at /opt/hostedtoolcache/buf/1.55.1/x64
/opt/hostedtoolcache/buf/1.55.1/x64/buf config ls-modules --format name
buf.build/arduino/arduino-cli
/opt/hostedtoolcache/buf/1.55.1/x64/buf build --error-format github-actions
/opt/hostedtoolcache/buf/1.55.1/x64/buf push --error-format github-actions --exclude-unnamed --git-metadata --source-control-url https://github.com/arduino/arduino-cli/commit/ae68728ffb883cde81566383e7ce97b0adfe0301 --create
Failure: you are not authenticated for buf.build. Set the BUF_TOKEN environment variable or run "buf registry login", using a Buf API token as the password. For details, visit https://buf.build/docs/bsr/authentication
Error: Failed push
```

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
