### PR TITLE
linker: allow multi-step link recipe (`c.combine`)

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -302,6 +302,10 @@ compiler.libraries.ldflags=
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} -o "{build.path}/{build.project_name}.elf" {object_files} {compiler.libraries.ldflags} "{archive_file_path}" "-L{build.path}" -lm
 ```
 
+If the linking process requires multiple steps, the recipe can be written using the **recipe.c.combine.NUMBER.pattern**
+syntax. In this case, each step will be executed in the order specified by the number. When multiple steps are defined,
+the **recipe.c.combine.pattern** property is ignored.
+
 #### Recipes for extraction of executable files and other binary data
 
 An arbitrary number of extra steps can be performed at the end of objects linking. These steps can be used to extract

--- a/internal/arduino/builder/builder.go
+++ b/internal/arduino/builder/builder.go
@@ -464,7 +464,7 @@ func (b *Builder) build() error {
 	}
 	b.Progress.CompleteStep()
 
-	if err := b.RunRecipe("recipe.objcopy.", ".pattern", true); err != nil {
+	if err := b.RunRecipe("recipe.objcopy", ".pattern", true); err != nil {
 		return err
 	}
 	b.Progress.CompleteStep()

--- a/internal/arduino/builder/linker.go
+++ b/internal/arduino/builder/linker.go
@@ -90,10 +90,5 @@ func (b *Builder) link() error {
 	properties.Set("archive_file_path", b.buildArtifacts.coreArchiveFilePath.String())
 	properties.Set("object_files", objectFileList)
 
-	command, err := b.prepareCommandForRecipe(properties, "recipe.c.combine.pattern", false)
-	if err != nil {
-		return err
-	}
-
-	return b.execCommand(command)
+	return b.RunRecipeWithProps("recipe.c.combine", ".pattern", properties, false)
 }

--- a/internal/arduino/builder/recipe.go
+++ b/internal/arduino/builder/recipe.go
@@ -27,8 +27,7 @@ import (
 
 // RunRecipe fixdoc
 func (b *Builder) RunRecipe(prefix, suffix string, skipIfOnlyUpdatingCompilationDatabase bool) error {
-	// TODO is it necessary to use Clone?
-	return b.RunRecipeWithProps(prefix, suffix, b.buildProperties.Clone(), skipIfOnlyUpdatingCompilationDatabase)
+	return b.RunRecipeWithProps(prefix, suffix, b.buildProperties, skipIfOnlyUpdatingCompilationDatabase)
 }
 
 func (b *Builder) RunRecipeWithProps(prefix, suffix string, buildProperties *properties.Map, skipIfOnlyUpdatingCompilationDatabase bool) error {
@@ -36,12 +35,10 @@ func (b *Builder) RunRecipeWithProps(prefix, suffix string, buildProperties *pro
 
 	recipes := findRecipes(buildProperties, prefix, suffix)
 
-	// TODO is it necessary to use Clone?
-	properties := buildProperties.Clone()
 	for _, recipe := range recipes {
 		logrus.Debugf("Running recipe: %s", recipe)
 
-		command, err := b.prepareCommandForRecipe(properties, recipe, false)
+		command, err := b.prepareCommandForRecipe(buildProperties, recipe, false)
 		if err != nil {
 			return err
 		}

--- a/internal/arduino/builder/recipe.go
+++ b/internal/arduino/builder/recipe.go
@@ -27,10 +27,13 @@ import (
 
 // RunRecipe fixdoc
 func (b *Builder) RunRecipe(prefix, suffix string, skipIfOnlyUpdatingCompilationDatabase bool) error {
+	// TODO is it necessary to use Clone?
+	return b.RunRecipeWithProps(prefix, suffix, b.buildProperties.Clone(), skipIfOnlyUpdatingCompilationDatabase)
+}
+
+func (b *Builder) RunRecipeWithProps(prefix, suffix string, buildProperties *properties.Map, skipIfOnlyUpdatingCompilationDatabase bool) error {
 	logrus.Debugf("Looking for recipes like %s", prefix+"*"+suffix)
 
-	// TODO is it necessary to use Clone?
-	buildProperties := b.buildProperties.Clone()
 	recipes := findRecipes(buildProperties, prefix, suffix)
 
 	// TODO is it necessary to use Clone?

--- a/internal/arduino/builder/recipe.go
+++ b/internal/arduino/builder/recipe.go
@@ -60,10 +60,18 @@ func (b *Builder) RunRecipe(prefix, suffix string, skipIfOnlyUpdatingCompilation
 
 func findRecipes(buildProperties *properties.Map, patternPrefix string, patternSuffix string) []string {
 	var recipes []string
+
+	exactKey := patternPrefix + patternSuffix
+
 	for _, key := range buildProperties.Keys() {
-		if strings.HasPrefix(key, patternPrefix) && strings.HasSuffix(key, patternSuffix) && buildProperties.Get(key) != "" {
+		if key != exactKey && strings.HasPrefix(key, patternPrefix) && strings.HasSuffix(key, patternSuffix) && buildProperties.Get(key) != "" {
 			recipes = append(recipes, key)
 		}
+	}
+
+	// If no recipes were found, check if the exact key exists
+	if len(recipes) == 0 && buildProperties.Get(exactKey) != "" {
+		recipes = append(recipes, exactKey)
 	}
 
 	sort.Strings(recipes)

--- a/internal/arduino/builder/recipe_test.go
+++ b/internal/arduino/builder/recipe_test.go
@@ -1,0 +1,81 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package builder
+
+import (
+	"testing"
+
+	properties "github.com/arduino/go-properties-orderedmap"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecipeFinder(t *testing.T) {
+	t.Run("NumberedRecipes", func(t *testing.T) {
+		buildProperties := properties.NewMap()
+		buildProperties.Set("recipe.test", "test")
+		buildProperties.Set("recipe.1.test", "test2")
+		buildProperties.Set("recipe.2.test", "test3")
+		recipes := findRecipes(buildProperties, "recipe", ".test")
+		require.Equal(t, []string{"recipe.1.test", "recipe.2.test"}, recipes)
+	})
+	t.Run("NumberedRecipesWithGaps", func(t *testing.T) {
+		buildProperties := properties.NewMap()
+		buildProperties.Set("recipe.test", "test")
+		buildProperties.Set("recipe.2.test", "test3")
+		buildProperties.Set("recipe.0.test", "test2")
+		recipes := findRecipes(buildProperties, "recipe", ".test")
+		require.Equal(t, []string{"recipe.0.test", "recipe.2.test"}, recipes)
+	})
+	t.Run("NumberedRecipesWithGapsAndDifferentLenghtNumbers", func(t *testing.T) {
+		buildProperties := properties.NewMap()
+		buildProperties.Set("recipe.test", "test")
+		buildProperties.Set("recipe.12.test", "test3")
+		buildProperties.Set("recipe.2.test", "test2")
+		recipes := findRecipes(buildProperties, "recipe", ".test")
+		// The order is sorted alphabetically, not numerically
+		require.Equal(t, []string{"recipe.12.test", "recipe.2.test"}, recipes)
+	})
+	t.Run("NumberedRecipesWithGapsAndNumbers", func(t *testing.T) {
+		buildProperties := properties.NewMap()
+		buildProperties.Set("recipe.test", "test")
+		buildProperties.Set("recipe.12.test", "test3")
+		buildProperties.Set("recipe.02.test", "test2")
+		buildProperties.Set("recipe.09.test", "test2")
+		recipes := findRecipes(buildProperties, "recipe", ".test")
+		require.Equal(t, []string{"recipe.02.test", "recipe.09.test", "recipe.12.test"}, recipes)
+	})
+	t.Run("UnnumberedRecipies", func(t *testing.T) {
+		buildProperties := properties.NewMap()
+		buildProperties.Set("recipe.test", "test")
+		buildProperties.Set("recipe.a.test", "test3")
+		buildProperties.Set("recipe.b.test", "test2")
+		recipes := findRecipes(buildProperties, "recipe", ".test")
+		require.Equal(t, []string{"recipe.a.test", "recipe.b.test"}, recipes)
+	})
+	t.Run("ObjcopyRecipies/1", func(t *testing.T) {
+		buildProperties := properties.NewMap()
+		buildProperties.Set("recipe.objcopy.eep.pattern", "test")
+		buildProperties.Set("recipe.objcopy.hex.pattern", "test")
+		recipes := findRecipes(buildProperties, "recipe.objcopy", ".pattern")
+		require.Equal(t, []string{"recipe.objcopy.eep.pattern", "recipe.objcopy.hex.pattern"}, recipes)
+	})
+	t.Run("ObjcopyRecipies/2", func(t *testing.T) {
+		buildProperties := properties.NewMap()
+		buildProperties.Set("recipe.objcopy.partitions.bin.pattern", "test")
+		recipes := findRecipes(buildProperties, "recipe.objcopy", ".pattern")
+		require.Equal(t, []string{"recipe.objcopy.partitions.bin.pattern"}, recipes)
+	})
+}


### PR DESCRIPTION
This PR introduces the possibility of using multiple commands for the `c.combine` pattern, and infrastructure that will enable using the same logic on any build step, if so decided. 

Two changes in behavior are introduced:

* When looking for multi-step recipes (e.g. hooks) in `RunRecipe()`, a key that exactly matches `prefix.suffix` is explicitly ignored if numbered entries are found, and only used as a fallback when no other entries are present. 
This change is consistent with current docs that require a `prefix.NNN.suffix` syntax for multi-step recipes. A property named `prefix.suffix` is undefined behavior, and is currently included among the numbered ones.

* Reuse the `RunRecipe` logic for the `recipe.c.combine` step to allow multi-stage linking. The above change in this context means that numbered steps have priority over the single property, but both can be specified to maintain backwards compatibility (the new numbered properties are ignored by the current IDE).

NO TESTS as I don't know where to add the test case... :innocent: BUT I tried with a core that defined these rules and got the exact behavior I described here. If someone can give me pointers I can add the proper test case.

Feel free to cherry-pick and/or edit and/or shoot down at will :sweat_smile: 