### PR TITLE
Move the "debian package" copyright file into the correct folder

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -19,7 +19,7 @@ ARG GO_BINARY
 
 COPY ./debian/${DEB_NAME} /${DEB_NAME}/
 COPY ./${GO_BINARY} /${DEB_NAME}/usr/bin/${BINARY_NAME}
-COPY ./debian/${DEB_NAME}/DEBIAN/copyright /usr/share/doc/${DEB_NAME}/copyright
+COPY ./debian/${DEB_NAME}/DEBIAN/copyright /${DEB_NAME}/usr/share/doc/${DEB_NAME}/copyright
 
 # Go application are tagged with `v` prefix, this remove the first v if present
 RUN export VERSION=$(echo "${VERSION}" | sed -e "s/^v\(.*\)/\1/") && \


### PR DESCRIPTION
## What kind of change does this PR introduce?

The Debian package was placing the copyright file in the wrong location (in `/usr/share/doc/copyright` instead of `/usr/share/doc/arduino-cli/copyright`).