### PR TITLE
commands: use the new endpoint to detect boards

### DIFF
--- a/commands/service_board_identify.go
+++ b/commands/service_board_identify.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -216,5 +217,14 @@ func apiByVidPid(ctx context.Context, vid, pid string, settings *configuration.S
 		}
 		response[i] = &rpc.BoardListItem{Name: v.Name, Fqbn: v.FQBN}
 	}
+
+	// In case multiple platform matches the same vid-pid we put on top
+	// the arduino ones
+	slices.SortFunc(response, func(a, b *rpc.BoardListItem) int {
+		if strings.HasPrefix(a.Fqbn, "arduino") {
+			return -1
+		}
+		return 0
+	})
 	return response, nil
 }

--- a/commands/service_board_identify_test.go
+++ b/commands/service_board_identify_test.go
@@ -63,6 +63,41 @@ func TestGetByVidPid(t *testing.T) {
 	require.NotNil(t, err)
 }
 
+func TestGetByVidPidPutArduinoOnTop(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `
+{
+  "items": [
+    {
+      "fqbn": "esp32:esp32:nano_nora",
+      "vendor": "esp32",
+      "architecture": "esp32",
+      "board_id": "nano_nora",
+      "name": "Arduino Nano ESP32"
+    },
+    {
+      "fqbn": "arduino:esp32:nano_nora",
+      "vendor": "arduino",
+      "architecture": "esp32",
+      "board_id": "nano_nora",
+      "name": "Arduino Nano ESP32"
+    }
+  ]
+}
+		`)
+	}))
+	defer ts.Close()
+
+	vidPidURL = ts.URL
+	settings := configuration.NewSettings()
+	res, err := apiByVidPid(context.Background(), "0x2341", "0x0070", settings)
+	require.Nil(t, err)
+	require.Len(t, res, 2)
+	require.Equal(t, "Arduino Nano ESP32", res[0].GetName())
+	require.Equal(t, "arduino:esp32:nano_nora", res[0].GetFqbn())
+	require.Equal(t, "esp32:esp32:nano_nora", res[1].GetFqbn())
+}
+
 func TestGetByVidPidNotFound(t *testing.T) {
 	settings := configuration.NewSettings()
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Use the new endpoint we have created some months ago, to retrieve board information.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
