### PR TITLE
fix: Multiple gRPC `Create/Init/Destroy` cycles causes multiple pluggable-discovery zombie process

### DIFF
--- a/commands/internal/instances/instances.go
+++ b/commands/internal/instances/instances.go
@@ -172,10 +172,12 @@ func IsValid(inst *rpc.Instance) bool {
 // Delete removes an instance.
 func Delete(inst *rpc.Instance) bool {
 	instancesMux.Lock()
-	defer instancesMux.Unlock()
-	if _, ok := instances[inst.GetId()]; !ok {
+	instance, ok := instances[inst.GetId()]
+	delete(instances, inst.GetId())
+	instancesMux.Unlock()
+	if !ok {
 		return false
 	}
-	delete(instances, inst.GetId())
+	instance.pm.Destroy()
 	return true
 }

--- a/internal/arduino/cores/packagemanager/package_manager.go
+++ b/internal/arduino/cores/packagemanager/package_manager.go
@@ -197,6 +197,11 @@ func (pm *PackageManager) NewExplorer() (explorer *Explorer, release func()) {
 	}, pm.packagesLock.RUnlock
 }
 
+// Destroy releases all resources held by the PackageManager.
+func (pm *PackageManager) Destroy() {
+	pm.discoveryManager.Clear()
+}
+
 // GetProfile returns the active profile for this package manager, or nil if no profile is selected.
 func (pme *Explorer) GetProfile() *sketch.Profile {
 	return pme.profile

--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -506,6 +506,13 @@ func (cli *ArduinoCLI) Create() *ArduinoCLIInstance {
 	}
 }
 
+// Destroy calls the "Destroy" gRPC method.
+func (inst *ArduinoCLIInstance) Destroy(ctx context.Context) error {
+	logCallf(">>> Destroy(%v)\n", inst.instance.GetId())
+	_, err := inst.cli.daemonClient.Destroy(ctx, &commands.DestroyRequest{Instance: inst.instance})
+	return err
+}
+
 // SetValue calls the "SetValue" gRPC method.
 func (cli *ArduinoCLI) SetValue(key, jsonData string) error {
 	req := &commands.SettingsSetValueRequest{

--- a/internal/integrationtest/daemon/discoveries_test.go
+++ b/internal/integrationtest/daemon/discoveries_test.go
@@ -1,0 +1,86 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2025 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package daemon
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/arduino/arduino-cli/internal/integrationtest"
+	"github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoardListMock(t *testing.T) {
+	env, cli := integrationtest.CreateEnvForDaemon(t)
+	defer env.CleanUp()
+
+	_, _, err := cli.Run("core", "update-index")
+	require.NoError(t, err)
+
+	cli.InstallMockedSerialDiscovery(t)
+
+	var tmp1, tmp2 string
+
+	{
+		// Create a new instance of the daemon
+		grpcInst := cli.Create()
+		require.NoError(t, grpcInst.Init("", "", func(ir *commands.InitResponse) {
+			fmt.Printf("INIT> %v\n", ir.GetMessage())
+		}))
+
+		// Run a BoardList
+		resp, err := grpcInst.BoardList(time.Second)
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Ports)
+		for _, port := range resp.Ports {
+			if port.GetPort().GetProtocol() == "serial" {
+				tmp1 = port.Port.GetProperties()["discovery_tmp"]
+			}
+		}
+		require.NotEmpty(t, tmp1)
+
+		// Close instance
+		require.NoError(t, grpcInst.Destroy(t.Context()))
+	}
+
+	{
+		// Create a second instance of the daemon
+		grpcInst := cli.Create()
+		require.NoError(t, grpcInst.Init("", "", func(ir *commands.InitResponse) {
+			fmt.Printf("INIT> %v\n", ir.GetMessage())
+		}))
+
+		// Run a BoardList
+		resp, err := grpcInst.BoardList(time.Second)
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Ports)
+		for _, port := range resp.Ports {
+			if port.GetPort().GetProtocol() == "serial" {
+				tmp2 = port.Port.GetProperties()["discovery_tmp"]
+			}
+		}
+		require.NotEmpty(t, tmp2)
+
+		// Close instance
+		require.NoError(t, grpcInst.Destroy(t.Context()))
+	}
+
+	// Check if the discoveries have been successfully close
+	require.NoFileExists(t, tmp1, "discovery has not been closed")
+	require.NoFileExists(t, tmp2, "discovery has not been closed")
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

The Arduino CLI gRPC daemon does not correctly clean up pluggable-discovery processes after a `Destroy` call.

## What is the current behavior?

Zombie processes are left.

## What is the new behavior?

No zombie processes are left.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #1981 
