### PR TITLE
Fixed integration test runner

### DIFF
--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -410,16 +410,16 @@ func (cli *ArduinoCLI) run(ctx context.Context, stdoutBuff, stderrBuff io.Writer
 		}
 	}()
 	if stdinBuff != nil {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			if _, err := io.Copy(stdin, stdinBuff); err != nil {
 				fmt.Fprintln(terminalErr, color.HiBlackString("<<< stdin copy error:"), err)
 			}
 		}()
 	}
-	cliErr := cliProc.WaitWithinContext(ctx)
 	wg.Wait()
-
-	return cliErr
+	return cliProc.WaitWithinContext(ctx)
 }
 
 // StartDaemon starts the Arduino CLI daemon. It returns the address of the daemon.


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Should fix some sporadic `<<< stderr copy error: read |0: file already closed` errors.

## What is the current behavior?

`copy error: read |0: file already closed` pops up randomly. This is probably due to the incorrect `Wait` happening before the `io.Copy` naturally terminates.

## What is the new behavior?

The `run` subroutines wait for the `io.Copy` completion before calling `Wait` on the running process.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

<!-- Any additional information that could help the review process -->
