### PR TITLE
Cherry Pick to 0.29.x: Disable DTR clearing on 1200-bps touch (only on Windows) (#2234)

### DIFF
--- a/arduino/serialutils/serialutils.go
+++ b/arduino/serialutils/serialutils.go
@@ -17,6 +17,7 @@ package serialutils
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -37,10 +38,15 @@ func TouchSerialPortAt1200bps(port string) error {
 		return errors.WithMessage(err, tr("opening port at 1200bps"))
 	}
 
-	// Set DTR to false
-	if err = p.SetDTR(false); err != nil {
-		p.Close()
-		return errors.WithMessage(err, tr("setting DTR to OFF"))
+	if runtime.GOOS != "windows" {
+		// This is not required on Windows
+		// TODO: Investigate if it can be removed for other OS too
+
+		// Set DTR to false
+		if err = p.SetDTR(false); err != nil {
+			p.Close()
+			return errors.WithMessage(err, tr("setting DTR to OFF"))
+		}
 	}
 
 	// Close serial port


### PR DESCRIPTION
Cherry pick this fix for the version 0.29.x. This version must be updated since it's used in the `arduino-cloud-cli`
### Original PR
The reason why it was originally introduced:
https://github.com/arduino/Arduino/pull/2709/commits/a6909bdb49d99253b4e684365e72e5dce31a49a7

Why we are removing it now?
* Windows does preserve the state of the RTS/DTR bits on successive opening of the serial port.
* The serial library used in the Arduino IDE 1.8.x has a bug when trying to set DTR=false, on successive opening of the port the DTR line is set back high by the USB serial driver. This works differently from the serial library we use in the Arduino CLI, that sets DTR=false for good and this change is preserved on the successive opening of the port.
* Having the serial port left in a state with DTR=false may cause problems to tools uploading later.

It may probably completely removed, but for now, to reduce the testing surface, it will be disabled only for Windows.

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
