### PR TITLE
Taskfile cache-dep-license will update also deb package license recap

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,6 +57,7 @@ tasks:
           exit 1
         fi
       - licensed cache
+      - task: update-deb-copyright
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
   general:check-dep-licenses:


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Running 'task genera:cache-dep-licenses` will automatically update the deb package license recap in one go.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
