### PR TITLE
Add WinGet installation instructions for Arduino CLI

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,6 +11,14 @@ brew update
 brew install arduino-cli
 ```
 
+## Install via WinGet (Windows)
+
+The Arduino CLI is available as a WinGet:
+
+```sh
+winget install ArduinoSA.CLI
+```
+
 ### Command line completion
 
 [Command line completion](command-line-completion.md#brew) files are already bundled in the homebrew installation.


### PR DESCRIPTION
Added installation instructions for Arduino CLI using WinGet on Windows.

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [x] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

docs update.

## Other information

<img width="979" height="512" alt="image" src="https://github.com/user-attachments/assets/f01a4b17-6b10-44d2-b2a1-99c381f4f240" />

```bash
arduino-cli version
winget install ArduinoSA.CLI
arduino-cli version
```

I tested the above command on Windows 11.
In PowerShell, the path will not be reflected unless you start a new shell.