### PR TITLE
[skip changelog] Use compatible runner for macOS Apple Silicon nightly builds

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -25,23 +25,34 @@ permissions:
 
 jobs:
   create-nightly-artifacts:
+    name: Build ${{ matrix.os.task }}
     outputs:
       version: ${{ steps.get-version.outputs.version }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runner }}
 
     strategy:
       matrix:
         os:
-          - Windows_32bit
-          - Windows_64bit
-          - Linux_32bit
-          - Linux_64bit
-          - Linux_ARMv6
-          - Linux_ARMv7
-          - Linux_ARM64
-          - macOS_64bit
-          - macOS_ARM64
-          - jsonschema
+          - task: Windows_32bit
+            runner: ubuntu-latest
+          - task: Windows_64bit
+            runner: ubuntu-latest
+          - task: Linux_32bit
+            runner: ubuntu-latest
+          - task: Linux_64bit
+            runner: ubuntu-latest
+          - task: Linux_ARMv6
+            runner: ubuntu-latest
+          - task: Linux_ARMv7
+            runner: ubuntu-latest
+          - task: Linux_ARM64
+            runner: ubuntu-latest
+          - task: macOS_64bit
+            runner: ubuntu-latest
+          - task: macOS_ARM64
+            runner: ubuntu-24.04-arm
+          - task: jsonschema
+            runner: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -56,7 +67,7 @@ jobs:
       - name: Build
         env:
           NIGHTLY: true
-        run: task dist:${{ matrix.os }}
+        run: task dist:${{ matrix.os.task }}
 
       - name: Output Version
         id: get-version
@@ -68,7 +79,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}-${{ matrix.os }}
+          name: ${{ env.ARTIFACT_NAME }}-${{ matrix.os.task }}
           path: ${{ env.DIST_DIR }}
 
   notarize-macos:


### PR DESCRIPTION
This was already done for the release and tester build workflows, but the fix was not applied to the nightly build workflow at that time, so this workflow continues to fail:

https://github.com/arduino/arduino-cli/actions/runs/17751636022/job/50447448221#step:4:217

It is standard practice to use the "latest" GitHub Actions runner identifiers in the project's workflows, which causes the workflow runs to always use the newest stable runner version. However, GitHub has broken from this established convention by choosing to not provide "latest" identifiers for the Linux ARM runners (https://github.com/actions/partner-runner-images/issues/118#issuecomment-3151859667). For this reason, the version-specific runner name was used in the workflow. It will be necessary to manually update the runner name as new stable versions are made available (or more likely after GitHub's removal of the runner in use breaks the workflows).

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `docker.elastic.co/beats-dev/golang-crossbuild:1.24.4-darwin-arm64-debian10` container is used for the release builds for the macOS Apple Silicon host. This container will only run on hosts of the linux/arm64 architecture.

The GitHub Actions runner machine previously used to perform the release builds is of the linux/amd64 architecture and so is not compatible with the container. This caused the release builds to fail:

```text
Status: Downloaded newer image for docker.elastic.co/beats-dev/golang-crossbuild:1.24.4-darwin-arm64-debian10
WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
exec /crossbuild: exec format error
task: Failed to run task "dist:macOS_ARM64": exit status 255
```

The bug was already fixed in the release and tester build workflows (https://github.com/arduino/arduino-cli/pull/2850, https://github.com/arduino/arduino-cli/pull/2896), but the same was never done for the nightly build workflow.

## What is the new behavior?

The failure is resolved by configuring the workflow to use the `ubuntu-24.04-arm` runner machine that is compatible with the container.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change

## Other information

In order to facilitate the review of this PR, I performed a run of the workflow in my fork, notarized using a certificate from my personal Apple Developer Program account:

https://github.com/per1234/arduino-cli/actions/runs/17781046849

---

It is standard practice to use the "latest" GitHub Actions runner identifiers in the project's workflows, which causes the workflow runs to always use the newest stable runner version. However, GitHub has broken from this established convention by choosing to not provide "latest" identifiers for the Linux ARM runners (https://github.com/actions/partner-runner-images/issues/118#issuecomment-3151859667). For this reason, there was not alternative but to use the version-specific `ubuntu-24.04-arm` runner name in the workflow. It will be necessary to manually update the runner name as new stable versions are made available (or more likely after GitHub's removal of the runner in use breaks the workflows).
