### PR TITLE
[skip changelog] Remove donation link from contributor guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,14 +4,14 @@ First of all, thanks for contributing! This document provides some basic guideli
 
 There are several ways you can get involved:
 
-| Type of contribution                              | Contribution method                                     |
-| ------------------------------------------------- | ------------------------------------------------------- |
-| - Support request<br/>- Question<br/>- Discussion | Post on the [Arduino Forum][forum]                      |
-| - Bug report<br/>- Feature request                | Issue report (read the [issue guidelines][issues])      |
-| Testing                                           | Try out the [nightly build][nightly]                    |
-| - Bug fix<br/>- Enhancement                       | Pull Request (read the [pull request guidelines][prs])  |
-| Translations for Arduino CLI                      | Use the [transifex][translate] platform                 |
-| Monetary                                          | - [Donate][donate]<br/>- [Buy official products][store] |
+| Type of contribution                              | Contribution method                                    |
+| ------------------------------------------------- | ------------------------------------------------------ |
+| - Support request<br/>- Question<br/>- Discussion | Post on the [Arduino Forum][forum]                     |
+| - Bug report<br/>- Feature request                | Issue report (read the [issue guidelines][issues])     |
+| Testing                                           | Try out the [nightly build][nightly]                   |
+| - Bug fix<br/>- Enhancement                       | Pull Request (read the [pull request guidelines][prs]) |
+| Translations for Arduino CLI                      | Use the [transifex][translate] platform                |
+| Monetary                                          | [Buy official products][store]                         |
 
 ## Issue Reports
 
@@ -342,7 +342,6 @@ If your PR doesn't need to be included in the changelog, please start the commit
 [nightly]: https://arduino.github.io/arduino-cli/latest/installation/#nightly-builds
 [prs]: #pull-requests
 [translate]: https://www.transifex.com/arduino-1/arduino-cli/
-[donate]: https://www.arduino.cc/en/Main/Contribute
 [store]: https://store.arduino.cc
 [issue-tracker]: https://github.com/arduino/arduino-cli/issues?q=
 [reactions]: https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The contributor guide contains a link to make monetary donations.

The Arduino company is no longer soliciting monetary donations, so has removed the page the link targets.

## What is the new behavior?

The broken link is removed from the contributor guide. Community members who wish to contribute to the project still have opportunities to do so via the other options listed in the contributor guide.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.
