### PR TITLE
Added Windows/ARM64 target host "flavor" for tools.

### DIFF
--- a/docs/package_index_json-specification.md
+++ b/docs/package_index_json-specification.md
@@ -195,11 +195,12 @@ we recommend to keep it simple and stick to the suggested value in the table.
 
 Some OS allows to run different flavours:
 
-| The OS...    | ...may also run builds for |
-| ------------ | -------------------------- |
-| Windows 64   | Windows 32                 |
-| MacOSX 64    | MacOSX 32                  |
-| MacOSX Arm64 | MacOSX 64 or MacOSX 32     |
+| The OS...     | ...may also run builds for |
+| ------------- | -------------------------- |
+| Windows 64    | Windows 32                 |
+| Windows Arm64 | Windows 32 or Windows 64   |
+| MacOSX 64     | MacOSX 32                  |
+| MacOSX Arm64  | MacOSX 64 or MacOSX 32     |
 
 This is taken into account when the tools are downloaded (for example if we are on a Windows 64 machine and the needed
 tool is available only for the Windows 32 flavour, then the Windows 32 flavour will be downloaded and used).
@@ -214,6 +215,7 @@ For completeness, the previous example `avr-gcc` comes with builds for:
 - Linux 64 (`x86_64-linux-gnu`)
 - MacOSX Arm64 will use the MacOSX 64 flavour
 - Windows 64 will use the Windows 32 flavour
+- Windows Arm64 will use the Windows 32 flavour
 
 Note: this information is not used to select the toolchain during compilation. If you want a specific version to be
 used, you should use the notation `{runtime.tools.TOOLNAME-VERSION.path}` in the platform.txt.

--- a/internal/arduino/cores/tools.go
+++ b/internal/arduino/cores/tools.go
@@ -189,6 +189,13 @@ func (f *Flavor) isCompatibleWith(osName, osArch string) (bool, int) {
 	switch osName + "," + osArch {
 	case "windows,amd64":
 		return regexpWindows32.MatchString(f.OS), 10
+	case "windows,arm64":
+		// Compatibility guaranteed through Prism emulation
+		if regexpWindows64.MatchString(f.OS) {
+			// Prefer amd64 version if available
+			return true, 20
+		}
+		return regexpWindows32.MatchString(f.OS), 10
 	case "darwin,amd64":
 		return regexpMac32.MatchString(f.OS), 10
 	case "darwin,arm64":

--- a/internal/arduino/cores/tools_test.go
+++ b/internal/arduino/cores/tools_test.go
@@ -64,8 +64,8 @@ func TestFlavorCompatibility(t *testing.T) {
 		ExactMatch  []*os
 	}
 	tests := []*test{
-		{&Flavor{OS: "i686-mingw32"}, []*os{windows32, windows64}, []*os{windows32}},
-		{&Flavor{OS: "x86_64-mingw32"}, []*os{windows64}, []*os{windows64}},
+		{&Flavor{OS: "i686-mingw32"}, []*os{windows32, windows64, windowsArm64}, []*os{windows32}},
+		{&Flavor{OS: "x86_64-mingw32"}, []*os{windows64, windowsArm64}, []*os{windows64}},
 		{&Flavor{OS: "arm64-mingw32"}, []*os{windowsArm64}, []*os{windowsArm64}},
 		{&Flavor{OS: "i386-apple-darwin11"}, []*os{darwin32, darwin64, darwinArm64}, []*os{darwin32}},
 		{&Flavor{OS: "x86_64-apple-darwin"}, []*os{darwin64, darwinArm64}, []*os{darwin64}},
@@ -163,6 +163,7 @@ func TestFlavorPrioritySelection(t *testing.T) {
 		Flavors: []*Flavor{
 			{OS: "i686-mingw32", Resource: &resources.DownloadResource{ArchiveFileName: "1"}},
 			{OS: "x86_64-mingw32", Resource: &resources.DownloadResource{ArchiveFileName: "2"}},
+			{OS: "arm64-mingw32", Resource: &resources.DownloadResource{ArchiveFileName: "3"}},
 		},
 	}).GetFlavourCompatibleWith("windows", "amd64")
 	require.NotNil(t, res)
@@ -170,10 +171,36 @@ func TestFlavorPrioritySelection(t *testing.T) {
 
 	res = (&ToolRelease{
 		Flavors: []*Flavor{
+			{OS: "i686-mingw32", Resource: &resources.DownloadResource{ArchiveFileName: "1"}},
 			{OS: "x86_64-mingw32", Resource: &resources.DownloadResource{ArchiveFileName: "2"}},
+			{OS: "arm64-mingw32", Resource: &resources.DownloadResource{ArchiveFileName: "3"}},
+		},
+	}).GetFlavourCompatibleWith("windows", "arm64")
+	require.NotNil(t, res)
+	require.Equal(t, "3", res.ArchiveFileName)
+
+	res = (&ToolRelease{
+		Flavors: []*Flavor{
 			{OS: "i686-mingw32", Resource: &resources.DownloadResource{ArchiveFileName: "1"}},
 		},
 	}).GetFlavourCompatibleWith("windows", "amd64")
 	require.NotNil(t, res)
+	require.Equal(t, "1", res.ArchiveFileName)
+
+	res = (&ToolRelease{
+		Flavors: []*Flavor{
+			{OS: "i686-mingw32", Resource: &resources.DownloadResource{ArchiveFileName: "1"}},
+			{OS: "x86_64-mingw32", Resource: &resources.DownloadResource{ArchiveFileName: "2"}},
+		},
+	}).GetFlavourCompatibleWith("windows", "arm64")
+	require.NotNil(t, res)
 	require.Equal(t, "2", res.ArchiveFileName)
+
+	res = (&ToolRelease{
+		Flavors: []*Flavor{
+			{OS: "i686-mingw32", Resource: &resources.DownloadResource{ArchiveFileName: "1"}},
+		},
+	}).GetFlavourCompatibleWith("windows", "arm64")
+	require.NotNil(t, res)
+	require.Equal(t, "1", res.ArchiveFileName)
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Adds the Windows/ARM64 pair to the list of supported tools "flavor".

## What is the current behavior?

Windows/ARM64 is not supported, there is no way to add support for such hardware combination.

## What is the new behavior?

Windows/ARM64 is supported.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

<!-- Any additional information that could help the review process -->
