### PR TITLE
fix: build.options now have the full path to used platforms

### DIFF
--- a/commands/service_compile.go
+++ b/commands/service_compile.go
@@ -264,7 +264,6 @@ func (s *arduinoCoreServerImpl) Compile(req *rpc.CompileRequest, stream rpc.Ardu
 		extraCoreBuildCachePaths,
 		int(req.GetJobs()),
 		req.GetBuildProperties(),
-		s.settings.HardwareDirectories(),
 		librariesDirs,
 		s.settings.IDEBuiltinLibrariesDir(),
 		fqbn,

--- a/internal/arduino/builder/builder.go
+++ b/internal/arduino/builder/builder.go
@@ -123,7 +123,6 @@ func NewBuilder(
 	extraCoreBuildCachePaths paths.PathList,
 	jobs int,
 	customBuildProperties []string,
-	hardwareDirs paths.PathList,
 	librariesDirs paths.PathList,
 	builtInLibrariesDirs *paths.Path,
 	fqbn *fqbn.FQBN,
@@ -225,7 +224,7 @@ func NewBuilder(
 		buildPlatform:                 buildPlatform,
 		toolEnv:                       toolEnv,
 		buildOptions: newBuildOptions(
-			hardwareDirs,
+			paths.PathList{targetPlatform.InstallDir, buildPlatform.InstallDir},
 			librariesDirs,
 			builtInLibrariesDirs,
 			buildPath,


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Previously, the path to the folder containing the platforms was used (for example, `/home/cmaglie/.arduino15/packages` instead of `/home/cmaglie/.arduino15/packages/arduino/hardware/avr/1.8.6`). This kept the `build.options` file unchanged even if a platform was updated, leading to a possible cache reuse even if a full rebuild is required.

## What is the current behavior?

```
~/Arduino/Blink$ arduino-cli compile --build-path build
Lo sketch usa 1438 byte (4%) dello spazio disponibile per i programmi. Il massimo è 32256 byte.
Le variabili globali usano 184 byte (8%) di memoria dinamica, lasciando altri 1864 byte liberi per le variabili locali. Il massimo è 2048 byte.
~/Arduino/Blink$ cat build/build.options.json 
{
  "additionalFiles": "",
  "compiler.optimization_flags": "",
  "customBuildProperties": "",
  "fqbn": "arduino:avr:uno",
  "hardwareFolders": "/home/cmaglie/.arduino15/packages,/home/cmaglie/Workspace/sketchbook-cores-beta/hardware",
  "otherLibrariesFolders": "/home/cmaglie/Workspace/sketchbook-cores-beta/libraries",
  "sketchLocation": "/home/cmaglie/Arduino/Blink"
}
```

## What is the new behavior?

```
~/Arduino/Blink$ arduino-cli compile --build-path build
Lo sketch usa 1438 byte (4%) dello spazio disponibile per i programmi. Il massimo è 32256 byte.
Le variabili globali usano 184 byte (8%) di memoria dinamica, lasciando altri 1864 byte liberi per le variabili locali. Il massimo è 2048 byte.
~/Arduino/Blink$ cat build/build.options.json 
{
  "additionalFiles": "",
  "compiler.optimization_flags": "",
  "customBuildProperties": "",
  "fqbn": "arduino:avr:uno",
  "hardwareFolders": "/home/cmaglie/.arduino15/packages/arduino/hardware/avr/1.8.6,/home/cmaglie/.arduino15/packages/arduino/hardware/avr/1.8.6",
  "otherLibrariesFolders": "/home/cmaglie/Workspace/sketchbook-cores-beta/libraries",
  "sketchLocation": "/home/cmaglie/Arduino/Blink"
}
~/Arduino/Blink$ 
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
