### PR TITLE
fix: return `AlreadyExists` when archive exists

### DIFF
--- a/commands/cmderrors/cmderrors.go
+++ b/commands/cmderrors/cmderrors.go
@@ -772,6 +772,25 @@ func (e *NotFoundError) GRPCStatus() *status.Status {
 	return status.New(codes.NotFound, e.Error())
 }
 
+// AlreadyExists is returned when creating a resource failed because one already exists
+type AlreadyExists struct {
+	Message string
+	Cause   error
+}
+
+func (e *AlreadyExists) Error() string {
+	return composeErrorMsg(e.Message, e.Cause)
+}
+
+func (e *AlreadyExists) Unwrap() error {
+	return e.Cause
+}
+
+// GRPCStatus converts the error into a *status.Status
+func (e *AlreadyExists) GRPCStatus() *status.Status {
+	return status.New(codes.AlreadyExists, e.Error())
+}
+
 // PermissionDeniedError is returned when a resource cannot be accessed or modified
 type PermissionDeniedError struct {
 	Message string

--- a/commands/service_sketch_archive.go
+++ b/commands/service_sketch_archive.go
@@ -66,7 +66,7 @@ func (s *arduinoCoreServerImpl) ArchiveSketch(ctx context.Context, req *rpc.Arch
 
 	if !req.GetOverwrite() {
 		if archivePath.Exist() {
-			return nil, &cmderrors.InvalidArgumentError{Message: i18n.Tr("Archive already exists")}
+			return nil, &cmderrors.AlreadyExists{Message: i18n.Tr("Archive already exists")}
 		}
 	}
 

--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -807,3 +807,17 @@ func (inst *ArduinoCLIInstance) ProfileLibRemove(
 	resp, err := inst.cli.daemonClient.ProfileLibRemove(ctx, req)
 	return resp, err
 }
+
+// ArchiveSketch calls the "ArchiveSketch" gRPC method.
+func (cli *ArduinoCLI) ArchiveSketch(ctx context.Context, sketchPath, archivePath string, includeBuildDir, overwrite bool) (*commands.ArchiveSketchResponse, error) {
+	req := &commands.ArchiveSketchRequest{
+		SketchPath:      sketchPath,
+		ArchivePath:     archivePath,
+		IncludeBuildDir: includeBuildDir,
+		Overwrite:       overwrite,
+	}
+	logCallf(">>> ArchiveSketch(%+v)\n", req)
+	resp, err := cli.daemonClient.ArchiveSketch(ctx, req)
+	logCallf("err=%v\n", err)
+	return resp, err
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->

Bug fix

## What is the current behavior?

<!-- You can also link to an open issue here -->

When a client archives a sketch via gRPC and the archiveTarget already exists, the CLI correctly errors, but with the incorrect status code. The status code is 3 (illegal argument) instead of 6 (already exists).
Currently, clients must parse the error message if they want to handle the archive -> fail -> archive with override flow. This might not work reliably with translations.

## What is the new behavior?

<!-- if this is a feature change -->

The CLI errors with the correct already exists status code when archiving a sketch, and the archive target already exists.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

Actually, this is a breaking change, but I do not know if any client is explicitly handling status code 3. The Arduino IDE 2.x just wipes the target if it exists: https://github.com/arduino/arduino-ide/blob/4d6cfad0ff603a106efd68ffe015d6fc7449f5fc/arduino-ide-extension/src/node/sketches-service-impl.ts#L637-L639

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
