### PR TITLE
fix(doc): clarify profile port protocol usage

### DIFF
--- a/docs/sketch-project-file.md
+++ b/docs/sketch-project-file.md
@@ -72,8 +72,9 @@ The following fields are available since Arduino CLI 1.1.0:
   used in the `monitor` command. Typically is used to set the baudrate for the serial port (for example
   `baudrate: 115200`) but any setting/value can be specified. Multiple settings can be set. These fields are optional.
 - `<PORT_PROTOCOL>` is the protocol for the port used to upload and monitor the board. Arduino CLI ignores this value at
-  runtime, so write it only if an external client (for example one using the gRPC [`Port`](/rpc/commands/#port)) needs to restore the `protocol` together with the port `address`. Clients that do not set it should assume their
-  own default (usually `serial`). This field is optional.
+  runtime, so write it only if an external client (for example one using the gRPC [`Port`](/rpc/commands/#port)) needs
+  to restore the `protocol` together with the port `address`. Clients that do not set it should assume their own default
+  (usually `serial`). This field is optional.
 
 #### Using a system-installed platform.
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

<!-- Bug fix, feature, docs update, ... -->

Docs update

## What is the current behavior?

<!-- You can also link to an open issue here -->

From the [sketch profile docs](https://arduino.github.io/arduino-cli/1.3/sketch-project-file/#build-profiles), it is not clear where the CLI uses the `port_protocol` prop. It does not.

## What is the new behavior?

The PR documents what `port_protocol` is for.

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->

Ref https://github.com/arduino/arduino-cli/pull/2717#issuecomment-3489806733
