### PR TITLE
Add Windows ARM64 binaries to nightly builds

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -37,6 +37,8 @@ jobs:
             runner: ubuntu-latest
           - task: Windows_64bit
             runner: ubuntu-latest
+          - task: Windows_Arm_64bit
+            runner: ubuntu-latest
           - task: Linux_32bit
             runner: ubuntu-latest
           - task: Linux_64bit

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -37,7 +37,7 @@ jobs:
             runner: ubuntu-latest
           - task: Windows_64bit
             runner: ubuntu-latest
-          - task: Windows_Arm_64bit
+          - task: Windows_ARM64
             runner: ubuntu-latest
           - task: Linux_32bit
             runner: ubuntu-latest

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -52,7 +52,7 @@ tasks:
       PACKAGE_PLATFORM: "Windows_64bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
 
-  Windows_Arm_64bit:
+  Windows_ARM64:
     desc: Builds Windows ARM 64 bit binaries
     cmds:
       - |
@@ -64,7 +64,7 @@ tasks:
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_arm64"
       BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}"
-      PACKAGE_PLATFORM: "Windows_Arm_64bit"
+      PACKAGE_PLATFORM: "Windows_ARM64"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
 
   Linux_32bit:

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -52,6 +52,21 @@ tasks:
       PACKAGE_PLATFORM: "Windows_64bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
 
+  Windows_Arm_64bit:
+    desc: Builds Windows ARM 64 bit binaries
+    cmds:
+      - |
+        CGO_ENABLED=0 GOOS=windows GOARCH=arm64 {{.BUILD_COMMAND}}
+
+        cd {{.DIST_DIR}}
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
+
+    vars:
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_arm64"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}"
+      PACKAGE_PLATFORM: "Windows_Arm_64bit"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
+
   Linux_32bit:
     desc: Builds Linux 32 bit binaries
     cmds:


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This adds the missing arduino-cli binary for Windows on ARM.

## What is the new behavior?

The nightly builds now include Windows ARM64 binaries.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking changes to existing builds.

If this is accepted, the next steps would be
- Adding this to the release builds 
- Adding MSI installers for Window son ARM (depending on which version of Wix is being used. If 3.14+ is being used then that's possible).
- Update docs with new links
 
Surprisingly, `serial-discovery` already provides ARM64 binaries: https://github.com/arduino/serial-discovery/releases
