### PR TITLE
fix: make integration test less dependent from external resources

### DIFF
--- a/internal/integrationtest/daemon/detect_core_changes_test.go
+++ b/internal/integrationtest/daemon/detect_core_changes_test.go
@@ -43,7 +43,7 @@ func TestDetectionOfChangesInCoreBeforeCompile(t *testing.T) {
 	}))
 
 	// Install avr core
-	installCl, err := grpcInst.PlatformInstall(context.Background(), "arduino", "avr", "", true)
+	installCl, err := grpcInst.PlatformInstall(context.Background(), "arduino", "avr", "1.8.6", true)
 	require.NoError(t, err)
 	for {
 		installResp, err := installCl.Recv()

--- a/internal/integrationtest/daemon/profile_lib_commands_test.go
+++ b/internal/integrationtest/daemon/profile_lib_commands_test.go
@@ -50,13 +50,13 @@ func latestVersion(t *testing.T, cli *integrationtest.ArduinoCLI, name string) s
 	return strings.Trim(v, `"`)
 }
 
-func TestProfileLibAddListAndRemov(t *testing.T) {
+func TestProfileLibAddListAndRemove(t *testing.T) {
 	env, cli := integrationtest.CreateEnvForDaemon(t)
 	t.Cleanup(func() { env.CleanUp() })
 
 	_, _, err := cli.Run("core", "update-index")
 	require.NoError(t, err)
-	_, _, err = cli.Run("core", "install", "arduino:avr")
+	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.6")
 	require.NoError(t, err)
 
 	tmp, err := paths.MkTempDir("", "")
@@ -330,7 +330,7 @@ func TestProfileLibRemoveWithDeps(t *testing.T) {
 
 	_, _, err := cli.Run("core", "update-index")
 	require.NoError(t, err)
-	_, _, err = cli.Run("core", "install", "arduino:avr")
+	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.6")
 	require.NoError(t, err)
 
 	tmp, err := paths.MkTempDir("", "")

--- a/internal/integrationtest/profiles/profiles_test.go
+++ b/internal/integrationtest/profiles/profiles_test.go
@@ -331,7 +331,7 @@ func TestProfileLibAddRemoveFromSpecificProfile(t *testing.T) {
 	// Init the environment explicitly
 	_, _, err := cli.Run("core", "update-index")
 	require.NoError(t, err)
-	_, _, err = cli.Run("core", "install", "arduino:avr")
+	_, _, err = cli.Run("core", "install", "arduino:avr@1.8.6")
 	require.NoError(t, err)
 	sk := createTempSketch(t, cli, "Simple")
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Use a fixed version of AVR platform to perform some tests

## What is the current behavior?

CI fails

## What is the new behavior?

CI succeeds

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
