### PR TITLE
Update connection timeout default value to 900s

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,7 @@
 - `network` - configuration options related to the network connection.
   - `proxy` - URL of the proxy server.
   - `connection_timeout` - network inactivity timeout, the value format must be a valid input for
-    [time.ParseDuration()](https://pkg.go.dev/time#ParseDuration), defaults to `60s` (60 seconds). `0` means it will
+    [time.ParseDuration()](https://pkg.go.dev/time#ParseDuration), defaults to `900s` (15 minutes). `0` means it will
     wait indefinitely.
   - `cloud_api.skip_board_detection_calls` - if set to `true` it will make the Arduino CLI skip network calls to Arduino
     Cloud API to help detection of an unknown board.

--- a/internal/cli/configuration/configuration.schema.json
+++ b/internal/cli/configuration/configuration.schema.json
@@ -155,7 +155,7 @@
           "type": "string"
         },
         "connection_timeout": {
-          "description": "timeout for network connections, defaults to '30s'",
+          "description": "timeout for network connections, defaults to '900s'",
           "type": "string",
           "pattern": "^[+-]?(([0-9]+(\\.[0-9]*)?|(\\.[0-9]+))(ns|us|µs|μs|ms|s|m|h))+$"
         },

--- a/internal/cli/configuration/defaults.go
+++ b/internal/cli/configuration/defaults.go
@@ -72,7 +72,7 @@ func SetDefaults(settings *Settings) {
 	// network settings
 	setKeyTypeSchema("network.proxy", "")
 	setKeyTypeSchema("network.user_agent_ext", "")
-	setDefaultValueAndKeyTypeSchema("network.connection_timeout", (time.Second * 60).String())
+	setDefaultValueAndKeyTypeSchema("network.connection_timeout", (time.Second * 900).String())
 	// network: Arduino Cloud API settings
 	setKeyTypeSchema("network.cloud_api.skip_board_detection_calls", false)
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)  before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?

Fixes https://github.com/arduino/arduino-ide/issues/2876

## What is the current behavior?

Timeout of 1 minute makes it impossible to download anything large, or not-so-large on bad connections (not everybody using Arduino lives in a 1st world country).

## What is the new behavior?

Raises the default timeout to 15 minutes. 

I honestly think there should be no timeout whatsoever, but I opted for being conservative. I'm happy to change the chosen timeout to anything longer than 15 minutes.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking changes.
