### PR TITLE
fix: use build.project_name for bootloader artifacts

### DIFF
--- a/internal/arduino/builder/sketch.go
+++ b/internal/arduino/builder/sketch.go
@@ -236,7 +236,10 @@ func (b *Builder) mergeSketchWithBootloader() error {
 		return nil
 	}
 
-	sketchFileName := b.sketch.MainFile.Base()
+	sketchFileName := b.buildProperties.Get("build.project_name")
+	if sketchFileName == "" {
+		sketchFileName = b.sketch.MainFile.Base()
+	}
 	sketchInBuildPath := b.buildPath.Join(sketchFileName + ".hex")
 	sketchInSubfolder := b.buildPath.Join("sketch", sketchFileName+".hex")
 

--- a/internal/arduino/builder/sketch_test.go
+++ b/internal/arduino/builder/sketch_test.go
@@ -17,12 +17,16 @@ package builder
 
 import (
 	"fmt"
+	"io"
 	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/arduino/arduino-cli/internal/arduino/builder/logger"
 	"github.com/arduino/arduino-cli/internal/arduino/sketch"
 	"github.com/arduino/go-paths-helper"
+	properties "github.com/arduino/go-properties-orderedmap"
+	"github.com/marcinbor85/gohex"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,6 +109,54 @@ func TestCopyAdditionalFiles(t *testing.T) {
 	info2, err := sk2.AdditionalFiles[0].Stat()
 	require.NoError(t, err)
 	require.Equal(t, info1.ModTime(), info2.ModTime())
+}
+
+func TestMergeSketchWithBootloaderUsesBuildProjectName(t *testing.T) {
+	tmp, err := paths.MkTempDir("", "")
+	require.NoError(t, err)
+	defer tmp.RemoveAll()
+
+	buildPath := tmp.Join("build")
+	platformPath := tmp.Join("platform")
+	require.NoError(t, buildPath.MkdirAll())
+	require.NoError(t, platformPath.Join("bootloaders").MkdirAll())
+
+	sk, err := sketch.New(paths.New("testdata", "TestLoadSketchFolder"))
+	require.NoError(t, err)
+
+	writeHexFile(t, buildPath.Join("custom-project.hex"), 0x0000, []byte{0x01, 0x02, 0x03, 0x04})
+	writeHexFile(t, platformPath.Join("bootloaders", "bootloader.hex"), 0x1000, []byte{0x05, 0x06, 0x07, 0x08})
+
+	buildProperties := properties.NewMap()
+	buildProperties.Set("build.project_name", "custom-project")
+	buildProperties.Set("bootloader.file", "bootloader.hex")
+	buildProperties.SetPath("runtime.platform.path", platformPath)
+	buildProperties.Set("upload.maximum_size", "4096")
+
+	b := Builder{
+		sketch:          sk,
+		buildPath:       buildPath,
+		buildProperties: buildProperties,
+		logger:          logger.New(io.Discard, io.Discard, logger.VerbosityQuiet, ""),
+	}
+	require.NoError(t, b.mergeSketchWithBootloader())
+	require.FileExists(t, buildPath.Join("custom-project.with_bootloader.hex").String())
+	require.FileExists(t, buildPath.Join("custom-project.with_bootloader.bin").String())
+	require.NoFileExists(t, buildPath.Join(sk.MainFile.Base()+".with_bootloader.hex").String())
+	require.NoFileExists(t, buildPath.Join(sk.MainFile.Base()+".with_bootloader.bin").String())
+}
+
+func writeHexFile(t *testing.T, path *paths.Path, address uint32, data []byte) {
+	t.Helper()
+
+	mem := gohex.NewMemory()
+	require.NoError(t, mem.AddBinary(address, data))
+
+	file, err := path.Create()
+	require.NoError(t, err)
+	defer file.Close()
+
+	mem.DumpIntelHex(file, 16)
 }
 
 func TestStripUTF8BOM(t *testing.T) {

--- a/internal/integrationtest/compile_1/compile_test.go
+++ b/internal/integrationtest/compile_1/compile_test.go
@@ -1251,6 +1251,33 @@ func buildWithCustomBuildPath(t *testing.T, env *integrationtest.Environment, cl
 		require.NoFileExists(t, buildDir.Join(sketchName+".ino.with_bootloader.hex").String())
 	})
 
+	t.Run("OutsideSketchWithBuildProjectName", func(t *testing.T) {
+		sketchName := "CompileWithCustomProjectName"
+		projectName := "custom_project"
+		sketchPath := cli.SketchbookDir().Join(sketchName)
+		defer sketchPath.RemoveAll()
+		fqbn := "arduino:avr:uno"
+
+		// Create a test sketch
+		_, _, err := cli.Run("sketch", "new", sketchPath.String())
+		require.NoError(t, err)
+
+		// Test the --build-path flag with a custom build.project_name
+		buildPath := cli.DataDir().Join("test_dir", "custom_project_build_dir")
+		_, _, err = cli.Run("compile", "-b", fqbn, sketchPath.String(), "--build-path", buildPath.String(), "--build-property", "build.project_name="+projectName)
+		require.NoError(t, err)
+
+		// Verifies expected binaries have been built to build_path
+		require.DirExists(t, buildPath.String())
+		require.FileExists(t, buildPath.Join(projectName+".eep").String())
+		require.FileExists(t, buildPath.Join(projectName+".elf").String())
+		require.FileExists(t, buildPath.Join(projectName+".hex").String())
+		require.FileExists(t, buildPath.Join(projectName+".with_bootloader.bin").String())
+		require.FileExists(t, buildPath.Join(projectName+".with_bootloader.hex").String())
+		require.NoFileExists(t, buildPath.Join(sketchName+".ino.with_bootloader.bin").String())
+		require.NoFileExists(t, buildPath.Join(sketchName+".ino.with_bootloader.hex").String())
+	})
+
 	t.Run("InsideSketch", func(t *testing.T) {
 		buildPath := sketchPath.Join("build")
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) - not applicable; this restores existing artifact naming behavior for custom `build.project_name` values.
- [x] `UPGRADING.md` has been updated with a migration guide (for breaking changes) - not applicable; this is not a breaking change.
- [x] `configuration.schema.json` updated if new parameters are added. - not applicable; no configuration parameters are added.

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Fixes #3108.

When `compile` is run with a custom `--build-property build.project_name=...`, the main output artifacts use the custom project name, but the bootloader merge step still looks for artifacts named after the original sketch file. As a result, `.with_bootloader.hex` and `.with_bootloader.bin` are not generated for the custom project name.

## What is the new behavior?

The bootloader merge step uses the resolved `build.project_name`, falling back to the sketch main filename only when the property is unavailable. This produces the expected custom-named bootloader artifacts alongside the other custom-named build outputs.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No.

## Other information

Validation run locally:

- `go test ./internal/arduino/builder -run TestMergeSketchWithBootloaderUsesBuildProjectName -count=1`
- `go test ./internal/arduino/builder -count=1`
- `go build`
- `go test ./internal/integrationtest/compile_1 -run '^TestCompile$/^WithCustomBuildPath$/^OutsideSketchWithBuildProjectName$' -count=1 -timeout 20m`
