### PR TITLE
WIP: feat: implement pre_upload check and pattern

### DIFF
--- a/commands/service_upload.go
+++ b/commands/service_upload.go
@@ -571,6 +571,8 @@ func (s *arduinoCoreServerImpl) runProgramAction(ctx context.Context, pme *packa
 		}
 	}
 
+	preUpload := uploadProperties.GetBoolean("upload.use_pre_upload_check")
+
 	// Run recipes for upload
 	toolEnv := pme.GetEnvVarsForSpawnedProcess()
 	if burnBootloader {
@@ -585,6 +587,11 @@ func (s *arduinoCoreServerImpl) runProgramAction(ctx context.Context, pme *packa
 			return nil, &cmderrors.FailedUploadError{Message: i18n.Tr("Failed programming"), Cause: err}
 		}
 	} else {
+		if preUpload && (runTool(uploadCtx, "pre_upload_check.pattern", uploadProperties, outStream, errStream, verbose, dryRun, toolEnv) != nil) {
+			if err := runTool(uploadCtx, "pre_upload.pattern", uploadProperties, outStream, errStream, verbose, dryRun, toolEnv); err != nil {
+				return nil, &cmderrors.FailedUploadError{Message: i18n.Tr("Failed uploading"), Cause: err}
+			}
+		}
 		if err := runTool(uploadCtx, "upload.pattern", uploadProperties, outStream, errStream, verbose, dryRun, toolEnv); err != nil {
 			return nil, &cmderrors.FailedUploadError{Message: i18n.Tr("Failed uploading"), Cause: err}
 		}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

For multi binary uploads it might be useful to skip flashing a part of the binary (if unchanged, or just compatible). By adding this pair of rules (activated by .upload.use_pre_upload_check=true) we can give maximum flexibility for platform developers who need this kind of behaviour.

pre_upload_check.pattern should return != 0 if we want to execute the second rule before upload.pattern

<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
