### PR TITLE
Fix i18n-push workflow

### DIFF
--- a/.github/workflows/i18n-nightly-push.yaml
+++ b/.github/workflows/i18n-nightly-push.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: "${{ env.GO_VERSION }}"
+          go-version-file: go.mod
 
       - name: Install Taskfile
         uses: arduino/setup-task@v2


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This should solve the issue in the workflow.

## What is the current behavior?

A failing workflow run, with:
```
Run task i18n:update
  task i18n:update
  shell: /usr/bin/bash -e {0}
  env:
    GOTOOLCHAIN: local
go: go.mod requires go >= 1.26.1 (running go 1.24.13; GOTOOLCHAIN=local)
go: go.mod requires go >= 1.26.1 (running go 1.24.13; GOTOOLCHAIN=local)
go: go.mod requires go >= 1.26.1 (running go 1.24.13; GOTOOLCHAIN=local)
task: Command "go list -m -f '{{.GoVersion}}'" failed: exit status 1
Error: task: Command "go list -m -f '{{.GoVersion}}'" failed: exit status 1

Error: Process completed with exit code 1.
```

## What is the new behavior?

A successful workflow run.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
