### PR TITLE
fix: gRPC `Monitor` call does not emit `applied_settings` response

### DIFF
--- a/commands/service_monitor.go
+++ b/commands/service_monitor.go
@@ -137,16 +137,26 @@ func (s *arduinoCoreServerImpl) Monitor(stream rpc.ArduinoCoreService_MonitorSer
 		monitor.Quit()
 		return &cmderrors.FailedMonitorError{Cause: err}
 	}
+	var openAppliedSettings []*rpc.MonitorPortSetting
 	if portConfig := openReq.GetPortConfiguration(); portConfig != nil {
 		for _, setting := range portConfig.GetSettings() {
-			boardSettings.Remove(setting.GetSettingId())
 			if err := monitor.Configure(setting.GetSettingId(), setting.GetValue()); err != nil {
 				logrus.Errorf("Could not set configuration %s=%s: %s", setting.GetSettingId(), setting.GetValue(), err)
+			} else {
+				boardSettings.Remove(setting.GetSettingId())
+				openAppliedSettings = append(openAppliedSettings, setting)
 			}
 		}
 	}
 	for setting, value := range boardSettings.AsMap() {
-		monitor.Configure(setting, value)
+		if err := monitor.Configure(setting, value); err != nil {
+			logrus.Errorf("Could not set configuration %s=%s: %s", setting, value, err)
+		} else {
+			openAppliedSettings = append(openAppliedSettings, &rpc.MonitorPortSetting{
+				SettingId: setting,
+				Value:     value,
+			})
+		}
 	}
 	monitorIO, err := monitor.Open(openReq.GetPort().GetAddress(), openReq.GetPort().GetProtocol())
 	if err != nil {
@@ -162,6 +172,11 @@ func (s *arduinoCoreServerImpl) Monitor(stream rpc.ArduinoCoreService_MonitorSer
 	// Send a message with Success set to true to notify the caller of the port being now active
 	syncSend := NewSynchronizedSend(stream.Send)
 	_ = syncSend.Send(&rpc.MonitorResponse{Message: &rpc.MonitorResponse_Success{Success: true}})
+	if len(openAppliedSettings) > 0 {
+		_ = syncSend.Send(&rpc.MonitorResponse{Message: &rpc.MonitorResponse_AppliedSettings{
+			AppliedSettings: &rpc.MonitorPortConfiguration{Settings: openAppliedSettings},
+		}})
+	}
 
 	ctx, cancel := context.WithCancel(stream.Context())
 	gracefulCloseInitiated := &atomic.Bool{}
@@ -180,10 +195,18 @@ func (s *arduinoCoreServerImpl) Monitor(stream rpc.ArduinoCoreService_MonitorSer
 				return
 			}
 			if conf := msg.GetUpdatedConfiguration(); conf != nil {
+				var appliedSettings []*rpc.MonitorPortSetting
 				for _, c := range conf.GetSettings() {
 					if err := monitor.Configure(c.GetSettingId(), c.GetValue()); err != nil {
 						syncSend.Send(&rpc.MonitorResponse{Message: &rpc.MonitorResponse_Error{Error: err.Error()}})
+					} else {
+						appliedSettings = append(appliedSettings, c)
 					}
+				}
+				if len(appliedSettings) > 0 {
+					syncSend.Send(&rpc.MonitorResponse{Message: &rpc.MonitorResponse_AppliedSettings{
+						AppliedSettings: &rpc.MonitorPortConfiguration{Settings: appliedSettings},
+					}})
 				}
 			}
 			if closeMsg := msg.GetClose(); closeMsg {

--- a/internal/integrationtest/arduino-cli.go
+++ b/internal/integrationtest/arduino-cli.go
@@ -693,8 +693,13 @@ func (inst *ArduinoCLIInstance) PlatformSearch(ctx context.Context, args string,
 
 // Monitor calls the "Monitor" gRPC method and sends the OpenRequest message.
 func (inst *ArduinoCLIInstance) Monitor(ctx context.Context, port *commands.Port) (commands.ArduinoCoreService_MonitorClient, error) {
+	return inst.MonitorWithConfig(ctx, port, nil)
+}
+
+// MonitorWithConfig calls the "Monitor" gRPC method and sends the OpenRequest message with an optional port configuration.
+func (inst *ArduinoCLIInstance) MonitorWithConfig(ctx context.Context, port *commands.Port, portConfig *commands.MonitorPortConfiguration) (commands.ArduinoCoreService_MonitorClient, error) {
 	req := &commands.MonitorRequest{}
-	logCallf(">>> Monitor(%+v)\n", req)
+	logCallf(">>> MonitorWithConfig(%+v)\n", req)
 	monitorClient, err := inst.cli.daemonClient.Monitor(ctx)
 	if err != nil {
 		return nil, err
@@ -702,8 +707,9 @@ func (inst *ArduinoCLIInstance) Monitor(ctx context.Context, port *commands.Port
 	err = monitorClient.Send(&commands.MonitorRequest{
 		Message: &commands.MonitorRequest_OpenRequest{
 			OpenRequest: &commands.MonitorPortOpenRequest{
-				Instance: inst.instance,
-				Port:     port,
+				Instance:          inst.instance,
+				Port:              port,
+				PortConfiguration: portConfig,
 			},
 		},
 	})

--- a/internal/integrationtest/monitor/monitor_grpc_test.go
+++ b/internal/integrationtest/monitor/monitor_grpc_test.go
@@ -190,4 +190,13 @@ func TestMonitorGRPCAppliedSettings(t *testing.T) {
 		updateSettings[s.GetSettingId()] = s.GetValue()
 	}
 	require.Equal(t, "9600", updateSettings["baudrate"], "applied_settings after update must reflect the new baudrate")
+
+	// Close the monitor to allow cleanup of the env (otherwise on Windows the
+	// tmp monitor.exe cannot be deleted because it's still open).
+	cancel()
+	_, err = mon.Recv()
+	require.EqualError(t, err, "rpc error: code = Canceled desc = context canceled")
+	// the mocked serial-monitor is designed to delay 2 seconds before closing,
+	// let's wait a bit to ensure the monitor process has exited before the test ends and the env is cleaned up.
+	time.Sleep(3 * time.Second)
 }

--- a/internal/integrationtest/monitor/monitor_grpc_test.go
+++ b/internal/integrationtest/monitor/monitor_grpc_test.go
@@ -115,3 +115,79 @@ func TestMonitorGRPCClose(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestMonitorGRPCAppliedSettings(t *testing.T) {
+	// See: https://github.com/arduino/arduino-cli/issues/2965
+
+	env, cli := integrationtest.CreateEnvForDaemon(t)
+	defer env.CleanUp()
+
+	_, _, err := cli.Run("core", "install", "arduino:avr@1.8.6")
+	require.NoError(t, err)
+
+	cli.InstallMockedSerialDiscovery(t)
+	cli.InstallMockedSerialMonitor(t)
+
+	grpcInst := cli.Create()
+	require.NoError(t, grpcInst.Init("", "", func(ir *commands.InitResponse) {
+		fmt.Printf("INIT> %v\n", ir.GetMessage())
+	}))
+
+	boardListResp, err := grpcInst.BoardList(time.Second)
+	require.NoError(t, err)
+	ports := boardListResp.GetPorts()
+	require.NotEmpty(t, ports)
+
+	// recvUntilAppliedSettings reads from the monitor stream, skipping rxData and other
+	// messages, until an applied_settings response is received or the test times out.
+	recvUntilAppliedSettings := func(mon commands.ArduinoCoreService_MonitorClient) *commands.MonitorPortConfiguration {
+		t.Helper()
+		for {
+			monResp, err := mon.Recv()
+			require.NoError(t, err)
+			fmt.Printf("MON> %v\n", monResp)
+			if as := monResp.GetAppliedSettings(); as != nil {
+				return as
+			}
+		}
+	}
+
+	// Open the monitor with a non-default baudrate (115200 vs the default 9600).
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	mon, err := grpcInst.MonitorWithConfig(ctx, ports[0].GetPort(), &commands.MonitorPortConfiguration{
+		Settings: []*commands.MonitorPortSetting{
+			{SettingId: "baudrate", Value: "115200"},
+		},
+	})
+	require.NoError(t, err)
+
+	// The server must emit applied_settings right after opening the port.
+	openApplied := recvUntilAppliedSettings(mon)
+	openSettings := map[string]string{}
+	for _, s := range openApplied.GetSettings() {
+		openSettings[s.GetSettingId()] = s.GetValue()
+	}
+	require.Equal(t, "115200", openSettings["baudrate"], "applied_settings after open must reflect the configured baudrate")
+
+	// Send an updated configuration to change the baudrate back to 9600.
+	err = mon.Send(&commands.MonitorRequest{
+		Message: &commands.MonitorRequest_UpdatedConfiguration{
+			UpdatedConfiguration: &commands.MonitorPortConfiguration{
+				Settings: []*commands.MonitorPortSetting{
+					{SettingId: "baudrate", Value: "9600"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// The server must emit applied_settings after the configuration update.
+	updateApplied := recvUntilAppliedSettings(mon)
+	updateSettings := map[string]string{}
+	for _, s := range updateApplied.GetSettings() {
+		updateSettings[s.GetSettingId()] = s.GetValue()
+	}
+	require.Equal(t, "9600", updateSettings["baudrate"], "applied_settings after update must reflect the new baudrate")
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fixes the problem described in detail in https://github.com/arduino/arduino-cli/issues/2965

## What is the current behavior?

The gRPC Monitor call does not emit `applied_settings` response

## What is the new behavior?

The gRPC Monitor call does emit `applied_settings` response, both after opening the port, and after applying changes.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Fix #2965 