### PR TITLE
Do not print stray "Running post-install/pre-uninstall script" messages

### DIFF
--- a/internal/arduino/cores/packagemanager/install_uninstall.go
+++ b/internal/arduino/cores/packagemanager/install_uninstall.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"runtime"
 
 	"github.com/arduino/arduino-cli/commands/cmderrors"
@@ -134,19 +135,15 @@ func (pme *Explorer) DownloadAndInstallPlatformAndTools(
 	// Perform post install
 	if !skipPostInstall {
 		log.Info("Running post_install script")
-		taskCB(&rpc.TaskProgress{Message: i18n.Tr("Configuring platform.")})
 		if !platformRelease.IsInstalled() {
 			return errors.New(i18n.Tr("platform not installed"))
 		}
-		stdout, stderr, err := pme.RunPreOrPostScript(platformRelease.InstallDir, "post_install")
-		skipEmptyMessageTaskProgressCB(taskCB)(&rpc.TaskProgress{Message: string(stdout), Completed: true})
-		skipEmptyMessageTaskProgressCB(taskCB)(&rpc.TaskProgress{Message: string(stderr), Completed: true})
-		if err != nil {
-			taskCB(&rpc.TaskProgress{Message: i18n.Tr("WARNING cannot configure platform: %s", err), Completed: true})
-		}
+		pme.RunPreOrPostScript(
+			platformRelease.InstallDir, "post_install",
+			taskCB, i18n.Tr("Configuring platform."), i18n.Tr("WARNING: cannot configure platform"))
 
 	} else {
-		log.Info("Skipping platform configuration.")
+		log.Info("Skipping post_install script")
 		taskCB(&rpc.TaskProgress{Message: i18n.Tr("Skipping platform configuration.")})
 	}
 
@@ -192,27 +189,41 @@ func (pme *Explorer) cacheInstalledJSON(platformRelease *cores.PlatformRelease) 
 	return nil
 }
 
-// RunPreOrPostScript runs either the post_install.sh (or post_install.bat) or the pre_uninstall.sh (or pre_uninstall.bat)
-// script for the specified platformRelease or toolRelease.
-func (pme *Explorer) RunPreOrPostScript(installDir *paths.Path, prefix string) ([]byte, []byte, error) {
-	scriptFilename := prefix + ".sh"
+// RunPreOrPostScript runs the pre/post script for the given install directory and
+// emits progress messages via taskCB. startMessage is sent only when the script actually exists.
+// warningMessage is sent if the script fails together with the error message.
+func (pme *Explorer) RunPreOrPostScript(
+	installDir *paths.Path, scriptPrefix string,
+	taskCB rpc.TaskProgressCB, startMessage string, warningMessage string,
+) {
+	scriptFilename := scriptPrefix + ".sh"
 	if runtime.GOOS == "windows" {
-		scriptFilename = prefix + ".bat"
+		scriptFilename = scriptPrefix + ".bat"
 	}
 	script := installDir.Join(scriptFilename)
-	if script.Exist() && script.IsNotDir() {
-		cmd, err := paths.NewProcessFromPath(pme.GetEnvVarsForSpawnedProcess(), script)
-		if err != nil {
-			return []byte{}, []byte{}, err
-		}
-		cmdStdout, cmdStderr := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
-		cmd.RedirectStdoutTo(cmdStdout)
-		cmd.RedirectStderrTo(cmdStderr)
-		cmd.SetDirFromPath(installDir)
-		err = cmd.Run()
-		return cmdStdout.Bytes(), cmdStderr.Bytes(), err
+	if !script.Exist() || script.IsDir() {
+		return
 	}
-	return []byte{}, []byte{}, nil
+	taskCB(&rpc.TaskProgress{Message: startMessage})
+	cmd, err := paths.NewProcessFromPath(pme.GetEnvVarsForSpawnedProcess(), script)
+	if err != nil {
+		taskCB(&rpc.TaskProgress{Message: fmt.Sprintf("%s: %s", warningMessage, err)})
+		return
+	}
+	cmdStdout, cmdStderr := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
+	cmd.RedirectStdoutTo(cmdStdout)
+	cmd.RedirectStderrTo(cmdStderr)
+	cmd.SetDirFromPath(installDir)
+	err = cmd.Run()
+	if stdout := cmdStdout.String(); len(stdout) > 0 {
+		taskCB(&rpc.TaskProgress{Message: stdout})
+	}
+	if stderr := cmdStderr.String(); len(stderr) > 0 {
+		taskCB(&rpc.TaskProgress{Message: stderr})
+	}
+	if err != nil {
+		taskCB(&rpc.TaskProgress{Message: fmt.Sprintf("%s: %s", warningMessage, err)})
+	}
 }
 
 // IsManagedPlatformRelease returns true if the PlatforRelease is managed by the PackageManager
@@ -254,16 +265,12 @@ func (pme *Explorer) UninstallPlatform(platformRelease *cores.PlatformRelease, t
 
 	if !skipPreUninstall {
 		log.Info("Running pre_uninstall script")
-		taskCB(&rpc.TaskProgress{Message: i18n.Tr("Running pre_uninstall script.")})
-		stdout, stderr, err := pme.RunPreOrPostScript(platformRelease.InstallDir, "pre_uninstall")
-		skipEmptyMessageTaskProgressCB(taskCB)(&rpc.TaskProgress{Message: string(stdout), Completed: true})
-		skipEmptyMessageTaskProgressCB(taskCB)(&rpc.TaskProgress{Message: string(stderr), Completed: true})
-		if err != nil {
-			taskCB(&rpc.TaskProgress{Message: i18n.Tr("WARNING cannot run pre_uninstall script: %s", err), Completed: true})
-		}
+		pme.RunPreOrPostScript(
+			platformRelease.InstallDir, "pre_uninstall",
+			taskCB, i18n.Tr("Running uninstall script."), i18n.Tr("WARNING: cannot run uninstall script"))
 	} else {
 		log.Info("Skipping pre_uninstall script.")
-		taskCB(&rpc.TaskProgress{Message: i18n.Tr("Skipping pre_uninstall script.")})
+		taskCB(&rpc.TaskProgress{Message: i18n.Tr("Skipping uninstall script.")})
 	}
 
 	if err := platformRelease.InstallDir.RemoveAll(); err != nil {
@@ -316,13 +323,9 @@ func (pme *Explorer) InstallTool(toolRelease *cores.ToolRelease, taskCB rpc.Task
 	// Perform post install
 	if !skipPostInstall {
 		log.Info("Running tool post_install script")
-		taskCB(&rpc.TaskProgress{Message: i18n.Tr("Configuring tool.")})
-		stdout, stderr, err := pme.RunPreOrPostScript(toolRelease.InstallDir, "post_install")
-		skipEmptyMessageTaskProgressCB(taskCB)(&rpc.TaskProgress{Message: string(stdout)})
-		skipEmptyMessageTaskProgressCB(taskCB)(&rpc.TaskProgress{Message: string(stderr)})
-		if err != nil {
-			taskCB(&rpc.TaskProgress{Message: i18n.Tr("WARNING cannot configure tool: %s", err)})
-		}
+		pme.RunPreOrPostScript(
+			toolRelease.InstallDir, "post_install",
+			taskCB, i18n.Tr("Configuring tool."), i18n.Tr("WARNING: cannot configure tool"))
 	} else {
 		log.Info("Skipping tool configuration.")
 		taskCB(&rpc.TaskProgress{Message: i18n.Tr("Skipping tool configuration.")})
@@ -368,16 +371,12 @@ func (pme *Explorer) UninstallTool(toolRelease *cores.ToolRelease, taskCB rpc.Ta
 
 	if !skipPreUninstall {
 		log.Info("Running pre_uninstall script")
-		taskCB(&rpc.TaskProgress{Message: i18n.Tr("Running pre_uninstall script.")})
-		stdout, stderr, err := pme.RunPreOrPostScript(toolRelease.InstallDir, "pre_uninstall")
-		skipEmptyMessageTaskProgressCB(taskCB)(&rpc.TaskProgress{Message: string(stdout), Completed: true})
-		skipEmptyMessageTaskProgressCB(taskCB)(&rpc.TaskProgress{Message: string(stderr), Completed: true})
-		if err != nil {
-			taskCB(&rpc.TaskProgress{Message: i18n.Tr("WARNING cannot run pre_uninstall script: %s", err), Completed: true})
-		}
+		pme.RunPreOrPostScript(
+			toolRelease.InstallDir, "pre_uninstall",
+			taskCB, i18n.Tr("Running uninstall script."), i18n.Tr("WARNING: cannot run uninstall script"))
 	} else {
 		log.Info("Skipping pre_uninstall script.")
-		taskCB(&rpc.TaskProgress{Message: i18n.Tr("Skipping pre_uninstall script.")})
+		taskCB(&rpc.TaskProgress{Message: i18n.Tr("Skipping uninstall script.")})
 	}
 
 	if err := toolRelease.InstallDir.RemoveAll(); err != nil {
@@ -407,13 +406,4 @@ func (pme *Explorer) IsToolRequired(toolRelease *cores.ToolRelease) bool {
 		}
 	}
 	return false
-}
-
-func skipEmptyMessageTaskProgressCB(taskCB rpc.TaskProgressCB) rpc.TaskProgressCB {
-	return func(msg *rpc.TaskProgress) {
-		if msg != nil && len(msg.GetMessage()) == 0 {
-			return
-		}
-		taskCB(msg)
-	}
 }

--- a/internal/arduino/cores/packagemanager/package_manager_test.go
+++ b/internal/arduino/cores/packagemanager/package_manager_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/arduino/arduino-cli/internal/arduino/cores"
 	"github.com/arduino/arduino-cli/pkg/fqbn"
+	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
 	"github.com/stretchr/testify/require"
@@ -1019,12 +1020,19 @@ func TestRunScript(t *testing.T) {
 			require.NoError(t, err)
 			err = os.Chmod(scriptPath.String(), 0777)
 			require.NoError(t, err)
-			stdout, stderr, err := pme.RunPreOrPostScript(dir, test.scriptName)
-			require.NoError(t, err)
+			var capturedMessages []string
+			taskCB := func(msg *rpc.TaskProgress) {
+				if msg != nil && msg.GetMessage() != "" {
+					capturedMessages = append(capturedMessages, msg.GetMessage())
+				}
+			}
+			pme.RunPreOrPostScript(dir, test.scriptName, taskCB, "start", "warning: %s")
 
-			// `HasPrefix` because windows seem to add a trailing space at the end
-			require.Equal(t, "sent in stdout", strings.Trim(string(stdout), "\n\r "))
-			require.Equal(t, "sent in stderr", strings.Trim(string(stderr), "\n\r "))
+			// start message + stdout + stderr; windows may add trailing whitespace
+			require.Len(t, capturedMessages, 3)
+			require.Equal(t, "start", capturedMessages[0])
+			require.Equal(t, "sent in stdout", strings.Trim(capturedMessages[1], "\n\r "))
+			require.Equal(t, "sent in stderr", strings.Trim(capturedMessages[2], "\n\r "))
 		})
 	}
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Do not print stray "Running post-install/pre-uninstall script" messages; only print them when the script is actually run.

## What is the current behavior?

```
$ arduino-cli core install arduino:samd
Tool arduino:arm-none-eabi-gcc@7-2017q4 already installed
Downloading packages...
arduino:arduinoOTA@1.2.1 arduino:arduinoOTA@1.2.1 already downloaded
arduino:avrdude@6.3.0-arduino9 arduino:avrdude@6.3.0-arduino9 already downloaded
arduino:bossac@1.7.0-arduino3 arduino:bossac@1.7.0-arduino3 already downloaded
arduino:CMSIS@4.5.0 arduino:CMSIS@4.5.0 already downloaded
arduino:CMSIS-Atmel@1.2.0 arduino:CMSIS-Atmel@1.2.0 already downloaded
arduino:openocd@0.10.0-arduino7 arduino:openocd@0.10.0-arduino7 already downloaded
arduino:samd@1.8.14 arduino:samd@1.8.14 already downloaded
Installing arduino:arduinoOTA@1.2.1...
Configuring tool....
arduino:arduinoOTA@1.2.1 installed
Installing arduino:avrdude@6.3.0-arduino9...
Configuring tool....
arduino:avrdude@6.3.0-arduino9 installed
Installing arduino:bossac@1.7.0-arduino3...
Configuring tool....
arduino:bossac@1.7.0-arduino3 installed
Installing arduino:CMSIS@4.5.0...
Configuring tool....
arduino:CMSIS@4.5.0 installed
Installing arduino:CMSIS-Atmel@1.2.0...
Configuring tool....
arduino:CMSIS-Atmel@1.2.0 installed
Installing arduino:openocd@0.10.0-arduino7...
Configuring tool....
arduino:openocd@0.10.0-arduino7 installed
Installing platform arduino:samd@1.8.14...
Configuring platform....
Platform arduino:samd@1.8.14 installed

$ arduino-cli core uninstall arduino:samd
Uninstalling arduino:samd@1.8.14...
Running pre_uninstall script....
Platform arduino:samd@1.8.14 uninstalled
Uninstalling arduino:arduinoOTA@1.2.1, tool is no more required...
Running pre_uninstall script....
Tool arduino:arduinoOTA@1.2.1 uninstalled
Uninstalling arduino:avrdude@6.3.0-arduino9, tool is no more required...
Running pre_uninstall script....
Tool arduino:avrdude@6.3.0-arduino9 uninstalled
Uninstalling arduino:bossac@1.7.0-arduino3, tool is no more required...
Running pre_uninstall script....
Tool arduino:bossac@1.7.0-arduino3 uninstalled
Uninstalling arduino:CMSIS@4.5.0, tool is no more required...
Running pre_uninstall script....
Tool arduino:CMSIS@4.5.0 uninstalled
Uninstalling arduino:CMSIS-Atmel@1.2.0, tool is no more required...
Running pre_uninstall script....
Tool arduino:CMSIS-Atmel@1.2.0 uninstalled
Uninstalling arduino:openocd@0.10.0-arduino7, tool is no more required...
Running pre_uninstall script....
Tool arduino:openocd@0.10.0-arduino7 uninstalled
```
## What is the new behavior?

```
$ arduino-cli core install arduino:samd
Tool arduino:arm-none-eabi-gcc@7-2017q4 already installed
Downloading packages...
arduino:arduinoOTA@1.2.1 arduino:arduinoOTA@1.2.1 already downloaded
arduino:avrdude@6.3.0-arduino9 arduino:avrdude@6.3.0-arduino9 already downloaded
arduino:bossac@1.7.0-arduino3 arduino:bossac@1.7.0-arduino3 already downloaded
arduino:CMSIS@4.5.0 arduino:CMSIS@4.5.0 already downloaded
arduino:CMSIS-Atmel@1.2.0 arduino:CMSIS-Atmel@1.2.0 already downloaded
arduino:openocd@0.10.0-arduino7 arduino:openocd@0.10.0-arduino7 already downloaded
arduino:samd@1.8.14 arduino:samd@1.8.14 already downloaded
Installing arduino:arduinoOTA@1.2.1...
arduino:arduinoOTA@1.2.1 installed
Installing arduino:avrdude@6.3.0-arduino9...
arduino:avrdude@6.3.0-arduino9 installed
Installing arduino:bossac@1.7.0-arduino3...
arduino:bossac@1.7.0-arduino3 installed
Installing arduino:CMSIS@4.5.0...
arduino:CMSIS@4.5.0 installed
Installing arduino:CMSIS-Atmel@1.2.0...
arduino:CMSIS-Atmel@1.2.0 installed
Installing arduino:openocd@0.10.0-arduino7...
arduino:openocd@0.10.0-arduino7 installed
Installing platform arduino:samd@1.8.14...
Platform arduino:samd@1.8.14 installed

$ arduino-cli core uninstall arduino:samd
Uninstalling arduino:samd@1.8.14...
Platform arduino:samd@1.8.14 uninstalled
Uninstalling arduino:arduinoOTA@1.2.1, tool is no more required...
Tool arduino:arduinoOTA@1.2.1 uninstalled
Uninstalling arduino:avrdude@6.3.0-arduino9, tool is no more required...
Tool arduino:avrdude@6.3.0-arduino9 uninstalled
Uninstalling arduino:bossac@1.7.0-arduino3, tool is no more required...
Tool arduino:bossac@1.7.0-arduino3 uninstalled
Uninstalling arduino:CMSIS@4.5.0, tool is no more required...
Tool arduino:CMSIS@4.5.0 uninstalled
Uninstalling arduino:CMSIS-Atmel@1.2.0, tool is no more required...
Tool arduino:CMSIS-Atmel@1.2.0 uninstalled
Uninstalling arduino:openocd@0.10.0-arduino7, tool is no more required...
Tool arduino:openocd@0.10.0-arduino7 uninstalled
```

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

Fix #3176 
