### PR TITLE
Use `{build.fpu}` and `{build.float-abi}` for lib paths, if present

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -237,10 +237,19 @@ The filenames of the compiled binaries should start with `lib` (e.g., `libFoo.a`
 **(available from Arduino IDE 1.8.12/arduino-builder 1.5.2/Arduino CLI 0.8.0)** The floating point ABI configuration of
 ARM core microcontrollers may be adjusted via compiler flags. An extra subfolder level can be used to provide files
 compiled for a specific floating point configuration: `src/{build.mcu}/{build.fpu}-{build.float-abi}`, where
-`{build.fpu}` is the value of the `-mfpu` compiler flag and `{build.float-abi}` is the value of the `-mfloat-abi`
-compiler flag. **(available from Arduino IDE 1.8.13/arduino-builder 1.5.3/Arduino CLI 0.11.0)** If floating point
-configuration flags are used but no folder matching that configuration is found, `src/{build.mcu}` is used as a
-fallback.
+`{build.fpu}` is the FPU type and `{build.float-abi}` is the floating-point ABI (e.g., `fpv4-sp-d16-softfp`).
+
+These values are determined as follows:
+
+1. **(available from Arduino CLI 1.6.0)** If the platform defines both `build.fpu` and `build.float-abi` build
+   properties (in `boards.txt` or `platform.txt`), Arduino CLI uses those property values directly to construct the
+   subfolder path.
+1. If either property is absent, Arduino CLI falls back to detecting the values by inspecting the fully expanded
+   `recipe.cpp.o.pattern` compiler command for `-mfpu=` and `-mfloat-abi=` flags. This ensures compatibility with
+   existing platforms that embed these settings inside the recipe rather than exposing them as standalone properties.
+
+**(available from Arduino IDE 1.8.13/arduino-builder 1.5.3/Arduino CLI 0.11.0)** If floating point configuration flags
+are used but no folder matching that configuration is found, `src/{build.mcu}` is used as a fallback.
 
 Below is an example library `src` folder structure that provides:
 

--- a/internal/arduino/builder/libraries.go
+++ b/internal/arduino/builder/libraries.go
@@ -65,27 +65,41 @@ func (b *Builder) findExpectedPrecompiledLibFolder(
 	buildProperties *properties.Map,
 ) *paths.Path {
 	mcu := buildProperties.Get("build.mcu")
-	// Add fpu specifications if they exist
-	// To do so, resolve recipe.cpp.o.pattern,
-	// search for -mfpu=xxx -mfloat-abi=yyy and add to a subfolder
-	command, _ := b.prepareCommandForRecipe(buildProperties, "recipe.cpp.o.pattern", true)
+
+	// Build the floating-point subfolder spec ("{fpu}-{float-abi}").
+	// Prefer the documented build properties build.fpu and build.float-abi when both
+	// are defined. If either is absent fall back to detecting the values by parsing
+	// recipe.cpp.o.pattern for -mfpu= and -mfloat-abi= compiler flags.
 	fpuSpecs := ""
-	for _, el := range command.GetArgs() {
-		if strings.Contains(el, FpuCflag) {
-			toAdd := strings.Split(el, "=")
-			if len(toAdd) > 1 {
-				fpuSpecs += strings.TrimSpace(toAdd[1]) + "-"
-				break
+	fpu, hasFpu := buildProperties.GetOk("build.fpu")
+	floatAbi, hasFloatAbi := buildProperties.GetOk("build.float-abi")
+	if hasFpu && hasFloatAbi {
+		fpuSpecs = fpu + "-" + floatAbi
+	} else {
+		// Fallback: resolve recipe.cpp.o.pattern and scan the resulting arguments.
+		command, _ := b.prepareCommandForRecipe(buildProperties, "recipe.cpp.o.pattern", true)
+		fpuPart := ""
+		floatAbiPart := ""
+		for _, el := range command.GetArgs() {
+			if strings.Contains(el, FpuCflag) {
+				toAdd := strings.Split(el, "=")
+				if len(toAdd) > 1 {
+					fpuPart = strings.TrimSpace(toAdd[1])
+					break
+				}
 			}
 		}
-	}
-	for _, el := range command.GetArgs() {
-		if strings.Contains(el, FloatAbiCflag) {
-			toAdd := strings.Split(el, "=")
-			if len(toAdd) > 1 {
-				fpuSpecs += strings.TrimSpace(toAdd[1]) + "-"
-				break
+		for _, el := range command.GetArgs() {
+			if strings.Contains(el, FloatAbiCflag) {
+				toAdd := strings.Split(el, "=")
+				if len(toAdd) > 1 {
+					floatAbiPart = strings.TrimSpace(toAdd[1])
+					break
+				}
 			}
+		}
+		if fpuPart != "" && floatAbiPart != "" {
+			fpuSpecs = fpuPart + "-" + floatAbiPart
 		}
 	}
 
@@ -93,7 +107,6 @@ func (b *Builder) findExpectedPrecompiledLibFolder(
 
 	// Try directory with full fpuSpecs first, if available
 	if len(fpuSpecs) > 0 {
-		fpuSpecs = strings.TrimRight(fpuSpecs, "-")
 		fullPrecompDir := library.SourceDir.Join(mcu).Join(fpuSpecs)
 		if fullPrecompDir.Exist() && directoryContainsFile(fullPrecompDir) {
 			b.logger.Info(i18n.Tr("Using precompiled library in %[1]s", fullPrecompDir))


### PR DESCRIPTION
If the platform/board defines the `build.fpu` and `build.float-abi` variables, Arduino CLI will now use those values directly to determine the expected subfolder for precompiled libraries. If either property is absent, Arduino CLI will fall back to parsing the compiler command for `-mfpu=` and `-mfloat-abi=` flags to maintain compatibility with existing platforms.

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

New feature / cleaner implementation of existing one

## What is the current behavior?

Arguments are extracted from recipe.cpp.o

## What is the new behavior?

Like the documentation appeared to say, use the {build.fpu} and {build.float-abi} vars if they are defined. Otherwise fallback to the pre-existing workaround.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No
