### PR TITLE
network: inject GITHUB_TOKEN as Authorization header for GitHub

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,11 @@
   - `cloud_api.skip_board_detection_calls` - if set to `true` it will make the Arduino CLI skip network calls to Arduino
     Cloud API to help detection of an unknown board.
 
+> **ⓘ** When the `GITHUB_TOKEN` environment variable is set, Arduino CLI automatically adds it as an
+> `Authorization: Bearer` header on requests to the GitHub Actions artifact download API:
+> `api.github.com/repos/{owner}/{repo}/actions/artifacts/{id}/{format}`. This allows downloading private workflow
+> artifacts. The token is **never** sent to any other URL, even when a redirect is followed.
+
 ### Default directories
 
 The following are the default directories selected by the Arduino CLI if alternatives are not specified in the
@@ -115,6 +120,10 @@ On Linux or macOS, you can use the [`export` command][export command] to set env
 can use the [`set` command][set command].
 
 `ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS` environment variables can be a list of space-separated URLs.
+
+The `GITHUB_TOKEN` environment variable is also recognised: when set, its value is sent as an `Authorization: Bearer`
+header on GitHub Actions artifact download requests only (see the note in the [Configuration keys](#configuration-keys)
+section above).
 
 #### Example
 

--- a/internal/cli/configuration/network.go
+++ b/internal/cli/configuration/network.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -99,9 +100,9 @@ func (settings *Settings) NewHttpClient(ctx context.Context) (*http.Client, erro
 	}
 	return &http.Client{
 		Transport: &httpClientRoundTripper{
-			transport: &http.Transport{
+			transport: maybeWrapWithGitHubAuth(&http.Transport{
 				Proxy: http.ProxyURL(proxy),
-			},
+			}),
 			userAgent: settings.UserAgent(ctx),
 		},
 		Timeout: settings.ConnectionTimeout(),
@@ -118,6 +119,39 @@ func (h *httpClientRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	return h.transport.RoundTrip(req)
 }
 
+// githubArtifactPathRE matches GitHub Actions artifact download paths:
+// /repos/{owner}/{repo}/actions/artifacts/{id}/{format}
+var githubArtifactPathRE = regexp.MustCompile(`^/repos/[^/]+/[^/]+/actions/artifacts/\d+/`)
+
+// isGitHubArtifactURL reports whether the request URL targets the GitHub Actions
+// artifact download API endpoint. Only these URLs receive the Authorization header.
+func isGitHubArtifactURL(u *url.URL) bool {
+	return u.Scheme == "https" && u.Host == "api.github.com" && githubArtifactPathRE.MatchString(u.Path)
+}
+
+// githubAuthRoundTripper adds an Authorization header for requests to GitHub-owned hosts.
+type githubAuthRoundTripper struct {
+	transport http.RoundTripper
+	token     string
+}
+
+func (g *githubAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if isGitHubArtifactURL(req.URL) {
+		req = req.Clone(req.Context())
+		req.Header.Set("Authorization", "Bearer "+g.token)
+	}
+	return g.transport.RoundTrip(req)
+}
+
+// maybeWrapWithGitHubAuth wraps inner with a githubAuthRoundTripper when the
+// GITHUB_TOKEN environment variable is set and non-empty; otherwise returns inner unchanged.
+func maybeWrapWithGitHubAuth(inner http.RoundTripper) http.RoundTripper {
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		return &githubAuthRoundTripper{transport: inner, token: token}
+	}
+	return inner
+}
+
 // DownloaderConfig returns the downloader configuration based on current settings.
 func (settings *Settings) DownloaderConfig(ctx context.Context) (downloader.Config, error) {
 	proxy, err := settings.NetworkProxy()
@@ -127,9 +161,9 @@ func (settings *Settings) DownloaderConfig(ctx context.Context) (downloader.Conf
 
 	return downloader.Config{
 		HttpClient: http.Client{
-			Transport: &http.Transport{
+			Transport: maybeWrapWithGitHubAuth(&http.Transport{
 				Proxy: http.ProxyURL(proxy),
-			},
+			}),
 		},
 		InactivityTimeout: settings.ConnectionTimeout(),
 		ExtraHeaders: map[string]string{

--- a/internal/cli/configuration/network_internal_test.go
+++ b/internal/cli/configuration/network_internal_test.go
@@ -1,0 +1,53 @@
+// This file is part of arduino-cli.
+//
+// Copyright (c) Arduino s.r.l. and/or its affiliated companies
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package configuration
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsGitHubArtifactURL(t *testing.T) {
+	allowed := []string{
+		"https://api.github.com/repos/owner/repo/actions/artifacts/12345/zip",
+		"https://api.github.com/repos/owner/repo/actions/artifacts/99/json",
+		"https://api.github.com/repos/my-org/my-repo/actions/artifacts/1/zip",
+	}
+	for _, raw := range allowed {
+		u, err := url.Parse(raw)
+		require.NoError(t, err)
+		require.True(t, isGitHubArtifactURL(u), "should be allowed: %s", raw)
+	}
+
+	rejected := []string{
+		// Wrong scheme
+		"http://api.github.com/repos/owner/repo/actions/artifacts/12345/zip",
+		// Wrong host
+		"https://github.com/repos/owner/repo/actions/artifacts/12345/zip",
+		"https://raw.githubusercontent.com/repos/owner/repo/actions/artifacts/12345/zip",
+		// Wrong path
+		"https://api.github.com/repos/owner/repo",
+		"https://api.github.com/repos/owner/repo/actions/artifacts",
+		"https://api.github.com/user",
+	}
+	for _, raw := range rejected {
+		u, err := url.Parse(raw)
+		require.NoError(t, err)
+		require.False(t, isGitHubArtifactURL(u), "should be rejected: %s", raw)
+	}
+}


### PR DESCRIPTION

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

When the `GITHUB_TOKEN` environment variable is set, add it as an 'Authorization: Bearer <token>' header for requests to GitHub-owned artifact download URLs (`api.github.com/repos/{owner}/{repo}/actions/artifacts/{id}/`). 

The header is injected via a `githubAuthRoundTripper` that wraps the underlying `http.Transport` and checks `req.URL` on every request, so credentials are never sent to non-GitHub servers or even user-controlled repos. The wrapper is applied to `DownloaderConfig` and therefore used in all platform, tool, library and index downloads.

With this change, it is now possible to fetch package indexes and/or platform/tool archives directly from GitHub artifact hosting.

Includes a test suite that ensures only the proper GitHub URL is given the token.

> [!IMPORTANT]
> Adding a more generic `AUTH_TOKEN` feature or host pattern was considered dangerous because it would have allowed exfiltrating information to unknown servers, even when the domain was limited (e.g. `AUTH_TOKEN_evil_site=${GITHUB_TOKEN}`). "Leaking" the GitHub token (or anything else) to the mentioned Github servers is AFAICS harmless.


## What is the current behavior?

No token is sent, workflow artifacts are _not usable_ for package_indexes or binary downloads.

## What is the new behavior?

It is possible to fetch content from workflow artifacts, allowing the generation of temporary (per-PR) package indexes which can be properly retrieved by the CLI.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No