### PR TITLE
fix(compiler): Sketch may be wrongly considered up-to-date (-> not recompiled when needed)

### DIFF
--- a/internal/arduino/builder/builder.go
+++ b/internal/arduino/builder/builder.go
@@ -341,7 +341,7 @@ func (b *Builder) preprocess() error {
 	b.Progress.CompleteStep()
 
 	b.logIfVerbose(false, i18n.Tr("Generating function prototypes..."))
-	if err := b.preprocessSketch(b.libsDetector.IncludeFolders(), b.libsDetector.IsSketchUnchanged()); err != nil {
+	if err := b.preprocessSketch(b.libsDetector.IncludeFolders()); err != nil {
 		return err
 	}
 	b.Progress.CompleteStep()

--- a/internal/arduino/builder/internal/detector/detector.go
+++ b/internal/arduino/builder/internal/detector/detector.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"os/exec"
 	"regexp"
 	"slices"
@@ -320,6 +321,15 @@ func (l *SketchLibrariesDetector) findIncludes(
 			l.preRunner.Cancel()
 		}
 	}()
+
+	// Only for testing purposes
+	if libraryDetector_ForcePrerunnerPriority {
+		// When set to true, it forces the library detector pre-runner (that is normally scheduled
+		// randomly by the goroutine scheduler) to run with priority, in particular before
+		// the library detection starts.
+		fmt.Println("TESTING: Waiting for pre-runner start...")
+		time.Sleep(time.Second)
+	}
 
 	l.addIncludeFolder(buildCorePath)
 	if buildVariantPath != nil {
@@ -732,3 +742,6 @@ func LibrariesLoader(
 	resolver := librariesresolver.NewCppResolver(allLibs, targetPlatform, buildPlatform)
 	return lm, resolver, verboseOut.Bytes(), nil
 }
+
+// libraryDetector_ForcePrerunnerPriority is used for testing purposes.
+var libraryDetector_ForcePrerunnerPriority = os.Getenv("TESTING_LIBRARY_DETECTOR_FORCE_PRERUNNER_PRIORITY") == "1"

--- a/internal/arduino/builder/internal/detector/detector.go
+++ b/internal/arduino/builder/internal/detector/detector.go
@@ -225,9 +225,9 @@ func (l *SketchLibrariesDetector) IncludeFoldersChanged() bool {
 	return l.detectedChangeInLibraries
 }
 
-// IsSketchUnchanged returns true if the sketch source and all included library
+// IsSketchDepsUnchanged returns true if the sketch or any of its dependencies is up-to-date
 // headers are unchanged since the last preprocessing run.
-func (l *SketchLibrariesDetector) IsSketchUnchanged() bool {
+func (l *SketchLibrariesDetector) IsSketchDepsUnchanged() bool {
 	return l.sketchIsUnchanged
 }
 

--- a/internal/arduino/builder/internal/detector/detector.go
+++ b/internal/arduino/builder/internal/detector/detector.go
@@ -225,7 +225,8 @@ func (l *SketchLibrariesDetector) IncludeFoldersChanged() bool {
 	return l.detectedChangeInLibraries
 }
 
-// IsSketchUnchanged returns true if the sketch or any of its dependencies is up-to-date
+// IsSketchUnchanged returns true if the sketch source and all included library
+// headers are unchanged since the last preprocessing run.
 func (l *SketchLibrariesDetector) IsSketchUnchanged() bool {
 	return l.sketchIsUnchanged
 }
@@ -305,6 +306,16 @@ func (l *SketchLibrariesDetector) findIncludes(
 		l.logger.Warn(i18n.Tr("Failed to load library discovery cache: %[1]s", err))
 	}
 
+	// Determine if the sketch is unchanged BEFORE starting the preRunner goroutines.
+	// The preRunner may start GCC tasks that write libsdetect.d as a side effect; if we
+	// checked after the preRunner, a fast GCC run could update libsdetect.d's timestamp
+	// and make the sketch appear unchanged even after a modification (issue #3202).
+	mergedSketchForCheck, err := l.makeSourceFile(sketchBuildPath, sketchBuildPath, paths.New(sketch.MainFile.Base()+".cpp.merged"))
+	if err != nil {
+		return err
+	}
+	l.sketchIsUnchanged, _ = mergedSketchForCheck.ObjFileIsUpToDate(logrus.WithField("runner", "sketchcheck"))
+
 	// Pre-run cache entries
 	l.preRunner = runner.New(ctx, jobs)
 	for _, entry := range l.cache.EntriesAhead() {
@@ -343,7 +354,6 @@ func (l *SketchLibrariesDetector) findIncludes(
 		if err != nil {
 			return err
 		}
-		l.sketchIsUnchanged, _ = mergedSketch.ObjFileIsUpToDate(logrus.WithField("runner", "prerun"))
 
 		// Queue all sources from sketch folder, except the preprocessed sketch "sketch.ino.cpp".
 		// The library discovery is performed on the `sketch.ino.cpp.merged` file.

--- a/internal/arduino/builder/internal/detector/detector.go
+++ b/internal/arduino/builder/internal/detector/detector.go
@@ -310,11 +310,11 @@ func (l *SketchLibrariesDetector) findIncludes(
 	// The preRunner may start GCC tasks that write libsdetect.d as a side effect; if we
 	// checked after the preRunner, a fast GCC run could update libsdetect.d's timestamp
 	// and make the sketch appear unchanged even after a modification (issue #3202).
-	mergedSketchForCheck, err := l.makeSourceFile(sketchBuildPath, sketchBuildPath, paths.New(sketch.MainFile.Base()+".cpp.merged"))
+	mergedSketch, err := l.makeSourceFile(sketchBuildPath, sketchBuildPath, paths.New(sketch.MainFile.Base()+".cpp.merged"))
 	if err != nil {
 		return err
 	}
-	l.sketchIsUnchanged, _ = mergedSketchForCheck.ObjFileIsUpToDate(logrus.WithField("runner", "sketchcheck"))
+	l.sketchIsUnchanged, _ = mergedSketch.ObjFileIsUpToDate(logrus.WithField("runner", "sketchcheck"))
 
 	// Pre-run cache entries
 	l.preRunner = runner.New(ctx, jobs)
@@ -350,11 +350,6 @@ func (l *SketchLibrariesDetector) findIncludes(
 	sourceFileQueue := &uniqueSourceFileQueue{}
 
 	if !l.useCachedLibrariesResolution {
-		mergedSketch, err := l.makeSourceFile(sketchBuildPath, sketchBuildPath, paths.New(sketch.MainFile.Base()+".cpp.merged"))
-		if err != nil {
-			return err
-		}
-
 		// Queue all sources from sketch folder, except the preprocessed sketch "sketch.ino.cpp".
 		// The library discovery is performed on the `sketch.ino.cpp.merged` file.
 		// The `sketch.ino.cpp` file is generated in a later stage from `sketch.ino.cpp.merged` by the

--- a/internal/arduino/builder/preprocess_sketch.go
+++ b/internal/arduino/builder/preprocess_sketch.go
@@ -23,11 +23,13 @@ import (
 )
 
 // preprocessSketch fixdoc
-func (b *Builder) preprocessSketch(includes paths.PathList, sketchUnchanged bool) error {
+func (b *Builder) preprocessSketch(includes paths.PathList) error {
 	unpreprocessedSourceFile := b.buildPath.Join("sketch", b.sketch.MainFile.Base()+".cpp.merged")
 	preprocessedSourceFile := b.buildPath.Join("sketch", b.sketch.MainFile.Base()+".cpp")
 
-	if sketchUnchanged && preprocessedSourceFile.Exist() {
+	// Skip preprocessing if the sketch and all included library headers are unchanged since
+	// the last preprocessing run.
+	if b.libsDetector.IsSketchUnchanged() && preprocessedSourceFile.Exist() {
 		b.logIfVerbose(false, i18n.Tr("Using cached sketch with function prototypes."))
 		return nil
 	}

--- a/internal/arduino/builder/preprocess_sketch.go
+++ b/internal/arduino/builder/preprocess_sketch.go
@@ -16,6 +16,8 @@
 package builder
 
 import (
+	"os"
+
 	"github.com/arduino/arduino-cli/internal/arduino/builder/internal/preprocessor"
 	"github.com/arduino/arduino-cli/internal/arduino/builder/logger"
 	"github.com/arduino/arduino-cli/internal/i18n"
@@ -26,10 +28,18 @@ import (
 func (b *Builder) preprocessSketch(includes paths.PathList) error {
 	unpreprocessedSourceFile := b.buildPath.Join("sketch", b.sketch.MainFile.Base()+".cpp.merged")
 	preprocessedSourceFile := b.buildPath.Join("sketch", b.sketch.MainFile.Base()+".cpp")
+	unpreprocessedSourceFileStat, err := unpreprocessedSourceFile.Stat()
+	if err != nil {
+		return err
+	}
+	preprocessedSourceFileStat, err := preprocessedSourceFile.Stat()
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
 
 	// Skip preprocessing if the sketch and all included library headers are unchanged since
 	// the last preprocessing run.
-	if b.libsDetector.IsSketchDepsUnchanged() && preprocessedSourceFile.Exist() {
+	if b.libsDetector.IsSketchDepsUnchanged() && preprocessedSourceFile.Exist() && !unpreprocessedSourceFileStat.ModTime().After(preprocessedSourceFileStat.ModTime()) {
 		b.logIfVerbose(false, i18n.Tr("Using cached sketch with function prototypes."))
 		return nil
 	}

--- a/internal/arduino/builder/preprocess_sketch.go
+++ b/internal/arduino/builder/preprocess_sketch.go
@@ -29,7 +29,7 @@ func (b *Builder) preprocessSketch(includes paths.PathList) error {
 
 	// Skip preprocessing if the sketch and all included library headers are unchanged since
 	// the last preprocessing run.
-	if b.libsDetector.IsSketchUnchanged() && preprocessedSourceFile.Exist() {
+	if b.libsDetector.IsSketchDepsUnchanged() && preprocessedSourceFile.Exist() {
 		b.logIfVerbose(false, i18n.Tr("Using cached sketch with function prototypes."))
 		return nil
 	}

--- a/internal/integrationtest/compile_5/arduino_preprocess_cache_test.go
+++ b/internal/integrationtest/compile_5/arduino_preprocess_cache_test.go
@@ -222,4 +222,96 @@ void myNewFunction() {}
 		require.Contains(t, string(out), "Generating function prototypes...")
 		require.Contains(t, string(out), "Using cached sketch with function prototypes.")
 	})
+
+	// Regression test for https://github.com/arduino/arduino-cli/issues/3202
+	// After a successful build, modifying the sketch to add an #error directive should cause the next build to fail.
+	t.Run("SketchModificationAfterSuccessfulBuildInvalidatesCache/1", func(t *testing.T) {
+		// Create a tmp sketch
+		tmp, err := paths.MkTempDir("", "")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = tmp.RemoveAll() })
+		sketch := tmp.Join("sketch")
+		require.NoError(t, sketch.MkdirAll())
+		sketchFile := sketch.Join("sketch.ino")
+		require.NoError(t, sketchFile.WriteFile([]byte(`
+void setup() {}
+void loop() {}
+`)))
+
+		// Enable the library detector prerunner priority to make sure that the prerunner
+		// is executed as first step of the compilation process, which makes it effective
+		// in catching the regression
+		env := cli.GetDefaultEnv()
+		env["TESTING_LIBRARY_DETECTOR_FORCE_PRERUNNER_PRIORITY"] = "1"
+
+		// Build successfully
+		_, _, err = cli.RunWithCustomEnv(env, "compile", "-b", "arduino:avr:uno", sketch.String())
+		require.NoError(t, err)
+
+		// Modify sketch to add a compile error
+		require.NoError(t, sketchFile.WriteFile([]byte(`
+void setup() {}
+void loop() {
+  #error TEST
+}
+`)))
+
+		// Build again: must fail with the error (not silently reuse stale object)
+		_, outerr, err := cli.RunWithCustomEnv(env, "compile", "-b", "arduino:avr:uno", sketch.String())
+		require.Error(t, err, "compilation should fail due to #error in sketch")
+		require.Contains(t, string(outerr), "#error TEST")
+
+		// Modify sketch to add a compile error
+		require.NoError(t, sketchFile.WriteFile([]byte(`
+void setup() {}
+void loop() {
+}
+`)))
+
+		// Build again: must not fail anymore
+		_, _, err = cli.RunWithCustomEnv(env, "compile", "-b", "arduino:avr:uno", sketch.String())
+		require.NoError(t, err, "compilation should succeed after removing #error in sketch")
+	})
+
+	// Regression test for https://github.com/arduino/arduino-cli/issues/3202
+	// After a successful build, modifying the sketch should cause the next build to not reuse the cached compilation results.
+	t.Run("SketchModificationAfterSuccessfulBuildInvalidatesCache/2", func(t *testing.T) {
+		// Create a tmp sketch
+		tmp, err := paths.MkTempDir("", "")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = tmp.RemoveAll() })
+		sketch := tmp.Join("sketch")
+		require.NoError(t, sketch.MkdirAll())
+		sketchFile := sketch.Join("sketch.ino")
+		require.NoError(t, sketchFile.WriteFile([]byte(`
+void setup() {}
+void loop() {}
+`)))
+
+		// Enable the library detector prerunner priority to make sure that the prerunner
+		// is executed as first step of the compilation process, which makes it effective
+		// in catching the regression
+		env := cli.GetDefaultEnv()
+		env["TESTING_LIBRARY_DETECTOR_FORCE_PRERUNNER_PRIORITY"] = "1"
+
+		// Build successfully
+		_, _, err = cli.RunWithCustomEnv(env, "compile", "-b", "arduino:avr:uno", sketch.String())
+		require.NoError(t, err)
+
+		// Modify sketch
+		require.NoError(t, sketchFile.WriteFile([]byte(`
+void setup() {
+	Serial.begin(9600);
+}
+void loop() {
+	Serial.println("Hello");
+	delay(1000);
+}
+`)))
+
+		// Build again: must now use the cached sketch with function prototypes.
+		out, _, err := cli.RunWithCustomEnv(env, "compile", "-v", "-b", "arduino:avr:uno", sketch.String())
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "Using cached sketch with function prototypes.")
+	})
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Fixes a race condition in the builder.

The root cause is that [`sketchIsUnchanged` is computed](https://github.com/arduino/arduino-cli/blob/fb6bae107847ea597e13622d2f656006161a1c4b/internal/arduino/builder/internal/detector/detector.go#L336) after the [`preRunner` goroutines are started](https://github.com/arduino/arduino-cli/blob/fb6bae107847ea597e13622d2f656006161a1c4b/internal/arduino/builder/internal/detector/detector.go#L308-L322). A `preRunner` GCC task for mergedSketch would write `libsdetect.d` with a fresh timestamp, making the subsequent check incorrectly report "sketch unchanged."

Actually, the race condition will not be easily triggered because the prerunner will usually be scheduled *after* the check, since Go tends to keep the current thread running rather than immediately starting just-spawned goroutines. The race condition becomes more likely if the sketch has many libraries and the PC has a multi-core processor (increasing the likelihood that a concurrent GCC is started quickly).

The fix is relatively simple: compute `sketchIsUnchanged` before `preRunner` is started.

## What is the current behavior?

In some circumstances, likely with complex sketches, the sketch may not be recompiled after being modified.

## What is the new behavior?

The sketch is always recompiled if a modification occurs.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

Should fix #3202 
