### PR TITLE
Support building for OpenBSD host

### DIFF
--- a/internal/locales/detect_openbsd.go
+++ b/internal/locales/detect_openbsd.go
@@ -1,0 +1,20 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package locales
+
+func getLocaleIdentifier() string {
+	return getLocaleIdentifierFromEnv()
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

`GOOS=openbsd go build ./....` will not fail anymore and build a binary

## What is the current behavior?

`GOOS=openbsd go build ./....`  fails with:

```
# github.com/arduino/arduino-cli/internal/locales
internal/locales/detect.go:24:9: undefined: getLocaleIdentifier
```

## What is the new behavior?

An arduino-cli binary is created.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No

## Other information

It might make sense to do the same change for NetBSD and DragonFly as well. However this doesn't seem to currently fix compilation. Maybe it makes sense to create an `_other.go` or `_unsupported.go` or `_bsd.go` file so people right away see the actual error instead of the file/os target not existing?