### PR TITLE
Improve error message for malformed third-party platform archives

### DIFF
--- a/internal/arduino/resources/install.go
+++ b/internal/arduino/resources/install.go
@@ -129,10 +129,10 @@ func findPackageRoot(parent *paths.Path) (*paths.Path, error) {
 	files.FilterOutPrefix("__MACOSX")
 
 	if len(files) == 0 {
-		return nil, errors.New(i18n.Tr("files in archive must be placed in a subdirectory"))
+		return nil, errors.New(i18n.Tr("the platform archive is not structured correctly: all files must be placed within a single root folder. This is likely a problem with the third-party platform; please report it to the platform's maintainer."))
 	}
 	if len(files) > 1 {
-		return nil, errors.New(i18n.Tr("no unique root dir in archive, found '%[1]s' and '%[2]s'", files[0], files[1]))
+		return nil, errors.New(i18n.Tr("the platform archive is not structured correctly: it must contain a single root folder, but found multiple ('%[1]s', '%[2]s'). This is likely a problem with the third-party platform; please report it to the platform's maintainer.", files[0], files[1]))
 	}
 
 	return files[0], nil

--- a/internal/arduino/resources/install_test.go
+++ b/internal/arduino/resources/install_test.go
@@ -59,7 +59,7 @@ func TestInstallPlatform(t *testing.T) {
 				Checksum:        "SHA-256:8b3fc6253c5ac2f3ba684eba0d62bb8a4ee93469fa822f81e2cd7d1b959c4044",
 				Size:            148,
 			},
-			error: "no unique root dir in archive",
+			error: "must contain a single root folder",
 		},
 		{
 			testName: "root folder not present",
@@ -68,7 +68,7 @@ func TestInstallPlatform(t *testing.T) {
 				Checksum:        "SHA-256:bc00db9784e20f50d7a5fceccb6bd95ebff4a3e847aac88365b95a6851a24963",
 				Size:            177,
 			},
-			error: "files in archive must be placed in a subdirectory",
+			error: "must be placed within a single root folder",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## What
Make the platform-archive structure errors in `findPackageRoot` user-actionable.

## Why
Installing a third-party core whose archive is structured incorrectly surfaced a low-level internal message, e.g.:

> searching package root dir: no unique root dir in archive, found '.../cores' and '.../firmwares'

This is hard for end users to act on, and GUI tools (e.g. Arduino IDE) sometimes display it verbatim. See #3131.

## How
Reword both `findPackageRoot` errors (zero root folders / multiple root folders) to explain that the archive is malformed and that it is likely a problem with the third-party platform, pointing the user to the platform maintainer. The multiple-root case still lists the offending folders.

Fixes #3131
