### PR TITLE
[skip changelog] Replace unbalanced backtick in comment

### DIFF
--- a/rpc/cc/arduino/cli/commands/v1/debug.pb.go
+++ b/rpc/cc/arduino/cli/commands/v1/debug.pb.go
@@ -646,7 +646,7 @@ func (*DebugGCCToolchainConfiguration) Descriptor() ([]byte, []int) {
 	return file_cc_arduino_cli_commands_v1_debug_proto_rawDescGZIP(), []int{6}
 }
 
-// Configuration specific for the 'openocd` server.
+// Configuration specific for the 'openocd' server.
 type DebugOpenOCDServerConfiguration struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/rpc/cc/arduino/cli/commands/v1/debug.proto
+++ b/rpc/cc/arduino/cli/commands/v1/debug.proto
@@ -141,7 +141,7 @@ message GetDebugConfigResponse {
 // Configurations specific for the 'gcc' toolchain.
 message DebugGCCToolchainConfiguration {}
 
-// Configuration specific for the 'openocd` server.
+// Configuration specific for the 'openocd' server.
 message DebugOpenOCDServerConfiguration {
   // Path to openocd.
   string path = 1;


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The comments in the Protocol Buffers source files are used in generated documentation. The generated documentation uses Markdown.

A comment in the Protocol Buffers source files contains an unbalanced backtick. Since the backtick has syntactical significance in the Markdown language, this causes the Markdown to be invalid, affecting parsing. This resulted in spurious failures of the link check:

```
  ERROR: 103 dead links found in ./docs/rpc/commands.md !
  [✖] #cc.arduino.cli.commands.v1.DebugRequest → Status: 404
  [✖] #cc.arduino.cli.commands.v1.DebugResponse → Status: 404

[...]
```

## What is the new behavior?

The problem is resolved by replacing the stray backtick with a single quote, matching the existing companion quote character. The alternative solution would be to replace the existing single quote character with a backtick. The switch to single quote was chosen for consistency with another occurrence of this comment elsewhere in the code.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.
