### PR TITLE
[skip changelog] Add link check exclusions for broken generated Protocol Buffer doc links

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,6 +5,12 @@
   "aliveStatusCodes": [200, 206],
   "ignorePatterns": [
     {
+      "pattern": "^#google-protobuf-Any$"
+    },
+    {
+      "pattern": "^#google-rpc-Status$"
+    },
+    {
       "pattern": "https?://localhost:\\d*/"
     },
     {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Documentation of the Protocol Buffers interface is automatically generated from the project source code.

Unfortunately the documentation generator produces some broken links. These cause the project infrastructure's link checker to fail:

```
ERROR: 104 dead links found in ./docs/rpc/commands.md !
[✖] #google-protobuf-Any → Status: 404
[✖] #google-rpc-Status → Status: 404
```

## What is the new behavior?

It will not be feasible to fix these links, so the only available resolution for those link check failures is to configure exclusions.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.