### PR TITLE
[skip changelog] Fix broken Language Reference links

### DIFF
--- a/docs/library-specification.md
+++ b/docs/library-specification.md
@@ -344,10 +344,10 @@ It is permitted to leave a field empty.
 
 ##### `REFERENCE_LINK`
 
-This field specifies the [Arduino Language Reference](https://www.arduino.cc/reference/en) page to open via the Arduino
-IDE's **Right Click > Find in Reference** or **Help > Find in Reference** when the cursor is on that keyword. Generally
-it does not make sense to define the `REFERENCE_LINK` field for 3rd party library keywords since they are not likely to
-be in the Arduino Language Reference.
+This field specifies the [Arduino Language Reference](https://docs.arduino.cc/language-reference/) page to open via the
+Arduino IDE's **Right Click > Find in Reference** or **Help > Find in Reference** when the cursor is on that keyword.
+Generally it does not make sense to define the `REFERENCE_LINK` field for 3rd party library keywords since they are not
+likely to be in the Arduino Language Reference.
 
 ##### `RSYNTAXTEXTAREA_TOKENTYPE`
 

--- a/docs/sketch-specification.md
+++ b/docs/sketch-specification.md
@@ -34,7 +34,7 @@ Sketches may consist of multiple code files.
 
 The following extensions are supported:
 
-- .ino - [Arduino language](https://www.arduino.cc/reference/en/) files.
+- .ino - [Arduino language](https://docs.arduino.cc/language-reference/) files.
 - .pde - Alternate extension for Arduino language files. This file extension is also used by Processing sketches. .ino
   is recommended to avoid confusion. **`.pde` extension is deprecated and will be removed in the future.**
 - .cpp - C++ files.


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The project documentation content contains links to the Arduino Language Reference. The URL of the Language Reference has changed due to restructuring of the arduino.cc website. A redirect was not set up for the URL used in the project documentation, so that change broke the links.

## What is the new behavior?

The links are updated to point to the current URL of the Arduino Language Reference.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.