### PR TITLE
[skip changelog] Fix Transifex project link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -341,7 +341,7 @@ If your PR doesn't need to be included in the changelog, please start the commit
 [issues]: #issue-reports
 [nightly]: https://arduino.github.io/arduino-cli/latest/installation/#nightly-builds
 [prs]: #pull-requests
-[translate]: https://www.transifex.com/arduino-1/arduino-cli/
+[translate]: https://explore.transifex.com/arduino-1/arduino-cli/
 [store]: https://store.arduino.cc
 [issue-tracker]: https://github.com/arduino/arduino-cli/issues?q=
 [reactions]: https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The contributor guide links to the Arduino CLI Transifex project. The URL of that project changed since the time the link was added to the guide. The old URL no longer leads to the intended content.

## What is the new behavior?

The link is updated to point to the current URL of the Transifex project.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.