### PR TITLE
[skip changelog] Adjust link exclusions for project's protoc-gen-doc version

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,10 +5,10 @@
   "aliveStatusCodes": [200, 206],
   "ignorePatterns": [
     {
-      "pattern": "^#google-protobuf-Any$"
+      "pattern": "^#google\\.protobuf\\.Any$"
     },
     {
-      "pattern": "^#google-rpc-Status$"
+      "pattern": "^#google\\.rpc\\.Status$"
     },
     {
       "pattern": "https?://localhost:\\d*/"


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [N/A] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Documentation of the Protocol Buffers interface is automatically generated from the project source code.

Unfortunately the [**protoc-gen-doc**](https://github.com/pseudomuto/protoc-gen-doc) documentation generator tool produces some broken links. These cause the project infrastructure's link checker to fail:

```
ERROR: 2 dead links found in ./docs/rpc/commands.md !
[✖] #google.protobuf.Any → Status: 404
[✖] #google.rpc.Status → Status: 404
```

It will not be feasible to fix these links, so the only available resolution for those link check failures is to configure exclusions.

The previous exclusions (https://github.com/arduino/arduino-cli/pull/3221) were tailored to the links generated by the modern version of **protoc-gen-doc**. It turns out that the project infrastructure has an unfortunate design where management of this tool dependency is only done in the GitHub Actions workflows:

https://github.com/arduino/arduino-cli/blob/5e8e4a30d28cb9e4361cfc4b26a19137079e295a/.github/workflows/check-markdown-task.yml#L122-L123

This means that when the documentation generation is performed locally by a contributor, a different version of **protoc-gen-doc** may be used than that used by the CI system. The outdated version of **protoc-gen-doc** installed by the Github Actions workflow generates links with different fragment ID format than the modern version of the tool. That resulted in exclusions that caused the link check to pass locally, but fail in the CI runs.

## What is the new behavior?

The link checker exclusions are updated to match the links generated by the outdated version of **protoc-gen-doc** used by the project's GitHub Actions workflows.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No breaking change.