### PR TITLE
cli: fix package index URLs not ending with a file name

### DIFF
--- a/internal/arduino/cores/packagemanager/package_manager.go
+++ b/internal/arduino/cores/packagemanager/package_manager.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -32,6 +31,7 @@ import (
 	"github.com/arduino/arduino-cli/internal/arduino/cores"
 	"github.com/arduino/arduino-cli/internal/arduino/cores/packageindex"
 	"github.com/arduino/arduino-cli/internal/arduino/discovery/discoverymanager"
+	"github.com/arduino/arduino-cli/internal/arduino/resources"
 	"github.com/arduino/arduino-cli/internal/arduino/sketch"
 	"github.com/arduino/arduino-cli/internal/i18n"
 	"github.com/arduino/arduino-cli/pkg/fqbn"
@@ -463,12 +463,9 @@ func (pme *Explorer) determineReferencedPlatformRelease(boardBuildProperties *pr
 
 // LoadPackageIndex loads a package index by looking up the local cached file from the specified URL
 func (pmb *Builder) LoadPackageIndex(URL *url.URL) error {
-	indexFileName := path.Base(URL.Path)
-	if indexFileName == "." || indexFileName == "" {
+	indexFileName, err := (&resources.IndexResource{URL: URL}).IndexFileName()
+	if err != nil {
 		return &cmderrors.InvalidURLError{Cause: errors.New(URL.String())}
-	}
-	if before, ok := strings.CutSuffix(indexFileName, ".tar.bz2"); ok {
-		indexFileName = before + ".json"
 	}
 	indexPath := pmb.IndexDir.Join(indexFileName)
 	index, err := packageindex.LoadIndex(indexPath)

--- a/internal/arduino/resources/index.go
+++ b/internal/arduino/resources/index.go
@@ -41,7 +41,12 @@ type IndexResource struct {
 }
 
 // IndexFileName returns the index file name as it is saved in data dir (package_xxx_index.json).
+// If the URL contains a fragment (e.g. #package_foo_index.json), that fragment is used as-is as
+// the local filename, allowing users to provide a meaningful name for URLs whose path provides none.
 func (res *IndexResource) IndexFileName() (string, error) {
+	if res.URL.Fragment != "" {
+		return res.URL.Fragment, nil
+	}
 	filename := path.Base(res.URL.Path) // == package_index.json[.gz] || packacge_index.tar.bz2
 	if filename == "." || filename == "" || filename == "/" {
 		return "", &cmderrors.InvalidURLError{}
@@ -73,15 +78,19 @@ func (res *IndexResource) Download(ctx context.Context, destDir *paths.Path, dow
 	defer tmp.RemoveAll()
 
 	// Download index file
+	// Strip any fragment from the request URL — fragments are client-side hints, not sent to the server.
+	reqURL := *res.URL
+	reqURL.Fragment = ""
+	reqURL.RawFragment = ""
 	downloadFileName := path.Base(res.URL.Path) // == package_index.json[.gz] || package_index.tar.bz2
-	indexFileName, err := res.IndexFileName()   // == package_index.json
+	indexFileName, err := res.IndexFileName()   // == package_index.json (or fragment-specified name)
 	if err != nil {
 		return err
 	}
 	tmpIndexPath := tmp.Join(downloadFileName)
 	config.DoNotResumeDownload = true // Disable resuming downloads for index files
-	if err := httpclient.DownloadFile(ctx, tmpIndexPath, res.URL.String(), "", i18n.Tr("Downloading index: %s", downloadFileName), downloadCB, config); err != nil {
-		return &cmderrors.FailedDownloadError{Message: i18n.Tr("Error downloading index '%s'", res.URL), Cause: err}
+	if err := httpclient.DownloadFile(ctx, tmpIndexPath, reqURL.String(), "", i18n.Tr("Downloading index: %s", downloadFileName), downloadCB, config); err != nil {
+		return &cmderrors.FailedDownloadError{Message: i18n.Tr("Error downloading index '%s'", &reqURL), Cause: err}
 	}
 
 	var signaturePath, tmpSignaturePath *paths.Path

--- a/internal/arduino/resources/resources_test.go
+++ b/internal/arduino/resources/resources_test.go
@@ -185,11 +185,49 @@ func TestIndexFileName(t *testing.T) {
 		{url: "package_arduino.cc_index.json.gz", expected: "package_arduino.cc_index.json"},
 		{url: "package_arduino.cc_index.tar.bz2", expected: "package_arduino.cc_index.json"},
 		{url: "http://drazzy.com/package_drazzy.com_index.json", expected: "package_drazzy.com_index.json"},
+		// URL fragment overrides path-derived name (e.g. GitHub Actions artifact URLs)
+		{url: "https://api.github.com/repos/owner/repo/actions/artifacts/123/zip#package_foo_index.json", expected: "package_foo_index.json"},
+		{url: "https://example.com/some/opaque/path#my_index.json", expected: "my_index.json"},
 	}
 	for _, tc := range tests {
-		ir := IndexResource{URL: &url.URL{Path: tc.url}}
+		u, err := url.Parse(tc.url)
+		require.NoError(t, err)
+		ir := IndexResource{URL: u}
 		name, err := ir.IndexFileName()
 		require.NoError(t, err, fmt.Sprintf("error trying url: %v", tc))
 		require.Equal(t, tc.expected, name)
 	}
+}
+
+func TestIndexDownloadWithURLFragment(t *testing.T) {
+	ctx := context.Background()
+
+	// Spawn a test server that serves a minimal JSON index at a path with no extension.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/artifacts/123/zip", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"packages":[]}`)
+	})
+	server := &http.Server{Handler: mux}
+	ln, err := net.Listen("tcp", "127.0.0.1:")
+	require.NoError(t, err)
+	defer ln.Close()
+	go server.Serve(ln)
+	defer server.Close()
+
+	// URL whose path ends in /zip (no useful extension) but whose fragment names the index.
+	rawURL := "http://" + ln.Addr().String() + "/artifacts/123/zip#package_fragment_index.json"
+	u, err := url.Parse(rawURL)
+	require.NoError(t, err)
+
+	destDir, err := paths.MkTempDir("", "")
+	require.NoError(t, err)
+	defer destDir.RemoveAll()
+
+	err = (&IndexResource{URL: u}).Download(ctx, destDir, func(*rpc.DownloadProgress) {}, downloader.GetDefaultConfig())
+	require.NoError(t, err)
+
+	// File must be saved under the fragment name, not "zip.json".
+	require.True(t, destDir.Join("package_fragment_index.json").Exist(), "expected package_fragment_index.json")
+	require.False(t, destDir.Join("zip.json").Exist(), "unexpected zip.json")
 }


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls) before creating one)
- [x] The PR follows [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

If an additional board-manager URL ends with a fragment (e.g. `#package_zephyr_index.json`), that name is used as the local filename instead of deriving it from the URL path.  This lets users give a meaningful name to opaque URLs (such as GitHub Actions artifact download links, whose path ends in `/zip`).

Note that this does not extend to platform/tool downloads, as those have an explicit file name in the package index JSON.

Example of the newly supported package index URL format:
```
https://api.github.com/repos/owner/repo/actions/artifacts/123/zip#package_foo_index.json
```

Fixes `Error initializing instance: Loading index file: loading json index file ~/.arduino15/zip: no such file or directory` when using a GitHub Actions artifact URL as an additional board manager URL.

Changes:
- `IndexFileName()`: return `URL.Fragment` when non-empty (highest priority)
- `Download()`: strip fragment before the HTTP request; use `indexFileName` (which may now be the fragment) in the progress label
- `LoadPackageIndex()`: delegate to `IndexResource.IndexFileName()` instead of (badly!) duplicating the extension-normalisation switch

Assisted-by: GitHub Copilot

## What is the current behavior?

Currently the CLI breaks on URLs that do not end with actual file names, because the download and later load of the same URL use different heuristics for naming paths (it was saved as `zip.json` and read as `zip`).

## What is the new behavior?

The behavior is unified in `resources.IndexFile`. A new feature is also added to use the fragment, if present, for the output file name. 
 
## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No