### PR TITLE
Quality: Invalid use of Go's `new` builtin — will not compile or produces wrong pointer

### DIFF
--- a/commands/service_settings.go
+++ b/commands/service_settings.go
@@ -70,14 +70,14 @@ func (s *arduinoCoreServerImpl) ConfigurationGet(ctx context.Context, req *rpc.C
 	}
 
 	if builtinLibs := s.settings.IDEBuiltinLibrariesDir(); builtinLibs != nil {
-		conf.Directories.Builtin.Libraries = new(builtinLibs.String())
+		conf.Directories.Builtin.Libraries = f.ToPtr(builtinLibs.String())
 	}
 
 	if ua := s.settings.ExtraUserAgent(); ua != "" {
 		conf.Network.ExtraUserAgent = &ua
 	}
 	if proxy, err := s.settings.NetworkProxy(); err == nil && proxy != nil {
-		conf.Network.Proxy = new(proxy.String())
+		conf.Network.Proxy = f.ToPtr(proxy.String())
 	}
 
 	if logFile := s.settings.LoggingFile(); logFile != nil {


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`new(builtinLibs.String())` and `new(proxy.String())` are invalid Go. The built-in `new()` requires a type argument (e.g., `new(string)`), not a value expression. `builtinLibs.String()` evaluates to a `string` value at runtime, so `new(...)` cannot accept it. This is either a compilation error preventing the package from building, or—if shadowed by some local declaration—it would allocate a zero-valued string instead of the intended value. The project imports `go.bug.st/f` which provides `f.ToPtr()` for exactly this purpose.


**Severity**: `critical`
**File**: `commands/service_settings.go`

### Solution
Replace the `new(value)` calls with the idiomatic pointer-helper from the already-imported `f` package:


### Changes
- `commands/service_settings.go` (modified)

## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [ ] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?



## What is the current behavior?



## What is the new behavior?



## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?



## Other information



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #3228