### PR TITLE
experimental: cache libraries loading during CLI init phase

### DIFF
--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"path/filepath"
 	"slices"
 
@@ -95,16 +96,22 @@ func (library *Library) String() string {
 }
 
 func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
+	writeLen := func(l int) error {
+		if l < 0 || l > math.MaxUint16 {
+			return fmt.Errorf("length %d is out of allowed range 0-%d", l, math.MaxUint16)
+		}
+		return binary.Write(out, binary.NativeEndian, uint16(l))
+	}
 	writeString := func(in string) error {
 		inBytes := []byte(in)
-		if err := binary.Write(out, binary.NativeEndian, uint16(len(inBytes))); err != nil {
+		if err := writeLen(len(inBytes)); err != nil {
 			return err
 		}
 		_, err := out.Write(inBytes)
 		return err
 	}
 	writeStringArray := func(in []string) error {
-		if err := binary.Write(out, binary.NativeEndian, uint16(len(in))); err != nil {
+		if err := writeLen(len(in)); err != nil {
 			return err
 		}
 		for _, i := range in {
@@ -115,7 +122,7 @@ func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 		return nil
 	}
 	writeMap := func(in map[string]bool) error {
-		if err := binary.Write(out, binary.NativeEndian, uint16(len(in))); err != nil {
+		if err := writeLen(len(in)); err != nil {
 			return err
 		}
 		for k, v := range in {
@@ -133,7 +140,7 @@ func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 		if in != nil {
 			keys = in.Keys()
 		}
-		if err := binary.Write(out, binary.NativeEndian, uint16(len(keys))); err != nil {
+		if err := writeLen(len(keys)); err != nil {
 			return err
 		}
 		for _, k := range keys {
@@ -161,7 +168,7 @@ func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 		}
 	}
 	writePathList := func(in []*paths.Path) error {
-		if err := binary.Write(out, binary.NativeEndian, uint16(len(in))); err != nil {
+		if err := writeLen(len(in)); err != nil {
 			return err
 		}
 		for _, p := range in {
@@ -262,25 +269,25 @@ func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 
 func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error {
 	readString := func() (string, error) {
-		var len uint16
-		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
+		var length uint16
+		if err := binary.Read(in, binary.NativeEndian, &length); err != nil {
 			return "", err
 		}
-		res := make([]byte, len)
+		res := make([]byte, length)
 		if _, err := in.Read(res); err != nil {
 			return "", err
 		}
 		return string(res), nil
 	}
 	readStringArray := func() ([]string, error) {
-		var len uint16
-		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
+		var length uint16
+		if err := binary.Read(in, binary.NativeEndian, &length); err != nil {
 			return nil, err
 		}
-		if len == 0 {
+		if length == 0 {
 			return nil, nil
 		}
-		res := make([]string, len)
+		res := make([]string, length)
 		for i := range res {
 			var err error
 			res[i], err = readString()
@@ -291,12 +298,12 @@ func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error 
 		return res, nil
 	}
 	readMap := func() (map[string]bool, error) {
-		var len uint16
-		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
+		var length uint16
+		if err := binary.Read(in, binary.NativeEndian, &length); err != nil {
 			return nil, err
 		}
 		res := map[string]bool{}
-		for range len {
+		for range length {
 			k, err := readString()
 			if err != nil {
 				return nil, err
@@ -321,12 +328,12 @@ func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error 
 		}
 	}
 	readPathList := func() (paths.PathList, error) {
-		var len uint16
-		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
+		var length uint16
+		if err := binary.Read(in, binary.NativeEndian, &length); err != nil {
 			return nil, err
 		}
 		list := paths.NewPathList()
-		for range len {
+		for range length {
 			if p, err := readPath(); err != nil {
 				return nil, err
 			} else {
@@ -336,12 +343,12 @@ func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error 
 		return list, nil
 	}
 	readProperties := func() (*properties.Map, error) {
-		var len uint16
-		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
+		var length uint16
+		if err := binary.Read(in, binary.NativeEndian, &length); err != nil {
 			return nil, err
 		}
 		props := properties.NewMap()
-		for range len {
+		for range length {
 			if k, err := readString(); err != nil {
 				return nil, err
 			} else if v, err := readString(); err != nil {

--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -16,8 +16,11 @@
 package libraries
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"slices"
 
 	"github.com/arduino/arduino-cli/internal/arduino/cores"
@@ -89,6 +92,234 @@ func (library *Library) String() string {
 		return library.Name
 	}
 	return library.Name + "@" + library.Version.String()
+}
+
+func (library *Library) MarshalBinary() []byte {
+	buffer := bytes.NewBuffer(make([]byte, 0, 4096))
+	writeString := func(in string) {
+		inBytes := []byte(in)
+		binary.Write(buffer, binary.NativeEndian, uint16(len(inBytes)))
+		buffer.Write(inBytes)
+	}
+	writeStringArray := func(in []string) {
+		binary.Write(buffer, binary.NativeEndian, uint16(len(in)))
+		for _, i := range in {
+			writeString(i)
+		}
+	}
+	writeMap := func(in map[string]bool) {
+		binary.Write(buffer, binary.NativeEndian, uint16(len(in)))
+		for k, v := range in {
+			writeString(k)
+			binary.Write(buffer, binary.NativeEndian, v)
+		}
+	}
+	writePath := func(in *paths.Path) {
+		if in == nil {
+			writeString("")
+		} else {
+			writeString(in.String())
+		}
+	}
+	writeString(library.Name)
+	writeString(library.Author)
+	writeString(library.Maintainer)
+	writeString(library.Sentence)
+	writeString(library.Paragraph)
+	writeString(library.Website)
+	writeString(library.Category)
+	writeStringArray(library.Architectures)
+	writeStringArray(library.Types)
+	writePath(library.InstallDir)
+	writeString(library.DirName)
+	writePath(library.SourceDir)
+	writePath(library.UtilityDir)
+	binary.Write(buffer, binary.NativeEndian, int32(library.Location))
+	// library.ContainerPlatform      *cores.PlatformRelease `json:""`
+	binary.Write(buffer, binary.NativeEndian, int32(library.Layout))
+	binary.Write(buffer, binary.NativeEndian, library.DotALinkage)
+	binary.Write(buffer, binary.NativeEndian, library.Precompiled)
+	binary.Write(buffer, binary.NativeEndian, library.PrecompiledWithSources)
+	writeString(library.LDflags)
+	binary.Write(buffer, binary.NativeEndian, library.IsLegacy)
+	binary.Write(buffer, binary.NativeEndian, library.InDevelopment)
+	writeString(library.Version.String())
+	writeString(library.License)
+	//writeStringArray(library.Properties.AsSlice())
+	writeStringArray(library.Examples.AsStrings())
+	writeStringArray(library.declaredHeaders)
+	writeStringArray(library.sourceHeaders)
+	writeMap(library.CompatibleWith)
+	return buffer.Bytes()
+}
+
+func (library *Library) UnmarshalBinary(in io.Reader) error {
+	readString := func() (string, error) {
+		var len uint16
+		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
+			return "", err
+		}
+		res := make([]byte, len)
+		if _, err := in.Read(res); err != nil {
+			return "", err
+		}
+		return string(res), nil
+	}
+	readStringArray := func() ([]string, error) {
+		var len uint16
+		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
+			return nil, err
+		}
+		res := make([]string, len)
+		for i := range res {
+			var err error
+			res[i], err = readString()
+			if err != nil {
+				return nil, err
+			}
+		}
+		return res, nil
+	}
+	readMap := func() (map[string]bool, error) {
+		var len uint16
+		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
+			return nil, err
+		}
+		res := map[string]bool{}
+		for i := uint16(0); i < len; i++ {
+			k, err := readString()
+			if err != nil {
+				return nil, err
+			}
+			var v bool
+			if err := binary.Read(in, binary.NativeEndian, &v); err != nil {
+				return nil, err
+			}
+			res[k] = v
+		}
+		return res, nil
+	}
+	var err error
+	library.Name, err = readString()
+	if err != nil {
+		return err
+	}
+	library.Author, err = readString()
+	if err != nil {
+		return err
+	}
+	library.Maintainer, err = readString()
+	if err != nil {
+		return err
+	}
+	library.Sentence, err = readString()
+	if err != nil {
+		return err
+	}
+	library.Paragraph, err = readString()
+	if err != nil {
+		return err
+	}
+	library.Website, err = readString()
+	if err != nil {
+		return err
+	}
+	library.Category, err = readString()
+	if err != nil {
+		return err
+	}
+	library.Architectures, err = readStringArray()
+	if err != nil {
+		return err
+	}
+	library.Types, err = readStringArray()
+	if err != nil {
+		return err
+	}
+	installDir, err := readString()
+	if err != nil {
+		return err
+	}
+	library.InstallDir = paths.New(installDir)
+	library.DirName, err = readString()
+	if err != nil {
+		return err
+	}
+	sourceDir, err := readString()
+	library.SourceDir = paths.New(sourceDir)
+	if err != nil {
+		return err
+	}
+	utilityDir, err := readString()
+	if err != nil {
+		return err
+	}
+	library.UtilityDir = paths.New(utilityDir)
+	var location int32
+	if err := binary.Read(in, binary.NativeEndian, &location); err != nil {
+		return err
+	}
+	library.Location = LibraryLocation(location)
+	// library.ContainerPlatform      *cores.PlatformRelease `json:""`
+	var layout int32
+	if err := binary.Read(in, binary.NativeEndian, &layout); err != nil {
+		return err
+	}
+	library.Layout = LibraryLayout(layout)
+	if err := binary.Read(in, binary.NativeEndian, &library.DotALinkage); err != nil {
+		return err
+	}
+	if err := binary.Read(in, binary.NativeEndian, &library.Precompiled); err != nil {
+		return err
+	}
+	if err := binary.Read(in, binary.NativeEndian, &library.PrecompiledWithSources); err != nil {
+		return err
+	}
+	library.LDflags, err = readString()
+	if err != nil {
+		return err
+	}
+	if err := binary.Read(in, binary.NativeEndian, &library.IsLegacy); err != nil {
+		return err
+	}
+	if err := binary.Read(in, binary.NativeEndian, &library.InDevelopment); err != nil {
+		return err
+	}
+	version, err := readString()
+	if err != nil {
+		return err
+	}
+	library.Version = semver.MustParse(version)
+	library.License, err = readString()
+	if err != nil {
+		return err
+	}
+	// props, err := readStringArray()
+	// if err != nil {
+	// 	return err
+	// }
+	// library.Properties, err = properties.LoadFromSlice(props)
+	// if err != nil {
+	// 	return err
+	// }
+	examples, err := readStringArray()
+	if err != nil {
+		return err
+	}
+	library.Examples = paths.NewPathList(examples...)
+	library.declaredHeaders, err = readStringArray()
+	if err != nil {
+		return err
+	}
+	library.sourceHeaders, err = readStringArray()
+	if err != nil {
+		return err
+	}
+	library.CompatibleWith, err = readMap()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // ToRPCLibrary converts this library into an rpc.Library

--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -288,7 +288,7 @@ func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error 
 			return nil, err
 		}
 		res := map[string]bool{}
-		for i := uint16(0); i < len; i++ {
+		for range len {
 			k, err := readString()
 			if err != nil {
 				return nil, err

--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -95,6 +95,20 @@ func (library *Library) String() string {
 	return library.Name + "@" + library.Version.String()
 }
 
+func toInt32(in int) int32 {
+	if in < math.MinInt32 || in > math.MaxInt32 {
+		panic(fmt.Sprintf("value %d is out of allowed range %d-%d", in, math.MinInt32, math.MaxInt32))
+	}
+	return int32(in)
+}
+
+func toUint16(in int) uint16 {
+	if in < 0 || in > math.MaxUint16 {
+		panic(fmt.Sprintf("value %d is out of allowed range 0-%d", in, math.MaxUint16))
+	}
+	return uint16(in)
+}
+
 func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 	writeLen := func(l int) error {
 		if l < 0 || l > math.MaxUint16 {
@@ -217,11 +231,11 @@ func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 	if err := writePath(library.UtilityDir); err != nil {
 		return err
 	}
-	if err := binary.Write(out, binary.NativeEndian, int32(library.Location)); err != nil {
+	if err := binary.Write(out, binary.NativeEndian, toInt32(int(library.Location))); err != nil {
 		return err
 	}
 	// library.ContainerPlatform      *cores.PlatformRelease `json:""`
-	if err := binary.Write(out, binary.NativeEndian, int32(library.Layout)); err != nil {
+	if err := binary.Write(out, binary.NativeEndian, toInt32(int(library.Layout))); err != nil {
 		return err
 	}
 	if err := binary.Write(out, binary.NativeEndian, library.DotALinkage); err != nil {
@@ -422,7 +436,7 @@ func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error 
 	if err := binary.Read(in, binary.NativeEndian, &layout); err != nil {
 		return err
 	}
-	library.Layout = LibraryLayout(layout)
+	library.Layout = LibraryLayout(toUint16(int(layout)))
 	if err := binary.Read(in, binary.NativeEndian, &library.DotALinkage); err != nil {
 		return err
 	}

--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -128,7 +128,10 @@ func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 		return nil
 	}
 	writeProperties := func(in *properties.Map) error {
-		keys := in.Keys()
+		var keys []string
+		if in != nil {
+			keys = in.Keys()
+		}
 		if err := binary.Write(out, binary.NativeEndian, uint16(len(keys))); err != nil {
 			return err
 		}

--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -16,7 +16,6 @@
 package libraries
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -94,18 +93,17 @@ func (library *Library) String() string {
 	return library.Name + "@" + library.Version.String()
 }
 
-func (library *Library) MarshalBinary() ([]byte, error) {
-	buffer := bytes.NewBuffer(make([]byte, 0, 4096))
+func (library *Library) MarshalBinary(out io.Writer) error {
 	writeString := func(in string) error {
 		inBytes := []byte(in)
-		if err := binary.Write(buffer, binary.NativeEndian, uint16(len(inBytes))); err != nil {
+		if err := binary.Write(out, binary.NativeEndian, uint16(len(inBytes))); err != nil {
 			return err
 		}
-		_, err := buffer.Write(inBytes)
+		_, err := out.Write(inBytes)
 		return err
 	}
 	writeStringArray := func(in []string) error {
-		if err := binary.Write(buffer, binary.NativeEndian, uint16(len(in))); err != nil {
+		if err := binary.Write(out, binary.NativeEndian, uint16(len(in))); err != nil {
 			return err
 		}
 		for _, i := range in {
@@ -116,14 +114,14 @@ func (library *Library) MarshalBinary() ([]byte, error) {
 		return nil
 	}
 	writeMap := func(in map[string]bool) error {
-		if err := binary.Write(buffer, binary.NativeEndian, uint16(len(in))); err != nil {
+		if err := binary.Write(out, binary.NativeEndian, uint16(len(in))); err != nil {
 			return err
 		}
 		for k, v := range in {
 			if err := writeString(k); err != nil {
 				return err
 			}
-			if err := binary.Write(buffer, binary.NativeEndian, v); err != nil {
+			if err := binary.Write(out, binary.NativeEndian, v); err != nil {
 				return err
 			}
 		}
@@ -137,89 +135,89 @@ func (library *Library) MarshalBinary() ([]byte, error) {
 		}
 	}
 	if err := writeString(library.Name); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeString(library.Author); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeString(library.Maintainer); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeString(library.Sentence); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeString(library.Paragraph); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeString(library.Website); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeString(library.Category); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeStringArray(library.Architectures); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeStringArray(library.Types); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writePath(library.InstallDir); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeString(library.DirName); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writePath(library.SourceDir); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writePath(library.UtilityDir); err != nil {
-		return nil, err
+		return err
 	}
-	if err := binary.Write(buffer, binary.NativeEndian, int32(library.Location)); err != nil {
-		return nil, err
+	if err := binary.Write(out, binary.NativeEndian, int32(library.Location)); err != nil {
+		return err
 	}
 	// library.ContainerPlatform      *cores.PlatformRelease `json:""`
-	if err := binary.Write(buffer, binary.NativeEndian, int32(library.Layout)); err != nil {
-		return nil, err
+	if err := binary.Write(out, binary.NativeEndian, int32(library.Layout)); err != nil {
+		return err
 	}
-	if err := binary.Write(buffer, binary.NativeEndian, library.DotALinkage); err != nil {
-		return nil, err
+	if err := binary.Write(out, binary.NativeEndian, library.DotALinkage); err != nil {
+		return err
 	}
-	if err := binary.Write(buffer, binary.NativeEndian, library.Precompiled); err != nil {
-		return nil, err
+	if err := binary.Write(out, binary.NativeEndian, library.Precompiled); err != nil {
+		return err
 	}
-	if err := binary.Write(buffer, binary.NativeEndian, library.PrecompiledWithSources); err != nil {
-		return nil, err
+	if err := binary.Write(out, binary.NativeEndian, library.PrecompiledWithSources); err != nil {
+		return err
 	}
 	if err := writeString(library.LDflags); err != nil {
-		return nil, err
+		return err
 	}
-	if err := binary.Write(buffer, binary.NativeEndian, library.IsLegacy); err != nil {
-		return nil, err
+	if err := binary.Write(out, binary.NativeEndian, library.IsLegacy); err != nil {
+		return err
 	}
-	if err := binary.Write(buffer, binary.NativeEndian, library.InDevelopment); err != nil {
-		return nil, err
+	if err := binary.Write(out, binary.NativeEndian, library.InDevelopment); err != nil {
+		return err
 	}
 	if err := writeString(library.Version.String()); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeString(library.License); err != nil {
-		return nil, err
+		return err
 	}
 	//writeStringArray(library.Properties.AsSlice())
 	if err := writeStringArray(library.Examples.AsStrings()); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeStringArray(library.declaredHeaders); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeStringArray(library.sourceHeaders); err != nil {
-		return nil, err
+		return err
 	}
 	if err := writeMap(library.CompatibleWith); err != nil {
-		return nil, err
+		return err
 	}
-	return buffer.Bytes(), nil
+	return nil
 }
 
 func (library *Library) UnmarshalBinary(in io.Reader) error {

--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -127,6 +127,22 @@ func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 		}
 		return nil
 	}
+	writeProperties := func(in *properties.Map) error {
+		keys := in.Keys()
+		if err := binary.Write(out, binary.NativeEndian, uint16(len(keys))); err != nil {
+			return err
+		}
+		for _, k := range keys {
+			v := in.Get(k)
+			if err := writeString(k); err != nil {
+				return err
+			}
+			if err := writeString(v); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 	writePath := func(in *paths.Path) error {
 		if in == nil {
 			return writeString("")
@@ -217,7 +233,6 @@ func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 	if err := writeString(library.License); err != nil {
 		return err
 	}
-	//writeStringArray(library.Properties.AsSlice())
 	if err := writePathList(library.Examples); err != nil {
 		return err
 	}
@@ -230,6 +245,10 @@ func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 	if err := writeMap(library.CompatibleWith); err != nil {
 		return err
 	}
+	if err := writeProperties(library.Properties); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -305,6 +324,23 @@ func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error 
 			}
 		}
 		return list, nil
+	}
+	readProperties := func() (*properties.Map, error) {
+		var len uint16
+		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
+			return nil, err
+		}
+		props := properties.NewMap()
+		for range len {
+			if k, err := readString(); err != nil {
+				return nil, err
+			} else if v, err := readString(); err != nil {
+				return nil, err
+			} else {
+				props.Set(k, v)
+			}
+		}
+		return props, nil
 	}
 	var err error
 	library.Name, err = readString()
@@ -398,14 +434,6 @@ func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error 
 	if err != nil {
 		return err
 	}
-	// props, err := readStringArray()
-	// if err != nil {
-	// 	return err
-	// }
-	// library.Properties, err = properties.LoadFromSlice(props)
-	// if err != nil {
-	// 	return err
-	// }
 	library.Examples, err = readPathList()
 	if err != nil {
 		return err
@@ -419,6 +447,10 @@ func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error 
 		return err
 	}
 	library.CompatibleWith, err = readMap()
+	if err != nil {
+		return err
+	}
+	library.Properties, err = readProperties()
 	if err != nil {
 		return err
 	}

--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -94,63 +94,132 @@ func (library *Library) String() string {
 	return library.Name + "@" + library.Version.String()
 }
 
-func (library *Library) MarshalBinary() []byte {
+func (library *Library) MarshalBinary() ([]byte, error) {
 	buffer := bytes.NewBuffer(make([]byte, 0, 4096))
-	writeString := func(in string) {
+	writeString := func(in string) error {
 		inBytes := []byte(in)
-		binary.Write(buffer, binary.NativeEndian, uint16(len(inBytes)))
-		buffer.Write(inBytes)
+		if err := binary.Write(buffer, binary.NativeEndian, uint16(len(inBytes))); err != nil {
+			return err
+		}
+		_, err := buffer.Write(inBytes)
+		return err
 	}
-	writeStringArray := func(in []string) {
-		binary.Write(buffer, binary.NativeEndian, uint16(len(in)))
+	writeStringArray := func(in []string) error {
+		if err := binary.Write(buffer, binary.NativeEndian, uint16(len(in))); err != nil {
+			return err
+		}
 		for _, i := range in {
-			writeString(i)
+			if err := writeString(i); err != nil {
+				return err
+			}
 		}
+		return nil
 	}
-	writeMap := func(in map[string]bool) {
-		binary.Write(buffer, binary.NativeEndian, uint16(len(in)))
+	writeMap := func(in map[string]bool) error {
+		if err := binary.Write(buffer, binary.NativeEndian, uint16(len(in))); err != nil {
+			return err
+		}
 		for k, v := range in {
-			writeString(k)
-			binary.Write(buffer, binary.NativeEndian, v)
+			if err := writeString(k); err != nil {
+				return err
+			}
+			if err := binary.Write(buffer, binary.NativeEndian, v); err != nil {
+				return err
+			}
 		}
+		return nil
 	}
-	writePath := func(in *paths.Path) {
+	writePath := func(in *paths.Path) error {
 		if in == nil {
-			writeString("")
+			return writeString("")
 		} else {
-			writeString(in.String())
+			return writeString(in.String())
 		}
 	}
-	writeString(library.Name)
-	writeString(library.Author)
-	writeString(library.Maintainer)
-	writeString(library.Sentence)
-	writeString(library.Paragraph)
-	writeString(library.Website)
-	writeString(library.Category)
-	writeStringArray(library.Architectures)
-	writeStringArray(library.Types)
-	writePath(library.InstallDir)
-	writeString(library.DirName)
-	writePath(library.SourceDir)
-	writePath(library.UtilityDir)
-	binary.Write(buffer, binary.NativeEndian, int32(library.Location))
+	if err := writeString(library.Name); err != nil {
+		return nil, err
+	}
+	if err := writeString(library.Author); err != nil {
+		return nil, err
+	}
+	if err := writeString(library.Maintainer); err != nil {
+		return nil, err
+	}
+	if err := writeString(library.Sentence); err != nil {
+		return nil, err
+	}
+	if err := writeString(library.Paragraph); err != nil {
+		return nil, err
+	}
+	if err := writeString(library.Website); err != nil {
+		return nil, err
+	}
+	if err := writeString(library.Category); err != nil {
+		return nil, err
+	}
+	if err := writeStringArray(library.Architectures); err != nil {
+		return nil, err
+	}
+	if err := writeStringArray(library.Types); err != nil {
+		return nil, err
+	}
+	if err := writePath(library.InstallDir); err != nil {
+		return nil, err
+	}
+	if err := writeString(library.DirName); err != nil {
+		return nil, err
+	}
+	if err := writePath(library.SourceDir); err != nil {
+		return nil, err
+	}
+	if err := writePath(library.UtilityDir); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buffer, binary.NativeEndian, int32(library.Location)); err != nil {
+		return nil, err
+	}
 	// library.ContainerPlatform      *cores.PlatformRelease `json:""`
-	binary.Write(buffer, binary.NativeEndian, int32(library.Layout))
-	binary.Write(buffer, binary.NativeEndian, library.DotALinkage)
-	binary.Write(buffer, binary.NativeEndian, library.Precompiled)
-	binary.Write(buffer, binary.NativeEndian, library.PrecompiledWithSources)
-	writeString(library.LDflags)
-	binary.Write(buffer, binary.NativeEndian, library.IsLegacy)
-	binary.Write(buffer, binary.NativeEndian, library.InDevelopment)
-	writeString(library.Version.String())
-	writeString(library.License)
+	if err := binary.Write(buffer, binary.NativeEndian, int32(library.Layout)); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buffer, binary.NativeEndian, library.DotALinkage); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buffer, binary.NativeEndian, library.Precompiled); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buffer, binary.NativeEndian, library.PrecompiledWithSources); err != nil {
+		return nil, err
+	}
+	if err := writeString(library.LDflags); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buffer, binary.NativeEndian, library.IsLegacy); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buffer, binary.NativeEndian, library.InDevelopment); err != nil {
+		return nil, err
+	}
+	if err := writeString(library.Version.String()); err != nil {
+		return nil, err
+	}
+	if err := writeString(library.License); err != nil {
+		return nil, err
+	}
 	//writeStringArray(library.Properties.AsSlice())
-	writeStringArray(library.Examples.AsStrings())
-	writeStringArray(library.declaredHeaders)
-	writeStringArray(library.sourceHeaders)
-	writeMap(library.CompatibleWith)
-	return buffer.Bytes()
+	if err := writeStringArray(library.Examples.AsStrings()); err != nil {
+		return nil, err
+	}
+	if err := writeStringArray(library.declaredHeaders); err != nil {
+		return nil, err
+	}
+	if err := writeStringArray(library.sourceHeaders); err != nil {
+		return nil, err
+	}
+	if err := writeMap(library.CompatibleWith); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
 }
 
 func (library *Library) UnmarshalBinary(in io.Reader) error {

--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"slices"
 
 	"github.com/arduino/arduino-cli/internal/arduino/cores"
@@ -149,6 +150,10 @@ func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 	writePath := func(in *paths.Path) error {
 		if in == nil {
 			return writeString("")
+		} else if inside, err := in.IsInsideDir(prefix); err != nil {
+			return err
+		} else if !inside {
+			return writeString(in.String())
 		} else if p, err := in.RelFrom(prefix); err != nil {
 			return err
 		} else {
@@ -309,6 +314,8 @@ func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error 
 			return nil, err
 		} else if p == "" {
 			return nil, nil
+		} else if filepath.IsAbs(p) {
+			return paths.New(p), nil
 		} else {
 			return prefix.Join(p), nil
 		}

--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -250,6 +250,9 @@ func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error 
 		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
 			return nil, err
 		}
+		if len == 0 {
+			return nil, nil
+		}
 		res := make([]string, len)
 		for i := range res {
 			var err error

--- a/internal/arduino/libraries/libraries.go
+++ b/internal/arduino/libraries/libraries.go
@@ -93,7 +93,7 @@ func (library *Library) String() string {
 	return library.Name + "@" + library.Version.String()
 }
 
-func (library *Library) MarshalBinary(out io.Writer) error {
+func (library *Library) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 	writeString := func(in string) error {
 		inBytes := []byte(in)
 		if err := binary.Write(out, binary.NativeEndian, uint16(len(inBytes))); err != nil {
@@ -130,9 +130,22 @@ func (library *Library) MarshalBinary(out io.Writer) error {
 	writePath := func(in *paths.Path) error {
 		if in == nil {
 			return writeString("")
+		} else if p, err := in.RelFrom(prefix); err != nil {
+			return err
 		} else {
-			return writeString(in.String())
+			return writeString(p.String())
 		}
+	}
+	writePathList := func(in []*paths.Path) error {
+		if err := binary.Write(out, binary.NativeEndian, uint16(len(in))); err != nil {
+			return err
+		}
+		for _, p := range in {
+			if err := writePath(p); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 	if err := writeString(library.Name); err != nil {
 		return err
@@ -205,7 +218,7 @@ func (library *Library) MarshalBinary(out io.Writer) error {
 		return err
 	}
 	//writeStringArray(library.Properties.AsSlice())
-	if err := writeStringArray(library.Examples.AsStrings()); err != nil {
+	if err := writePathList(library.Examples); err != nil {
 		return err
 	}
 	if err := writeStringArray(library.declaredHeaders); err != nil {
@@ -220,7 +233,7 @@ func (library *Library) MarshalBinary(out io.Writer) error {
 	return nil
 }
 
-func (library *Library) UnmarshalBinary(in io.Reader) error {
+func (library *Library) UnmarshalBinary(in io.Reader, prefix *paths.Path) error {
 	readString := func() (string, error) {
 		var len uint16
 		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
@@ -266,6 +279,30 @@ func (library *Library) UnmarshalBinary(in io.Reader) error {
 		}
 		return res, nil
 	}
+	readPath := func() (*paths.Path, error) {
+		if p, err := readString(); err != nil {
+			return nil, err
+		} else if p == "" {
+			return nil, nil
+		} else {
+			return prefix.Join(p), nil
+		}
+	}
+	readPathList := func() (paths.PathList, error) {
+		var len uint16
+		if err := binary.Read(in, binary.NativeEndian, &len); err != nil {
+			return nil, err
+		}
+		list := paths.NewPathList()
+		for range len {
+			if p, err := readPath(); err != nil {
+				return nil, err
+			} else {
+				list.Add(p)
+			}
+		}
+		return list, nil
+	}
 	var err error
 	library.Name, err = readString()
 	if err != nil {
@@ -303,25 +340,22 @@ func (library *Library) UnmarshalBinary(in io.Reader) error {
 	if err != nil {
 		return err
 	}
-	installDir, err := readString()
+	library.InstallDir, err = readPath()
 	if err != nil {
 		return err
 	}
-	library.InstallDir = paths.New(installDir)
 	library.DirName, err = readString()
 	if err != nil {
 		return err
 	}
-	sourceDir, err := readString()
-	library.SourceDir = paths.New(sourceDir)
+	library.SourceDir, err = readPath()
 	if err != nil {
 		return err
 	}
-	utilityDir, err := readString()
+	library.UtilityDir, err = readPath()
 	if err != nil {
 		return err
 	}
-	library.UtilityDir = paths.New(utilityDir)
 	var location int32
 	if err := binary.Read(in, binary.NativeEndian, &location); err != nil {
 		return err
@@ -369,11 +403,10 @@ func (library *Library) UnmarshalBinary(in io.Reader) error {
 	// if err != nil {
 	// 	return err
 	// }
-	examples, err := readStringArray()
+	library.Examples, err = readPathList()
 	if err != nil {
 		return err
 	}
-	library.Examples = paths.NewPathList(examples...)
 	library.declaredHeaders, err = readStringArray()
 	if err != nil {
 		return err

--- a/internal/arduino/libraries/libraries_binary_test.go
+++ b/internal/arduino/libraries/libraries_binary_test.go
@@ -1,0 +1,182 @@
+// This file is part of arduino-cli.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package libraries
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	paths "github.com/arduino/go-paths-helper"
+	properties "github.com/arduino/go-properties-orderedmap"
+	"github.com/stretchr/testify/require"
+	semver "go.bug.st/relaxed-semver"
+)
+
+// newFullyPopulatedLibrary returns a Library with every field set to a
+// non-nil/non-empty value, so that a MarshalBinary/UnmarshalBinary round
+// trip can be checked field-by-field (and as a whole) without running into
+// the nil-vs-empty ambiguities that some of the collection fields have.
+func newFullyPopulatedLibrary(prefix *paths.Path, name string) *Library {
+	props := properties.NewMap()
+	props.Set("name", name)
+	props.Set("version", "1.2.3")
+
+	examples := paths.NewPathList()
+	examples.Add(prefix.Join(name, "examples", "Blink"))
+	examples.Add(paths.New("/opt/outside/examples/Other"))
+
+	return &Library{
+		Name:                   name,
+		Author:                 "John Doe",
+		Maintainer:             "John Doe <john@example.com>",
+		Sentence:               "A test library",
+		Paragraph:              "This is a longer description of the library.",
+		Website:                "https://example.com/" + name,
+		Category:               "Other",
+		Architectures:          []string{"avr", "esp32"},
+		Types:                  []string{"Contributed"},
+		InstallDir:             prefix.Join(name),
+		DirName:                name,
+		SourceDir:              prefix.Join(name, "src"),
+		UtilityDir:             paths.New("/opt/outside/utility"),
+		Location:               User,
+		Layout:                 RecursiveLayout,
+		DotALinkage:            true,
+		Precompiled:            true,
+		PrecompiledWithSources: true,
+		LDflags:                "-lm",
+		IsLegacy:               false,
+		InDevelopment:          true,
+		Version:                semver.MustParse("1.2.3"),
+		License:                "MIT",
+		Properties:             props,
+		Examples:               examples,
+		declaredHeaders:        []string{name + ".h"},
+		sourceHeaders:          []string{name + ".h", "utility.h"},
+		CompatibleWith:         map[string]bool{"avr": true, "esp32": false},
+	}
+}
+
+func TestLibraryMarshalUnmarshalBinary(t *testing.T) {
+	prefix := paths.New("/home/build/libraries")
+	lib := newFullyPopulatedLibrary(prefix, "MyLib")
+
+	var buf bytes.Buffer
+	require.NoError(t, lib.MarshalBinary(&buf, prefix))
+
+	got := &Library{}
+	require.NoError(t, got.UnmarshalBinary(&buf, prefix))
+
+	// ContainerPlatform is intentionally not (un)marshaled.
+	require.Nil(t, got.ContainerPlatform)
+	require.Equal(t, lib, got)
+
+	// The whole message must have been consumed.
+	require.Equal(t, 0, buf.Len())
+}
+
+func TestLibraryMarshalUnmarshalBinaryPathOutsidePrefix(t *testing.T) {
+	// When a path is not inside the given prefix, it must be stored (and
+	// restored) as an absolute path instead of a relative one.
+	prefix := paths.New("/home/build/libraries")
+	lib := newFullyPopulatedLibrary(prefix, "MyLib")
+	lib.SourceDir = paths.New("/completely/different/location/src")
+
+	var buf bytes.Buffer
+	require.NoError(t, lib.MarshalBinary(&buf, prefix))
+
+	got := &Library{}
+	require.NoError(t, got.UnmarshalBinary(&buf, prefix))
+	require.Equal(t, lib.SourceDir.String(), got.SourceDir.String())
+}
+
+func TestLibraryMarshalUnmarshalBinaryNilAndEmptyFields(t *testing.T) {
+	// Document current round-trip behaviour for zero-valued/nil fields:
+	// - nil paths round-trip to nil
+	// - nil string slices round-trip to nil
+	// - a nil CompatibleWith map and a nil Properties map round-trip to
+	//   non-nil empty values, since the reader always allocates a map.
+	prefix := paths.New("/home/build/libraries")
+	lib := &Library{
+		Name:    "MinimalLib",
+		DirName: "MinimalLib",
+		Version: semver.MustParse("0.0.1"),
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, lib.MarshalBinary(&buf, prefix))
+
+	got := &Library{}
+	require.NoError(t, got.UnmarshalBinary(&buf, prefix))
+
+	require.Equal(t, "MinimalLib", got.Name)
+	require.Equal(t, "MinimalLib", got.DirName)
+	require.Equal(t, "0.0.1", got.Version.String())
+
+	require.Nil(t, got.InstallDir)
+	require.Nil(t, got.SourceDir)
+	require.Nil(t, got.UtilityDir)
+	require.Nil(t, got.Architectures)
+	require.Nil(t, got.Types)
+	require.Nil(t, got.declaredHeaders)
+	require.Nil(t, got.sourceHeaders)
+
+	require.NotNil(t, got.CompatibleWith)
+	require.Empty(t, got.CompatibleWith)
+	require.NotNil(t, got.Properties)
+	require.Empty(t, got.Properties.Keys())
+	require.NotNil(t, got.Examples)
+	require.Empty(t, got.Examples)
+}
+
+func TestLibraryMarshalBinaryStringTooLong(t *testing.T) {
+	prefix := paths.New("/home/build/libraries")
+	lib := newFullyPopulatedLibrary(prefix, "MyLib")
+	lib.Name = strings.Repeat("a", 1<<16) // one too many for a uint16 length prefix
+
+	var buf bytes.Buffer
+	err := lib.MarshalBinary(&buf, prefix)
+	require.ErrorContains(t, err, "out of allowed range")
+}
+
+func TestListMarshalUnmarshalBinary(t *testing.T) {
+	prefix := paths.New("/home/build/libraries")
+	list := List{
+		newFullyPopulatedLibrary(prefix, "LibOne"),
+		newFullyPopulatedLibrary(prefix, "LibTwo"),
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, list.MarshalBinary(&buf, prefix))
+
+	var got List
+	require.NoError(t, got.UnmarshalBinary(&buf, prefix))
+
+	require.Equal(t, list, got)
+	require.Equal(t, 0, buf.Len())
+}
+
+func TestListUnmarshalBinaryInvalidMagicNumber(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, binary.Write(&buf, binary.NativeEndian, uint32(0xDEADBEEF)))
+	require.NoError(t, binary.Write(&buf, binary.NativeEndian, int32(0)))
+
+	var list List
+	err := list.UnmarshalBinary(&buf, paths.New("/home/build/libraries"))
+	require.ErrorContains(t, err, "invalid cache version")
+}

--- a/internal/arduino/libraries/libraries_binary_test.go
+++ b/internal/arduino/libraries/libraries_binary_test.go
@@ -13,6 +13,8 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
+//go:build linux
+
 package libraries
 
 import (

--- a/internal/arduino/libraries/librarieslist.go
+++ b/internal/arduino/libraries/librarieslist.go
@@ -74,7 +74,7 @@ func (list *List) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 	if err := binary.Write(out, binary.NativeEndian, list.binaryMagicNumber()); err != nil {
 		return err
 	}
-	if err := binary.Write(out, binary.NativeEndian, int32(len(*list))); err != nil {
+	if err := binary.Write(out, binary.NativeEndian, toInt32(len(*list))); err != nil {
 		return err
 	}
 	for _, lib := range *list {

--- a/internal/arduino/libraries/librarieslist.go
+++ b/internal/arduino/libraries/librarieslist.go
@@ -17,6 +17,7 @@ package libraries
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -41,7 +42,18 @@ func (list *List) Add(libs ...*Library) {
 	}
 }
 
+func (list *List) binaryMagicNumber() uint32 {
+	return 0xAD000001
+}
+
 func (list *List) UnmarshalBinary(in io.Reader, prefix *paths.Path) error {
+	var magic uint32
+	if err := binary.Read(in, binary.NativeEndian, &magic); err != nil {
+		return err
+	}
+	if magic != list.binaryMagicNumber() {
+		return errors.New("invalid cache version")
+	}
 	var n int32
 	if err := binary.Read(in, binary.NativeEndian, &n); err != nil {
 		return err
@@ -59,6 +71,9 @@ func (list *List) UnmarshalBinary(in io.Reader, prefix *paths.Path) error {
 }
 
 func (list *List) MarshalBinary(out io.Writer, prefix *paths.Path) error {
+	if err := binary.Write(out, binary.NativeEndian, list.binaryMagicNumber()); err != nil {
+		return err
+	}
 	if err := binary.Write(out, binary.NativeEndian, int32(len(*list))); err != nil {
 		return err
 	}

--- a/internal/arduino/libraries/librarieslist.go
+++ b/internal/arduino/libraries/librarieslist.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/arduino/go-paths-helper"
 	semver "go.bug.st/relaxed-semver"
 )
 
@@ -40,7 +41,7 @@ func (list *List) Add(libs ...*Library) {
 	}
 }
 
-func (list *List) UnmarshalBinary(in io.Reader) error {
+func (list *List) UnmarshalBinary(in io.Reader, prefix *paths.Path) error {
 	var n int32
 	if err := binary.Read(in, binary.NativeEndian, &n); err != nil {
 		return err
@@ -48,7 +49,7 @@ func (list *List) UnmarshalBinary(in io.Reader) error {
 	res := make([]*Library, n)
 	for i := range res {
 		var lib Library
-		if err := lib.UnmarshalBinary(in); err != nil {
+		if err := lib.UnmarshalBinary(in, prefix); err != nil {
 			return err
 		}
 		res[i] = &lib
@@ -57,12 +58,12 @@ func (list *List) UnmarshalBinary(in io.Reader) error {
 	return nil
 }
 
-func (list *List) MarshalBinary(out io.Writer) error {
+func (list *List) MarshalBinary(out io.Writer, prefix *paths.Path) error {
 	if err := binary.Write(out, binary.NativeEndian, int32(len(*list))); err != nil {
 		return err
 	}
 	for _, lib := range *list {
-		if err := lib.MarshalBinary(out); err != nil {
+		if err := lib.MarshalBinary(out, prefix); err != nil {
 			return fmt.Errorf("could not encode lib data of %s: %w", lib.InstallDir.String(), err)
 		}
 	}

--- a/internal/arduino/libraries/librarieslist.go
+++ b/internal/arduino/libraries/librarieslist.go
@@ -16,6 +16,9 @@
 package libraries
 
 import (
+	"encoding/binary"
+	"fmt"
+	"io"
 	"slices"
 	"sort"
 
@@ -35,6 +38,35 @@ func (list *List) Add(libs ...*Library) {
 	for _, lib := range libs {
 		*list = append(*list, lib)
 	}
+}
+
+func (list *List) UnmarshalBinary(in io.Reader) error {
+	var n int32
+	if err := binary.Read(in, binary.NativeEndian, &n); err != nil {
+		return err
+	}
+	res := make([]*Library, n)
+	for i := range res {
+		var lib Library
+		if err := lib.UnmarshalBinary(in); err != nil {
+			return err
+		}
+		res[i] = &lib
+	}
+	*list = res
+	return nil
+}
+
+func (list *List) MarshalBinary(out io.Writer) error {
+	if err := binary.Write(out, binary.NativeEndian, int32(len(*list))); err != nil {
+		return err
+	}
+	for _, lib := range *list {
+		if err := lib.MarshalBinary(out); err != nil {
+			return fmt.Errorf("could not encode lib data of %s: %w", lib.InstallDir.String(), err)
+		}
+	}
+	return nil
 }
 
 // Remove removes the given library from the list

--- a/internal/arduino/libraries/librariesmanager/librariesmanager.go
+++ b/internal/arduino/libraries/librariesmanager/librariesmanager.go
@@ -268,7 +268,11 @@ func (lm *LibrariesManager) loadLibrariesFromDir(librariesDir *LibrariesDir) []*
 			return append(statuses, s)
 		}
 		for _, lib := range loadedLibs {
-			if _, err := cache.Write(lib.MarshalBinary()); err != nil {
+			data, err := lib.MarshalBinary()
+			if err != nil {
+				panic("could not encode lib data for: " + lib.InstallDir.String())
+			}
+			if _, err := cache.Write(data); err != nil {
 				cacheFilePath.Remove()
 				s := status.Newf(codes.FailedPrecondition, "writing lib cache %[1]s: %[2]s", cacheFilePath, err)
 				return append(statuses, s)

--- a/internal/arduino/libraries/librariesmanager/librariesmanager.go
+++ b/internal/arduino/libraries/librariesmanager/librariesmanager.go
@@ -251,6 +251,11 @@ func (lm *LibrariesManager) loadLibrariesFromDir(librariesDir *LibrariesDir) []*
 			s := status.Newf(codes.FailedPrecondition, "creating lib cache %[1]s: %[2]s", cacheFilePath, err)
 			return append(statuses, s)
 		}
+		// Preload source files and header
+		for _, lib := range loadedLibs {
+			lib.SourceHeaders()
+		}
+		// Write the cache
 		err = loadedLibs.MarshalBinary(cache, librariesDir.Path)
 		cache.Close()
 		if err != nil {

--- a/internal/arduino/libraries/librariesmanager/librariesmanager.go
+++ b/internal/arduino/libraries/librariesmanager/librariesmanager.go
@@ -213,7 +213,7 @@ func (lm *LibrariesManager) loadLibrariesFromDir(librariesDir *LibrariesDir) []*
 		}
 		defer cache.Close()
 
-		if err := loadedLibs.UnmarshalBinary(cache); err != nil {
+		if err := loadedLibs.UnmarshalBinary(cache, librariesDir.Path); err != nil {
 			s := status.Newf(codes.FailedPrecondition, "reading lib cache %[1]s: %[2]s", cacheFilePath, err)
 			return append(statuses, s)
 		}
@@ -251,7 +251,7 @@ func (lm *LibrariesManager) loadLibrariesFromDir(librariesDir *LibrariesDir) []*
 			s := status.Newf(codes.FailedPrecondition, "creating lib cache %[1]s: %[2]s", cacheFilePath, err)
 			return append(statuses, s)
 		}
-		err = loadedLibs.MarshalBinary(cache)
+		err = loadedLibs.MarshalBinary(cache, librariesDir.Path)
 		cache.Close()
 		if err != nil {
 			cacheFilePath.Remove()

--- a/internal/arduino/libraries/librariesmanager/librariesmanager.go
+++ b/internal/arduino/libraries/librariesmanager/librariesmanager.go
@@ -245,23 +245,24 @@ func (lm *LibrariesManager) loadLibrariesFromDir(librariesDir *LibrariesDir) []*
 			loadedLibs = append(loadedLibs, library)
 		}
 
-		// Write lib cache
-		cache, err := cacheFilePath.Create()
-		if err != nil {
-			s := status.Newf(codes.FailedPrecondition, "creating lib cache %[1]s: %[2]s", cacheFilePath, err)
-			return append(statuses, s)
-		}
 		// Preload source files and header
 		for _, lib := range loadedLibs {
 			lib.SourceHeaders()
 		}
-		// Write the cache
-		err = loadedLibs.MarshalBinary(cache, librariesDir.Path)
-		cache.Close()
-		if err != nil {
-			cacheFilePath.Remove()
-			s := status.Newf(codes.FailedPrecondition, "writing lib cache %[1]s: %[2]s", cacheFilePath, err)
-			return append(statuses, s)
+		if librariesDir.Location != libraries.Unmanaged {
+			// Write lib cache
+			cache, err := cacheFilePath.Create()
+			if err != nil {
+				s := status.Newf(codes.FailedPrecondition, "creating lib cache %[1]s: %[2]s", cacheFilePath, err)
+				return append(statuses, s)
+			}
+			err = loadedLibs.MarshalBinary(cache, librariesDir.Path)
+			cache.Close()
+			if err != nil {
+				cacheFilePath.Remove()
+				s := status.Newf(codes.FailedPrecondition, "writing lib cache %[1]s: %[2]s", cacheFilePath, err)
+				return append(statuses, s)
+			}
 		}
 	}
 

--- a/internal/arduino/libraries/librariesmanager/librariesmanager.go
+++ b/internal/arduino/libraries/librariesmanager/librariesmanager.go
@@ -200,9 +200,10 @@ func (lm *LibrariesManager) loadLibrariesFromDir(librariesDir *LibrariesDir) []*
 	statuses := []*status.Status{}
 
 	librariesDir.scanned = true
-
 	var loadedLibs libraries.List
-	if cacheFilePath := librariesDir.Path.Join("libraries-loader-cache"); cacheFilePath.Exist() {
+	cacheEnabled := os.Getenv("ARDUINO_CLI_ENABLE_EXP_LIBS_LOAD_CACHING") != ""
+	cacheFilePath := librariesDir.Path.Join("libraries-loader-cache")
+	if cacheEnabled && cacheFilePath.Exist() {
 		logrus.WithField("file", cacheFilePath).Info("Using library cache")
 
 		// Load lib cache
@@ -227,7 +228,7 @@ func (lm *LibrariesManager) loadLibrariesFromDir(librariesDir *LibrariesDir) []*
 				return statuses
 			}
 			if err != nil {
-				s := status.Newf(codes.FailedPrecondition, i18n.Tr("reading dir %[1]s: %[2]s", librariesDir.Path, err))
+				s := status.Newf(codes.FailedPrecondition, "reading dir %[1]s: %[2]s", librariesDir.Path, err)
 				return append(statuses, s)
 			}
 			d.FilterDirs()
@@ -238,7 +239,7 @@ func (lm *LibrariesManager) loadLibrariesFromDir(librariesDir *LibrariesDir) []*
 		for _, libDir := range libDirs {
 			library, err := libraries.Load(libDir, librariesDir.Location)
 			if err != nil {
-				s := status.Newf(codes.Internal, i18n.Tr("loading library from %[1]s: %[2]s", libDir, err))
+				s := status.Newf(codes.Internal, "loading library from %[1]s: %[2]s", libDir, err)
 				statuses = append(statuses, s)
 				continue
 			}
@@ -249,7 +250,7 @@ func (lm *LibrariesManager) loadLibrariesFromDir(librariesDir *LibrariesDir) []*
 		for _, lib := range loadedLibs {
 			lib.SourceHeaders()
 		}
-		if librariesDir.Location != libraries.Unmanaged {
+		if cacheEnabled && librariesDir.Location != libraries.Unmanaged {
 			// Write lib cache
 			cache, err := cacheFilePath.Create()
 			if err != nil {


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [X] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

If many libraries are installed, the initial scanning performed by the Arduino CLI may take some time. This is an experimental feature that allows the CLI to cache the scanning result after the first run. The feature is experimental and not widely tested, so it's enabled only through an environment variable.

## What is the current behavior?

<!-- You can also link to an open issue here -->

## What is the new behavior?

<!-- if this is a feature change -->

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
