### PR TITLE
builder: handle ANSI-colored include diagnostics

### DIFF
--- a/internal/arduino/builder/internal/detector/detector.go
+++ b/internal/arduino/builder/internal/detector/detector.go
@@ -648,10 +648,14 @@ func (l *SketchLibrariesDetector) failIfImportedLibraryIsWrong() error {
 	return nil
 }
 
-var includeRegexp = regexp.MustCompile(`(?ms)^\s*[0-9 |]*\s*#[ \t]*include\s*[<"](\S+)[">]`)
+var (
+	ansiControlSequenceRegexp = regexp.MustCompile("\x1b\\[[0-?]*[ -/]*[@-~]")
+	includeRegexp             = regexp.MustCompile(`(?ms)^\s*[0-9 |]*\s*#[ \t]*include\s*[<"](\S+)[">]`)
+)
 
 // IncludesFinderWithRegExp fixdoc
 func IncludesFinderWithRegExp(source string) string {
+	source = ansiControlSequenceRegexp.ReplaceAllString(source, "")
 	match := includeRegexp.FindStringSubmatch(source)
 	if match != nil {
 		return strings.TrimSpace(match[1])

--- a/internal/arduino/builder/internal/detector/detector_test.go
+++ b/internal/arduino/builder/internal/detector/detector_test.go
@@ -85,3 +85,14 @@ func TestIncludesFinderWithRegExpPaddedIncludes5(t *testing.T) {
 
 	require.Equal(t, "Foobar.h", include)
 }
+
+func TestIncludesFinderWithRegExpANSIColoredOutput(t *testing.T) {
+	output := "\x1b[01m\x1b[K/some/path/sketch.ino:1:10:\x1b[m\x1b[K \x1b[01;31m\x1b[Kfatal error:\x1b[m\x1b[K SPI.h: No such file or directory\n" +
+		"    1 | #include <\x1b[01m\x1b[KSPI.h\x1b[m\x1b[K>\n" +
+		"      |          ^~~~~~~\n" +
+		"compilation terminated.\n"
+
+	include := detector.IncludesFinderWithRegExp(output)
+
+	require.Equal(t, "SPI.h", include)
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates.
- [x] The PR follows the contributing guidelines.
- [x] Tests for the changes have been added.
- [x] Documentation is not required because this fixes internal diagnostic parsing without changing the public interface.
- [x] `UPGRADING.md` is not required because there is no breaking change.
- [x] `configuration.schema.json` is not affected.

## What kind of change does this PR introduce?

Bug fix for library dependency detection during compilation.

## What is the current behavior?

When compiler diagnostics contain ANSI CSI color sequences, the missing-header parser includes those escape sequences in the extracted header name. For example, `SPI.h` can be returned with embedded control bytes, so the library resolver cannot match the include.

This is reproducible when `-fdiagnostics-color=always` is supplied through build properties.

Fixes #3020.

## What is the new behavior?

ANSI CSI sequences are removed only from the detector's internal copy of compiler stderr before parsing the missing include. The original compiler output remains untouched, so user-visible colored diagnostics are preserved.

A regression test covers a realistic GCC-colored missing-header diagnostic.

## Does this PR introduce a breaking change, and is titled accordingly?

No.

## Other information

Local verification:

- `go test ./internal/arduino/builder/internal/detector -count=1`
- `go test ./internal/arduino/builder/... -count=1`
- `go vet ./internal/arduino/builder/internal/detector`
- `git diff --check`

The first upstream run passed all unit, style, lint, artifact, macOS, Linux, and other Windows jobs. Its only failure was the unrelated Windows board integration mock not returning its synthetic serial port in `TestBoardListMock/ContainsMockedPorts`.
