### PR TITLE
compile: preserve existing profile in dump

### DIFF
--- a/internal/cli/compile/compile.go
+++ b/internal/cli/compile/compile.go
@@ -325,7 +325,9 @@ func runCompileCommand(cmd *cobra.Command, args []string, srv rpc.ArduinoCoreSer
 
 			var libs strings.Builder
 			for _, lib := range builderRes.GetUsedLibraries() {
-				if lib.GetLocation() != rpc.LibraryLocation_LIBRARY_LOCATION_USER && lib.GetLocation() != rpc.LibraryLocation_LIBRARY_LOCATION_UNMANAGED {
+				if lib.GetLocation() != rpc.LibraryLocation_LIBRARY_LOCATION_USER &&
+					lib.GetLocation() != rpc.LibraryLocation_LIBRARY_LOCATION_UNMANAGED &&
+					lib.GetLocation() != rpc.LibraryLocation_LIBRARY_LOCATION_PROFILE {
 					continue
 				}
 				if lib.GetVersion() == "" || lib.Location == rpc.LibraryLocation_LIBRARY_LOCATION_UNMANAGED {
@@ -344,9 +346,12 @@ func runCompileCommand(cmd *cobra.Command, args []string, srv rpc.ArduinoCoreSer
 				}
 			}
 
-			newProfileName := "my_profile_name"
-			if split := strings.Split(compileRequest.GetFqbn(), ":"); len(split) > 2 {
-				newProfileName = split[2]
+			newProfileName := profile.GetName()
+			if newProfileName == "" {
+				newProfileName = "my_profile_name"
+				if split := strings.Split(compileRequest.GetFqbn(), ":"); len(split) > 2 {
+					newProfileName = split[2]
+				}
 			}
 			profileOut = fmt.Sprintln("profiles:")
 			profileOut += fmt.Sprintln("  " + newProfileName + ":")
@@ -370,7 +375,11 @@ func runCompileCommand(cmd *cobra.Command, args []string, srv rpc.ArduinoCoreSer
 				profileOut += fmt.Sprintln("    libraries:")
 				profileOut += fmt.Sprint(libs.String())
 			}
-			profileOut += fmt.Sprintln()
+			if profile.GetName() != "" {
+				profileOut += fmt.Sprintln("default_profile: " + newProfileName)
+			} else {
+				profileOut += fmt.Sprintln()
+			}
 		} else {
 			// An error occurred, output the buffered build errors instead of the profile
 			if stdOut, stdErr, err := feedback.DirectStreams(); err == nil {

--- a/internal/integrationtest/compile_4/dump_profile_test.go
+++ b/internal/integrationtest/compile_4/dump_profile_test.go
@@ -69,3 +69,48 @@ func TestDumpProfileClean(t *testing.T) {
 		require.NotContains(t, string(stdout), validProfile)
 	})
 }
+
+func TestDumpExistingProfile(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	t.Cleanup(env.CleanUp)
+
+	_, _, err := cli.Run("core", "install", "arduino:avr@1.8.6")
+	require.NoError(t, err)
+
+	tmpDir, err := paths.MkTempDir("", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tmpDir.RemoveAll })
+
+	sketchPath := tmpDir.Join("ProfileSketch")
+	require.NoError(t, sketchPath.MkdirAll())
+	require.NoError(t, sketchPath.Join("ProfileSketch.ino").WriteFile([]byte(`#include <Servo.h>
+
+void setup() {}
+void loop() {}
+`)))
+	require.NoError(t, sketchPath.Join("sketch.yaml").WriteFile([]byte(`profiles:
+  project_default:
+    fqbn: arduino:avr:uno
+    platforms:
+      - platform: arduino:avr (1.8.6)
+    libraries:
+      - Servo (1.3.0)
+default_profile: project_default
+`)))
+
+	_, _, err = cli.Run("compile", sketchPath.String())
+	require.NoError(t, err)
+
+	stdout, stderr, err := cli.Run("compile", "--dump-profile", sketchPath.String())
+	require.NoError(t, err)
+	require.Empty(t, stderr)
+	require.Equal(t, strings.TrimSpace(`profiles:
+  project_default:
+    fqbn: arduino:avr:uno
+    platforms:
+      - platform: arduino:avr (1.8.6)
+    libraries:
+      - Servo (1.3.0)
+default_profile: project_default
+`), strings.TrimSpace(string(stdout)))
+}


### PR DESCRIPTION
Closes #3009.

## Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (searched open and closed pull requests before implementation and again before submission)
- [x] The PR follows the contributing guidelines
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated — not needed; this restores the existing `--dump-profile` contract
- [ ] `UPGRADING.md` has been updated — not applicable; this is not a breaking change
- [ ] `configuration.schema.json` updated — not applicable; no configuration parameter is added

## What kind of change does this PR introduce?

Bug fix for `arduino-cli compile --dump-profile` when the compile uses an existing sketch profile.

## What is the current behavior?

When a sketch profile is selected, the dump derives a new profile name from the FQBN, drops libraries loaded from the profile cache, and omits `default_profile`. A profile named `project_default` with `Servo (1.3.0)` therefore dumps as `uno` without its library and cannot round-trip the selected configuration.

## What is the new behavior?

The dump now:

- keeps the selected profile name;
- includes used libraries whose location is `LIBRARY_LOCATION_PROFILE`;
- emits `default_profile` for an existing selected profile;
- preserves the existing FQBN-derived output when compiling without a sketch profile.

## Does this PR introduce a breaking change?

No. It preserves existing no-profile output and makes profile-based dumps complete and reusable.

## Validation

- Exact pre-fix CLI reproduction against current `master`
- Exact post-fix manual profile dump with AVR 1.8.8 and Servo 1.3.0
- `go test ./internal/cli/compile -count=1`
- `go test -v ./internal/integrationtest/compile_4 -run '^TestDump(ProfileClean|ExistingProfile)$' -count=1`
- `gofmt -d` and `git diff --check`
