### PR TITLE
builder: add library discovery macros

### DIFF
--- a/docs/platform-specification.md
+++ b/docs/platform-specification.md
@@ -146,6 +146,21 @@ The following automatically generated properties can be used globally in all con
   intent, `-DARDUINO_LIB_DISCOVERY_PHASE` was added to `recipe.preproc.macros` during library discovery in Arduino
   Builder 1.5.3/Arduino CLI 0.10.0. That flag was replaced by the more flexible `{build.library_discovery_phase}`
   property.
+- `{build.library_discovery_flags}`: a series of `-D` flags, one set per library resolved during library discovery. It
+  is available to sketch and library compile recipes only; it is deliberately not exposed to core-compile recipes. This
+  property was added in Arduino CLI 1.6.0.<br /> For each library, the property contains a flag with the form
+  `-DFOUND_<SLUG>_LIB=0x<hex-version>`, and one with the form `-DFOUND_<SLUG>_LIB_<SOURCE>=1`.
+  - `<SLUG>` is the library name converted to a valid uppercase C identifier (runs of characters outside `[A-Za-z0-9_]`
+    become a single `_`).
+  - `<hex-version>` is the library's version, in the form of a 24-bit value assembled from the major/minor/patch
+    components (`MMmmpp`). Each component is clamped to `0xFF`. Pre-release/build metadata components are discarded. An
+    unknown or unparseable version is encoded as `1`.
+  - `<SOURCE>` identifies where the library was found:
+    - `IN_IDE`: Arduino IDE's built-in libraries.
+    - `IN_PLATFORM`: libraries bundled with the platform.
+    - `IN_PROFILE`: libraries specified as a dependency by the build profile.
+    - `IN_SKETCHBOOK`: libraries located under `directories.user`, or under a path specified via a `--libraries` flag.
+    - `IN_SPECIFIED_PATH`: libraries under a path specified via a `--library` flag.
 - `{compiler.optimization_flags}`: see ["Sketch debugging configuration"](#sketch-debugging-configuration) for details
 - `{extra.time.utc}`: Unix time (seconds since 1970-01-01T00:00:00Z) according to the machine the build is running on
 - `{extra.time.local}`: Unix time with local timezone and DST offset

--- a/internal/arduino/builder/archive_compiled_files.go
+++ b/internal/arduino/builder/archive_compiled_files.go
@@ -56,6 +56,9 @@ func (b *Builder) archiveCompiledFiles(archiveFilePath *paths.Path, objectFilesT
 
 	for _, objectFile := range objectFilesToArchive {
 		properties := b.buildProperties.Clone()
+		if b.pathIsCore(archiveFilePath) {
+			properties.Remove("build.library_discovery_flags")
+		}
 		properties.Set("archive_file", archiveFilePath.Base())
 		properties.SetPath("archive_file_path", archiveFilePath)
 		properties.SetPath("object_file", objectFile)

--- a/internal/arduino/builder/builder.go
+++ b/internal/arduino/builder/builder.go
@@ -327,6 +327,7 @@ func (b *Builder) preprocess() error {
 	if err != nil {
 		return err
 	}
+	b.buildProperties.Set("build.library_discovery_flags", buildLibraryDiscoveryFlags(b.libsDetector.ImportedLibraries()))
 	if b.libsDetector.IncludeFoldersChanged() && b.librariesBuildPath.Exist() {
 		if b.logger.VerbosityLevel() == logger.VerbosityVerbose {
 			b.logger.Info(i18n.Tr("The list of included libraries has been changed... rebuilding all libraries."))

--- a/internal/arduino/builder/compilation.go
+++ b/internal/arduino/builder/compilation.go
@@ -29,6 +29,16 @@ import (
 	"github.com/arduino/go-paths-helper"
 )
 
+// pathIsCore reports whether the provided path is in (or exactly matches)
+// the core build folder where all core intermediate files are stored.
+func (b *Builder) pathIsCore(path *paths.Path) bool {
+	if path.EquivalentTo(b.coreBuildPath) {
+		return true
+	}
+	inside, _ := path.IsInsideDir(b.coreBuildPath)
+	return inside
+}
+
 func (b *Builder) compileFiles(
 	sourceDir *paths.Path,
 	buildPath *paths.Path,
@@ -129,6 +139,9 @@ func (b *Builder) compileFileWithRecipe(
 	properties := b.buildProperties.Clone()
 	properties.Set("compiler.warning_flags", properties.Get("compiler.warning_flags."+b.logger.WarningsLevel()))
 	properties.Set("includes", strings.Join(includes, " "))
+	if b.pathIsCore(buildPath) {
+		properties.Remove("build.library_discovery_flags")
+	}
 	properties.SetPath("source_file", source)
 	properties.SetPath("object_file", objectFile)
 	command, err := b.prepareCommandForRecipe(properties, recipe, false)

--- a/internal/arduino/builder/compilation_test.go
+++ b/internal/arduino/builder/compilation_test.go
@@ -1,0 +1,90 @@
+// This file is part of arduino-cli.
+//
+// Copyright (C) Arduino s.r.l. and/or its affiliated companies
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+
+package builder
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/arduino/arduino-cli/internal/arduino/builder/internal/compilation"
+	"github.com/arduino/arduino-cli/internal/arduino/builder/logger"
+	paths "github.com/arduino/go-paths-helper"
+	properties "github.com/arduino/go-properties-orderedmap"
+	"github.com/stretchr/testify/require"
+)
+
+// lastCommandArgs saves db to dbPath and returns the Arguments of the single
+// recorded command. Used to inspect the expanded recipe command line without
+// actually executing a compiler.
+func lastCommandArgs(t *testing.T, db *compilation.Database, dbPath *paths.Path) []string {
+	t.Helper()
+	db.SaveToFile()
+	raw, err := dbPath.ReadFile()
+	require.NoError(t, err)
+	var contents []compilation.Command
+	require.NoError(t, json.Unmarshal(raw, &contents))
+	require.Len(t, contents, 1)
+	return contents[0].Arguments
+}
+
+func TestPathIsCore(t *testing.T) {
+	coreBuildPath := paths.New("build", "core")
+	b := &Builder{coreBuildPath: coreBuildPath}
+
+	require.True(t, b.pathIsCore(paths.New("build", "core")))
+	require.True(t, b.pathIsCore(paths.New("build", "core", "core.a")))
+	require.True(t, b.pathIsCore(paths.New("build", "core", "variant", "objs.a")))
+	require.False(t, b.pathIsCore(paths.New("build", "sketch")))
+	require.False(t, b.pathIsCore(paths.New("build", "libraries", "Bridge.a")))
+	require.False(t, b.pathIsCore(paths.New("build", "core.a")))
+}
+
+func TestCompileFileWithRecipeExcludesLibraryDiscoveryFlagsForCore(t *testing.T) {
+	tmpDir := paths.New(t.TempDir())
+	sourceFile := tmpDir.Join("sketch.ino.cpp")
+	require.NoError(t, sourceFile.WriteFile([]byte("// test\n")))
+
+	coreBuildPath := tmpDir.Join("core-build")
+	otherBuildPath := tmpDir.Join("other-build")
+
+	newTestBuilder := func(dbPath *paths.Path) (*Builder, *compilation.Database) {
+		props := properties.NewMap()
+		props.Set("recipe.o.pattern", "echo {build.library_discovery_flags}")
+		props.Set("build.library_discovery_flags", "-DFOUND_TESTLIB_LIB=0x010203")
+		db := compilation.NewDatabase(dbPath)
+		return &Builder{
+			buildProperties:               props,
+			coreBuildPath:                 coreBuildPath,
+			logger:                        logger.New(io.Discard, io.Discard, logger.VerbosityQuiet, "none"),
+			onlyUpdateCompilationDatabase: true,
+			compilationDatabase:           db,
+		}, db
+	}
+
+	t.Run("CoreBuildPathExcludesFlag", func(t *testing.T) {
+		dbPath := tmpDir.Join("core_compile_commands.json")
+		b, db := newTestBuilder(dbPath)
+		_, err := b.compileFileWithRecipe(tmpDir, sourceFile, coreBuildPath, nil, "recipe.o.pattern")
+		require.NoError(t, err)
+		args := lastCommandArgs(t, db, dbPath)
+		require.Contains(t, args, "{build.library_discovery_flags}")
+		require.NotContains(t, args, "-DFOUND_TESTLIB_LIB=0x010203")
+	})
+
+	t.Run("NonCoreBuildPathKeepsFlag", func(t *testing.T) {
+		dbPath := tmpDir.Join("other_compile_commands.json")
+		b, db := newTestBuilder(dbPath)
+		_, err := b.compileFileWithRecipe(tmpDir, sourceFile, otherBuildPath, nil, "recipe.o.pattern")
+		require.NoError(t, err)
+		args := lastCommandArgs(t, db, dbPath)
+		require.Contains(t, args, "-DFOUND_TESTLIB_LIB=0x010203")
+	})
+}

--- a/internal/arduino/builder/library_discovery_flags.go
+++ b/internal/arduino/builder/library_discovery_flags.go
@@ -11,7 +11,10 @@ package builder
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
+
+	semver "go.bug.st/relaxed-semver"
 )
 
 var (
@@ -30,4 +33,44 @@ func librarySlug(name string) string {
 		slug = "_" + slug
 	}
 	return slug
+}
+
+var versionComponents = regexp.MustCompile(`^(\d+)(?:\.(\d+))?(?:\.(\d+))?`)
+
+// encodeLibraryVersion packs a library version into a 24-bit
+// major/minor/patch value (0xMMmmpp). A nil version, or a version string
+// with no leading numeric major component, encodes to 1 (the lowest
+// non-zero encoded value, i.e. 0.0.1) per the "unknown version" convention.
+// Each component is clamped to [0, 255] so it can't overflow into the next
+// byte. Minor/patch default to 0 when absent (e.g. "1" or "1.2" are valid).
+func encodeLibraryVersion(v *semver.Version) uint32 {
+	if v == nil {
+		return 1
+	}
+	m := versionComponents.FindStringSubmatch(v.String())
+	if m == nil {
+		return 1
+	}
+	major := clampVersionComponent(m[1])
+	minor := clampVersionComponent(m[2])
+	patch := clampVersionComponent(m[3])
+	return uint32(major)<<16 | uint32(minor)<<8 | uint32(patch)
+}
+
+// clampVersionComponent parses a numeric version component (possibly
+// empty, meaning "absent") and clamps it to [0, 255]. The uint8 return
+// type makes that bound visible to the type system, so callers can widen
+// it to a larger integer type without any risk of overflow.
+func clampVersionComponent(s string) uint8 {
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n > 255 {
+		return 255
+	}
+	if n < 0 {
+		return 0
+	}
+	return uint8(n)
 }

--- a/internal/arduino/builder/library_discovery_flags.go
+++ b/internal/arduino/builder/library_discovery_flags.go
@@ -1,0 +1,33 @@
+// This file is part of arduino-cli.
+//
+// Copyright (C) Arduino s.r.l. and/or its affiliated companies
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+
+package builder
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	invalidIdentifierChars = regexp.MustCompile(`[^A-Za-z0-9_]+`)
+	leadingDigit           = regexp.MustCompile(`^[0-9]`)
+)
+
+// librarySlug converts a library name into a valid uppercase C identifier.
+// Runs of characters outside [A-Za-z0-9_] collapse to a single "_"; the
+// result is uppercased, and a leading "_" is added if it would otherwise
+// start with a digit.
+func librarySlug(name string) string {
+	slug := invalidIdentifierChars.ReplaceAllString(name, "_")
+	slug = strings.ToUpper(slug)
+	if leadingDigit.MatchString(slug) {
+		slug = "_" + slug
+	}
+	return slug
+}

--- a/internal/arduino/builder/library_discovery_flags.go
+++ b/internal/arduino/builder/library_discovery_flags.go
@@ -77,12 +77,41 @@ func clampVersionComponent(s string) uint8 {
 	return uint8(n)
 }
 
-// buildLibraryDiscoveryFlags renders one "-DFOUND_<SLUG>_LIB=0x<hex>" flag
-// per library in libs, joined by spaces, in libs' existing order.
+// librarySourceSuffix maps a library's discovery location to the macro
+// suffix identifying where it was found. Returns "" for any location with
+// no defined suffix (currently none — every known LibraryLocation value is
+// mapped — but this keeps the function total instead of panicking on a
+// future enum addition).
+func librarySourceSuffix(location libraries.LibraryLocation) string {
+	switch location {
+	case libraries.User:
+		return "IN_SKETCHBOOK"
+	case libraries.PlatformBuiltIn, libraries.ReferencedPlatformBuiltIn:
+		return "IN_PLATFORM"
+	case libraries.Profile:
+		return "IN_PROFILE"
+	case libraries.IDEBuiltIn:
+		return "IN_IDE"
+	case libraries.Unmanaged:
+		return "IN_SPECIFIED_PATH"
+	default:
+		return ""
+	}
+}
+
+// buildLibraryDiscoveryFlags renders the discovery macros for each library
+// in libs, joined by spaces, in libs' existing order: a
+// "-DFOUND_<SLUG>_LIB=0x<hex>" version macro, plus a
+// "-DFOUND_<SLUG>_LIB_<SUFFIX>=1" macro identifying where the library was
+// found (omitted if librarySourceSuffix has no mapping for its location).
 func buildLibraryDiscoveryFlags(libs libraries.List) string {
 	flags := make([]string, 0, len(libs))
 	for _, lib := range libs {
-		flags = append(flags, fmt.Sprintf("-DFOUND_%s_LIB=0x%06X", librarySlug(lib.Name), encodeLibraryVersion(lib.Version)))
+		slug := librarySlug(lib.Name)
+		flags = append(flags, fmt.Sprintf("-DFOUND_%s_LIB=0x%06X", slug, encodeLibraryVersion(lib.Version)))
+		if suffix := librarySourceSuffix(lib.Location); suffix != "" {
+			flags = append(flags, fmt.Sprintf("-DFOUND_%s_LIB_%s=1", slug, suffix))
+		}
 	}
 	return strings.Join(flags, " ")
 }

--- a/internal/arduino/builder/library_discovery_flags.go
+++ b/internal/arduino/builder/library_discovery_flags.go
@@ -10,10 +10,12 @@
 package builder
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/arduino/arduino-cli/internal/arduino/libraries"
 	semver "go.bug.st/relaxed-semver"
 )
 
@@ -73,4 +75,14 @@ func clampVersionComponent(s string) uint8 {
 		return 0
 	}
 	return uint8(n)
+}
+
+// buildLibraryDiscoveryFlags renders one "-DFOUND_<SLUG>_LIB=0x<hex>" flag
+// per library in libs, joined by spaces, in libs' existing order.
+func buildLibraryDiscoveryFlags(libs libraries.List) string {
+	flags := make([]string, 0, len(libs))
+	for _, lib := range libs {
+		flags = append(flags, fmt.Sprintf("-DFOUND_%s_LIB=0x%06X", librarySlug(lib.Name), encodeLibraryVersion(lib.Version)))
+	}
+	return strings.Join(flags, " ")
 }

--- a/internal/arduino/builder/library_discovery_flags_test.go
+++ b/internal/arduino/builder/library_discovery_flags_test.go
@@ -12,6 +12,8 @@ package builder
 import (
 	"testing"
 
+	semver "go.bug.st/relaxed-semver"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,6 +35,32 @@ func TestLibrarySlug(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			require.Equal(t, c.want, librarySlug(c.in))
+		})
+	}
+}
+
+func TestEncodeLibraryVersion(t *testing.T) {
+	parse := func(s string) *semver.Version {
+		v, err := semver.Parse(s)
+		require.NoError(t, err)
+		return v
+	}
+
+	cases := []struct {
+		name string
+		in   *semver.Version
+		want uint32
+	}{
+		{"Full", parse("1.2.3"), 0x010203},
+		{"MajorMinorOnly", parse("1.2"), 0x010200},
+		{"MajorOnly", parse("1"), 0x010000},
+		{"Nil", nil, 1},
+		{"EmptyRawVersion", parse(""), 1},
+		{"OverflowComponentClamped", parse("300.0.0"), 0xFF0000},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, encodeLibraryVersion(c.in))
 		})
 	}
 }

--- a/internal/arduino/builder/library_discovery_flags_test.go
+++ b/internal/arduino/builder/library_discovery_flags_test.go
@@ -12,6 +12,7 @@ package builder
 import (
 	"testing"
 
+	"github.com/arduino/arduino-cli/internal/arduino/libraries"
 	semver "go.bug.st/relaxed-semver"
 
 	"github.com/stretchr/testify/require"
@@ -40,27 +41,51 @@ func TestLibrarySlug(t *testing.T) {
 }
 
 func TestEncodeLibraryVersion(t *testing.T) {
-	parse := func(s string) *semver.Version {
-		v, err := semver.Parse(s)
-		require.NoError(t, err)
-		return v
-	}
-
 	cases := []struct {
 		name string
 		in   *semver.Version
 		want uint32
 	}{
-		{"Full", parse("1.2.3"), 0x010203},
-		{"MajorMinorOnly", parse("1.2"), 0x010200},
-		{"MajorOnly", parse("1"), 0x010000},
+		{"Full", parseVersion(t, "1.2.3"), 0x010203},
+		{"MajorMinorOnly", parseVersion(t, "1.2"), 0x010200},
+		{"MajorOnly", parseVersion(t, "1"), 0x010000},
 		{"Nil", nil, 1},
-		{"EmptyRawVersion", parse(""), 1},
-		{"OverflowComponentClamped", parse("300.0.0"), 0xFF0000},
+		{"EmptyRawVersion", parseVersion(t, ""), 1},
+		{"OverflowComponentClamped", parseVersion(t, "300.0.0"), 0xFF0000},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			require.Equal(t, c.want, encodeLibraryVersion(c.in))
 		})
 	}
+}
+
+func TestBuildLibraryDiscoveryFlags(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		require.Equal(t, "", buildLibraryDiscoveryFlags(libraries.List{}))
+	})
+
+	t.Run("SingleLibrary", func(t *testing.T) {
+		libs := libraries.List{
+			{Name: "Bridge", Version: parseVersion(t, "1.2.3")},
+		}
+		require.Equal(t, "-DFOUND_BRIDGE_LIB=0x010203", buildLibraryDiscoveryFlags(libs))
+	})
+
+	t.Run("MultipleLibrariesJoinedWithSpace", func(t *testing.T) {
+		libs := libraries.List{
+			{Name: "Bridge", Version: parseVersion(t, "1.2.3")},
+			{Name: "Bridge Client-2", Version: nil},
+		}
+		require.Equal(t,
+			"-DFOUND_BRIDGE_LIB=0x010203 -DFOUND_BRIDGE_CLIENT_2_LIB=0x000001",
+			buildLibraryDiscoveryFlags(libs))
+	})
+}
+
+func parseVersion(t *testing.T, s string) *semver.Version {
+	t.Helper()
+	v, err := semver.Parse(s)
+	require.NoError(t, err)
+	return v
 }

--- a/internal/arduino/builder/library_discovery_flags_test.go
+++ b/internal/arduino/builder/library_discovery_flags_test.go
@@ -60,6 +60,27 @@ func TestEncodeLibraryVersion(t *testing.T) {
 	}
 }
 
+func TestLibrarySourceSuffix(t *testing.T) {
+	cases := []struct {
+		name string
+		in   libraries.LibraryLocation
+		want string
+	}{
+		{"User", libraries.User, "IN_SKETCHBOOK"},
+		{"PlatformBuiltIn", libraries.PlatformBuiltIn, "IN_PLATFORM"},
+		{"ReferencedPlatformBuiltIn", libraries.ReferencedPlatformBuiltIn, "IN_PLATFORM"},
+		{"Profile", libraries.Profile, "IN_PROFILE"},
+		{"IDEBuiltIn", libraries.IDEBuiltIn, "IN_IDE"},
+		{"Unmanaged", libraries.Unmanaged, "IN_SPECIFIED_PATH"},
+		{"OutOfRange", libraries.LibraryLocation(99), ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, librarySourceSuffix(c.in))
+		})
+	}
+}
+
 func TestBuildLibraryDiscoveryFlags(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		require.Equal(t, "", buildLibraryDiscoveryFlags(libraries.List{}))
@@ -67,19 +88,28 @@ func TestBuildLibraryDiscoveryFlags(t *testing.T) {
 
 	t.Run("SingleLibrary", func(t *testing.T) {
 		libs := libraries.List{
-			{Name: "Bridge", Version: parseVersion(t, "1.2.3")},
+			{Name: "Bridge", Version: parseVersion(t, "1.2.3"), Location: libraries.User},
 		}
-		require.Equal(t, "-DFOUND_BRIDGE_LIB=0x010203", buildLibraryDiscoveryFlags(libs))
+		require.Equal(t,
+			"-DFOUND_BRIDGE_LIB=0x010203 -DFOUND_BRIDGE_LIB_IN_SKETCHBOOK=1",
+			buildLibraryDiscoveryFlags(libs))
 	})
 
 	t.Run("MultipleLibrariesJoinedWithSpace", func(t *testing.T) {
 		libs := libraries.List{
-			{Name: "Bridge", Version: parseVersion(t, "1.2.3")},
-			{Name: "Bridge Client-2", Version: nil},
+			{Name: "Bridge", Version: parseVersion(t, "1.2.3"), Location: libraries.User},
+			{Name: "Bridge Client-2", Version: nil, Location: libraries.PlatformBuiltIn},
 		}
 		require.Equal(t,
-			"-DFOUND_BRIDGE_LIB=0x010203 -DFOUND_BRIDGE_CLIENT_2_LIB=0x000001",
+			"-DFOUND_BRIDGE_LIB=0x010203 -DFOUND_BRIDGE_LIB_IN_SKETCHBOOK=1 -DFOUND_BRIDGE_CLIENT_2_LIB=0x000001 -DFOUND_BRIDGE_CLIENT_2_LIB_IN_PLATFORM=1",
 			buildLibraryDiscoveryFlags(libs))
+	})
+
+	t.Run("UnrecognizedLocationGetsNoSourceMacro", func(t *testing.T) {
+		libs := libraries.List{
+			{Name: "Bridge", Version: parseVersion(t, "1.2.3"), Location: libraries.LibraryLocation(99)},
+		}
+		require.Equal(t, "-DFOUND_BRIDGE_LIB=0x010203", buildLibraryDiscoveryFlags(libs))
 	})
 }
 

--- a/internal/arduino/builder/library_discovery_flags_test.go
+++ b/internal/arduino/builder/library_discovery_flags_test.go
@@ -1,0 +1,38 @@
+// This file is part of arduino-cli.
+//
+// Copyright (C) Arduino s.r.l. and/or its affiliated companies
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLibrarySlug(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"PlainName", "Bridge", "BRIDGE"},
+		{"AlreadyUpper", "WIFI101", "WIFI101"},
+		{"SpacesAndDash", "Bridge Client-2", "BRIDGE_CLIENT_2"},
+		{"Dots", "Adafruit.SSD1306", "ADAFRUIT_SSD1306"},
+		{"ConsecutiveSeparators", "Foo   Bar--Baz", "FOO_BAR_BAZ"},
+		{"LeadingDigit", "101Lib", "_101LIB"},
+		{"Empty", "", ""},
+		{"OnlySeparators", "---", "_"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, librarySlug(c.in))
+		})
+	}
+}

--- a/internal/integrationtest/compile_3/compile_library_discovery_flags_test.go
+++ b/internal/integrationtest/compile_3/compile_library_discovery_flags_test.go
@@ -1,0 +1,61 @@
+// This file is part of arduino-cli.
+//
+// Copyright (C) Arduino s.r.l. and/or its affiliated companies
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+
+package compile_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/arduino/arduino-cli/internal/integrationtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileLibraryDiscoveryFlags(t *testing.T) {
+	env, cli := integrationtest.CreateArduinoCLIWithEnvironment(t)
+	defer env.CleanUp()
+
+	_, _, err := cli.Run("core", "update-index")
+	require.NoError(t, err)
+	_, _, err = cli.Run("core", "install", "arduino:avr")
+	require.NoError(t, err)
+
+	sketchPath := cli.CopySketch("sketch_with_discovery_test_library")
+	librariesDir := sketchPath.Join("libraries")
+
+	// Deliberately NOT using --show-properties: that flag returns before
+	// Builder.preprocess() ever runs, so build.library_discovery_flags
+	// (set inside preprocess()) would never appear — the same reason
+	// {includes} is absent from --show-properties output too. A real
+	// compile does run preprocess(), and its build properties (including
+	// ours) are always captured into the RPC response's build_properties
+	// field regardless of --show-properties; --json is how this test
+	// observes that field.
+	stdout, stderr, err := cli.Run("compile",
+		"--fqbn", "arduino:avr:uno",
+		"--libraries", librariesDir.String(),
+		"--json",
+		sketchPath.String())
+	require.NoError(t, err)
+	require.Empty(t, stderr)
+
+	// Decode only build_properties, not the shared cliCompileResponse type
+	// (compile_show_properties_test.go): that type wraps the full
+	// rpc.BuilderResult, whose UsedLibraries[].Location enum field cannot
+	// be unmarshaled by encoding/json from protobuf-JSON's string encoding
+	// once a sketch actually resolves a library, which this fixture does
+	// (that file's own fixture is library-free, so it never hits this).
+	var resp struct {
+		BuilderResult struct {
+			BuildProperties []string `json:"build_properties"`
+		} `json:"builder_result"`
+	}
+	require.NoError(t, json.Unmarshal(stdout, &resp))
+	require.Contains(t, resp.BuilderResult.BuildProperties, "build.library_discovery_flags=-DFOUND_DISCOVERYTESTLIB_LIB=0x010203")
+}

--- a/internal/integrationtest/compile_3/compile_library_discovery_flags_test.go
+++ b/internal/integrationtest/compile_3/compile_library_discovery_flags_test.go
@@ -27,7 +27,7 @@ func TestCompileLibraryDiscoveryFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	sketchPath := cli.CopySketch("sketch_with_discovery_test_library")
-	librariesDir := sketchPath.Join("libraries")
+	libraryDir := sketchPath.Join("libraries", "DiscoveryTestLib")
 
 	// Deliberately NOT using --show-properties: that flag returns before
 	// Builder.preprocess() ever runs, so build.library_discovery_flags
@@ -37,9 +37,15 @@ func TestCompileLibraryDiscoveryFlags(t *testing.T) {
 	// ours) are always captured into the RPC response's build_properties
 	// field regardless of --show-properties; --json is how this test
 	// observes that field.
+	//
+	// Uses --library (singular, path to a single library's root folder),
+	// not --libraries (plural, path to a folder of libraries): the former
+	// sets Location == libraries.Unmanaged, the latter Location ==
+	// libraries.User — deliberately picking --library here to exercise the
+	// IN_SPECIFIED_PATH suffix.
 	stdout, stderr, err := cli.Run("compile",
 		"--fqbn", "arduino:avr:uno",
-		"--libraries", librariesDir.String(),
+		"--library", libraryDir.String(),
 		"--json",
 		sketchPath.String())
 	require.NoError(t, err)
@@ -57,5 +63,7 @@ func TestCompileLibraryDiscoveryFlags(t *testing.T) {
 		} `json:"builder_result"`
 	}
 	require.NoError(t, json.Unmarshal(stdout, &resp))
-	require.Contains(t, resp.BuilderResult.BuildProperties, "build.library_discovery_flags=-DFOUND_DISCOVERYTESTLIB_LIB=0x010203")
+	// The fixture library is provided via --library, i.e.
+	// Location == libraries.Unmanaged, hence IN_SPECIFIED_PATH.
+	require.Contains(t, resp.BuilderResult.BuildProperties, "build.library_discovery_flags=-DFOUND_DISCOVERYTESTLIB_LIB=0x010203 -DFOUND_DISCOVERYTESTLIB_LIB_IN_SPECIFIED_PATH=1")
 }

--- a/internal/integrationtest/testdata/sketch_with_discovery_test_library/libraries/DiscoveryTestLib/DiscoveryTestLib.h
+++ b/internal/integrationtest/testdata/sketch_with_discovery_test_library/libraries/DiscoveryTestLib/DiscoveryTestLib.h
@@ -1,0 +1,3 @@
+#ifndef DISCOVERYTESTLIB_H
+#define DISCOVERYTESTLIB_H
+#endif

--- a/internal/integrationtest/testdata/sketch_with_discovery_test_library/libraries/DiscoveryTestLib/library.properties
+++ b/internal/integrationtest/testdata/sketch_with_discovery_test_library/libraries/DiscoveryTestLib/library.properties
@@ -1,0 +1,10 @@
+name=DiscoveryTestLib
+version=1.2.3
+author=Test Author
+maintainer=Test Author <test@example.com>
+sentence=Test library for library discovery macros.
+paragraph=Test library for library discovery macros.
+category=Other
+url=http://example.com/
+architectures=*
+includes=DiscoveryTestLib.h

--- a/internal/integrationtest/testdata/sketch_with_discovery_test_library/sketch_with_discovery_test_library.ino
+++ b/internal/integrationtest/testdata/sketch_with_discovery_test_library/sketch_with_discovery_test_library.ino
@@ -1,0 +1,4 @@
+#include <DiscoveryTestLib.h>
+
+void setup() {}
+void loop() {}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This PR adds a set of library discovery macros, addressing the need described in #3124.

## What is the current behavior?

The set of libraries used in the build are not directly inspectable at compile time. This can be worked around in fragile ways, for example with `__has_include` or checking an include guard, but it's very library-specific.

## What is the new behavior?

A new default property `{build.library_discovery_macros}` is populated by the CLI and available while building all sketch and library files. For each discovered library two macros are defined:
 * `FOUND_<LIB>_LIB` is set to the hex representation the version code (`0x<major><minor><patch>`  as 3 hex bytes, each capped to `0xff`).
 * `FOUND_<LIB>_LIB_IN_<SOURCE>` " details the source of the library. Only one of the following is defined and set to `1`:
    * `IN_SKETCHBOOK`: user's `Arduino/libraries` folder, 
    * `IN_PLATFORM`: used core's `libraries/` folder,
    *  `IN_PROFILE`: specifically added by the used build profile ,
    * `IN_SPECIFIED_PATH`: specifically added via `--library` command line option

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

No.
