### PR TITLE
chore: allow forcing tools installation in foreign architecture

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,6 +125,10 @@ The `GITHUB_TOKEN` environment variable is also recognised: when set, its value 
 header on GitHub Actions artifact download requests only (see the note in the [Configuration keys](#configuration-keys)
 section above).
 
+`ARDUINO_FORCE_TOOLS_ARCH` can be set to a Go architecture name such as `arm64` or `amd64` to force installation of
+tools packages built for that architecture. The selected tools must provide an exact flavor for the current operating
+system; no emulation fallback is applied. This is intended for cross-architecture or emulated environments.
+
 #### Example
 
 Setting an additional Boards Manager URL using the `ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS` environment variable:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,6 +205,7 @@ schema should be considered unstable in this version.
 [arduino-cli global flags]: commands/arduino-cli_config.md#options-inherited-from-parent-commands
 [export command]: https://ss64.com/bash/export.html
 [set command]: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1
+[tool flavour]: package_index_json-specification.md#tools-flavours-available-builds-made-for-different-os
 [arduino-cli config init]: commands/arduino-cli_config_init.md
 [json]: https://www.json.org
 [toml]: https://github.com/toml-lang/toml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,9 +125,10 @@ The `GITHUB_TOKEN` environment variable is also recognised: when set, its value 
 header on GitHub Actions artifact download requests only (see the note in the [Configuration keys](#configuration-keys)
 section above).
 
-`ARDUINO_FORCE_TOOLS_ARCH` can be set to a Go architecture name such as `arm64` or `amd64` to force installation of
-tools packages built for that architecture. The selected tools must provide an exact flavor for the current operating
-system; no emulation fallback is applied. This is intended for cross-architecture or emulated environments.
+`ARDUINO_FORCE_TOOLS_ARCH` can be set to a Go architecture name such as `arm64` or `amd64` to force installation of tool
+dependencies in the "[flavour][tool flavour]" for the specified architecture, rather than for the host machine's
+architecture. The tools must be available in the exact flavour for the host machine's operating system; no emulation
+fallback is applied. This is intended for cross-architecture or emulated environments.
 
 #### Example
 

--- a/internal/arduino/cores/tools.go
+++ b/internal/arduino/cores/tools.go
@@ -16,6 +16,7 @@
 package cores
 
 import (
+	"os"
 	"regexp"
 	"runtime"
 
@@ -212,7 +213,27 @@ func (f *Flavor) isCompatibleWith(osName, osArch string) (bool, int) {
 
 // GetCompatibleFlavour returns the downloadable resource compatible with the running O.S.
 func (tr *ToolRelease) GetCompatibleFlavour() *resources.DownloadResource {
+	// This is useful when the CLI is running under emulation, or when the
+	// downloaded tool will be used by a different architecture than the CLI.
+	// Do not use the compatibility rules in this case: an explicitly requested
+	// architecture must not silently fall back to another one.
+	if forcedArch := os.Getenv("ARDUINO_FORCE_TOOLS_ARCH"); forcedArch != "" {
+		return tr.GetFlavourFor(runtime.GOOS, forcedArch)
+	}
 	return tr.GetFlavourCompatibleWith(runtime.GOOS, runtime.GOARCH)
+}
+
+// GetFlavourFor returns the downloadable resource built for the specified O.S.
+// and architecture. Unlike GetFlavourCompatibleWith, it does not consider
+// emulation or other compatibility fallbacks. This can be used to explicitly
+// select a tool for a foreign architecture.
+func (tr *ToolRelease) GetFlavourFor(osName, osArch string) *resources.DownloadResource {
+	for _, flavour := range tr.Flavors {
+		if flavour.isExactMatchWith(osName, osArch) {
+			return flavour.Resource
+		}
+	}
+	return nil
 }
 
 // GetFlavourCompatibleWith returns the downloadable resource compatible with the specified O.S.

--- a/internal/arduino/cores/tools_test.go
+++ b/internal/arduino/cores/tools_test.go
@@ -201,3 +201,22 @@ func TestFlavorPrioritySelection(t *testing.T) {
 	require.NotNil(t, res)
 	require.Equal(t, "1", res.ArchiveFileName)
 }
+
+func TestFlavorForcedArchitecture(t *testing.T) {
+	tr := &ToolRelease{
+		Flavors: []*Flavor{
+			{OS: "x86_64-linux-gnu", Resource: &resources.DownloadResource{ArchiveFileName: "amd64"}},
+			{OS: "aarch64-linux-gnu", Resource: &resources.DownloadResource{ArchiveFileName: "arm64"}},
+		},
+	}
+
+	// An explicit architecture must select the requested flavor even when it
+	// does not match the architecture of the running test process.
+	require.Equal(t, "arm64", tr.GetFlavourFor("linux", "arm64").ArchiveFileName)
+
+	t.Setenv("ARDUINO_FORCE_TOOLS_ARCH", "arm64")
+	require.Equal(t, "arm64", tr.GetCompatibleFlavour().ArchiveFileName)
+
+	t.Setenv("ARDUINO_FORCE_TOOLS_ARCH", "386")
+	require.Nil(t, tr.GetCompatibleFlavour())
+}

--- a/internal/arduino/cores/tools_test.go
+++ b/internal/arduino/cores/tools_test.go
@@ -16,6 +16,7 @@
 package cores
 
 import (
+	"runtime"
 	"slices"
 	"testing"
 
@@ -203,6 +204,10 @@ func TestFlavorPrioritySelection(t *testing.T) {
 }
 
 func TestFlavorForcedArchitecture(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("forced architecture test requires Linux tool flavors")
+	}
+
 	tr := &ToolRelease{
 		Flavors: []*Flavor{
 			{OS: "x86_64-linux-gnu", Resource: &resources.DownloadResource{ArchiveFileName: "amd64"}},


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

See [how to contribute](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/)

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-cli/pulls)
      before creating one)
- [x] The PR follows
      [our contributing guidelines](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] `UPGRADING.md` has been updated with a migration guide (for breaking changes)
- [ ] `configuration.schema.json` updated if new parameters are added.

## What kind of change does this PR introduce?

This PR adds a new feature to allow overriding the architecture of the tools being installed by `arduino-cli core install`

## What is the current behavior?

No way to install tools for foreing architecture (unless manually/wget)

## What is the new behavior?

`ARDUINO_FORCE_TOOLS_ARCH=arm64 arduino-cli core install vendor:core` (run from linux,amd64) will install the tools for linux,arm64. No change in behaviour if the env variable is not specified.

## Does this PR introduce a breaking change, and is [titled accordingly](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#breaking)?

<!-- If this PR is merged, will any users need to change their code, command-line invocations, build scripts or data files
when upgrading from an older version of Arduino CLI? -->

## Other information

<!-- Any additional information that could help the review process -->
